### PR TITLE
Extract the sidebar HTML into shared layout

### DIFF
--- a/lib/dashboard/github.rb
+++ b/lib/dashboard/github.rb
@@ -11,7 +11,7 @@ class GitHub
       # Not on alpghagov, make a separate call to the API. Cache it for
       # development speed.
       @@cache ||= {}
-      @@cache[app_name] = client.repo(app_name)
+      @@cache[app_name] ||= client.repo(app_name)
     else
       all_alphagov_repos.find { |repo| repo.name == app_name } || raise("alphagov/#{app_name} not found")
     end

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,60 +1,45 @@
 ---
-layout: header_footer_only
+layout: false
 title: Dashboard
 navigation_weight: 1
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dashboard.yml
 edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dashboard.yml
 ---
 
-<div id="toc-heading" class="toc-show fixedsticky">
-  <a href="#toc" class="toc-show__label js-toc-show">
-    Table of contents <span class="toc-show__icon"></span>
-  </a>
-</div>
-
-<div class="app-pane__body">
-  <div class="app-pane__toc">
-    <div class="toc" data-module="table-of-contents">
-      <a href="#" class="toc__close js-toc-close">Close</a>
-      <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
+<% content_for :sidebar do %>
+  <ul>
+    <% dashboard.chapters.each do |chapter| %>
+      <li>
+        <a href='#<%= chapter.id %>'><%= chapter.name %></a>
         <ul>
-          <% dashboard.chapters.each do |chapter| %>
+          <% chapter.sections.each do |section| %>
             <li>
-              <a href='#<%= chapter.id %>'><%= chapter.name %></a>
-              <ul>
-                <% chapter.sections.each do |section| %>
-                  <li>
-                    <a href='#<%= section.id %>'><%= section.name %></a>
-                  </li>
-                <% end %>
-              </ul>
+              <a href='#<%= section.id %>'><%= section.name %></a>
             </li>
           <% end %>
         </ul>
-      </nav>
-    </div>
-  </div>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 
-  <div class="app-pane__content">
-    <main id="content" class="technical-documentation" data-module="anchored-headings">
-      <%= partial 'partials/header' %>
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
 
-      <% dashboard.chapters.each do |chapter| %>
-        <h2 id='<%= chapter.id %>'><%= chapter.name %></h2>
+  <% dashboard.chapters.each do |chapter| %>
+    <h2 id='<%= chapter.id %>'><%= chapter.name %></h2>
 
-        <% chapter.sections.each do |section| %>
-          <h3 id='<%= section.id %>'><%= section.name %></h3>
+    <% chapter.sections.each do |section| %>
+      <h3 id='<%= section.id %>'><%= section.name %></h3>
 
-          <% section.entries.each do |entry| %>
-            <div class='entry'>
-              <a href='<%= entry.url %>'><%= entry.name %></a>
-              <small><%= entry.description %></small>
-            </div>
-          <% end %>
-        <% end %>
+      <% section.entries.each do |entry| %>
+        <div class='entry'>
+          <a href='<%= entry.url %>'><%= entry.name %></a>
+          <small><%= entry.description %></small>
+        </div>
       <% end %>
+    <% end %>
+  <% end %>
 
-      <%= partial 'partials/source', locals: { page: current_page.data } %>
-    </main>
-  </div>
-</div>
+  <%= partial 'partials/source', locals: { page: current_page.data } %>
+<% end %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -1,44 +1,27 @@
-<% wrap_layout :header_footer_only do %>
-  <div id="toc-heading" class="toc-show fixedsticky">
-    <a href="#toc" class="toc-show__label js-toc-show">
-      Table of contents <span class="toc-show__icon"></span>
-    </a>
-  </div>
-
-
-  <div class="app-pane__body">
-    <div class="app-pane__toc">
-      <div class="toc" data-module="table-of-contents">
-        <a href="#" class="toc__close js-toc-close">Close</a>
-        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
-          <ul>
-            <li><%= link_to 'Search API', '/apis/search-api.html' %></li>
-            <li>
-              <%= link_to 'Publishing API', '/apis/publishing-api.html' %>
-              <ul>
-                <% publishing_api_pages.each do |page| %>
-                  <li><%= link_to page.title, "/apis/publishing-api/#{page.filename}.html" %></li>
-                <% end %>
-              </ul>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-
-    <div class="app-pane__content">
-      <main id="content" class="technical-documentation" data-module="anchored-headings">
-        <%= partial 'partials/header' %>
-        <% if locals.key?(:page) %>
-          <%= partial 'partials/source', page: page %>
+<% content_for :sidebar do %>
+  <ul>
+    <li><%= link_to 'Search API', '/apis/search-api.html' %></li>
+    <li>
+      <%= link_to 'Publishing API', '/apis/publishing-api.html' %>
+      <ul>
+        <% publishing_api_pages.each do |page| %>
+          <li><%= link_to page.title, "/apis/publishing-api/#{page.filename}.html" %></li>
         <% end %>
