### PR TITLE
Add "Keeping software current"

### DIFF
--- a/source/opsmanual/keeping-software-current.html.md
+++ b/source/opsmanual/keeping-software-current.html.md
@@ -1,0 +1,35 @@
+---
+title: Keeping software current
+parent: /opsmanual.html
+---
+
+# Keeping software current
+
+One of our core values is to use secure and up to date software. This document lays out the recommendations for keeping our Ruby on Rails software current.
+
+## Introduction
+
+We run a lot of Rails applications. This means that we have dependencies on both Rails and Ruby versions.
+
+### Upgrading Rails
+
+It's very important that we're running a currently supported version of Rails for all applications, otherwise we aren't covered by security fixes. We should:
+
+- Be running on the current major version - this currently means 4.y.z
+- Maintain our applications at the latest current bugfix release for the minor version we're on (expressed in Gemfile syntax as: ~> X.Y.Z)
+- Keep abreast of breaking changes for the next major version (5.y.z), and have a plan to migrate our apps before 4.2.x is deprecated
+
+### Upgrading Ruby
+
+New versions of Ruby bring us improved performance and nicer syntax for certain things, but also can cause issues with the libraries etc. we use. We should:
+
+- Be running on the current major version - this currently means 2.y.z
+- Maintain our applications at the current or next-to-current minor version - this means 2.3.z, 2.2.z or 2.1.z depending on your app's dependencies
+
+### Current state
+
+The current state of the Ruby and Rails versions is:
+
+[Listed in this versions spreadsheet with team ownership by Alex Tomlins][sheet]
+
+[sheet]: https://docs.google.com/spreadsheets/d/1FJmr39c9eXgpA-qHUU6GAbbJrnenc0P7JcyY2NB9PgU


### PR DESCRIPTION
We currently have some documentation in the confluence wiki. We'd like to move most of this to this site, so that it's easier to find.

This page comes from:

https://gov-uk.atlassian.net/wiki/display/TECH/Keeping+GOV.UK%27s+software+current.

I've removed some outdated bits.

https://trello.com/c/RfRRgVqU