### PR TITLE
Add "Content Preview" documentation

### DIFF
--- a/source/opsmanual/content-preview.html.md
+++ b/source/opsmanual/content-preview.html.md
@@ -14,15 +14,11 @@ sent for publication. This allows content editors to preview their
 content before making it live, without having to manually copy it into a
 separate version of the publishing tool.
 
-Content Preview only contains applications that read from the
-content-store. Initially, these are:
-
--   government-frontend (Whitehall case studies only)
--   manuals-frontend (manuals published by specialist publisher)
--   contacts-frontend
--   static (supplies assets and templates for the other apps)
+Content Preview contains [most frontend applications][preview-puppet].
 
 Content Preview exists in each of integration, staging and production.
+
+[preview-puppet]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata/class/draft_frontend.yaml
 
 ## Design
 

--- a/source/opsmanual/content-preview.html.md
+++ b/source/opsmanual/content-preview.html.md
@@ -1,0 +1,78 @@
+# Content Preview
+
+## Overview
+
+The Content Preview site, also known as Draft GOV.UK, is intended to be
+a full version of GOV.UK that includes content that has not yet been
+sent for publication. This allows content editors to preview their
+content before making it live, without having to manually copy it into a
+separate version of the publishing tool.
+
+Content Preview only contains applications that read from the
+content-store. Initially, these are:
+
+-   government-frontend (Whitehall case studies only)
+-   manuals-frontend (manuals published by specialist publisher)
+-   contacts-frontend
+-   static (supplies assets and templates for the other apps)
+
+Content Preview exists in each of integration, staging and production.
+
+## Design
+
+Content Preview consists of separate 'draft' instances of the router,
+frontend and content-store machines. These are located at
+draft-cache-{1,2}.router, draft-frontend-{1,2}.frontend, and
+draft-content-store-{1,2}.api respectively.
+
+Publishing tools send content to the
+[publishing-api](https://github.com/alphagov/publishing-api). All
+content is initially pushed to the draft content store, and then to the
+live content store when it is published.
+
+The draft-frontend and draft-cache machines host draft instances of the
+frontend apps and router which serve the content from the draft
+content-store. Both router and content-store share mongo clusters with
+their respective live versions, although they use separate databases on
+these clusters.
+
+Because draft involves content-store apps only, there are no instances
+of MySQL or PostgreSQL in Content Preview, and no backend apps (except
+for router-api).
+
+## Location
+
+Content Preview is available in all three environments.
+
+-   <https://draft-origin.publishing.service.gov.uk>
+-   <https://draft-origin.staging.publishing.service.gov.uk>
+-   <https://draft-origin.integration.publishing.service.gov.uk>
+
+The machines are available in the same organisations as their live
+counterparts, and use a `draft-` prefix, eg:
+
+-   draft-cache-1.router.integration
+-   draft-frontend-2.frontend.production
+-   draft-content-store.1.api.integration
+
+and so on.
+
+## Authentication
+
+Because Whitehall permits content to be access-limited before
+publication, the draft environment enforces signon authentication for
+all routes. This is performed by the
+[authenticating-proxy](https://github.com/alphagov/authenticating-proxy)
+app, which sits between Varnish and the router.
+
+Draft content items can contain an optional `access_limited` hash in
+their metadata, which contains a list of signon user UIDs corresponding
+to the users who are permitted to see that content. All other users will
+see a 403 Forbidden page.
+
+(This is achieved by the API adapters passing the UID in the headers of
+the request to content-store, in the same way as the govuk-request-id.)
+
+Publishing API strips out the `access_limited` hash before sending data
+to the live content-store, since all published content is viewable by
+everyone.

--- a/source/opsmanual/content-preview.html.md
+++ b/source/opsmanual/content-preview.html.md
@@ -75,6 +75,13 @@ see a 403 Forbidden page.
 (This is achieved by the API adapters passing the UID in the headers of
 the request to content-store, in the same way as the govuk-request-id.)
 
+Publishing apps can also add an `auth_bypass_ids` list to the access limited hash,
+to allow unauthenticated access for preview or fact checking. The ID is encoded
+in a JSON Web Token and appended to the URL provided to the users.
+Authenticating-proxy decodes the token and extracts the ID, and again passes
+it to the content-store in the request headers, where it is compared with the
+ID stored on the requested content item.
+
 Publishing API strips out the `access_limited` hash before sending data
 to the live content-store, since all published content is viewable by
 everyone.

--- a/source/opsmanual/content-preview.html.md
+++ b/source/opsmanual/content-preview.html.md
@@ -1,3 +1,9 @@
+---
+title: Content Preview
+parent: /opsmanual.html
+layout: opsmanual_layout
+---
+
 # Content Preview
 
 ## Overview


### PR DESCRIPTION
This will replace:

https://github.gds/pages/gds/opsmanual/2nd-line/applications/content-preview.html

For the desks of @kevindew or @danielroseman.

https://trello.com/c/ZErfvzXs