### PR TITLE
Fix signon repo name

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -114,10 +114,8 @@
   type: Supporting apps
   team: Finding Things
 
-- github_repo_name: signonotron2
+- github_repo_name: signon
   type: Supporting apps
-  app_name: signon
-  production_url: https://signon.publishing.service.gov.uk
   team: Core Formats
 
 - github_repo_name: support


### PR DESCRIPTION
Signonotron2 is now called "signon" :gift_heart:.