### PR TITLE
Implement periodic review system

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -63,6 +63,10 @@ helpers do
     ApplicationsByTeam.teams
   end
 
+  def page_freshness
+    PageFreshness.new(sitemap)
+  end
+
   require 'table_of_contents/helpers'
   include TableOfContents::Helpers
 end

--- a/lib/page_freshness.rb
+++ b/lib/page_freshness.rb
@@ -1,0 +1,29 @@
+class PageFreshness
+  attr_reader :sitemap
+
+  def initialize(sitemap)
+    @sitemap = sitemap
+  end
+
+  def expired_pages
+    expired = sitemap.resources.select do |page|
+      page.data.review_by && Date.today > page.data.review_by
+    end
+
+    expired.map do |page|
+      { title: page.data.title, url: page.url, expired_at: page.data.review_by }
+    end
+  end
+
+  def expiring_soon
+    soon = sitemap.resources.select do |page|
+      page.data.review_by && Date.today > (page.data.review_by - 7.days)
+    end
+
+    pages = soon.map do |page|
+      { title: page.data.title, url: page.url, expired_at: page.data.review_by }
+    end
+
+    pages - expired_pages
+  end
+end

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -19,6 +19,14 @@
 
     <div class="app-pane__content toc-open-disabled">
       <main id="content" class="technical-documentation" data-module="anchored-headings">
+        <% if current_page.data.review_by && Date.today > current_page.data.review_by  %>
+          <div class='warning'>
+            This page was set to be reviewed before <%= current_page.data.review_by %>
+            by the page owner: <%= current_page.data.owner_slack %>. This might mean the
+            content is out of date
+          </div>
+        <% end %>
+
         <%= yield %>
         <%= partial 'partials/source' %>
       </main>

--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -31,15 +31,41 @@ title: Dev manual
     <strong>Work in progress</strong><br/><br/>
 
     We're currently moving <a href='https://github.gds/pages/gds/opsmanual'>
-    the opsmanual</a> to this site. Follow along option
+    the opsmanual</a> to this site. Follow along
     <a href='https://trello.com/b/pWnVP4wF'>on our Trello board</a>.
   </blockquote>
 
-  <h4>Top tasks</h4>
+  <h2>Top tasks</h2>
 
   <ul>
     <% most_important_pages.each do |page| %>
       <li><%= link_to page.data.title, page.path %></li>
     <% end %>
   </ul>
+
+  <h2>Keeping the opsmanual up to date</h2>
+
+  <p>Everyone on GOV.UK is responsible for keeping the opsmanual up to date. To ensure
+  this, every page should have a named owner.</p>
+
+
+  <% if page_freshness.expiring_soon.any? %>
+    <h3>Pages to be reviewed soon</h3>
+
+    <ul>
+    <% page_freshness.expiring_soon.each do |page| %>
+      <li><%= link_to page[:title], page[:url] %></li>
+    <% end %>
+    </ul>
+  <% end %>
+
+  <% if page_freshness.expired_pages.any? %>
+    <h3>Expired pages</h3>
+
+    <ul>
+    <% page_freshness.expired_pages.each do |page| %>
+      <li><%= link_to page[:title], page[:url] %></li>
+    <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -3,6 +3,8 @@ title: Run an A/B test
 parent: /manual.html
 layout: manual_layout
 section: Tools
+owner_slack: "@tijmen"
+review_by: 2017-04-14
 ---
 
 # Run an A/B test

--- a/source/manual/alerts/asset-master-attachment-processing.html.md
+++ b/source/manual/alerts/asset-master-attachment-processing.html.md
@@ -3,6 +3,8 @@ title: 'asset master attachment processing'
 parent: /manual.html
 layout: manual_layout
 section: Icinga alerts
+owner_slack: "#2ndline"
+review_by: 2016-01-01
 ---
 
 # asset master attachment processing
@@ -14,4 +16,3 @@ which scans files and then moves them into either a "clean" or
 "infected" directory. If you have received an alert regarding this it
 means that the job has not run for over half an hour and is probably
 locked (or processing a large amount of files).
-

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -3,6 +3,8 @@ title: Taxonomy
 parent: /manual.html
 layout: manual_layout
 section: Publishing
+owner_slack: "@tijmen"
+review_by: 2017-05-01
 ---
 
 # Taxonomy

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,4 +1,8 @@
 <div class="meta-links">
   <%= link_to "View source", view_source_url %>
   <%= link_to "Report problem", report_issue_url %>
+
+  <% if current_page.data.review_by %>
+    Page owner: <%= current_page.data.owner_slack %>, Review by: <%= current_page.data.review_by %>
+  <% end %>
 </div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -11,3 +11,11 @@
     margin-right: 10px;
   }
 }
+
+.warning {
+  padding: 10px;
+  margin-top: 40px;
+  background-color: $error-background;
+  border: 1px solid $error-colour;
+  color: $error-colour;
+}


### PR DESCRIPTION
This adds a system to keep track of pages that need to be updated.

- Every page can have a `expire_by` and `owner_slack` attribute
- When its set we will show this information at the bottom of the page
- A week before the page is set to expire, the page title appears under "Pages to be reviewed soon" on the manual homepage
- After the page is expired the page with display a warning on the top of the page indicating that it may no longer be accurate
- The expired page is also listed under "Expired pages" on the manuals page

---

![screen shot 2017-04-12 at 10 05 19](https://cloud.githubusercontent.com/assets/233676/24950105/c2cddaca-1f67-11e7-8d03-4aba3d14e48f.png)
![screen shot 2017-04-12 at 10 05 24](https://cloud.githubusercontent.com/assets/233676/24950088/b5aa38a2-1f67-11e7-8079-e1b705c000f7.png)
![screen shot 2017-04-12 at 10 06 01](https://cloud.githubusercontent.com/assets/233676/24950089/b5ac3d28-1f67-11e7-93e5-079b135f58c1.png)


https://trello.com/c/ZUd0ITTZ