### PR TITLE
Change the urls for viewing and editing the dictionary source

### DIFF
--- a/source/dictionary.html.md.erb
+++ b/source/dictionary.html.md.erb
@@ -1,8 +1,8 @@
 ---
 layout: dictionary_layout
 title: Dictionary
-source_url: https://github.com/alphagov/govuk-developers/blob/master/source/dictionary.html.md.erb
-edit_url: https://github.com/alphagov/govuk-developers/edit/master/source/dictionary.html.md.erb
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dictionary.yml
+edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dictionary.yml
 ---
 
 (Originally from [the Wiki](https://gov-uk.atlassian.net/wiki/display/TECH/Publishing+Platform))


### PR DESCRIPTION
These should point at the YAML file that contains the dictionary
content instead of the source file for the dictionary page.