### PR TITLE
Add document type pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -37,6 +37,7 @@ end
 ignore 'publishing_api_template.html.md.erb'
 ignore 'schema_template.html.md.erb'
 ignore 'application_template.html.md.erb'
+ignore 'document_type_template.html.md.erb'
 
 PublishingApiDocs.pages.each do |page|
   proxy "/apis/publishing-api/#{page.filename}.html", "publishing_api_template.html", locals: {
@@ -58,6 +59,13 @@ AppDocs.pages.each do |application|
   proxy "/apps/#{application.app_name}.html", "application_template.html", locals: {
     page_title: application.title,
     application: application,
+  }
+end
+
+DocumentTypes.pages.each do |page|
+  proxy "/document-types/#{page.name}.html", "document_type_template.html", locals: {
+    page: page,
+    page_title: page.name
   }
 end
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,3 +10,4 @@ header_links:
   Publishing API: /apis/publishing-api.html
   Search API: /apis/search-api.html
   Content Schemas: /content-schemas.html
+  Document types: /document-types.html

--- a/lib/document_types.rb
+++ b/lib/document_types.rb
@@ -1,0 +1,54 @@
+class DocumentTypes
+  def self.pages
+    @@pages ||= begin
+      facet_query.dig("facets", "content_store_document_type", "options").map { |o|
+        Page.new(o.dig("value", "slug"), o.dig("documents"))
+      }.sort_by(&:name)
+    end
+  end
+
+  def self.coverage_percentage
+    ((pages_with_document_type / facet_query.fetch("total").to_f) * 100).round(1)
+  end
+
+  def self.pages_with_document_type
+    pages.sum(&:total_count)
+  end
+
+  def self.facet_query
+    @@facet_query ||= begin
+      json = Faraday.get('https://www.gov.uk/api/search.json?facet_content_store_document_type=200&count=0').body
+      JSON.parse(json)
+    end
+  end
+
+  class Page
+    attr_reader :name, :count
+
+    def initialize(name, count)
+      @name = name
+      @count = count
+    end
+
+    def total_count
+      count
+    end
+
+    def examples
+      search.dig("results")
+    end
+
+    def search_url
+      "https://www.gov.uk/api/search.json?filter_content_store_document_type=#{name}&count=10"
+    end
+
+  private
+
+    def search
+      @search ||= begin
+        json = Faraday.get(search_url).body
+        JSON.parse(json)
+      end
+    end
+  end
+end

--- a/source/document-types.html.md.erb
+++ b/source/document-types.html.md.erb
@@ -1,0 +1,13 @@
+---
+layout: document_type_layout
+title: Document types on GOV.UK
+---
+
+The document type describes what a page on GOV.UK looks like.
+
+All documents have a document type in the [content-store][content-store], but not
+all document types have been indexed in search yet. This means some types are
+missing from the list on the left. At the moment the list covers types for
+<%= DocumentTypes.coverage_percentage %>% of the pages in search index.
+
+[content-store]: https://github.com/alphagov/content-store

--- a/source/document_type_template.html.md.erb
+++ b/source/document_type_template.html.md.erb
@@ -1,0 +1,15 @@
+---
+layout: document_type_layout
+---
+
+There are <strong><%= page.total_count %></strong> pages with document type '<%= page.name %>' on GOV.UK.
+
+<h2>Most popular pages</h2>
+
+<ul>
+<% page.examples.each do |example| %>
+  <li><%= link_to example['title'], "https://www.gov.uk/#{example['link']}" %></li>
+<% end %>
+</ul>
+
+<%= link_to 'Source query from Search API', page.search_url %>

--- a/source/layouts/document_type_layout.html.erb
+++ b/source/layouts/document_type_layout.html.erb
@@ -1,0 +1,33 @@
+<% wrap_layout :header_footer_only do %>
+  <div id="toc-heading" class="toc-show fixedsticky">
+    <a href="#toc" class="toc-show__label js-toc-show">
+      Table of contents <span class="toc-show__icon"></span>
+    </a>
+  </div>
+
+  <div class="app-pane__body">
+    <div class="app-pane__toc">
+      <div class="toc" data-module="table-of-contents">
+        <a href="#" class="toc__close js-toc-close">Close</a>
+        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
+          <ul>
+            <li><a href='/document-types.html'>Document types</a>
+              <ul>
+              <% DocumentTypes.pages.each do |page| %>
+                <li><%= link_to "#{page.name} - #{page.total_count}", "/document-types/#{page.name}.html" %></li>
+              <% end %>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+    <div class="app-pane__content">
+      <main id="content" class="technical-documentation" data-module="anchored-headings">
+        <%= partial 'partials/header' %>
+        <%= yield %>
+      </main>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This adds pages for all document types in the search index.

![screen shot 2017-01-31 at 10 07 35](https://cloud.githubusercontent.com/assets/233676/22460531/207d4aa0-e79d-11e6-80ed-56db12338a0d.png)

We've recently started indexing these (thanks @alecgibson & @carvil), so not all pages in the index have document types yet.

The user need for these pages is that we'd like to start creating a canonical list of document types. This will allow us to make groupings (like "publication" or "announcement") consistently across the site.

Review here: https://govuk-tech-docs-pr-30.herokuapp.com/document-types.html

cc @jennyd 

https://trello.com/c/EfrOXi9L