### PR TITLE
Add page with GitHub topics + show topics on app pages

### DIFF
--- a/lib/app_docs.rb
+++ b/lib/app_docs.rb
@@ -1,12 +1,16 @@
 class AppDocs
   def self.pages
-    YAML.load_file('data/applications.yml').map do |app_data|
+    @pages ||= YAML.load_file('data/applications.yml').map do |app_data|
       App.new(app_data)
     end
   end
 
   def self.app_data
     @publishing_app_data ||= AppData.new
+  end
+
+  def self.topics_on_github
+    pages.reject(&:retired?).flat_map(&:topics).sort.uniq
   end
 
   class App
@@ -76,6 +80,10 @@ class AppDocs
       app_data["production_url"] || (type.in?(["Publishing app", "Admin app"]) ? "https://#{app_name}.publishing.service.gov.uk" : nil)
     end
 
+    def topics
+      github_repo_data["topics"]
+    end
+
   private
 
     def puppet_name
@@ -83,8 +91,11 @@ class AppDocs
     end
 
     def description_from_github
-      repo = GitHub.client.repo(github_repo_name)
-      repo["description"]
+      github_repo_data["description"]
+    end
+
+    def github_repo_data
+      @github_repo_data ||= GitHub.client.repo(github_repo_name)
     end
   end
 end

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -37,6 +37,7 @@ private
       end
 
       Octokit.middleware = stack
+      Octokit.default_media_type = "application/vnd.github.mercy-preview+json"
 
       github_client = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'])
       github_client.auto_paginate = true

--- a/source/opsmanual/github.html.md.erb
+++ b/source/opsmanual/github.html.md.erb
@@ -1,0 +1,22 @@
+---
+title: How we use GitHub
+parent: /opsmanual.html
+layout: opsmanual_layout
+---
+
+# How we use GitHub
+
+We share the [alphagov GitHub organisation][alphagov] with the other teams in the
+Government Digital Service (GDS).
+
+This can sometimes make it hard to find repositories that belong to our team. We use
+GitHub "topics" to organise the repos. All repos owned by us should be tagged with
+[`govuk`](https://github.com/search?q=topic:govuk).
+
+## Topics on GitHub
+
+<% AppDocs.topics_on_github.each do |topic| %>
+- <%= link_to topic, "https://github.com/search?q=topic:#{topic}+org:alphagov" %>
+<% end %>
+
+[alphagov]: https://github.com/alphagov

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,4 +1,4 @@
-<div class="edit-links">
+<div class="meta-links">
   Something wrong? Something to add?
   <%= link_to "View source on GitHub", page.source_url %> or
   <%= link_to "edit directly on GitHub", page.edit_url %>.

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -7,6 +7,8 @@ edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/appl
 
 <%= application.description %>
 
+GitHub topics: <%= application.topics.map { |topic| link_to(topic, "https://github.com/search?q=topic:#{topic}+org:alphagov") }.to_sentence %>
+
 <% if application.retired? %>
 
 This application is retired.
@@ -16,6 +18,8 @@ This application is retired.
 </ul>
 
 <% else %>
+
+### Ownership
 
 <% if application.product_manager %>
 Product Manager: **<%= application.product_manager %>**.


### PR DESCRIPTION
Topics are tags for repositories (https://github.com/blog/2309-introducing-topics). 

We've tagged most of the GOV.UK repos with `govuk` now. This page explains that, and links to other topics that have been used. Also shows the topics on the application pages.

https://trello.com/c/CdGSaozQ