### PR TITLE
Fix redirect from guide to opsmanual

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -84,4 +84,4 @@ DocumentTypes.pages.each do |document_type|
   }
 end
 
-redirect "/guides.html", to: "/opsmanual.html"
+redirect "guides.html", to: "opsmanual.html"

--- a/lib/supertypes.rb
+++ b/lib/supertypes.rb
@@ -1,7 +1,9 @@
 class Supertypes
   def self.all
-    data = HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk_document_types/master/data/supertypes.yml")
-    data.map { |id, config| Supertype.new(id, config) }
+    @all_supertypes ||= begin
+      data = HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk_document_types/master/data/supertypes.yml")
+      data.map { |id, config| Supertype.new(id, config) }
+    end
   end
 
   class Supertype


### PR DESCRIPTION
https://github.com/alphagov/govuk-developer-docs/pull/73 broke the site, because contrary to middleman's readme we shouldn't be using leading slashes.

https://trello.com/c/5x8NHLhf