### PR TITLE
[DO NOT MERGE] Change business-support-finder to "retired"

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -159,7 +159,16 @@
 # frontend
 
 - github_repo_name: business-support-finder
+  retired: true
   type: Frontend apps
+  team: Finding Things
+  repo_url: https://github.com/gds-attic/business-support-finder
+  description: |
+    Application that was used to display the "business support finder", an early
+    finder-style page with search functionality for finding details of business
+    finance support schemes. In March 2017, it was replaced with a new-style finder
+    rendered by [finder-frontend](/apps/finder-frontend.html) and published by
+    [specialist-publisher](/apps/specialist-publisher.html).
 
 - github_repo_name: calculators
   type: Frontend apps


### PR DESCRIPTION
This commit changes the status of business-support-finder to "retired" and adds some details of its replacement.

Trello: https://trello.com/c/9O34PdXb/547-remove-business-support-finder-application