### PR TITLE
Only require the spec helper once

### DIFF
--- a/spec/app/app_docs_spec.rb
+++ b/spec/app/app_docs_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe AppDocs::App do
   describe "production_url" do
     it "has a good default" do

--- a/spec/app/content_schema_spec.rb
+++ b/spec/app/content_schema_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe ContentSchema do
   describe '#frontend_schema' do
     it "it can link to GitHub" do

--- a/spec/app/document_types_spec.rb
+++ b/spec/app/document_types_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe DocumentTypes do
   describe ".pages" do
     it "returns document types" do

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe ExternalDoc do
   describe '.fetch' do
     it 'returns the markdown file without title' do

--- a/spec/app/github_spec.rb
+++ b/spec/app/github_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe GitHub do
   describe "#repo" do
     it "returns a repo if the user is specified" do

--- a/spec/app/source_url_spec.rb
+++ b/spec/app/source_url_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 Dir.glob(::File.expand_path('../../helpers/**/*.rb', __FILE__)).each { |f| require_relative f }
 
 RSpec.describe SourceUrl do

--- a/spec/app/supertypes_spec.rb
+++ b/spec/app/supertypes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Supertypes do
   describe '.all' do
     it 'works' do


### PR DESCRIPTION
The generated `.rspec` file contains `--require spec_helper` which will cause this file to always be loaded, without a need to explicitly require it in any files.