### PR TITLE
Update the applications pages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,43 @@
+require_relative './lib/requires'
+
 namespace :assets do
   task :precompile do
     sh 'git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build'
+  end
+end
+
+desc "Find deployable applications that are not in this repo"
+task :verify_deployable_apps do
+  response = Faraday.get("https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml")
+  common_yaml = YAML.load(response.body.to_s)
+  deployable_applications = common_yaml["deployable_applications"].map { |k, v| v['repository'] || k }
+  our_applications = AppDocs.pages.map(&:github_repo_name)
+
+  intentionally_missing =
+    %w[
+    backdrop
+    spotlight
+    stagecraft
+    performanceplatform-admin
+    performanceplatform-big-screen-view
+
+    EFG
+
+    govuk-cdn-logs-monitor
+    govuk-content-schemas
+    govuk_crawler_worker
+    smokey
+
+    errbit
+    kibana-gds
+    sidekiq-monitoring
+
+    govuk-delivery
+  ]
+
+  puts "Deployables is not included in applications.yml:"
+
+  (deployable_applications - (our_applications + intentionally_missing)).uniq.each do |missing_app|
+    puts missing_app
   end
 end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -1,159 +1,159 @@
 # publishing apps
 
 - github_repo_name: collections-publisher
-  type: Publishing app
+  type: Publishing apps
   team: Finding Things
 
 - github_repo_name: contacts-admin
-  type: Publishing app
+  type: Publishing apps
   puppet_name: contacts
 
 - github_repo_name: content-tagger
-  type: Publishing app
+  type: Publishing apps
   team: Finding Things
 
 - github_repo_name: local-links-manager
-  type: Publishing app
+  type: Publishing apps
 
 - github_repo_name: manuals-publisher
-  type: Publishing app
+  type: Publishing apps
 
 - github_repo_name: maslow
-  type: Publishing app
+  type: Publishing apps
 
 - github_repo_name: panopticon
-  type: Publishing app
+  type: Publishing apps
   team: Finding Things
 
 - github_repo_name: policy-publisher
-  type: Publishing app
+  type: Publishing apps
   team: Finding Things
 
 - github_repo_name: publisher
-  type: Publishing app
+  type: Publishing apps
 
 - github_repo_name: short-url-manager
-  type: Publishing app
+  type: Publishing apps
 
 - github_repo_name: specialist-publisher
-  type: Publishing app
+  type: Publishing apps
   team: Finding Things
 
 - github_repo_name: travel-advice-publisher
-  type: Publishing app
+  type: Publishing apps
 
 - github_repo_name: whitehall
-  type: Publishing app
+  type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
 
 # api
 
 - github_repo_name: content-store
-  type: API
+  type: APIs
 
 - github_repo_name: email-alert-api
-  type: API
+  type: APIs
 
 - github_repo_name: email-alert-service
-  type: API
+  type: APIs
 
 - github_repo_name: govuk_content_api
-  type: API
+  type: APIs
   puppet_name: contentapi
 
 - github_repo_name: govuk_need_api
-  type: API
+  type: APIs
 
 - github_repo_name: imminence
-  type: API
+  type: APIs
 
 - github_repo_name: publishing-api
-  type: API
+  type: APIs
 
 - github_repo_name: rummager
-  type: API
+  type: APIs
   team: Finding Things
 
 - github_repo_name: asset-manager
-  type: API
+  type: APIs
 
 - github_repo_name: router-api
-  type: API
+  type: APIs
 
 - github_repo_name: support-api
-  type: API
+  type: APIs
 
 - github_repo_name: hmrc-manuals-api
-  type: API
+  type: APIs
 
 # admin
 
 - github_repo_name: search-admin
-  type: Supporting app
+  type: Supporting apps
   team: Finding Things
 
 - github_repo_name: signonotron2
-  type: Supporting app
+  type: Supporting apps
   app_name: signon
   production_url: https://signon.publishing.service.gov.uk
 
 - github_repo_name: support
-  type: Supporting app
+  type: Supporting apps
 
 # frontend
 
 - github_repo_name: business-support-finder
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: calculators
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: calendars
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: collections
-  type: Frontend app
+  type: Frontend apps
   team: Finding Things
 
 - github_repo_name: contacts-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: design-principles
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: email-alert-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: feedback
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: finder-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: government-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: info-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: licence-finder
-  type: Frontend app
+  type: Frontend apps
   team: Finding Things
 
 - github_repo_name: manuals-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: multipage-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: smart-answers
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: specialist-frontend
-  type: Frontend app
+  type: Frontend apps
 
 - github_repo_name: static
