### PR TITLE
Expand taxonomy guide and link to the taxonomy gem

### DIFF
--- a/source/guides/_taxonomy.html.md.erb
+++ b/source/guides/_taxonomy.html.md.erb
@@ -1,6 +1,6 @@
 # Taxonomy
 
-GOV.UK's "single subject taxonomy" intends to describe all content on GOV.UK. It is being developed theme-by-theme, starting with education.
+GOV.UK's "single subject taxonomy" will describe all content on GOV.UK. It is being developed theme-by-theme, starting with education.
 
 ## 1. Editing taxonomy
 
@@ -26,6 +26,8 @@ This is the content item for the top-level "Education" taxon:
 
 You can use this to find the structure of the taxonomy by following the `child_taxons` links.
 
+To manipulate and browse taxonomies in ruby code, use the [govuk_taxonomy_helpers](http://www.rubydoc.info/gems/govuk_taxonomy_helpers) gem.
+
 ## 4. Accessing tagged content
 
 All content tagged to a particular taxon you fetch from the search API ([rummager][rummager]).
@@ -34,9 +36,13 @@ This works with a `content_id` rather than URL. To find all content tagged to th
 
 [https://www.gov.uk/api/search.json?filter_taxons[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0](https://www.gov.uk/api/search.json?filter_taxons[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0)
 
-You can also access all content tagged to the taxon and its children. The following will give you everything tagged to "Education" and all child-taxons of education:
+You can also access all content tagged to a taxon and the part of the taxonomy below it. The following will give you everything tagged to topics in the "Education" taxonomy:
 
-[https://www.gov.uk/api/search.json?filter_part_of_taxonomy_tree[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0](https://www.gov.uk/api/search.json?filter_part_of_taxonomy_tree[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0)
+[https://www.gov.uk/api/search.json?filter_part_of_taxonomy_tree[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&fields=title,taxons,part_of_taxonomy_tree](https://www.gov.uk/api/search.json?filter_part_of_taxonomy_tree[]=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&fields=title,taxons,part_of_taxonomy_tree)
+
+You can see the number of documents in each topic by using `taxons` as a facet:
+
+[https://www.gov.uk/api/search.json?filter_part_of_taxonomy_tree=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&facet_taxons=1000&count=0](https://www.gov.uk/api/search.json?filter_part_of_taxonomy_tree=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&facet_taxons=1000&count=0)
 
 [education-taxon]: https://www.gov.uk/api/content/education
 [example-guidance]: https://www-origin.integration.publishing.service.gov.uk/api/content/government/publications/managing-staff-employment-in-schools


### PR DESCRIPTION
Add a bit more detail on the rummager fields and link to the taxonomy helpers gem.

Trello https://trello.com/c/OaHe7Ylt/514-document-taxon-fields-in-rummager
Replaces https://github.com/alphagov/rummager/pull/758