### PR TITLE
Add example pages for apps

### DIFF
--- a/lib/app_data.rb
+++ b/lib/app_data.rb
@@ -1,0 +1,24 @@
+class AppData
+  SEARCH_URL = 'https://www.gov.uk/api/search.json?facet_publishing_app=100,examples:10,example_scope:global&facet_rendering_app=100,examples:10,example_scope:global&count=0'
+
+  def publishing_examples
+    extract_examples_from_search_result("publishing_app")
+  end
+
+  def rendering_examples
+    extract_examples_from_search_result("rendering_app")
+  end
+
+private
+
+  def result
+    @result ||= JSON.parse(Faraday.get(SEARCH_URL).body)
+  end
+
+  def extract_examples_from_search_result(facet_name)
+    result.dig("facets", facet_name, "options").reduce({}) do |hash, option|
+      hash[option.dig("value", "slug")] = option.dig("value", "example_info", "examples")
+      hash
+    end
+  end
+end

--- a/lib/app_docs.rb
+++ b/lib/app_docs.rb
@@ -5,6 +5,10 @@ class AppDocs
     end
   end
 
+  def self.app_data
+    @publishing_app_data ||= AppData.new
+  end
+
   class App
     attr_reader :app_data
 
@@ -26,6 +30,14 @@ class AppDocs
 
     def app_name
       app_data["app_name"] || github_repo_name
+    end
+
+    def example_published_pages
+      AppDocs.app_data.publishing_examples[app_name]
+    end
+
+    def example_rendered_pages
+      AppDocs.app_data.rendering_examples[app_name]
     end
 
     def github_repo_name

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -34,6 +34,26 @@ The team that owns this application isn't specified. Help out by
   <% end %>
 </ul>
 
+<% if application.example_published_pages %>
+<h3>Example pages published by <%= application.app_name %></h3>
+
+<ul>
+<% application.example_published_pages.each do |example| %>
+  <li><%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
+<% end %>
+</ul>
+<% end %>
+
+<% if application.example_rendered_pages %>
+<h3>Example pages rendered by <%= application.app_name %></h3>
+
+<ul>
+<% application.example_rendered_pages.each do |example| %>
+  <li><%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
+<% end %>
+</ul>
+<% end %>
+
 <% end %>
 
 <%= partial 'partials/source', locals: { page: current_page.data } %>


### PR DESCRIPTION
This adds a list of pages published or rendered to the application pages.

This data is fetched from the search API. Unfortunately most of the `rendering_app`/`publishing_app` is still missing, so not all pages will have the examples.


## Screenshots

![screen shot 2017-03-08 at 09 12 52](https://cloud.githubusercontent.com/assets/233676/23697423/9baca32a-03df-11e7-871f-45290fc11875.png)
![screen shot 2017-03-08 at 09 13 06](https://cloud.githubusercontent.com/assets/233676/23697422/9bac9394-03df-11e7-8e32-a2de6fd0022e.png)
![screen shot 2017-03-08 at 09 13 19](https://cloud.githubusercontent.com/assets/233676/23697424/9bad327c-03df-11e7-9109-30907f10eab8.png)
