### PR TITLE
Add an "Opsmanual" section to the docs

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -38,6 +38,13 @@ helpers do
     AppDocs.pages.reject(&:retired?).sort_by(&:app_name)
   end
 
+  # Returns all pages under a certain directory.
+  def sub_pages(dir)
+    sitemap.resources.select do |resource|
+      resource.path.start_with?(dir)
+    end
+  end
+
   require 'table_of_contents/helpers'
   include TableOfContents::Helpers
 end
@@ -76,3 +83,5 @@ DocumentTypes.pages.each do |document_type|
     page: document_type,
   }
 end
+
+redirect "/guides.html", to: "/opsmanual.html"

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,7 +10,7 @@ header_links:
   Dashboard: /
   Dictionary: /dictionary.html
   Applications: /apps.html
-  Guides: /guides.html
+  Opsmanual: /opsmanual.html
   API docs: /apis.html
   Content schemas: /content-schemas.html
   Document types: /document-types.html

--- a/source/guides.html.md.erb
+++ b/source/guides.html.md.erb
@@ -1,7 +1,0 @@
----
-layout: layout
-title: Guides
----
-
-<%= partial 'guides/taxonomy' %>
-<%= partial 'guides/ab_testing' %>

--- a/source/opsmanual.html.erb
+++ b/source/opsmanual.html.erb
@@ -1,0 +1,26 @@
+---
+layout: false
+title: Opsmanual
+---
+
+<% content_for :sidebar do %>
+  <ul>
+    <li>
+      <% sub_pages('opsmanual/').each do |page| %>
+        <%= link_to page.data.title, page.path %>
+      <% end %>
+    </li>
+  </ul>
+<% end %>
+
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
+
+<blockquote>
+  <strong>Work in progress</strong><br/><br/>
+
+  We're currently moving <a href='https://github.gds/pages/gds/opsmanual'>
+  the opsmanual</a> to this site. Follow along option
+  <a href='https://trello.com/b/pWnVP4wF'>on our Trello board</a>.
+</blockquote>
+<% end %>

--- a/source/opsmanual/ab_testing.html.md.erb
+++ b/source/opsmanual/ab_testing.html.md.erb
@@ -1,3 +1,8 @@
+---
+title: A/B testing
+parent: /opsmanual.html
+---
+
 # A/B testing
 
 ## 1. Overview

--- a/source/opsmanual/taxonomy.html.md.erb
+++ b/source/opsmanual/taxonomy.html.md.erb
@@ -1,3 +1,8 @@
+---
+title: Taxonomy
+parent: /opsmanual.html
+---
+
 # Taxonomy
 
 GOV.UK's "single subject taxonomy" will describe all content on GOV.UK. It is being developed theme-by-theme, starting with education.


### PR DESCRIPTION
This adds an "Opsmanual" section to the docs. We intend to move the current opsmanual into here (first PR for that is https://github.com/alphagov/govuk-developer-docs/pull/72). I've also moved the two guides into the new section.