### PR TITLE
Move dev-docs specific changes to the HTML renderer out of /lib

### DIFF
--- a/app/developer_docs_renderer.rb
+++ b/app/developer_docs_renderer.rb
@@ -1,9 +1,8 @@
 class DeveloperDocsRenderer < TechDocsHTMLRenderer
   def header(text, header_level)
-    %(<h#{header_level} id="#{githubify_fragment_id(text)}" class="anchored-heading">
-        <a href="##{githubify_fragment_id(text)}" class="anchored-heading__icon" aria-hidden="true"></a>
-        #{text}
-      </h#{header_level}>)
+    anchor = githubify_fragment_id(text)
+    tag = "h" + header_level.to_s
+    "<#{tag} id='#{anchor}' class='anchored-heading'>#{text}</#{tag}>"
   end
 
   # Redcarpet uses a different algo to create fragment ids than github

--- a/app/developer_docs_renderer.rb
+++ b/app/developer_docs_renderer.rb
@@ -2,7 +2,7 @@ class DeveloperDocsRenderer < TechDocsHTMLRenderer
   def header(text, header_level)
     anchor = githubify_fragment_id(text)
     tag = "h" + header_level.to_s
-    "<#{tag} id='#{anchor}' class='anchored-heading'>#{text}</#{tag}>"
+    "<#{tag} id='#{anchor}'>#{text}</#{tag}>"
   end
 
   # Redcarpet uses a different algo to create fragment ids than github

--- a/app/developer_docs_renderer.rb
+++ b/app/developer_docs_renderer.rb
@@ -1,0 +1,20 @@
+class DeveloperDocsRenderer < TechDocsHTMLRenderer
+  def header(text, header_level)
+    %(<h#{header_level} id="#{githubify_fragment_id(text)}" class="anchored-heading">
+        <a href="##{githubify_fragment_id(text)}" class="anchored-heading__icon" aria-hidden="true"></a>
+        #{text}
+      </h#{header_level}>)
+  end
+
+  # Redcarpet uses a different algo to create fragment ids than github
+  # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
+  # this implementation modified for our purposes from version at jch/html-pipeline
+  # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
+  def githubify_fragment_id(text)
+    text
+      .downcase # lower case
+      .gsub(/<[^>]*>/, '') # crudely remove html tags
+      .gsub(/[^\w\- ]/, '') # remove any non-word characters
+      .tr(' ', '-') # replace spaces with hyphens
+  end
+end

--- a/app/requires.rb
+++ b/app/requires.rb
@@ -4,4 +4,5 @@ require 'middleman-core'
 require 'yaml'
 require 'json'
 
+Dir[File.dirname(__FILE__) + '/../lib/*.rb'].each { |file| require file }
 Dir[File.dirname(__FILE__) + '/**/*.rb'].each { |file| require file }

--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,7 @@ config[:tech_docs] = YAML.load_file('config/tech-docs.yml').with_indifferent_acc
 set :markdown_engine, :redcarpet
 
 set :markdown,
-    renderer: TechDocsHTMLRenderer.new(
+    renderer: DeveloperDocsRenderer.new(
       with_toc_data: true
     ),
     fenced_code_blocks: true,

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,3 @@
-Dir[File.dirname(__FILE__) + '/lib/*.rb'].each { |file| require file }
-
 require_relative './app/requires'
 
 config[:tech_docs] = YAML.load_file('config/tech-docs.yml').with_indifferent_access

--- a/lib/tech_docs_html_renderer.rb
+++ b/lib/tech_docs_html_renderer.rb
@@ -3,6 +3,11 @@ require 'middleman-core/renderers/redcarpet'
 class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
   include Redcarpet::Render::SmartyPants
 
+  def header(text, level)
+    anchor = UniqueIdentifierGenerator.instance.create(text, level)
+    %(<h#{level} id="#{anchor}">#{text}</h#{level}>)
+  end
+
   def image(link, *args)
     %(<a href="#{link}" target="_blank" rel="noopener noreferrer">#{super}</a>)
   end
@@ -13,24 +18,5 @@ class TechDocsHTMLRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
         #{header}#{body}
       </table>
     </div>)
-  end
-
-  def header(text, header_level)
-    %(<h#{header_level} id="#{githubify_fragment_id(text)}" class="anchored-heading">
-        <a href="##{githubify_fragment_id(text)}" class="anchored-heading__icon" aria-hidden="true"></a>
-        #{text}
-      </h#{header_level}>)
-  end
-
-  # Redcarpet uses a different algo to create fragment ids than github
-  # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
-  # this implementation modified for our purposes from version at jch/html-pipeline
-  # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
-  def githubify_fragment_id(text)
-    text
-      .downcase # lower case
-      .gsub(/<[^>]*>/, '') # crudely remove html tags
-      .gsub(/[^\w\- ]/, '') # remove any non-word characters
-      .tr(' ', '-') # replace spaces with hyphens
   end
 end


### PR DESCRIPTION
To keep our application specific code seperate from the template app,
we are trying to keep our changes in the /app folder.