### PR TITLE
Fix in-page navigation for emergency page

### DIFF
--- a/source/opsmanual/emergency-publishing.html.md
+++ b/source/opsmanual/emergency-publishing.html.md
@@ -29,6 +29,8 @@ required will be supplied by the GOV.UK on-call escalations contact:
 
 ### Prerequisites
 
+You'll need this:
+
 - Text for the heading
 - Text for 'extra info', which is a sentence displayed under the heading
 - A URL for users to find more information (it might not be provided at first)


### PR DESCRIPTION
There's a small bug in the template that means that the in-page nav will show the content of a `<ul>` if it directly follows the heading tag. Having a paragraph after the heading fixes this.

## Before

<img width="964" alt="screen shot 2017-04-05 at 13 35 30" src="https://cloud.githubusercontent.com/assets/233676/24705698/ff1f88ec-1a04-11e7-849c-098dd7177173.png">

## After

<img width="654" alt="screen shot 2017-04-05 at 13 37 48" src="https://cloud.githubusercontent.com/assets/233676/24705722/13cd4932-1a05-11e7-8ee8-eb3c7f6c505e.png">

cc @36degrees
