### PR TITLE
Add a redirect for the dictionary page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -89,4 +89,6 @@ DocumentTypes.pages.each do |document_type|
   }
 end
 
-redirect "guides.html", to: "opsmanual.html"
+YAML.load_file('data/redirects.yml').each do |from, to|
+  redirect from, to: to
+end

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -1,0 +1,1 @@
+guides.html: opsmanual.html

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -1,1 +1,2 @@
+dictionary.html: opsmanual/dictionary.html
 guides.html: opsmanual.html


### PR DESCRIPTION
The dictionary was moved into the opsmanual section, but is linked from the wiki.