### PR TITLE
Add a page for the dictionary

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -6,6 +6,7 @@ service_name: Developer docs
 
 header_links:
   Dashboard: /
+  Dictionary: /dictionary.html
   Applications: /apps.html
   Guides: /guides.html
   API docs: /apis.html

--- a/data/dictionary.yml
+++ b/data/dictionary.yml
@@ -1,0 +1,77 @@
+---
+- word: Base path
+  synonyms: slug, location
+  implementation_detail: 'No'
+  description: A reserved URL on www.gov.uk that is associated with a content item.
+- word: Content
+  synonyms: ''
+  implementation_detail: 'No'
+  description: The data, generally words, that an editor has written and wants to eventually publish for users.
+- word: Content ID
+  synonyms: artefact, document
+  implementation_detail: 'Yes'
+  description: A unique identifier shared by content items which represent the same content. A content id may have content items in different states, locations and translations.
+- word: Content Item
+  synonyms: ''
+  implementation_detail: 'Yes'
+  description: The representation of an edition of a document with links to be stored in the Content Store.
+- word: Dependency resolution
+  synonyms: ''
+  implementation_detail: 'Yes'
+  description: The process of recursively following dependencies (links) between documents to work out which expanded links need updating.
+- word: Details
+  synonyms: details hash
+  implementation_detail: 'Yes'
+  description: Part of the schema that captures content-y data in a way that is opaque to the publishing platform, but understandable by a rendering application.
+- word: Document
+  synonyms: ''
+  implementation_detail: 'Yes'
+  description: A collection of editions, used to refer to all of the iterations of a single piece of content in a certain translation.
+- word: Document Type
+  synonyms: format, content type
+  implementation_detail: 'No'
+  description: A way to classify content items in publishing applications. Sometimes displayed to the end user.
+- word: Edition
+  synonyms: a version
+  implementation_detail: 'Yes'
+  description: Captures a version of a document, or representation of some entity required to render GOV.UK.
+- word: Expanded links
+  synonyms: ''
+  implementation_detail: 'Yes'
+  description: Allows rendering applications to see titles and descriptions of linked documents, and follow links recursively, without having to make multiple content store requests.
+- word: Links
+  synonyms: links hash
+  implementation_detail: 'Yes'
+  description: Part of the schema that captures that other content that has been tagged to the content.
+- word: Publishing
+  synonyms: ''
+  implementation_detail: 'No'
+  description: Putting content live on GOV.UK
+- word: Publishing Application
+  synonyms: backend application
+  implementation_detail: 'No'
+  description: Associates a document with the application that was used to publish it.
+- word: Rendering application
+  synonyms: frontend application
+  implementation_detail: 'Yes'
+  description: Associates a document with the application that was used to render it.
+- word: Route
+  synonyms: ''
+  implementation_detail: 'Yes'
+  description: A record that describes how the router should hand control rendering over to a rendering application based on URL.
+- word: Schema
+  synonyms: ''
+  implementation_detail: 'Yes'
+  description: A JSON schema representation of a kind of document. Usually maps one to one with document type.
+- word: Tagging
+  synonyms: ''
+  implementation_detail: 'No'
+  description: Lets editors capture how a piece of content relates to another piece of content.
+- word: Unpublishing
+  synonyms: ''
+  implementation_detail: 'No'
+  description: Taking content off the live site, because it was published in error, or is being redirected to a better form of the content.
+- word: Withdrawing
+  synonyms: ''
+  implementation_detail: 'No'
+  description: Putting a big notice on a page because it's no longer current/accurate.

--- a/source/dictionary.html.md.erb
+++ b/source/dictionary.html.md.erb
@@ -1,0 +1,18 @@
+---
+layout: dictionary_layout
+title: Dictionary
+source_url: https://github.com/alphagov/govuk-developers/blob/master/source/dictionary.html.md.erb
+edit_url: https://github.com/alphagov/govuk-developers/edit/master/source/dictionary.html.md.erb
+---
+
+(Originally from [the Wiki](https://gov-uk.atlassian.net/wiki/display/TECH/Publishing+Platform))
+
+<% data.dictionary.each do |entry| %>
+  <div>
+    <h2 id=<%="#{entry.word.parameterize}"%>-definition>
+      <%= entry.word %>
+    </h2>
+    <small>Synonyms: <%= entry.synonyms %></small>
+    <p><%= entry.description %></p>
+  </div>
+<% end %>

--- a/source/layouts/dictionary_layout.erb
+++ b/source/layouts/dictionary_layout.erb
@@ -1,0 +1,17 @@
+<% content_for :sidebar do %>
+  <ul>
+  <% data.dictionary.each do |entry| %>
+    <li>
+      <%= link_to entry.word, "/dictionary.html##{entry.word.parameterize}-definition" %>
+    </li>
+  <% end %>
+  </ul>
+<% end %>
+
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
+
+  <%= yield %>
+
+  <%= partial 'partials/source', locals: { page: current_page.data } %>
+<% end %>


### PR DESCRIPTION
- This adds a page containing the content of the dictionary that is
currently on the GOV.UK wiki.

[Trello card](https://trello.com/c/gn40a8Yn/18-add-dictionary-with-core-concepts-on-gov-uk)
![screen shot 2017-02-08 at 17 56 55](https://cloud.githubusercontent.com/assets/12881990/22750338/5998fbd6-ee28-11e6-9c9a-83efd74d4cd0.png)
