### PR TITLE
Simplify document types

### DIFF
--- a/lib/document_types.rb
+++ b/lib/document_types.rb
@@ -8,11 +8,7 @@ class DocumentTypes
   end
 
   def self.coverage_percentage
-    ((pages_with_document_type / facet_query.fetch("total").to_f) * 100).round(1)
-  end
-
-  def self.pages_with_document_type
-    pages.sum(&:total_count)
+    ((pages.sum(&:total_count) / facet_query.fetch("total").to_f) * 100).round(1)
   end
 
   def self.facet_query

--- a/lib/document_types.rb
+++ b/lib/document_types.rb
@@ -2,7 +2,11 @@ class DocumentTypes
   def self.pages
     @@pages ||= begin
       facet_query.dig("facets", "content_store_document_type", "options").map { |o|
-        Page.new(o.dig("value", "slug"), o.dig("documents"))
+        Page.new(
+          name: o.dig("value", "slug"),
+          count: o.dig("documents"),
+          examples: o.dig("value", "example_info", "examples"),
+        )
       }.sort_by(&:name)
     end
   end
@@ -13,38 +17,22 @@ class DocumentTypes
 
   def self.facet_query
     @@facet_query ||= begin
-      json = Faraday.get('https://www.gov.uk/api/search.json?facet_content_store_document_type=200&count=0').body
+      json = Faraday.get('https://www.gov.uk/api/search.json?facet_content_store_document_type=100,examples:10,example_scope:global&count=0').body
       JSON.parse(json)
     end
   end
 
   class Page
-    attr_reader :name, :count
+    attr_reader :name, :total_count, :examples
 
-    def initialize(name, count)
+    def initialize(name:, total_count:, examples:)
       @name = name
-      @count = count
-    end
-
-    def total_count
-      count
-    end
-
-    def examples
-      search.dig("results")
+      @total_count = total_count
+      @examples = examples
     end
 
     def search_url
       "https://www.gov.uk/api/search.json?filter_content_store_document_type=#{name}&count=10"
-    end
-
-  private
-
-    def search
-      @search ||= begin
-        json = Faraday.get(search_url).body
-        JSON.parse(json)
-      end
     end
   end
 end


### PR DESCRIPTION
We currently have to make one request per document_type to find the example pages for each type.

Since https://github.com/alphagov/rummager/pull/743 we can request examples for each facet. This saves us a lot of requests when building the pages.

cc @rubenarakelyan 