### PR TITLE
Add ownership by team to applications section

### DIFF
--- a/app/applications_by_team.rb
+++ b/app/applications_by_team.rb
@@ -1,0 +1,49 @@
+class ApplicationsByTeam
+  UNKNOWN = "unknown".freeze
+
+  def self.teams
+    applications.keys.reject { |team| team == UNKNOWN }
+  end
+
+  def self.[](team)
+    for_team(team)
+  end
+
+  def self.for_team(team)
+    applications.fetch(team, []).map(&:app_name)
+  end
+
+  def self.no_known_owner
+    applications[UNKNOWN].map(&:app_name)
+  end
+
+  def self.applications
+    @_applications ||=
+      YAML.load_file('data/applications.yml')
+        .map {|app_data| App.new(app_data) }
+        .reject(&:retired?)
+        .sort_by(&:app_name)
+        .group_by(&:team)
+  end
+
+  class App
+    attr_reader :app_data
+
+    def initialize(app_data)
+      @app_data = app_data
+    end
+
+    def retired?
+      app_data.fetch("retired", false)
+    end
+
+    def app_name
+      app_data.fetch("github_repo_name", UNKNOWN)
+    end
+
+    def team
+      app_data.fetch("team", UNKNOWN)
+    end
+
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -52,6 +52,10 @@ helpers do
       .group_by { |page| page.data.section }
   end
 
+  def teams
+    ApplicationsByTeam.teams
+  end
+
   require 'table_of_contents/helpers'
   include TableOfContents::Helpers
 end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -3,6 +3,7 @@
 - github_repo_name: collections-publisher
   type: Publishing apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: contacts-admin
   type: Publishing apps
@@ -13,6 +14,7 @@
 - github_repo_name: content-tagger
   type: Publishing apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: local-links-manager
   type: Publishing apps
@@ -46,6 +48,7 @@
 - github_repo_name: policy-publisher
   type: Publishing apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: publisher
   type: Publishing apps
@@ -64,6 +67,7 @@
 - github_repo_name: specialist-publisher
   type: Publishing apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
@@ -80,6 +84,8 @@
 
 - github_repo_name: business-support-api
   type: APIs
+  product_manager: Antonia Simmons
+  team: Holding Government To Account
 
 - github_repo_name: content-store
   type: APIs
@@ -100,6 +106,7 @@
   type: APIs
   puppet_name: contentapi
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: govuk_need_api
   type: APIs
@@ -164,6 +171,8 @@
 
 - github_repo_name: support
   type: Supporting apps
+  team: Publisher Data and Content Tools
+  product_manager: Ben Andrews
 
 - github_repo_name: authenticating-proxy
   type: Supporting apps
@@ -173,10 +182,12 @@
 - github_repo_name: bouncer
   type: Supporting apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: transition
   type: Supporting apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: release
   type: Supporting apps
@@ -211,6 +222,7 @@
 - github_repo_name: collections
   type: Frontend apps
   product_manager: Holly Garrett
+  team: Navigation and Taxonomy
 
 - github_repo_name: contacts-frontend
   type: Frontend apps
@@ -222,6 +234,8 @@
 
 - github_repo_name: email-alert-frontend
   type: Frontend apps
+  team: Worldwide Publishing
+  product_manager: Rob Rankin
 
 - github_repo_name: feedback
   type: Frontend apps

--- a/source/apps/by-team.html.md.erb
+++ b/source/apps/by-team.html.md.erb
@@ -1,0 +1,25 @@
+---
+layout: application_layout
+title: Application ownership by team
+---
+
+<% unless ApplicationsByTeam.no_known_owner.empty? %>
+
+## Repos without a home
+
+You can help us improve this documentation by [editing this page](https://github.com/alphagov/govuk-developer-docs/edit/master/data/applications.yml).
+
+<% ApplicationsByTeam.no_known_owner.each do |app_name| %>
+- [<%= app_name %>](<%= "/apps/#{app_name}.html" %>)
+<% end %>
+
+<% end %>
+
+<% teams.each do |team| %>
+## <%= team %>
+
+<% ApplicationsByTeam[team].each do |app_name| %>
+- [<%= app_name %>](<%= "/apps/#{app_name}.html" %>)
+<% end %>
+
+<% end %>

--- a/source/layouts/application_layout.html.erb
+++ b/source/layouts/application_layout.html.erb
@@ -1,13 +1,26 @@
 <% content_for :sidebar do %>
   <ul>
+
+  <li><%= link_to 'By Team', '/apps/by_team.html' %></li>
+  <li>
+    <ul class='subnav'>
+    <% renderer = TechDocsHTMLRenderer.new %>
+    <% teams.each do |team_name| %>
+      <li><%= link_to team_name, "/apps/by-team.html#" + renderer.githubify_fragment_id(team_name) %></li>
+    <% end %>
+    </ul>
+  </li>
+
   <% active_app_pages.group_by(&:type).each do |name, apps| %>
     <li><%= link_to name, '/apps.html' %></li>
 
-    <ul>
-    <% apps.each do |app| %>
-      <li><%= sidebar_link app.app_name, "/apps/#{app.app_name}.html" %></li>
-    <% end %>
-    </ul>
+    <li>
+      <ul class='subnav'>
+      <% apps.each do |app| %>
+        <li><%= sidebar_link app.app_name, "/apps/#{app.app_name}.html" %></li>
+      <% end %>
+      </ul>
+    </li>
   <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
First draft of a section to look at applications sorted by owning team.

[Trello](https://trello.com/c/bM1an40m/48-make-it-easy-to-determine-ownership-of-a-repo-project)