-  type: Frontend app
+  type: Frontend apps

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -32,6 +32,10 @@
 - github_repo_name: publisher
   type: Publishing apps
 
+- github_repo_name: service-manual-publisher
+  team: Service Manual
+  type: Publishing apps
+
 - github_repo_name: short-url-manager
   type: Publishing apps
 
@@ -150,6 +154,10 @@
   type: Frontend apps
 
 - github_repo_name: smart-answers
+  type: Frontend apps
+
+- github_repo_name: service-manual-frontend
+  team: Service Manual
   type: Frontend apps
 
 - github_repo_name: specialist-frontend

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -52,6 +52,9 @@
 
 # api
 
+- github_repo_name: business-support-api
+  type: APIs
+
 - github_repo_name: content-store
   type: APIs
 
@@ -90,7 +93,13 @@
 - github_repo_name: hmrc-manuals-api
   type: APIs
 
-# admin
+- github_repo_name: mapit
+  type: APIs
+
+- github_repo_name: metadata-api
+  type: APIs
+
+# Support
 
 - github_repo_name: search-admin
   type: Supporting apps
@@ -102,6 +111,22 @@
   production_url: https://signon.publishing.service.gov.uk
 
 - github_repo_name: support
+  type: Supporting apps
+
+- github_repo_name: authenticating-proxy
+  type: Supporting apps
+  team: Publishing Platform
+
+- github_repo_name: bouncer
+  type: Supporting apps
+
+- github_repo_name: transition
+  type: Supporting apps
+
+- github_repo_name: release
+  type: Supporting apps
+
+- github_repo_name: router
   type: Supporting apps
 
 # frontend

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -1,63 +1,9 @@
 - name: "Applications"
   sections:
-    - name: Publishing applications
-      repos:
-        - collections-publisher
-        - contacts-admin
-        - content-tagger
-        - hmrc-manuals-api
-        - local-links-manager
-        - manuals-publisher
-        - maslow
-        - panopticon
-        - policy-publisher
-        - publisher
-        - short-url-manager
-        - specialist-publisher
-        - travel-advice-publisher
-        - whitehall
-
+    - name: Publishing apps
     - name: APIs
-      repos:
-        - content-store
-        - email-alert-api
-        - email-alert-service
-        - govuk_content_api
-        - govuk_need_api
-        - imminence
-        - publishing-api
-        - rummager
-        - asset-manager
-        - router-api
-        - support-api
-
-    - name: Admin applications
-      repos:
-        - search-admin
-        - signonotron2
-        - support
-
-    - name: Frontend applications
-      repos:
-        - business-support-finder
-        - calculators
-        - calendars
-        - collections
-        - contacts-frontend
-        - design-principles
-        - email-alert-frontend
-        - feedback
-        - finder-frontend
-        - frontend
-        - government-frontend
-        - info-frontend
-        - licence-finder
-        - manuals-frontend
-        - multipage-frontend
-        - smart-answers
-        - specialist-frontend
-        - whitehall
-        - static
+    - name: Supporting apps
+    - name: Frontend apps
 
 - name: Developing
   sections:

--- a/lib/app_docs.rb
+++ b/lib/app_docs.rb
@@ -16,6 +16,10 @@ class AppDocs
       app_data["app_name"] || github_repo_name
     end
 
+    def github_repo_name
+      app_data.fetch("github_repo_name")
+    end
+
     def title
       app_name
     end
@@ -50,10 +54,6 @@ class AppDocs
     end
 
   private
-
-    def github_repo_name
-      app_data.fetch("github_repo_name")
-    end
 
     def puppet_name
       app_data["puppet_name"] || app_name.underscore

--- a/lib/dashboard/dashboard.rb
+++ b/lib/dashboard/dashboard.rb
@@ -41,10 +41,21 @@ private
 
   class Section < Thing
     def entries
-      repos + sites
+      from_application_page + repos + sites
     end
 
   private
