### PR TITLE
Configure markdown renderer option to not use intra-word emphasis

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,8 @@ set :markdown,
       with_toc_data: true
     ),
     fenced_code_blocks: true,
-    tables: true
+    tables: true,
+    no_intra_emphasis: true
 
 configure :development do
   activate :livereload


### PR DESCRIPTION
- The no_intra_emphasis option for the markdown renderer is now set to
true, which stops the renderer from trying to parse the inside of words.
- Without this setting, words with underscores in the middle of them cause
 the formatting to be incorrect.

#### Before: Markdown not being rendered properly in the 'Link' paragraph
![screen shot 2017-02-01 at 11 13 44](https://cloud.githubusercontent.com/assets/12881990/22512326/87db8f60-e890-11e6-80c6-24a7135cdbdf.png)

#### After: With markdown being rendered in the same way as its source repo in the 'Link' paragraph
![screen shot 2017-02-01 at 11 12 47](https://cloud.githubusercontent.com/assets/12881990/22512321/813d691c-e890-11e6-9ec5-eeba31f1adce.png)