### PR TITLE
Add sitemap.xml for search indexes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'middleman-compass', '>= 4.0.0'
 gem 'middleman-sprockets', '~> 4.0.0'
 gem 'middleman-autoprefixer', '~> 2.7.0'
 gem 'middleman-syntax', '~> 3.0.0'
+gem 'middleman-search_engine_sitemap', '~> 1.4'
 
 gem 'table_of_contents', github: 'alphagov/table_of_contents'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     autoprefixer-rails (6.5.4)
       execjs
     backports (3.6.8)
+    builder (3.2.3)
     chunky_png (1.3.8)
     coffee-script (2.4.1)
       coffee-script-source
@@ -114,6 +115,9 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
+    middleman-search_engine_sitemap (1.4.0)
+      builder
+      middleman-core (~> 4.0)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -191,6 +195,7 @@ DEPENDENCIES
   middleman-autoprefixer (~> 2.7.0)
   middleman-compass (>= 4.0.0)
   middleman-livereload
+  middleman-search_engine_sitemap (~> 1.4)
   middleman-sprockets (~> 4.0.0)
   middleman-syntax (~> 3.0.0)
   octokit

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,7 @@
 require_relative './lib/requires'
 
+config[:tech_docs] = YAML.load_file('config/tech-docs.yml').with_indifferent_access
+
 set :markdown_engine, :redcarpet
 
 set :markdown,
@@ -17,6 +19,11 @@ end
 activate :autoprefixer
 activate :sprockets
 activate :syntax
+
+# Configure the sitemap for Google
+set :url_root, config[:tech_docs][:host]
+activate :search_engine_sitemap,
+  default_change_frequency: 'weekly'
 
 helpers do
   def dashboard
@@ -63,6 +70,3 @@ DocumentTypes.pages.each do |page|
     page_title: page.name
   }
 end
-
-config[:tech_docs] = YAML.load_file('config/tech-docs.yml')
-                         .with_indifferent_access

--- a/source/error.html.erb
+++ b/source/error.html.erb
@@ -1,6 +1,7 @@
 ---
 layout: header_footer_only
 title: Page not found
+hide_from_sitemap: true
 ---
 
 <div class="app-pane__body">

--- a/source/templates/publishing_api_template.html.md.erb
+++ b/source/templates/publishing_api_template.html.md.erb
@@ -1,6 +1,7 @@
 ---
 layout: api_layout
 parent: apis/publishing-api.html
+hide_from_sitemap: true
 ---
 
 <%= ExternalDoc.fetch(page.raw_source) %>


### PR DESCRIPTION
This adds a sitemap.xml to make it easier for Google to index all pages on the site.

Will be visible on:

https://docs.publishing.service.gov.uk/sitemap.xml

This ignores the error page, the rest will be indexed.