### PR TITLE
Show all document types

### DIFF
--- a/lib/document_types.rb
+++ b/lib/document_types.rb
@@ -1,15 +1,21 @@
 class DocumentTypes
   FACET_QUERY = 'https://www.gov.uk/api/search.json?facet_content_store_document_type=500,examples:10,example_scope:global&count=0'.freeze
+  DOCUMENT_TYPES_URL = 'https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml'.freeze
 
   def self.pages
     @@pages ||= begin
-      facet_query.dig("facets", "content_store_document_type", "options").map { |o|
+      known_from_search = facet_query.dig("facets", "content_store_document_type", "options").map { |o|
         Page.new(
           name: o.dig("value", "slug"),
           total_count: o.dig("documents"),
           examples: o.dig("value", "example_info", "examples"),
         )
-      }.sort_by(&:name)
+      }
+
+      all_document_types.map do |document_type|
+        from_search = known_from_search.find { |p| p.name == document_type }
+        from_search || Page.new(name: document_type, total_count: 0, examples: [])
+      end
     end
   end
 
@@ -19,6 +25,10 @@ class DocumentTypes
 
   def self.facet_query
     @@facet_query ||= HTTP.get(FACET_QUERY)
+  end
+
+  def self.all_document_types
+    HTTP.get_yaml(DOCUMENT_TYPES_URL).sort
   end
 
   class Page

--- a/lib/document_types.rb
+++ b/lib/document_types.rb
@@ -1,5 +1,5 @@
 class DocumentTypes
-  FACET_QUERY = 'https://www.gov.uk/api/search.json?facet_content_store_document_type=100,examples:10,example_scope:global&count=0'.freeze
+  FACET_QUERY = 'https://www.gov.uk/api/search.json?facet_content_store_document_type=500,examples:10,example_scope:global&count=0'.freeze
 
   def self.pages
     @@pages ||= begin

--- a/source/document-types.html.md.erb
+++ b/source/document-types.html.md.erb
@@ -5,12 +5,12 @@ title: Document types on GOV.UK
 
 The document type describes what a page on GOV.UK looks like.
 
-All documents have a document type in the [content-store][content-store], but not
+> **WARNING:** All documents have a document type in the [content-store][content-store], but not
 all document types have been indexed in search yet. This means some types are
 missing from the list on the left. At the moment the list covers types for
 <%= DocumentTypes.coverage_percentage %>% of the pages in search index.
 
-The data for the list is generated [by running a facet query against search][query].
+> The data for the list is generated [by running a facet query against search][query].
 
 ## Supertypes
 

--- a/source/layouts/document_type_layout.html.erb
+++ b/source/layouts/document_type_layout.html.erb
@@ -3,7 +3,7 @@
     <li><%= sidebar_link 'Document types', "/document-types.html" %>
       <ul>
       <% DocumentTypes.pages.each do |page| %>
-        <li><%= sidebar_link "#{page.name} - #{page.total_count}", "/document-types/#{page.name}.html" %></li>
+        <li><%= sidebar_link page.name, "/document-types/#{page.name}.html" %></li>
       <% end %>
       </ul>
     </li>

--- a/source/templates/document_type_template.html.md.erb
+++ b/source/templates/document_type_template.html.md.erb
@@ -3,7 +3,8 @@ layout: document_type_layout
 parent: /document-types.html
 ---
 
-There are <strong><%= page.total_count %></strong> pages with document type '<%= page.name %>' on GOV.UK.
+There are <strong><%= page.total_count %></strong> pages with document type
+'<%= page.name %>' in the GOV.UK search index.
 
 ## Supertypes
 
@@ -13,12 +14,12 @@ There are <strong><%= page.total_count %></strong> pages with document type '<%=
 | <%= link_to supertype.name, "/document-types.html" %> | <%= supertype.for_document_type(page.name) %> |
 <% end %>
 
-<h2>Most popular pages</h2>
+<% if page.examples.any? %>
+## Example pages
 
-<ul>
 <% page.examples.each do |example| %>
-  <li><%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
+- <%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
 <% end %>
-</ul>
 
 <%= link_to 'Source query from Search API', page.search_url %>
+<% end %>

--- a/spec/fixtures/allowed-document-types-fixture.json
+++ b/spec/fixtures/allowed-document-types-fixture.json
@@ -1,0 +1,4 @@
+- announcement
+- answer
+- asylum_support_decision
+- authored_article

--- a/spec/lib/document_types_spec.rb
+++ b/spec/lib/document_types_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe DocumentTypes do
   describe ".pages" do
     it "returns document types" do
-      stub_request(:get, "https://www.gov.uk/api/search.json?count=0&facet_content_store_document_type=100,examples:10,example_scope:global").
+      stub_request(:get, "https://www.gov.uk/api/search.json?count=0&facet_content_store_document_type=500,examples:10,example_scope:global").
         to_return(
           body: File.read("spec/fixtures/rummager-app-search-response.json"),
           headers: {

--- a/spec/lib/document_types_spec.rb
+++ b/spec/lib/document_types_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe DocumentTypes do
           }
         )
 
+      stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml").
+        to_return(body: File.read("spec/fixtures/allowed-document-types-fixture.json"))
+
       document_type = DocumentTypes.pages.first
 
-      expect(document_type.examples.first).to eql(
-        "title" => "Disclosure and Barring Service – About us",
-        "link" => "/government/organisations/disclosure-and-barring-service/about"
-      )
+      expect(document_type.examples.first.keys).to eql(%w[title link])
     end
   end
 end


### PR DESCRIPTION
Since https://github.com/alphagov/govuk-content-schemas/pull/550 there's a central list of allowed document types. By using this list we add the types that aren't currently in the search index.