+      </ul>
+    </li>
+  </ul>
+<% end %>
 
-        <%= yield %>
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
 
-        <% if locals.key?(:page) %>
-          <%= partial 'partials/source', page: page %>
-        <% end %>
-      </main>
-    </div>
-  </div>
+  <% if locals.key?(:page) %>
+    <%= partial 'partials/source', page: page %>
+  <% end %>
+
+  <%= yield %>
+
+  <% if locals.key?(:page) %>
+    <%= partial 'partials/source', page: page %>
+  <% end %>
 <% end %>

--- a/source/layouts/application_layout.html.erb
+++ b/source/layouts/application_layout.html.erb
@@ -1,45 +1,26 @@
-<% wrap_layout :header_footer_only do %>
-  <div id="toc-heading" class="toc-show fixedsticky">
-    <a href="#toc" class="toc-show__label js-toc-show">
-      Table of contents <span class="toc-show__icon"></span>
-    </a>
-  </div>
+<% content_for :sidebar do %>
+  <ul>
+  <% app_pages.group_by(&:type).each do |name, apps| %>
+    <li><%= link_to name, '/apps.html' %></li>
 
-  <% html = yield %>
+    <ul>
+    <% apps.each do |app| %>
+      <li><%= link_to app.title, "/apps/#{app.app_name}.html" %></li>
+    <% end %>
+    </ul>
+  <% end %>
+  </ul>
+<% end %>
 
-  <div class="app-pane__body">
-    <div class="app-pane__toc">
-      <div class="toc" data-module="table-of-contents">
-        <a href="#" class="toc__close js-toc-close">Close</a>
-        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
-          <ul>
-          <% app_pages.group_by(&:type).each do |name, apps| %>
-            <li><%= link_to name, '/apps.html' %></li>
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
+  <% if locals.key?(:page) %>
+    <%= partial 'partials/source', page: page %>
+  <% end %>
 
-            <ul>
-            <% apps.each do |app| %>
-              <li><%= link_to app.title, "/apps/#{app.app_name}.html" %></li>
-            <% end %>
-            </ul>
-          <% end %>
-          </ul>
-        </nav>
-      </div>
-    </div>
+  <%= yield %>
 
-    <div class="app-pane__content">
-      <main id="content" class="technical-documentation" data-module="anchored-headings">
-        <%= partial 'partials/header' %>
-        <% if locals.key?(:page) %>
-          <%= partial 'partials/source', page: page %>
-        <% end %>
-
-        <%= yield %>
-
-        <% if locals.key?(:page) %>
-          <%= partial 'partials/source', page: page %>
-        <% end %>
-      </main>
-    </div>
-  </div>
+  <% if locals.key?(:page) %>
+    <%= partial 'partials/source', page: page %>
+  <% end %>
 <% end %>

--- a/source/layouts/document_type_layout.html.erb
+++ b/source/layouts/document_type_layout.html.erb
@@ -1,33 +1,16 @@
-<% wrap_layout :header_footer_only do %>
-  <div id="toc-heading" class="toc-show fixedsticky">
-    <a href="#toc" class="toc-show__label js-toc-show">
-      Table of contents <span class="toc-show__icon"></span>
-    </a>
-  </div>
+<% content_for :sidebar do %>
+  <ul>
+    <li><a href='/document-types.html'>Document types</a>
+      <ul>
+      <% DocumentTypes.pages.each do |page| %>
+        <li><%= link_to "#{page.name} - #{page.total_count}", "/document-types/#{page.name}.html" %></li>
+      <% end %>
+      </ul>
+    </li>
+  </ul>
+<% end %>
 