+
+    # Pull the the applications from applications.yml into the first categories
+    def from_application_page
+      app_data = YAML.load_file("data/applications.yml")
+      applications_in_this_section = app_data.select { |a| a['type'] == name }
+
+      applications_in_this_section.map do |a|
+        repo = GitHub.client.repo(a['github_repo_name'])
+        App.new("name" => a['github_repo_name'], "description" => repo["description"])
+      end
+    end
 
     def repos
       data['repos'].to_a.map do |app_name|
@@ -73,6 +84,12 @@ private
 
     def url
       data.html_url
+    end
+  end
+
+  class App < Thing
+    def url
+      "/apps/#{id}.html"
     end
   end
 end

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -1,16 +1,54 @@
 ---
 layout: application_layout
 navigation_weight: 3
-title: Applications
+title: Applications on GOV.UK
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/source.apps.html.md.erb
+edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/source.apps.html.md.erb
 ---
 
-GOV.UK consists of many separate applications. Publishing apps are used by users
-in government to publish content. Frontend applications render content to end
-users on GOV.UK. APIs perform services in between.
+The publishing platform of GOV.UK consists of at least <%= app_pages.size %>
+separate applications. Most of them are built using [Ruby on Rails][rails].
 
-Applications are hosted on our infrastructure, which is
-[configured using puppet][govuk-puppet]. They are deployed to the servers
-[using capistrano scripts][govuk-app-deployment].
+Applications are hosted on an infrastructure [configured using puppet][govuk-puppet].
+They are deployed using [capistrano scripts][govuk-app-deployment].
 
+## Frontend apps
+
+Frontend apps render content to visitors to [www.gov.uk](https://www.gov.uk/).
+For example, a [HMRC manual page](hmrc-manual) is rendered by an application called
+[manuals-frontend][manuals-frontend].
+
+You can use the [chrome extension][extension] to find out which application
+is rendering any given page.
+
+All frontend applications use a [Ruby gem called slimmer][slimmer], which wraps
+the generated HTML into a layout with GOV.UK styling. To avoid having to update
+all applications for a global design change, slimmer pulls in the actual ERB
+templates from the ["static" application][static], which also serves stylesheets,
+javascript and images.
+
+## Publishing apps
+
+Publishing apps are used by editors to publish content to GOV.UK. For example,
+[specialist-publisher][specialist-publisher] publishes
+[specialist documents][specialist documents].
+
+The apps are secured by behind a [single signon system][signon]. They use an
+[omniauth adapter called gds-sso][gds-sso] to authenticate the user. The styling
+of the apps are shared using [a gem called govuk\_admin\_template][govuk_admin_template].
+
+[rails]: http://rubyonrails.org/
+[extension]: https://github.com/alphagov/govuk-toolkit-chrome
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet
 [govuk-app-deployment]: https://github.com/alphagov/govuk-app-deployment
+[slimmer]: https://github.com/alphagov/slimmer
+[gds-sso]: https://github.com/alphagov/gds-sso
+[govuk_admin_template]: https://github.com/alphagov/govuk_admin_template
+[hmrc-manual]: https://www.gov.uk/hmrc-internal-manuals/vat-clothing/vclothing1100
+[specialist documents]: https://www.gov.uk/cma-cases/legal-services-market-study
+[manuals-frontend]: /apps/manuals-frontend.html
+[static]: /apps/static.html
+[signon]: /apps/signon.html
+[specialist-publisher]: /apps/specialist-publisher.html
+
+<%= partial 'partials/source', locals: { page: current_page.data } %>

--- a/source/layouts/application_layout.html.erb
+++ b/source/layouts/application_layout.html.erb
@@ -14,7 +14,7 @@
         <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
           <ul>
           <% app_pages.group_by(&:type).each do |name, apps| %>
-            <li><%= link_to name, '#' %></li>
+            <li><%= link_to name, '/apps.html' %></li>
 
             <ul>
             <% apps.each do |app| %>


### PR DESCRIPTION
This PR updates the "Application" pages.

- Adds an explanation of GOV.UK frontend & publishing apps
- Adds missing applications (+ rake task to keep it in sync with puppet)
 
![screen shot 2016-12-22 at 13 16 39](https://cloud.githubusercontent.com/assets/233676/21426832/feae36d2-c848-11e6-866b-f06270f74486.png)

Best reviewed per-commit and with the preview on Heroku: 

https://govuk-tech-docs-pr-25.herokuapp.com/
