### PR TITLE
Update name of govuk_schemas gem

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -26,7 +26,7 @@
 
     - name: Schemas
       repos:
-        - govuk_schemas_gem
+        - govuk_schemas
         - govuk-content-schema-test-helpers
         - govuk-content-schemas
 


### PR DESCRIPTION
This repo still has the old name for the gem (govuk_schemas_gem instead
of govuk_schemas) which is stopping the homepage from displaying.