### PR TITLE
Use docs.publishing.service.gov.uk & govuk-developer-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # GOV.UK Developer Docs
 
-> ⚠️ This project is being rebuilt and is undergoing rapid change. File an issue before opening a PR.
-
-
-Live at: https://govuk-tech-docs.herokuapp.com (normal GDS username/password)
-
-We're in the process of moving this to docs.publishing.service.gov.uk so it can be open.
+👉 https://docs.publishing.service.gov.uk
 
 ## Technical documentation
 
@@ -13,7 +8,7 @@ This is a static site generated with Middleman.
 
 ## Tech docs template
 
-This project uses the [tech-docs-template](https://github.com/alphagov/tech-docs-template).
+This project uses [alphagov/tech-docs-template](https://github.com/alphagov/tech-docs-template).
 
 This means that some of the files (like the CSS, javascripts and layouts) are
 managed in the template and are not supposed to be modified here.
@@ -67,6 +62,13 @@ bundle exec middleman build
 
 This will create a bunch of static files in `/build`.
 
+### Deployment
+
+This project is re-deployed by a Jenkins task every hour (to pick up external
+changes). It is [hosted on S3][terraform].
+
 ## Licence
 
 [MIT License](LICENCE.md)
+
+[terraform]: https://github.com/alphagov/govuk-terraform-provisioning/tree/master/projects/developer_docs/resources

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk-developers",
+  "name": "govuk-developer-docs",
   "scripts": {
   },
   "env": {

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,4 @@
-# will be docs.publishing.service.gov.uk
-host: https://govuk-tech-docs.herokuapp.com/
+host: https://docs.publishing.service.gov.uk
 service_link: /
 
 show_govuk_logo: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,1 @@
-<a href='http://govuk-tech-docs.herokuapp.com/'>Go to govuk-tech-docs.herokuapp.com</a>
+<a href='https://docs.publishing.service.gov.uk/'>Go to docs.publishing.service.gov.uk</a>

--- a/source/application_template.html.md.erb
+++ b/source/application_template.html.md.erb
@@ -1,8 +1,8 @@
 ---
 layout: application_layout
 parent: applications.html
-source_url: https://github.com/alphagov/govuk-developers/blob/master/data/applications.yml
-edit_url: https://github.com/alphagov/govuk-developers/edit/master/data/applications.yml
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
+edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/applications.yml
 ---
 
 <%= application.description %>
@@ -26,4 +26,4 @@ The team that owns this application isn't specified. Help out by
 
 <%= partial 'partials/source', locals: { page: current_page.data } %>
 
-[app-yaml]: https://github.com/alphagov/govuk-developers/edit/master/data/applications.yml
+[app-yaml]: https://github.com/alphagov/govuk-developer-docs/edit/master/data/applications.yml

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,8 +2,8 @@
 layout: header_footer_only
 title: Dashboard
 navigation_weight: 1
-source_url: https://github.com/alphagov/govuk-developers/blob/master/data/dashboard.yml
-edit_url: https://github.com/alphagov/govuk-developers/edit/master/data/dashboard.yml
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dashboard.yml
+edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dashboard.yml
 ---
 
 <div id="toc-heading" class="toc-show fixedsticky">


### PR DESCRIPTION
This site is now publicly available on https://docs.publishing.service.gov.uk. The repo name was updated to better communicate the repo's intent.