-  <div class="app-pane__body">
-    <div class="app-pane__toc">
-      <div class="toc" data-module="table-of-contents">
-        <a href="#" class="toc__close js-toc-close">Close</a>
-        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
-          <ul>
-            <li><a href='/document-types.html'>Document types</a>
-              <ul>
-              <% DocumentTypes.pages.each do |page| %>
-                <li><%= link_to "#{page.name} - #{page.total_count}", "/document-types/#{page.name}.html" %></li>
-              <% end %>
-              </ul>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-
-    <div class="app-pane__content">
-      <main id="content" class="technical-documentation" data-module="anchored-headings">
-        <%= partial 'partials/header' %>
-        <%= yield %>
-      </main>
-    </div>
-  </div>
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
+  <%= yield %>
 <% end %>

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -1,0 +1,24 @@
+<% wrap_layout :header_footer_only do %>
+  <div id="toc-heading" class="toc-show fixedsticky">
+    <a href="#toc" class="toc-show__label js-toc-show">
+      Table of contents <span class="toc-show__icon"></span>
+    </a>
+  </div>
+
+  <div class="app-pane__body">
+    <div class="app-pane__toc">
+      <div class="toc" data-module="table-of-contents">
+        <a href="#" class="toc__close js-toc-close">Close</a>
+        <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
+          <%= yield_content :sidebar %>
+        </nav>
+      </div>
+    </div>
+
+    <div class="app-pane__content">
+      <main id="content" class="technical-documentation" data-module="anchored-headings">
+        <%= yield %>
+      </main>
+    </div>
+  </div>
+<% end %>

--- a/source/layouts/schema_layout.erb
+++ b/source/layouts/schema_layout.erb
@@ -1,38 +1,22 @@
-<% wrap_layout :header_footer_only do %>
-  <div id="toc-heading" class="toc-show fixedsticky">
-    <a href="#toc" class="toc-show__label js-toc-show">
-      Table of contents <span class="toc-show__icon"></span>
-    </a>
-  </div>
+<% content_for :sidebar do %>
+  <ul>
+    <% GovukSchemas::Schema.schema_names.sort.each do |schema_name| %>
+      <li><%= link_to schema_name, "/content-schemas/#{schema_name}.html" %></li>
+      <% if current_page.path.include?("content-schemas/#{schema_name}.html") %>
+        <ul>
+          <li><%= link_to 'Frontend schema', '#frontend-schema' %>
+          <li><%= link_to 'Publisher content schema', '#publisher-content-schema' %>
+          <li><%= link_to 'Publisher links schema', '#publisher-links-schema' %>
+        </ul>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>
 
-  <div class="app-pane__body">
-    <div class="app-pane__toc">
-      <div class="toc" data-module="table-of-contents">
-        <a href="#" class="toc__close js-toc-close">Close</a>
-        <nav  id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
-          <ul>
-            <% GovukSchemas::Schema.schema_names.sort.each do |schema_name| %>
-              <li><%= link_to schema_name, "/content-schemas/#{schema_name}.html" %></li>
-              <% if current_page.path.include?("content-schemas/#{schema_name}.html") %>
-                <ul>
-                  <li><%= link_to 'Frontend schema', '#frontend-schema' %>
-                  <li><%= link_to 'Publisher content schema', '#publisher-content-schema' %>
-                  <li><%= link_to 'Publisher links schema', '#publisher-links-schema' %>
-                </ul>
-              <% end %>
-            <% end %>
-          </ul>
-        </nav>
-      </div>
-    </div>
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
 
-    <div class="app-pane__content">
-      <main id="content" class="technical-documentation" data-module="anchored-headings">
-        <%= partial 'partials/header' %>
-        <%= yield %>
-      </main>
-    </div>
-  </div>
+  <%= yield %>
 
   <style media="screen">
     .technical-documentation pre {


### PR DESCRIPTION
This extracts the layout for the sidebar into a common layout, so we don't have to repeat ourselves so much.