### PR TITLE
Improve linking to GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node {
     }
 
     stage("Lint Ruby") {
-      govuk.rubyLinter("*/*")
+      govuk.rubyLinter("lib helpers spec bin")
     }
 
     stage("Tests") {

--- a/helpers/url_helpers.rb
+++ b/helpers/url_helpers.rb
@@ -2,4 +2,12 @@ module UrlHelpers
   def document_type_url(document_type_name)
     "/document-types/#{document_type_name}.html"
   end
+
+  def view_source_url
+    SourceUrl.new(locals, current_page).source_url
+  end
+
+  def report_issue_url
+    "https://github.com/alphagov/govuk-developer-docs/issues/new?labels=bug&title=Problem with '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
+  end
 end

--- a/lib/publishing_api_docs.rb
+++ b/lib/publishing_api_docs.rb
@@ -25,10 +25,6 @@ class PublishingApiDocs
       "https://github.com/alphagov/publishing-api/blob/master/doc/#{filename}.md"
     end
 
-    def edit_url
-      "https://github.com/alphagov/publishing-api/edit/master/doc/#{filename}.md"
-    end
-
     def raw_source
       "https://raw.githubusercontent.com/alphagov/publishing-api/master/doc/#{filename}.md"
     end

--- a/lib/source_url.rb
+++ b/lib/source_url.rb
@@ -1,0 +1,31 @@
+class SourceUrl
+  attr_reader :locals, :current_page
+
+  def initialize(locals, current_page)
+    @locals = locals
+    @current_page = current_page
+  end
+
+  def source_url
+    override_from_page || source_from_yaml_file || source_from_file
+  end
+
+private
+
+  # If a `page` local exists, see if it has a `source_url`. This is used by the
+  # pages that are created by the proxy system because they can't use frontmatter
+  def override_from_page
+    locals.key?(:page) ? locals[:page].try(:source_url) : false
+  end
+
+  # In the frontmatter we can specify a `source_url`. Use this if the actual
+  # source of the page is in another GitHub repo.
+  def source_from_yaml_file
+    current_page.data.source_url
+  end
+
+  # As the last fallback link to the source file in this repository.
+  def source_from_file
+    "https://github.com/alphagov/govuk-developer-docs/blob/master/source/#{current_page.file_descriptor[:relative_path]}"
+  end
+end

--- a/source/apis/search-api.html.md.erb
+++ b/source/apis/search-api.html.md.erb
@@ -3,7 +3,6 @@ layout: api_layout
 title: Search API
 parent: /apis.html
 source_url: https://github.com/alphagov/rummager/blob/master/docs/search-api.md
-edit_url: https://github.com/alphagov/rummager/edit/master/docs/search-api.md
 ---
 
 <%= ExternalDoc.fetch('https://raw.githubusercontent.com/alphagov/rummager/master/docs/search-api.md') %>

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -1,8 +1,6 @@
 ---
 layout: application_layout
 title: Applications on GOV.UK
-source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/source/apps.html.md.erb
-edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/source/apps.html.md.erb
 ---
 
 The publishing platform of GOV.UK consists of at least <%= active_app_pages.size %>
@@ -49,5 +47,3 @@ of the apps are shared using [a gem called govuk\_admin\_template][govuk_admin_t
 [static]: /apps/static.html
 [signon]: /apps/signon.html
 [specialist-publisher]: /apps/specialist-publisher.html
-
-<%= partial 'partials/source', locals: { page: current_page.data } %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,7 +2,6 @@
 layout: false
 title: Dashboard
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dashboard.yml
-edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dashboard.yml
 ---
 
 <% content_for :sidebar do %>
@@ -39,6 +38,4 @@ edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dash
       <% end %>
     <% end %>
   <% end %>
-
-  <%= partial 'partials/source', locals: { page: current_page.data } %>
 <% end %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -15,14 +15,5 @@
 
 <% wrap_layout :layout_with_sidebar do %>
   <%= partial 'partials/header' %>
-
-  <% if locals.key?(:page) %>
-    <%= partial 'partials/source', page: page %>
-  <% end %>
-
   <%= yield %>
-
-  <% if locals.key?(:page) %>
-    <%= partial 'partials/source', page: page %>
-  <% end %>
 <% end %>

--- a/source/layouts/application_layout.html.erb
+++ b/source/layouts/application_layout.html.erb
@@ -14,13 +14,5 @@
 
 <% wrap_layout :layout_with_sidebar do %>
   <%= partial 'partials/header' %>
-  <% if locals.key?(:page) %>
-    <%= partial 'partials/source', page: page %>
-  <% end %>
-
   <%= yield %>
-
-  <% if locals.key?(:page) %>
-    <%= partial 'partials/source', page: page %>
-  <% end %>
 <% end %>

--- a/source/layouts/getting_started_layout.html.erb
+++ b/source/layouts/getting_started_layout.html.erb
@@ -8,8 +8,4 @@
   <%= partial 'partials/header' %>
 
   <%= html %>
-
-  <% if locals.key?(:page) %>
-    <%= partial 'partials/source', page: page %>
-  <% end %>
 <% end %>

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -18,6 +18,7 @@
     <div class="app-pane__content toc-open-disabled">
       <main id="content" class="technical-documentation" data-module="anchored-headings">
         <%= yield %>
+        <%= partial 'partials/source' %>
       </main>
     </div>
   </div>

--- a/source/layouts/opsmanual_layout.html.erb
+++ b/source/layouts/opsmanual_layout.html.erb
@@ -7,9 +7,4 @@
 
 <% wrap_layout :layout_with_sidebar do %>
   <%= html %>
-
-  <div class='meta-links'>
-    <%= link_to "Source on GitHub",
-      "https://github.com/alphagov/govuk-developer-docs/blob/master/source/#{current_page.path}.md" %>
-  </div>
 <% end %>

--- a/source/opsmanual/dictionary.html.erb
+++ b/source/opsmanual/dictionary.html.erb
@@ -3,7 +3,6 @@ title: Dictionary
 parent: /opsmanual.html
 layout: false
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dictionary.yml
-edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dictionary.yml
 ---
 
 <% content_for :sidebar do %>
@@ -36,6 +35,4 @@ edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/dict
       <p><%= entry.description %></p>
     </div>
   <% end %>
-
-  <%= partial 'partials/source', locals: { page: current_page.data } %>
 <% end %>

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,5 +1,3 @@
 <div class="meta-links">
-  Something wrong? Something to add?
-  <%= link_to "View source on GitHub", page.source_url %> or
-  <%= link_to "edit directly on GitHub", page.edit_url %>.
+  <%= link_to "View source", (locals.key?(:page) ? page.try(:source_url) : false) || current_page.data.source_url || "https://github.com/alphagov/govuk-developer-docs/blob/master/source/#{current_page.file_descriptor[:relative_path]}" %>
 </div>

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,4 +1,4 @@
 <div class="meta-links">
-  <%= link_to "View source", (locals.key?(:page) ? page.try(:source_url) : false) || current_page.data.source_url || "https://github.com/alphagov/govuk-developer-docs/blob/master/source/#{current_page.file_descriptor[:relative_path]}" %>
-  <%= link_to "Report problem", "https://github.com/alphagov/govuk-developer-docs/issues/new?labels=bug&title=Problem with '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})" %>
+  <%= link_to "View source", view_source_url %>
+  <%= link_to "Report problem", report_issue_url %>
 </div>

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,3 +1,4 @@
 <div class="meta-links">
   <%= link_to "View source", (locals.key?(:page) ? page.try(:source_url) : false) || current_page.data.source_url || "https://github.com/alphagov/govuk-developer-docs/blob/master/source/#{current_page.file_descriptor[:relative_path]}" %>
+  <%= link_to "Report problem", "https://github.com/alphagov/govuk-developer-docs/issues/new?labels=bug&title=Problem with '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})" %>
 </div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -4,4 +4,8 @@
 .meta-links {
   margin-top: 50px;
   text-align: center;
+
+  a {
+    margin: 0 10px;
+  }
 }

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -2,7 +2,6 @@
 layout: application_layout
 parent: /apps.html
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
-edit_url: https://github.com/alphagov/govuk-developer-docs/edit/master/data/applications.yml
 ---
 
 <%= application.description %>
@@ -65,7 +64,5 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
 <% end %>
 
 <% end %>
-
-<%= partial 'partials/source', locals: { page: current_page.data } %>
 
 [app-yaml]: https://github.com/alphagov/govuk-developer-docs/edit/master/data/applications.yml

--- a/spec/lib/source_url_spec.rb
+++ b/spec/lib/source_url_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+Dir.glob(::File.expand_path('../../helpers/**/*.rb', __FILE__)).each { |f| require_relative f }
+
+RSpec.describe SourceUrl do
+  describe "#source_url" do
+    it "returns the URL from the page local" do
+      locals = { page: double(source_url: "https://example.org/via-page") }
+
+      source_url = SourceUrl.new(locals, double).source_url
+
+      expect(source_url).to eql("https://example.org/via-page")
+    end
+
+    it "returns the URL from the frontmatter" do
+      current_page = double(data: double(source_url: "https://example.org/via-frontmatter"))
+
+      source_url = SourceUrl.new({}, current_page).source_url
+
+      expect(source_url).to eql("https://example.org/via-frontmatter")
+    end
+
+    it "returns the source from this repository" do
+      current_page = double(data: double(source_url: nil), file_descriptor: { relative_path: 'foo.html.md' })
+
+      source_url = SourceUrl.new({}, current_page).source_url
+
+      expect(source_url).to eql("https://github.com/alphagov/govuk-developer-docs/blob/master/source/foo.html.md")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,6 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching!
 
-  config.warnings = true
-
   if config.files_to_run.one?
     config.default_formatter = 'doc'
   end


### PR DESCRIPTION
This PR:

- Adds a consistent link to `View source` at the bottom of all pages. For simplicity the direct edit link is removed. The link is either determined by the `page` local, the `source_url` in frontmatter or the source file in this repo.
- Adds a link to the GitHub issues with the title & url prefilled. This will allow users to easily report problems with a page.

## Screens

<img width="1017" alt="screen shot 2017-04-07 at 10 13 42" src="https://cloud.githubusercontent.com/assets/233676/24793670/d5085472-1b7a-11e7-8d46-57887d2815d8.png">

---

<img width="1003" alt="screen shot 2017-04-07 at 09 53 00" src="https://cloud.githubusercontent.com/assets/233676/24792943/f1096af6-1b77-11e7-92d7-48459d8e73b2.png">
