### PR TITLE
Allow apps to be marked "retired"

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -34,8 +34,8 @@ helpers do
     PublishingApiDocs.pages
   end
 
-  def app_pages
-    AppDocs.pages.sort_by(&:title)
+  def active_app_pages
+    AppDocs.pages.reject(&:retired?).sort_by(&:app_name)
   end
 
   require 'table_of_contents/helpers'
@@ -62,7 +62,7 @@ end
 
 AppDocs.pages.each do |application|
   proxy "/apps/#{application.app_name}.html", "templates/application_template.html", locals: {
-    page_title: "Application: #{application.title}",
+    page_title: application.page_title,
     application: application,
   }
 end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -25,6 +25,7 @@
 - github_repo_name: panopticon
   type: Publishing apps
   team: Finding Things
+  description: Application that was used for route registration, tagging and search
 
 - github_repo_name: policy-publisher
   type: Publishing apps

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -23,9 +23,19 @@
   team: Content Tools
 
 - github_repo_name: panopticon
+  retired: true
   type: Publishing apps
   team: Finding Things
-  description: Application that was used for route registration, tagging and search
+  repo_url: https://github.com/gds-attic/panopticon
+  description: |
+    Application that was at one time used for management of "artefacts", route
+    registration, tagging and search indexing. The functionality was slowly moved
+    to the new publishing platform during migration (2016/2017). In February 2017
+    the last functionality was removed. Most features moved to
+    [publishing-api](/apps/publishing-api.html) (like route registration), managing
+    of artefacts was moved to [publisher](/apps/publisher.html), and tagging moved
+    to [content-tagger](/apps/content-tagger.html). Publishing apps became
+    responsible for sending their pages to search.
 
 - github_repo_name: policy-publisher
   type: Publishing apps

--- a/lib/app_docs.rb
+++ b/lib/app_docs.rb
@@ -12,6 +12,18 @@ class AppDocs
       @app_data = app_data
     end
 
+    def retired?
+      app_data["retired"]
+    end
+
+    def page_title
+      if retired?
+        "Application: #{app_name} (retired)"
+      else
+        "Application: #{app_name}"
+      end
+    end
+
     def app_name
       app_data["app_name"] || github_repo_name
     end
@@ -20,12 +32,8 @@ class AppDocs
       app_data.fetch("github_repo_name")
     end
 
-    def title
-      app_name
-    end
-
     def repo_url
-      "https://github.com/alphagov/#{github_repo_name}"
+      app_data["repo_url"] || "https://github.com/alphagov/#{github_repo_name}"
     end
 
     def puppet_url

--- a/lib/app_docs.rb
+++ b/lib/app_docs.rb
@@ -45,8 +45,7 @@ class AppDocs
     end
 
     def description
-      repo = GitHub.client.repo(github_repo_name)
-      repo["description"]
+      app_data["description"] || description_from_github
     end
 
     def production_url
@@ -57,6 +56,11 @@ class AppDocs
 
     def puppet_name
       app_data["puppet_name"] || app_name.underscore
+    end
+
+    def description_from_github
+      repo = GitHub.client.repo(github_repo_name)
+      repo["description"]
     end
   end
 end

--- a/lib/dashboard/dashboard.rb
+++ b/lib/dashboard/dashboard.rb
@@ -48,12 +48,12 @@ private
 
     # Pull the the applications from applications.yml into the first categories
     def from_application_page
-      app_data = YAML.load_file("data/applications.yml")
-      applications_in_this_section = app_data.select { |a| a['type'] == name }
+      applications_in_this_section = AppDocs.pages.reject(&:retired?).select do |app|
+        app.type == name
+      end
 
-      applications_in_this_section.map do |a|
-        repo = GitHub.client.repo(a['github_repo_name'])
-        App.new("name" => a['github_repo_name'], "description" => repo["description"])
+      applications_in_this_section.map do |app|
+        App.new("name" => app.app_name, "description" => app.description)
       end
     end
 

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -6,7 +6,7 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/source/
 edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/source/apps.html.md.erb
 ---
 
-The publishing platform of GOV.UK consists of at least <%= app_pages.size %>
+The publishing platform of GOV.UK consists of at least <%= active_app_pages.size %>
 separate applications. Most of them are built using [Ruby on Rails][rails].
 
 Applications are hosted on an infrastructure [configured using puppet][govuk-puppet].

--- a/source/layouts/application_layout.html.erb
+++ b/source/layouts/application_layout.html.erb
@@ -1,11 +1,11 @@
 <% content_for :sidebar do %>
   <ul>
-  <% app_pages.group_by(&:type).each do |name, apps| %>
+  <% active_app_pages.group_by(&:type).each do |name, apps| %>
     <li><%= link_to name, '/apps.html' %></li>
 
     <ul>
     <% apps.each do |app| %>
-      <li><%= link_to app.title, "/apps/#{app.app_name}.html" %></li>
+      <li><%= link_to app.app_name, "/apps/#{app.app_name}.html" %></li>
     <% end %>
     </ul>
   <% end %>

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -7,6 +7,15 @@ edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/appl
 
 <%= application.description %>
 
+This application is retired.
+
+<% if application.retired? %>
+<ul>
+  <li><%= link_to "GitHub repo", application.repo_url %></li>
+</ul>
+
+<% else %>
+
 <% if application.team %>
 Owned by team **<%= application.team %>**.
 <% else %>
@@ -23,6 +32,8 @@ The team that owns this application isn't specified. Help out by
     <li><%= link_to application.production_url.gsub('https://', ''), application.production_url %></li>
   <% end %>
 </ul>
+
+<% end %>
 
 <%= partial 'partials/source', locals: { page: current_page.data } %>
 


### PR DESCRIPTION
Setting `retired: true` for an application will:

- Hide it from the dashboard
- Hide it from the sidebar on the applications page
- Doesn't count it in lists of active apps
- Shows "(retired)" in the page title, shows a link to gds-attic repo

![screen shot 2017-02-16 at 10 21 32](https://cloud.githubusercontent.com/assets/233676/23017324/b603df8a-f431-11e6-8579-ff1d754ff552.png)

Also marks panopticon as retired - https://trello.com/c/dGPNmVub/482-retire-panopticon