### PR TITLE
Fix issue with in-document links

### DIFF
--- a/lib/tech_docs_html_renderer.rb
+++ b/lib/tech_docs_html_renderer.rb
@@ -14,4 +14,23 @@ class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
       </table>
     </div>)
   end
+
+  def header(text, header_level)
+    %(<h#{header_level} id="#{githubify_fragment_id(text)}" class="anchored-heading">
+        <a href="##{githubify_fragment_id(text)}" class="anchored-heading__icon" aria-hidden="true"></a>
+        #{text}
+      </h2>)
+  end
+
+  # Redcarpet uses a different algo to create fragment ids than github
+  # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
+  # this implementation modified for our purposes from version at jch/html-pipeline
+  # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
+  def githubify_fragment_id(text)
+    text
+      .downcase # lower case
+      .gsub(/<[^>]*>/, '') # crudely remove html tags
+      .gsub(/[^\w\- ]/, '') # remove any non-word characters
+      .tr(' ', '-') # replace spaces with hyphens
+  end
 end


### PR DESCRIPTION
Documents imported from the [publishing-api/docs](https://github.com/alphagov/publishing-api/tree/master/doc) folder have a table-of-contents which doesn't work here.

The documents are published on github, and made available here.
Due to a mismatch in Markdown -> HTML rendering between Github and
Middleman/Redcarpet, generated fragment IDs are created using a
different algorithm.

In this PR, I override the default Redcarpet `header` function to
make it use a Github flavoured ID scheme.

[Trello](https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links)