### PR TITLE
Add Content Tools to repos they own

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -20,6 +20,7 @@
 
 - github_repo_name: maslow
   type: Publishing apps
+  team: Content Tools
 
 - github_repo_name: panopticon
   type: Publishing apps
@@ -107,6 +108,7 @@
 
 - github_repo_name: metadata-api
   type: APIs
+  team: Content Tools
 
 # Support
 
@@ -150,9 +152,11 @@
 
 - github_repo_name: calculators
   type: Frontend apps
+  team: Content Tools
 
 - github_repo_name: calendars
   type: Frontend apps
+  team: Content Tools
 
 - github_repo_name: collections
   type: Frontend apps
@@ -169,6 +173,7 @@
 
 - github_repo_name: feedback
   type: Frontend apps
+  team: Content Tools
 
 - github_repo_name: finder-frontend
   type: Frontend apps
@@ -183,6 +188,7 @@
 
 - github_repo_name: info-frontend
   type: Frontend apps
+  team: Content Tools
 
 - github_repo_name: licence-finder
   type: Frontend apps
@@ -196,6 +202,7 @@
 
 - github_repo_name: smart-answers
   type: Frontend apps
+  team: Content Tools
 
 - github_repo_name: service-manual-frontend
   team: Service Manual


### PR DESCRIPTION
Mostly taken from

https://gov-uk.atlassian.net/wiki/display/GOVUK/Product+group+structure+and+details

and

https://gov-uk.atlassian.net/wiki/display/CT/GOV.UK+Content+Tools