### PR TITLE
Fix bug in showing which repos are retired

### DIFF
--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -7,9 +7,10 @@ edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/appl
 
 <%= application.description %>
 
+<% if application.retired? %>
+
 This application is retired.
 
-<% if application.retired? %>
 <ul>
   <li><%= link_to "GitHub repo", application.repo_url %></li>
 </ul>


### PR DESCRIPTION
"This application is retired." is currently showing everywhere.

