### PR TITLE
Add documentation for document "supertypes"

### DIFF
--- a/helpers/url_helpers.rb
+++ b/helpers/url_helpers.rb
@@ -1,0 +1,5 @@
+module UrlHelpers
+  def document_type_url(document_type_name)
+    "/document-types/#{document_type_name}.html"
+  end
+end

--- a/lib/supertypes.rb
+++ b/lib/supertypes.rb
@@ -1,0 +1,23 @@
+class Supertypes
+  def self.all
+    yaml = Faraday.get("https://raw.githubusercontent.com/alphagov/govuk_document_types/master/data/supertypes.yml").body
+    YAML.load(yaml).map { |id, config| Supertype.new(id, config) }
+  end
+
+  class Supertype
+    attr_reader :id, :name, :description, :default, :items
+
+    def initialize(id, config)
+      @id = id
+      @name = config.fetch("name")
+      @description = config.fetch("description")
+      @default = config.fetch("default")
+      @items = config.fetch("items")
+    end
+
+    def for_document_type(document_type)
+      item = items.find { |item| item.fetch("document_types").include?(document_type) }
+      item ? item['id'] : default
+    end
+  end
+end

--- a/source/document-types.html.md.erb
+++ b/source/document-types.html.md.erb
@@ -12,5 +12,29 @@ missing from the list on the left. At the moment the list covers types for
 
 The data for the list is generated [by running a facet query against search][query].
 
+## Supertypes
+
+Document types can be grouped into "document supertypes". The types are defined
+in a YAML file [in the GOV.UK Document Types gem][govuk_document_types].
+
+<% Supertypes.all.each do |supertype| %>
+### <%= supertype.name %>
+
+<%= supertype.description %>
+
+| Name | Types |
+| --- | --- |
+<% supertype.items.map do |item| %>
+| <%= item.fetch("id") %> | <%= item.fetch("document_types").map { |d| link_to(d, document_type_url(d)) }.join("<br/>") %> |
+<% end %>
+| <%= supertype.default %> | All other types |
+
+<% end %>
+
 [content-store]: https://github.com/alphagov/content-store
+[govuk_document_types]: https://github.com/alphagov/govuk_document_types
 [query]: <%= DocumentTypes::FACET_QUERY %>
+
+<style>
+table td:first-child { width: 150px; }
+</style>

--- a/source/templates/document_type_template.html.md.erb
+++ b/source/templates/document_type_template.html.md.erb
@@ -5,6 +5,14 @@ parent: /document-types.html
 
 There are <strong><%= page.total_count %></strong> pages with document type '<%= page.name %>' on GOV.UK.
 
+## Supertypes
+
+| Type | Group |
+| --- | --- |
+<% Supertypes.all.each do |supertype| %>
+| <%= link_to supertype.name, "/document-types.html" %> | <%= supertype.for_document_type(page.name) %> |
+<% end %>
+
 <h2>Most popular pages</h2>
 
 <ul>


### PR DESCRIPTION
Supertypes are groupings of document types. A good example of this is the concept of "announcement" (which groups document types like news and speeches) and "publication" (which encompasses things like guides and policy).

The types are taken directly from the gem.

![screen shot 2017-03-06 at 14 10 49](https://cloud.githubusercontent.com/assets/233676/23613286/bc93fd3c-0276-11e7-8cb5-b45fdd779904.png)
![screen shot 2017-03-06 at 14 10 55](https://cloud.githubusercontent.com/assets/233676/23613285/bc937bb4-0276-11e7-82dd-a868eb652d50.png)


https://trello.com/c/07lAcDtC