### PR TITLE
Add page about the taxonomy

### DIFF
--- a/source/guides.html.md.erb
+++ b/source/guides.html.md.erb
@@ -3,6 +3,8 @@ layout: layout
 title: Guides
 ---
 
+<%= partial 'guides/taxonomy' %>
+
 # A/B testing
 
 ## 1. Overview

--- a/source/guides/_taxonomy.html.md.erb
+++ b/source/guides/_taxonomy.html.md.erb
@@ -1,0 +1,41 @@
+# Taxonomy
+
+GOV.UK's "single subject taxonomy" intends to describe all content on GOV.UK. It is being developed theme-by-theme, starting with education.
+
+## 1. Editing taxonomy
+
+The taxonomy is managed in [content-tagger][edit-taxonomy].
+
+The topics in the taxonomy (we call them "taxons" in code) are persisted in the publishing-api as content items. For an example [see the "Education" taxon][education-taxon].
+
+
+## 2. Tagging
+
+All pages can be tagged to the taxonomy, currently in [content-tagger][content-tagger] too.
+
+In the future, editors will also be able to tag to the taxonomy in publishing apps like [Whitehall][whitehall].
+
+The relationship between a page and a taxon is persisted in the publishing-api "links hash". For example, see the [taxons link in the content item for this guidance document][example-guidance].
+
+## 3. Accessing the taxonomy
+
+This is the content item for the top-level "Education" taxon:
+
+[https://www.gov.uk/api/content/education][education-taxon]
+
+You can use this to find the structure of the taxonomy by following the `child_taxons` links.
+
+## 4. Accessing tagged content
+
+All content tagged to a particular taxon you fetch from the search API ([rummager][rummager]).
+
+This works with a `content_id` rather than URL. To find all content tagged to the above mentioned ["Education taxon"][education-taxon]:
+
+[https://www.gov.uk/api/search.json?filter_taxons[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0](https://www.gov.uk/api/search.json?filter_taxons[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0)
+
+[education-taxon]: https://www.gov.uk/api/content/education
+[example-guidance]: https://www-origin.integration.publishing.service.gov.uk/api/content/government/publications/managing-staff-employment-in-schools
+[edit-taxonomy]: https://content-tagger.publishing.service.gov.uk/taxon
+[content-tagger]: https://content-tagger.publishing.service.gov.uk/
+[whitehall]: /apps/whitehall.html
+[rummager]: /apps/rummager.html

--- a/source/guides/_taxonomy.html.md.erb
+++ b/source/guides/_taxonomy.html.md.erb
@@ -8,6 +8,7 @@ The taxonomy is managed in [content-tagger][edit-taxonomy].
 
 The topics in the taxonomy (we call them "taxons" in code) are persisted in the publishing-api as content items. For an example [see the "Education" taxon][education-taxon].
 
+The link type `parent_taxons` is used to store the relationship between taxons. Link expansion makes sure that the taxons will have a `child_taxons` link type too.
 
 ## 2. Tagging
 


### PR DESCRIPTION
This is a first pass at a page to explain the technical stuff behind the taxonomy.

It's intended for GOV.UK developers that are interested in using the taxonomy, like @pmanrubia and @tomnatt currently.

I *think* that it makes sense for a page like this to exist on this site, rather than say content-tagger, because it's a concept that touches many apps on GOV.UK - content-store, rummager, content-tagger, publishing-api and soon publishing apps and collections.

Thoughts? @pmanrubia @tomnatt @MatMoore @carvil  

**Preview**: https://govuk-tech-docs-pr-46.herokuapp.com/guides.html#taxonomy