### PR TITLE
Add guide to A/B testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/alphagov/table_of_contents.git
-  revision: ee6d26c6ead059e60b212f10f906766ec89b25df
+  revision: 2b3639c05eb68e5d00e63469f784b203eb6257a1
   specs:
     table_of_contents (0.1.0)
       nokogiri
@@ -128,7 +128,7 @@ GEM
     minitest (5.9.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)

--- a/config.rb
+++ b/config.rb
@@ -37,6 +37,9 @@ helpers do
   def app_pages
     AppDocs.pages.sort_by(&:title)
   end
+
+  require 'table_of_contents/helpers'
+  include TableOfContents::Helpers
 end
 
 ignore 'templates/*'

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -7,6 +7,7 @@ service_name: Developer docs
 header_links:
   Dashboard: /
   Applications: /apps.html
+  Guides: /guides.html
   API docs: /apis.html
   Content schemas: /content-schemas.html
   Document types: /document-types.html

--- a/source/guides.html.md.erb
+++ b/source/guides.html.md.erb
@@ -1,0 +1,77 @@
+---
+layout: layout
+title: Guides
+---
+
+# A/B testing
+
+## 1. Overview
+
+There are two ways of doing A/B testing on GOV.UK. The first uses Javascript to change the contents on a page. The second uses our CDN to allow frontend applications to render different pages.
+
+For a general introduction to A/B testing from a content design perspective, see the [Confluence Wiki](https://bit.ly/AB-testing-GOVUK)
+
+## 2. Javascript testing
+
+Javascript testing uses the [Multivariate test framework][multivariate-testing] from the [GOV.UK frontend toolkit][govuk_frontend_toolkit]. It works by running a piece of Javascript after the page is loaded.
+
+A [step-by-step walkthrough is provided on the Wiki](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=85786770).
+
+[multivariate-testing]: https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/javascript.md#multivariate-test-framework
+[govuk_frontend_toolkit]: https://github.com/alphagov/govuk_frontend_toolkit
+
+## 3. Using Fastly
+
+This method uses Fastly, our Content Delivery Network (CDN).
+
+### 3.1 How it works
+
+#### Fastly receives the request
+
+When the user requests a GOV.UK page that has A/B testing enabled, they will reach Fastly first.
+
+Fastly appends the `GOVUK-ABTest-Example` header to the request for downstream apps:
+
+- If the request already has a cookie, use the value of that
+- If not, randomly assign the user to a test variant and set it value based on that
+
+Fastly will then try to get a response from its cache. The `Vary: GOVUK-ABTest-Example` header on previously cached responses will ensure that the right version is returned to the user.
+
+If there's nothing in Fastly's cache, it'll send the request down the stack to GOV.UK.
+
+#### GOV.UK (Varnish caching layer)
+
+Varnish tries to get a response from the cache. Because Fastly has sent the `GOVUK-ABTest-Example` header, it knows whether to return the `A` or `B` version from the cache. If there's nothing in the cache, Varnish forwards the request to the application server.
+
+#### Application layer
+
+The application (for example, [government-frontend](/apps/government-frontend.html) or [collections](/apps/collections.html)) inspects the `GOVUK-ABTest-Example` header to determine which version of the content to return.
+
+It also adds an extra response header: `Vary: GOVUK-ABTest-Example`. This instructs Fastly and Varnish to cache both versions of the page separately.
+
+#### Varnish (response)
+
+Varnish saves the response in the cache. The `Vary: GOVUK-ABTest-Example` response header will ensure that `A` and `B` are cached separately.
+
+#### Fastly responds
+
+Fastly also saves the response in the cache. The `Vary: GOVUK-ABTest-Example` response header will ensure that `A` and `B` are cached separately.
+
+If the original request did not have the `ABTest-Example` cookie, Fastly will set a `Set-Cookie` header to the response based on the value of the `GOVUK-ABTest-Example` header.
+
+### 3.2 Checklist for enabling A/B testing
+
+1. Get your cookie listed on the [cookies page](https://www.gov.uk/help/cookies). The content team can help.
+2. You will have to make appropriate changes in [govuk-cdn-config][govuk-cdn-config].
+3. Use the [govuk\_ab\_testing gem][govuk_ab_testing] to serve different versions to your users.
+4. Configure Google Analytics
+
+[govuk_ab_testing]: https://github.com/alphagov/govuk_ab_testing
+[govuk-cdn-config]: https://github.com/alphagov/govuk-cdn-config
+
+## Resources
+
+- ["A/B testing at the edge" - Fastly blog](https://www.fastly.com/blog/ab-testing-edge)
+- ["Best Practices for Using the Vary Header" - Fastly blog](https://www.fastly.com/blog/best-practices-for-using-the-vary-header)
+
+[fastly]: https://www.fastly.com/


### PR DESCRIPTION
The new A/B testing method using Fastly is a fairly complicated system that touches a few parts of a stack. This is an attempt at a guide for developers that want to use the system.

This is the first "guide" on the docs site. The idea is that this is a more appropriate place than the opsmanual (which is closed and only accessible via the VPN) and the wiki (which is closed and not user friendly). Feedback welcome on that too.

I've copied most from https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=128385031 by @suzannehamilton. We should probably replace that page with this.

https://trello.com/c/bh7iFV7G