### PR TITLE
Import Nagios alerts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,31 +48,3 @@ task :verify_deployable_apps do
     puts missing_app
   end
 end
-
-task :import_nagios do
-  nagios = File.read("../opsmanual/2nd-line/nagios.md")
-
-  chapters = nagios.split("\n## ")
-
-  `rm source/manual/alerts/*`
-
-  chapters.each do |chapter|
-    title = chapter.lines.first
-    filename = title.parameterize
-
-    next if filename == 'nagios-alerts-documentation-and-suggested-actions'
-
-    body = <<~doc
-    ---
-    title: '#{title.strip.gsub("'", '').gsub('"', '')}'
-    parent: /manual.html
-    layout: manual_layout
-    section: Alerts
-    ---
-
-    # #{chapter}
-    doc
-
-    File.write("source/manual/alerts/#{filename}.html.md", body)
-  end
-end

--- a/Rakefile
+++ b/Rakefile
@@ -48,3 +48,31 @@ task :verify_deployable_apps do
     puts missing_app
   end
 end
+
+task :import_nagios do
+  nagios = File.read("../opsmanual/2nd-line/nagios.md")
+
+  chapters = nagios.split("\n## ")
+
+  `rm source/manual/alerts/*`
+
+  chapters.each do |chapter|
+    title = chapter.lines.first
+    filename = title.parameterize
+
+    next if filename == 'nagios-alerts-documentation-and-suggested-actions'
+
+    body = <<~doc
+    ---
+    title: '#{title.strip.gsub("'", '').gsub('"', '')}'
+    parent: /manual.html
+    layout: manual_layout
+    section: Alerts
+    ---
+
+    # #{chapter}
+    doc
+
+    File.write("source/manual/alerts/#{filename}.html.md", body)
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -48,7 +48,7 @@ helpers do
   def manual_pages
     sitemap.resources
       .select { |resource| resource.path.start_with?('manual/') && resource.path.end_with?('.html') }
-      .sort_by { |page| page.data.title }
+      .sort_by { |page| page.data.title || raise("#{page.path} doesn't have a title") }
       .group_by { |page| page.data.section || "Uncategorised" }
   end
 

--- a/source/manual/alerts/application-health-checks.html.md
+++ b/source/manual/alerts/application-health-checks.html.md
@@ -1,0 +1,33 @@
+---
+title: 'Application health checks'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Application health checks
+
+### 'publisher app health check not ok'
+
+If the message is a warning about 'scheduled\_queue', eg '71 scheduled
+edition(s); 3 item(s) queued', this alert means that the number of
+editions in the database which are scheduled to be published in the
+future is different from the number currently in the queue. This can
+happen in Staging and Integration as a result of the data sync from
+Production. Run this Rake task to requeue all scheduled editions:
+
+    cd /var/apps/publisher
+    sudo -u deploy govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing
+
+### 'whitehall app health check not ok'
+
+If the message is a warning about 'scheduled\_queue', eg '850 scheduled
+edition(s); 840 job(s) queued', this alert means that the number of
+editions in the database which are scheduled to be published in the
+future is different from the number currently in the queue. This can
+happen in Staging and Integration as a result of the data sync from
+Production. Run this Rake task to requeue all scheduled editions:
+
+    cd /var/apps/whitehall
+    sudo -u deploy govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs
+

--- a/source/manual/alerts/asset-master-attachment-processing.html.md
+++ b/source/manual/alerts/asset-master-attachment-processing.html.md
@@ -1,0 +1,17 @@
+---
+title: 'asset master attachment processing'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# asset master attachment processing
+
+When new assets get uploaded to asset-master-1, there is a script
+(/usr/local/bin/process-uploaded-attachment.sh) run by the assets user
+every minute in a cronjob. This kicks off a script (virus-scan-file.sh)
+which scans files and then moves them into either a "clean" or
+"infected" directory. If you have received an alert regarding this it
+means that the job has not run for over half an hour and is probably
+locked (or processing a large amount of files).
+

--- a/source/manual/alerts/check-we-are-not-exceeding-our-aws-ses-email-quota.html.md
+++ b/source/manual/alerts/check-we-are-not-exceeding-our-aws-ses-email-quota.html.md
@@ -1,0 +1,18 @@
+---
+title: 'Check we are not exceeding our AWS SES email quota'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Check we are not exceeding our AWS SES email quota
+
+There is not a lot we can do about this. Likely suspects for elevated
+email volumes. - Application errors - cron errors - On integration and
+staging this can be caused by data syncs - Can also be caused by
+deploying lots of applications
+
+Potential impacts include applications that send emails (such as signon)
+not being able to do so. This issue should happen less often as we move
+apps to Errbit.
+

--- a/source/manual/alerts/clamav-definitions-out-of-date.html.md
+++ b/source/manual/alerts/clamav-definitions-out-of-date.html.md
@@ -1,0 +1,19 @@
+---
+title: 'ClamAV definitions out of date'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# ClamAV definitions out of date
+
+This could be because of a number of reasons. Check that the database is
+up to date by calling the freshclam command directly with verbose:
+
+    fab $environment -H asset-master-1.backend sdo:'freshclam -v'
+
+If it reports the virus databases are up to date then you may need to
+check the [ClamAV virusdb
+archive](http://lists.clamav.net/pipermail/clamav-virusdb/) to
+investigate.
+

--- a/source/manual/alerts/defined-cpu-type-does-not-match.html.md
+++ b/source/manual/alerts/defined-cpu-type-does-not-match.html.md
@@ -1,0 +1,18 @@
+---
+title: 'defined cpu type does not match'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# defined cpu type does not match
+
+We have two types of VM hosts that use either Intel or AMD processors.
+Some VMs have significant performance degradation when on the AMD CPUs
+and thus should live on the more performant Intel processor-based hosts.
+
+If an alert reports that the defined CPU model name does not match what
+it has been defined with, we should firstly try to find out why (has the
+machine been recently rebuilt or vMotioned?) and then migrate the VM to
+the correct host.
+

--- a/source/manual/alerts/duplicate-ssh-host-keys.html.md
+++ b/source/manual/alerts/duplicate-ssh-host-keys.html.md
@@ -1,0 +1,27 @@
+---
+title: 'duplicate SSH host keys'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'duplicate SSH host keys'
+
+This check indicates that more than one machine in an environment is
+using the same SSH host key. This is bad because it means that we can't
+verify the authenticity of a particular host and it could be used in a
+[MITM attack](http://en.wikipedia.org/wiki/Man-in-the-middle_attack).
+
+The check will list the affected machines and key fingerprints. To
+determine which key the fingerprint belongs to (RSA, DSA or ECDSA) you
+can run the following command on the host:
+
+    for file in /etc/ssh/ssh_host_*.pub; do sudo ssh-keygen -lf $file; done
+
+The immediate problem can be resolved by deleting the host keys and
+regenerating them with `dpkg-reconfigure openssh-server`. However you
+need to bear in mind that the:
+
+-   root cause in templating/provisioning also needs to be fixed
+-   key change should be communicated to all people with login accounts
+

--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -1,0 +1,184 @@
+---
+title: 'Elasticsearch Cluster Health'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Elasticsearch Cluster Health
+
+Elasticsearch reports cluster health as one of three possible states, based on
+the state of its primary and replica shards.
+
+- `green` - all primary and secondary (replica) shards are allocated. There are
+  two (or more) copies of all shards across the nodes on the cluster.
+- `yellow` - all primary shards are allocated, but at least one replica shard
+  is not allocated. Any shards that only exist as a primary are at risk of data
+  loss _should another node in the cluster fail_.
+- `red` - at least one primary shard is not allocated. This can happen when an
+  entire cluster is cold started, before it's initially allocated the primary
+  shards. If it happens at other times this may be a sign of data loss.
+
+More [comprehensive documentation on cluster
+health](https://www.elastic.co/guide/en/elasticsearch/guide/current/_cluster_health.html)
+can be found in the Elasticsearch documentation.
+
+Make sure you understand the consequences of the problem before jumping to a
+solution.
+
+Nagios uses the `check_elasticsearch` check from 
+[nagios-plugins](https://github.com/alphagov/nagios-plugins/) to
+monitor the health of the Elasticsearch cluster. This plugin uses various
+endpoints of the Elasticsearch API, but also extrapolates additional information
+to help you diagnose any problems.
+
+You can also access the Elasticsearch health API directly. Start with the
+[`/_cluster/health` endpoint](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html)
+and go from there.
+
+| Response json from the `/_cluster/health` endpoint looks like
+
+    { "cluster_name":"logging",
+      "status":"green",
+      "timed_out":false,
+      "number_of_nodes":3,
+      "number_of_data_nodes":3,
+      "active_primary_shards":225,
+      "active_shards":335,
+      "relocating_shards":0,
+      "initializing_shards":0,
+      "unassigned_shards":0
+    }
+
+### Investigating problems
+
+Some tools available to investigate problems include:
+
+[elasticsearch-head](http://mobz.github.io/elasticsearch-head/)
+
+:   a plugin that helps you have a nice UI for looking at current state
+    of elasticsearch.
+
+    To use this following steps might be handy
+
+    -   forward port 9200 from the elasticsearch box to your localhost
+
+        One way to do this is
+        `ssh -L9200:localhost:9200 logs-elasticsearch-1.management.staging`
+    -   access at <http://localhost:9200/_plugin/head/>
+
+    The tabs on top right corner for Cluster Status & Cluster Health
+    come handy
+
+You can find our Elasticsearch clusters by running
+`fab production puppet_class:govuk_elasticsearch hosts`.
+
+Configuration files for elasticsearch are in
+`/var/apps/<name>/config/elasticsearch.yml`
+
+Elasticsearch logs live at
+`/var/logs/elasticsearch/<logging|govuk-production>.log`
+
+**Note:** If you have had a health alert for the logs-elasticsearch
+cluster you may need to change where LogStash writes to to ensure we can
+keep getting getting syslog entries (see section [Manual repointing of
+LogStash to logs-elasticsearch cluster]()).
+
+### How to fix unassigned nodes in indices?
+
+We can have a red status on elasticsearch cluster health when you have
+unassigned shards for some indices. (We have seen a similar scenario
+occur on the integration environment, when logs-es-1/3 ran out of space
+and logs-es-2 reached it load limit \[number of file open error\]).
+
+This can be solved by:
+
+Restarting elasticsearch node in order giving elastic node enough time
+to start up and reallocate the shards allocated to it before starting
+the other elasticsearch (this can be checked using elasticsearch-head or
+using cluster health api). This should be enough to fix the issue
+
+An exception to the above case can happen after the restart of the
+cluster, when some shards in indices can have both primary and replica
+version unassigned. Then any further restarting would not fix the issue.
+Closing and opening the index with such an issue should fix the problem:
+
+    curl -XPOST 'localhost:9200/<index_name>/_close?pretty=true'
+    curl -XPOST 'localhost:9200/<index_name>/_open?pretty=true'
+
+**NB**: Make sure a thorough analysis is done before fixing the problem,
+as any down time to es cluster can result in loss of data.
+
+### Split Brain
+
+Split brain occurs when two parts of the cluster lose connectivity with each
+other and both independently elect new master nodes, and each part of the
+cluster starts operating independently, allowing the data indexed to diverge.
+
+We guard against split brain problem by following the
+[recommended practise](http://asquera.de/opensource/2012/11/25/elasticsearch-pre-flight-checklist/#avoiding-split-brain)
+of setting minimum number of master-eligible nodes to `([the size of the cluster] / 2) + 1` N/2+1.
+
+This means that when adding or removing nodes you need to ensure that all
+nodes get the updated configuration with the new value for this calculation.
+
+If split brain does occur, you can use the following steps to fix it. But it is
+**strongly** suggested to thoroughly investigate the problem first before 
+doing so.
+
+- By stopping the node which considers itself to belong to two cluster
+  and belongs to two different masters. example:
+
+    cluster of three boxes: e1, e2, e3
+    Clusters present after split brain:
+      e1 <-> e2
+      e2 <-> e3
+
+    As per first cluster, e1 is the master, and the latter cluster e3 is the master
+
+- Waiting for the cluster health to change to yellow before restarting
+  the stopped Elasticsearch box.
+
+### Manual repointing of LogStash to logs-elasticsearch cluster
+
+Currently logstash (logging-1.management) talks only to
+logs-elasticsearch-cluster (which is mapped through a dns entry to
+logs-elasticsearch-1.management) for sending logs.
+
+If logs-elasticsearch-1.management is not available, we need to tell
+logstash on logging-1 to send its syslog data to a different
+elasticsearch node. This is done by changing the /etc/hosts file on
+logging-1.management
+
+### 'elasticsearch not receiving syslog from logstash' Check
+
+The problem behind this warning is that logstash has stopped sending
+things. Restart logstash on logging-1.management with:
+
+`fab <environment> -H logging-1.management app.restart:logstash`
+
+[Further information on GOV.UK
+logging](https://github.gds/pages/gds/opsmanual/infrastructure/logging/index.html)
+
+### 'One or more indexes are missing replica shards.' despite cluster being green
+
+For some reason the elasticsearch plugin [does not consider a replica in the
+`REALLOCATING` state to be
+healthy](https://github.com/alphagov/nagios-plugins/blob/6534386f658ce573a8b65e0f9147f61b1b0fe964/plugins/command/check_elasticsearch.py#L453).
+
+You can identify reallocating replica shards using Elasticsearch Head - they
+will be displayed in purple (reallocating) and without a thick border (replica).
+
+Alternatively, you can run check_elasticsearch directly on the
+logs-elasticsearch box:
+
+```
+check_elasticsearch -vv
+```
+
+As long as the cluster health is green, Elasticsearch should be reasonably happy
+and you can leave it to reallocate the replicas, which may take some time.
+
+You can monitor the progress of shard (re)allocation using the [cat recovery
+endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-recovery.html).
+

--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -1,0 +1,30 @@
+---
+title: 'Email Alerts'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Email Alerts
+
+GOV.UK sends out emails when certain publications are published. We have
+set up a check to verify that emails are sent for certain publication
+types (the drug and medical device alerts and travel advice updates).
+
+If the check fails inspect the [console
+logs](https://deploy.publishing.service.gov.uk/job/email-alert-check)
+for the job. This will tell you which emails are missing. You can find
+more information about the [architecture on the
+Wiki](https://gov-uk.atlassian.net/wiki/display/GOVUK/Email+notifications+and+atom+feeds).
+
+[DetailedTravel Advice Issue
+Guidance](https://github.gds/pages/gds/opsmanual/2nd-line/applications/travel-advice-publisher.html)
+
+If you need to force the sending of a travel advice email alert, there
+is a rake task in the travel advice publisher, which you can run using
+[this Jenkins
+job](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE=backend-1.backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D),
+where the edition ID of the travel advice content item can be found in
+the URL of the country's edit page in the travel advice publisher and
+looks like "fedc13e231ccd7d63e1abf65".
+

--- a/source/manual/alerts/es-rotate.html.md
+++ b/source/manual/alerts/es-rotate.html.md
@@ -1,0 +1,25 @@
+---
+title: 'es-rotate'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# es-rotate
+
+This alert triggers when the es-rotate hasn't completed successfully.
+
+es-rotate is part of [es-tools](https://github.com/alphagov/estools).
+
+Its job is to rotate the elasticsearch alias for the current day's logs,
+and to delete old indexes.
+
+If it doesn't run, it's fine to rerun manually on the affected host,
+using:
+
+    sudo -u nobody /usr/local/bin/es-rotate-passive-check
+
+If there is a problem you can find out more information using the
+elasticsearch-head plugin (see "Elasticsearch cluster health" alert for
+more details).
+

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -1,0 +1,21 @@
+---
+title: 'Fetch analytics data for search failed'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Fetch analytics data for search failed
+
+This checks the latest build state of [a job in production
+Jenkins](https://deploy.publishing.service.gov.uk/job/search-fetch-analytics-data/)
+which runs every night and populates the search index with the latest data from
+Google Analytics.
+
+The only downside of this not running is that the popularity data is slightly
+out of date. The search index is locked while it runs so it shouldn’t be re-run
+whilst people are publishing.
+
+If the job is failing often, make sure the team currently responsible for search
+are aware of the problem.
+

--- a/source/manual/alerts/free-memory-warning-on-backend.html.md
+++ b/source/manual/alerts/free-memory-warning-on-backend.html.md
@@ -1,0 +1,51 @@
+---
+title: 'Free memory warning on backend'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Free memory warning on backend
+
+### Background
+
+This is often caused by an application slowly leaking memory, which
+isn't usually an issue for apps that are deployed/restarted frequently.
+Some less frequently deployed apps will continue to grow over time.
+
+### Investigation of the problem
+
+Check
+[Graphite](https://graphite.publishing.service.gov.uk/render/?width=1133&height=630&_salt=1413553577.366&from=-24days&hideLegend=false&target=highestAverage%28backend-1_backend.processes-*.ps_rss%2C5%29)
+to see which apps are consuming a lot of memory, and are growing over
+time.
+
+You could also try using htop and sorting by memory to locate high
+memory usage, though this won't identify creeping memory leaks in the
+same way Graphite will.
+
+Identify if the service is being run under Unicorn or not. Unicorn
+worker processes can be killed and automatically respawned if they
+consume too much memory.
+
+### Kill memory leaking Unicorn workers
+
+Once you've identified a Unicorn application with a memory leak, you can
+gracefully kill a Unicorn worker to reclaim some memory. Sending a
+SIGQUIT to the worker causes it to finish serving its current request
+then exit, the master will notice this and spawn a fresh worker. This
+fabric task will kill the worker using the most memory:
+
+    fab $environment -H backend-1.backend app.respawn_large_unicorns:APP-NAME
+
+This will only kill the most bloated Unicorn worker, so you may need to
+run it multiple times if the alert persists.
+
+### Restart other memory leaking apps
+
+For leaky applications not managed by Unicorn (for example, Whitehall's
+Sidekiq worker), restart it to reset the memory usage, and increase free
+memory on the host:
+
+    fab $environment -H whitehall-backend-1.backend app.restart:whitehall-admin-procfile-worker
+

--- a/source/manual/alerts/high-disk-time.html.md
+++ b/source/manual/alerts/high-disk-time.html.md
@@ -1,0 +1,25 @@
+---
+title: 'high disk time'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'high disk time'
+
+This alert tells us that reads and/or writes to disk are taking longer
+than expected. In most cases this is only informational; you may not
+need to take any action, but it may explain the cause for other alerts.
+
+For example if you're loading lots of data into a database and it's slow
+because the disk is struggling to keep up then you may also see alerts
+for replication lag or slow request times for applications that use the
+same database server. You may want to stop loading data and resume at a
+quieter time of day.
+
+If you see this alert fire for many machines in the same environment, or
+even across multiple environments, then our cloud provider may be at
+fault. Even if it's not yet causing other alerts it may be worth
+checking their status pages, talking to other projects that use that
+provider, or contacting their support.
+

--- a/source/manual/alerts/high-zombie-procs.html.md
+++ b/source/manual/alerts/high-zombie-procs.html.md
@@ -1,0 +1,22 @@
+---
+title: 'high zombie procs'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'high zombie procs'
+
+You can check what the zombie processes are by SSHing onto the machine
+and running the command:
+
+    ps -A -o user,pid,ppid,state,cmd | awk 'NR==1 || $4=="Z" { print }'
+
+The `PPID` field gives you the parent process ID, which you may be able
+to use to diagnose what caused the problem, or at least which process to
+restart.
+
+If there are a number of zombie processes on one of the backend boxes,
+restarting Imminence (with `sudo service imminence restart`) may fix the
+problem; if that doesn't help, reboot the machine at a convenient time.
+

--- a/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
+++ b/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
@@ -1,0 +1,57 @@
+---
+title: 'Logs are not being received from the CDN'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Logs are not being received from the CDN
+
+Sometimes, we stop receiving either GOV.UK or Bouncer logs from Fastly
+to logs-cdn-1.management. We run Rsyslog on this machine, and Fastly
+send us logs using Syslog on their side to a port we have previously
+specified.
+
+Firstly, look at how old and how large /mnt/logs\_cdn/cdn-govuk.log or
+/mnt/logs\_cdn/cdn-bouncer.log is. In GOV.UK's case, the file should be
+created early in the morning each day, and the filesize should be
+positive and greater than 0 bytes. At the end of each day, a file is
+created for the following day, the previous day's file is gzipped up.
+Bouncer's logs rotate once per hour.
+
+To fix, try (in order):
+
+-   if you have access to Fastly, check if Fastly have recorded an error
+    when writing to our rsyslog endpoint by logging in to the [Fastly
+    control panel](https://app.fastly.com/) and open the following URL
+    in your browser:
+
+        https://app.fastly.com/service/<service-id>/logging_status
+
+    You can find the service ID in the
+    [deployment](https://github.gds/gds/deployment/blob/8a85170d639fb82f0f86653aba2e536655811741/puppet/hieradata/production.yaml#L15-L18)
+    repository.
+
+    In particular, notice the `BrokenNow` boolean which indicates if
+    Fastly are currently unable to log to our endpoint.
+
+-   restarting Rsyslog on the box: sudo service rsyslog restart, then
+    sudo
+    tail -f /mnt/logs\_cdn/cdn-govuk.log, or
+    /mnt/logs\_cdn/cdn-bouncer.log, to check that logs are being
+    streamed in to us. You'll be able to see when they are, as the
+    filesize increases and human-readable log lines are entered in to
+    that file. It can take as long as 45 minutes for logs to start
+    coming through, so acknowledge the alert and come back to it later.
+-   redeploying the existing Fastly service configuration using [this
+    Jenkins
+    job](https://deploy.publishing.service.gov.uk/job/Deploy_CDN/).
+    Authenticate with the 2nd Line user, details of which can be found
+    in the infra\_team cred store. If you don't have access, ask someone
+    on the Infrastructure team to deploy it for you.
+-   tailing syslog - sudo tail -f /var/log/syslog for the current file,
+    and sudo zless syslog.x.gz for any gzipped files replacing x with
+    the number from the file itself. It's pretty verbose, and might not
+    be much use, but it's worth a look.
+-   contacting Fastly
+

--- a/source/manual/alerts/low-available-disk-inodes.html.md
+++ b/source/manual/alerts/low-available-disk-inodes.html.md
@@ -1,0 +1,51 @@
+---
+title: 'Low available disk inodes'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Low available disk inodes
+
+The inode usage on a box can be checked using:
+
+    df -i
+
+which will give an output like:
+
+    Filesystem           Inodes  IUsed   IFree IUse% Mounted on
+    /dev/mapper/os-root 3121152 151646 2969506    5% /
+
+with a row for each filesystem currently mounted.
+
+### Low available disk inodes on Jenkins
+
+If Jenkins is running out of inodes (rather than disk space) then it may
+be possible to free some by clearing out old workspaces:
+
+    find /var/lib/jenkins/workspace/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \;
+
+Which will find any directories that are older than 1 day and delete
+them.
+
+### Low available disk space on Jenkins
+
+One possible cause of this is that the /var/lib/docker directory is
+consuming a large amount of disk space. This has been found to happen on
+the ci-agent machines.
+
+Verify this:
+
+    cd /var/lib
+    sudo ncdu
+
+If `/var/lib/docker` is consuming a large amount of disk space run the
+following as root:
+
+    docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
+    docker volume rm $(docker volume ls -qf dangling=true)
+
+This will remove 'dangling' images and volumes. A comprehensive set of
+instructions can be found is this [Docker resource cleanup
+gist](https://gist.github.com/bastman/5b57ddb3c11942094f8d0a97d461b430).
+

--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -1,0 +1,155 @@
+---
+title: 'Low available disk space'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Low available disk space
+
+### Low available disk space on root
+
+You can try clearing out the APT cache:
+
+> sudo apt-get clean
+
+### Low available disc space on /mnt/uploads for asset-master-1 and asset-slave-1
+
+Nagios is set up to monitor disc usage by /mnt/uploads on
+asset-master-1.backend and asset-slave-1.backend. Usually, the culprit
+behind space-chomping is /mnt/uploads/whitehall, and there are two
+folders on which to focus clean-up efforts on:
+
+-   /mnt/uploads/whitehall/attachment-cache
+-   /mnt/uploads/whitehall/carrierwave-tmp
+
+Running the following command from within the above folders (ie cd to
+/mnt/uploads...) usually works best as it means that we don't end up
+with the parent folders being deleted:
+
+`find -type d -ctime +1 -exec rm -rf {} +`
+
+In the above example, we:
+
+-   `find -type d` - find all directories within the folder you are
+    currently cd'd in to
+-   `-ctime +1` - limit the results of the above `find` to files created
+    over a day (24hrs) ago
+-   `-exec rm -rf {} +` - execute a force removal on the folders found,
+    with the above conditions
+
+The + is a gnuism which allows the command to run more efficiently. This
+[man page](http://unixhelp.ed.ac.uk/CGI/man-cgi?find) explains the +
+functionality:
+
+> This variant of the -exec option runs the specified command on the
+> selected files, but the command line is built by appending each
+> selected file name at the end; the total number of invoca-tions of the
+> command will be much less than the number of matched files. The
+> command line is built in much the same ways that xargs builds its
+> command lines. Only one instance of '{}' is allowed within the
+> command. The command is executed in the starting directory.
+
+This command will take a while to complete, depending - of course - on
+how large your two starting folders are. After it has completed, push
+Nagios to re-check the service on each affected host.
+
+### No disk space on the MySQL master
+
+If the MySQL master runs out of disk space, all of the apps that rely on
+MySQL may crash. You'll probably notice this in Nagios. There's a lot of
+red.
+
+Binary logs take up space that could be freed. If the slave and the
+backup are at a reasonably up-to-date binlog position
+(`SHOW SLAVE STATUS \G`), the older binlogs can be removed from the
+master.
+
+To recover:
+
+1.  SSH to mysql-master-1.backend
+2.  Stop mysql using `sudo service mysql stop` (this may never return)
+3.  At this point `service mysql status` may return `stop/killed`,
+    indicating that Upstart has tried to kill MySQL but it is refusing
+    to die
+4.  `cd /var/lib/mysql && ls`
+5.  Remove enough (5 to 10?) binlog files so that you can start MySQL
+6.  Edit the `mysql-bin.index` file to remove references to the binlog
+    files you removed manually
+7.  `sudo service mysql start`
+8.  `mysql -u root -p`
+9.  `PURGE BINARY LOGS TO 'mysql-bin.########';`
+
+If there's no disk space available, purging binary logs from within
+MySQL doesn't work - this is why we first need to manually delete some
+logs and update the index.
+
+### Low available disk space on monogodb mount on exception-handler (errbit)
+
+You can clear out resolved exceptions by running the following rake
+task:
+
+    rake errbit:db:clear_resolved
+
+Depending on the size of the db this could take a while to complete. The
+last thing this rake task does is run the mongo repair database command
+to release the disk space freed up. This command requires free space on
+the drive equal to the size of the db + 2GB so it's likely it will fail.
+
+To resolve this you can dump the database, drop it, and restore it:
+
+    mongodump -d errbit_production
+    echo 'db.dropDatabase()' | mongo errbit_production
+    mongorestore dump/errbit_production
+
+This will result in freeing up all the empty space. Obviously it takes
+errbit offline for a while as the db is dropped and restored, but our
+apps are robust in the face of errbit being down.
+
+### No disk space in general
+
+If you cant find any of the above cases causing low disk spaces, it can
+be useful to run the command `sudo ncdu <mountpoint>`, where mountpoint
+will be the path specified in the nagios alert. It will calculate all
+the disk space being used, and then bring you into an ncurses file
+explorer-style interface. Press enter to go into a directory, and d to
+delete any large files.
+
+Press q to quit, or ? for help.
+
+If a particular mountpoint is rather large, it may be helpful to first
+scan it to see which directory inside it is using the most space, then
+use ncdu on that directory. Do it with the following command:
+`sudo du -hc --max-depth=1 <mountpoint>`
+
+### Disk space used by logfiles
+
+You may discover that disk space is mostly being used up by logfiles.
+This is probably caused by logrotate failing to properly rotate a
+logfile for whatever reason, so it will probably just be one or two of
+the latest logfiles using a high proportion of the disk space.
+
+If it is out of hours, free up room to resolve the incident without
+performing the maintenace tasks described below. Pass to 2ndline to deal
+with during working hours.
+
+Firstly see if you can remove any old logfiles, where dir is the
+directory where the large file lives: `find <dir> -mtime +45 -type f`
+
+You can remove them by running: `find <dir> -mtime +45 -type f -delete`
+
+45 days is specified as this is how long we're obliged to keep logfiles,
+but that could be smaller if required.
+
+Ideally see if you can copy the large file elsewhere (on a different
+mount point which has free space) and then entirely truncate that log:
+`truncate -s 0 <logfile>`. Manually gzip the file (gzip &lt;file&gt;)
+and put it back in the log file directory.
+
+You can force a logrotate run afterwards:
+`logrotate -vf /etc/logrotate.d/<type of logs>`
+
+**If you have nowhere to move the logs and it is causing an incident,
+uptime of the server takes precedent over logfiles, so just truncate the
+logs to free up space**
+

--- a/source/manual/alerts/mongod-replication-lag.html.md
+++ b/source/manual/alerts/mongod-replication-lag.html.md
@@ -1,0 +1,39 @@
+---
+title: 'mongod replication lag'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'mongod replication lag'
+
+### Investigating the problem
+
+There is a fabric task to show various mongo replication status
+information.:
+
+    fab <environment> -H mongo-?.backend mongo.status
+
+-   The `db.printReplicationInfo()` section shows where the primary
+    node's
+    [oplog](http://docs.mongodb.org/manual/core/replica-set-oplog/) is
+    up to.
+-   The `db.printSlaveReplicationInfo()` section shows where each
+    secondary is synced to and how far behind the master it is.
+-   The `rs.status()` section shows the current status of each node and
+    the last heartbeat error message for the secondaries.
+
+### Possible fixes
+
+-   Try restarting one of the lagging mongod secondaries:
+
+        fab <environment> -H mongo-?.backend app.restart:mongodb
+
+This may restart replication on that node, and also cause the other
+lagging node to resync with the primary node and restart its own
+replication.
+
+-   If restarting doesn't solve the problem force a resync with fabric:
+
+        fab <environment> -H mongo-?.backend mongo.force_resync
+

--- a/source/manual/alerts/mongodb-rollback.html.md
+++ b/source/manual/alerts/mongodb-rollback.html.md
@@ -1,0 +1,63 @@
+---
+title: 'MongoDB rollback'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# MongoDB rollback
+
+### What is a rollback
+
+Explanation from the [MongoDB
+documentation](http://docs.mongodb.org/manual/core/replication/#replica-set-rollbacks):
+
+> In some failover situations primaries will have accepted write
+> operations that have not replicated to the secondaries after a
+> failover occurs. This case is rare and typically occurs as a result of
+> a network partition with replication lag. When this member (the former
+> primary) rejoins the replica set and attempts to continue replication
+> as a secondary the former primary must revert these operations or
+> “roll back” these operations to maintain database consistency across
+> the replica set.
+
+### How to investigate
+
+The rolled-back records can be viewed with
+[bsondump](http://docs.mongodb.org/manual/reference/program/bsondump/)
+which will output human readable JSON.
+
+Some judgement is required to determine whether it is necessary to
+recover the rolled-back data. In one example, we found that the user had
+resubmitted the affected record(s) a few minutes later, presumably in
+response to a UI error. Therefore recovery was not necessary.
+
+### How to recover
+
+If you are happy that the rolled-back data should be restored and
+doesn't conflict with any existing records, then you can use
+[mongorestore](http://docs.mongodb.org/manual/reference/program/mongorestore/).
+
+The following arguments are necessary:
+
+-   `-h`: Hostname of the current `PRIMARY` node, from `rs.status()`.
+-   `-d`: Name of the database, from the BSON filename.
+-   `-c`: Name of the collection, from the BSON filename.
+-   `--objcheck`: Validate BSON. Not the default in MongoDB 2.2
+
+For example:
+
+    dcarley@production-licensing-mongo-1:/var/lib/mongodb/rollback$ mongorestore -h licensing-mongo-2 -d licensify-audit -c audit --objcheck licensify-audit.audit.2013-05-30T12-45-42.1.bson
+    connected to: licensing-mongo-2
+    Thu May 30 13:56:52 licensify-audit.audit.2013-05-30T12-45-42.1.bson
+    Thu May 30 13:56:52 going into namespace [licensify-audit.audit]
+    1 objects found
+
+Unfortunately `mongorestore` may not give any feedback about whether the
+restore was successful. It is advisable to check the logs on the host
+you referenced, and query MongoDB for the `_id` of the records you
+expect.
+
+When satisfied, the BSON files and rollback directory can be deleted.
+This will resolve the Nagios alert.
+

--- a/source/manual/alerts/mysql-replication-checks.html.md
+++ b/source/manual/alerts/mysql-replication-checks.html.md
@@ -1,0 +1,102 @@
+---
+title: 'MySQL replication checks'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# MySQL replication checks
+
+There are two checks for MySQL replication:
+
+### 'mysql replication lag'
+
+Checks the value of `Seconds_Behind_Master` to a threshold. As described
+in the MySQL documentation:
+
+> Seconds\_Behind\_Master: The number of seconds that the slave SQL
+> thread is behind processing the master binary log. A high number (or
+> an increasing one) can indicate that the slave is unable to handle
+> events from the master in a timely fashion.
+
+This is unable to reliably detect when replication is completely stopped
+or broken. In such an event, it will return a NULL value and raise an
+UNKNOWN alert. This should correlate with a CRITICAL alert for 'mysql
+replication running'.
+
+If `Seconds_Behind_Master` shows as `NULL`, you may be able to fix
+replication by running the `mysql.reset_slave` Fabric task:
+
+    fab $environment -H <mysql_slave_hostname> mysql.reset_slave
+
+<div class="admonition note">
+
+An alert for 'MySQL replication lag' on mysql-backup-\* machines may be
+caused by a database backup or a Jenkins data synchronisation job, such
+as:
+
+> <https://deploy.publishing.service.gov.uk/job/Copy_Data_to_Staging/>
+
+You can verify this by checking for a running mysqldump process on the
+affected host, e.g.:
+
+    ps auxwww | grep mysqldump
+
+In such cases, the alert should return to normal once the backup
+completes.
+
+</div>
+
+### 'mysql replication running'
+
+Checks whether `Slave_IO_Running` and `Slave_SQL_Running` both return
+`Yes` to indicate that replication is currently active. As described in
+the MySQL documentation:
+
+> Slave\_IO\_Running: Whether the I/O thread for reading the master's
+> binary log is running. Normally, you want this to be Yes unless you
+> have not yet started replication or have explicitly stopped it with
+> STOP SLAVE.
+>
+> Slave\_SQL\_Running: Whether the SQL thread for executing events in
+> the relay log is running. As with the I/O thread, this should normally
+> be Yes.
+
+To check the status of the slave,
+
+1.  Log onto the server (e.g. mysql-backup-1.backend.integration).
+2.  Open a mysql shell:
+
+> `sudo -i mysql`
+
+3.  Run:
+
+> `mysql> SHOW SLAVE STATUS \G`
+
+### 'Relay log read failure: Could not parse relay log event entry'
+
+This can happen if the relay log file is corrupted. To check this, run
+`SHOW SLAVE STATUS` and find the value for `Relay_Log_File` - it will be
+something like `mysql-backup-1-relay-bin.000XXX` where `mysql-backup-1`
+is replaced by the name of the server on which replication is broken.
+Run `mysqlbinlog <relay-log-file> > /dev/null`
+
+if this results in error messages being displayed, the log file is
+corrupted and you should try
+
+Find the current relay log position - the value for `Relay_Log_Pos:` in
+the `SHOW SLAVE STATUS` output
+
+From a mysql command prompt -
+
+`SLAVE STOP;`
+
+`change master to master_log_file='<relay_log_file>',master_log_pos=<relay_log_pos>;`
+
+`SLAVE START;`
+
+You should then see `SHOW SLAVE STATUS` output return to normal.
+
+More details in -
+[<http://alexzeng.wordpress.com/2013/10/17/how-to-fix-mysql-slave-after-relay-log-corrupted/>](http://alexzeng.wordpress.com/2013/10/17/how-to-fix-mysql-slave-after-relay-log-corrupted/)
+

--- a/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
+++ b/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
@@ -1,0 +1,44 @@
+---
+title: 'MySQL Xtrabackups to S3'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# MySQL Xtrabackups to S3
+
+We send backups to an Amazon S3 bucket every 15 minutes. This is
+performed using a nightly "base" backup and "incremental" backups which
+run every 15 minutes, which are linked to the base backup.
+
+[Further detail on the implementation can be found
+here](https://github.gds/pages/gds/opsmanual/infrastructure/backups/mysql.md)
+
+### MySQL Xtrabackup daily base push
+
+If this alert triggers it means the nightly base backup has failed to
+run. Check the logs in Kibana using this query:
+
+@source\_host:mysql-backup\* AND @fields.syslog\_program:xtrabackup\_s3\_base
+
+As this runs on a slave, it is safe to rerun at anytime. Log into the
+machine and run:
+
+sudo -i /usr/bin/timeout 1h /usr/bin/setlock -N /var/run/mysql\_xtrabackup /usr/local/bin/xtrabackup\_s3\_base
+
+If it errors you should be able to find out what the issue is.
+
+### MySQL Xtrabackup incremental-push
+
+When this alert triggers it means the incremental backups, which run
+every 15 minutes, have had a problem. Check Kibana with the following
+query:
+
+@source\_host:mysql-backup\* AND @fields.syslog\_program:xtrabackup\_s3\_incremental
+
+It is safe to run manually, though this will by nature run regularly so
+you should be able to view what the problem is in the logs. If the
+incremental backup is failing, it may be worth rerunning the base backup
+job, and then running the incremental job. Other possible problems could
+point to connectivity to Amazon S3.
+

--- a/source/manual/alerts/nginx-5xx-rate-too-high-for-many-apps-boxes.html.md
+++ b/source/manual/alerts/nginx-5xx-rate-too-high-for-many-apps-boxes.html.md
@@ -1,0 +1,35 @@
+---
+title: 'nginx 5xx rate too high for many apps/boxes'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# "nginx 5xx rate too high" for many apps/boxes
+
+If the message is "UNKNOWN: INTERNAL ERROR: RuntimeError: no valid
+datapoints" or "UNKNOWN: INTERNAL ERROR: RuntimeError: no data returned
+for target", it probably means that statsd or collectd stopped
+submitting data for a period. Statsd metrics (those that begin with
+`stats.`) don't get created until the first event of a given type. For
+infrequently-used apps which rarely have errors, the `http_5xx` may
+never get created. You can force creation by creating a zero-value
+`http_500` counter:
+
+    fab $environment -H frontend-1.frontend statsd.create_counter:frontend-1_frontend.nginx_logs.static_publishing_service_gov_uk.http_500
+
+Note that the `http_5xx` counters are created by carbon-aggregator, so
+they will automatically be created when a corresponding `http_500`
+counter gets created. You should *not* create a statsd counter for
+`http_5xx` as this will confuse carbon-aggregator.
+
+For collectd metrics (those without a leading `stats.` prefix), you
+probably just need to wait for the metric to get created.
+
+### Spikes
+
+The alert should link to a graphite graph - often certain applications
+such as whitehall can have spikes - if you can determine this is a spike
+it is best to acknowledge the alert and let the team that owns the app
+know
+

--- a/source/manual/alerts/nginx-high-conn-writing-upstream-indicator-check.html.md
+++ b/source/manual/alerts/nginx-high-conn-writing-upstream-indicator-check.html.md
@@ -1,0 +1,32 @@
+---
+title: 'nginx high conn writing -- upstream indicator Check'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'nginx high conn writing -- upstream indicator' Check
+
+### What is the 'nginx high conn writing -- upstream indicator' check?
+
+-   If you see this alert it may be that we are having or about to have
+    an outage -- this is an early warning check.
+-   This check is there to flag up potential problems occurring upstream
+    -- a service not returning fast enough so we have the set write
+    connecting building up. This was a pattern spotted in a number of
+    recent outages as at April 2013.
+-   outage documentation:
+    <https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/12vOWq9DQWsPJDEnv2ZZpr8hOAAMGeNux1j1vvdlznd0/edit?usp=sharing>
+
+### Other useful information
+
+-   Checks are specifically on the nginx frontend boxes as thats the
+    closest place to the problem we can monitor and avoids the false
+    positives that checking the Load balancers might give us.
+-   The warning and alert levels have been selected to fire early in the
+    case of outages to be a useful flag of what might be happening, but
+    not so low that we get too many false positives.
+-   We should really monitor what's going on at the rack/unicorn level
+    which would give us more accurate information. We don't currently
+    have that ability, hence this check.
+

--- a/source/manual/alerts/nginx-requests-too-low.html.md
+++ b/source/manual/alerts/nginx-requests-too-low.html.md
@@ -1,0 +1,17 @@
+---
+title: 'nginx requests too low'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'nginx requests too low'
+
+-   An Icinga check that alerts when the number of Nginx requests drops
+    below a critical threshold.
+-   We have seen misconfigured firewall configs on our vSE.
+-   It could be a genuine low number of requests or it may be indicative
+    of a bigger problem as described above. The threshold is
+    configurable in hieradata so we can tweak for environments where we
+    expect to see lower traffic levels.
+

--- a/source/manual/alerts/ntp-drift-too-high.html.md
+++ b/source/manual/alerts/ntp-drift-too-high.html.md
@@ -1,0 +1,14 @@
+---
+title: 'ntp drift too high'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'ntp drift too high'
+
+There are tasks in fabric-scripts to make this less painful:
+
+    fab $environment -H jumpbox-1.management ntp.status
+    fab $environment -H jumpbox-1.management ntp.resync
+

--- a/source/manual/alerts/offsite-backups.html.md
+++ b/source/manual/alerts/offsite-backups.html.md
@@ -1,0 +1,50 @@
+---
+title: 'Offsite backups'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Offsite backups
+
+All of our offsite backups use duplicity. Most, but not all, are
+encrypted using GPG.
+
+If a backup fails then then start by looking at any output captured by
+cron and sent to the "machine email" list. This is linked from the
+Nagios alert under "extra actions".
+
+To proceed further you will need to know a few things which you can
+determine either from the job configuration in Puppet or by listing
+crontabs for users, eg. `sudo crontab -lu govuk-backup`:
+
+1.  the user that the backup normally runs as, eg. `govuk-backup` or
+    `root`.
+2.  the script that is run, eg. `/var/spool/duplicity/<job>.sh`.
+3.  the destination for the backup, eg. `rsync://<user>@<host>:/<path>`
+4.  the archive directory used as a local cache, eg.
+    `/data/backups/.cache/duplicity`
+
+<div class="admonition note">
+
+The `sudo -i` in these commands is important because it prevents GPG
+from using keyrings in your own user's home directory.
+
+</div>
+
+Start by checking the status of the destination to see what backups
+succeeded recently:
+
+    sudo -iu <user> duplicity collection-status --archive-dir <archive_directory> <destination>
+
+You can try running the backup again manually. This may take some time
+so it's recommended to use `tmux` or `screen`:
+
+    sudo -iu <user> /var/spool/duplicity/<script>
+
+You can look for output of the backup jobs in the "machine email plat1"
+google group. If the log contains the line
+`"Warning, found the following orphaned backup files` then try running
+the command
+`sudo -iugovuk-backup duplicity cleanup <destination>  --no-encryption --force`
+

--- a/source/manual/alerts/onsite-backups.html.md
+++ b/source/manual/alerts/onsite-backups.html.md
@@ -1,0 +1,15 @@
+---
+title: 'Onsite backups'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Onsite backups
+
+The backup machine (e.g. backup-1.management.integration) collects
+backups from the various data stores.
+
+The location of the backups is defined in
+[govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/node/s_backup.pp)
+

--- a/source/manual/alerts/outstanding-security-updates.html.md
+++ b/source/manual/alerts/outstanding-security-updates.html.md
@@ -1,0 +1,69 @@
+---
+title: 'Outstanding security updates'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'Outstanding security updates'
+
+Most security updates should be automagically applied overnight by
+[unattended-upgrades](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package)
+and our Nagios check accounts for that by delaying alerts for up to
+24hrs.
+
+To see which packages are outstading you can use the
+apt.security\_updates fabric task.
+
+Before running an unattended upgrade manually it's worth checking why it
+failed to run. Logs of the previous runs can be found in
+`/var/log/unattended-upgrades`. The most recent run log can be found at
+`unattended-upgrades.log`, whereas older logs can be found tarballed by
+date in the same directory.
+
+Perform an unattended upgrade manually with the apt.unattended\_upgrade
+fabric task.
+
+It has been known to alert about packages that were not currently
+installed and thus not picked up by unattended-upgrades, such as
+`libunwind7` and `dh-apparmor`. Such examples of new packages can be
+taken care of by manually installing them with `apt-get install`.
+
+<div class="admonition note">
+
+We explicitly exclude or 'blacklist' some security updates from being
+applied by unattended-upgrades. This currently includes MySQL Server,
+which would represent a single point of failure if upgraded
+automatically; in such cases a manual upgrade during office hours is
+preferable.
+
+Please see the apt::unattended\_upgrades::blacklist: node in Hiera for
+details of the exact packages that are blacklisted.
+
+</div>
+
+You should only consider running `apt-get dist-upgrade` as a last
+resort, because it will aggressively upgrade and even downgrade packages
+as it deems necessary. Run it with `--dry-run` in Integration first and
+review the output very carefully. If in doubt ask someone in the
+Infrastructure team.
+
+You may see an alert telling you that a connection to NRPE could not be
+established. See [Nagios NRPE connection
+failures](alerts/nagios-nrpe-connection-failures.html) for more
+information.
+
+### 'Problem with MergeList' error
+
+`apt-get` is known to fail occasionally on machines running Ubuntu
+Trusty with an error similar to:
+
+    Exception: invalid literal for int() with base 10:
+    'E: Error: Opening the cache (E:Encountered a section with no Package: header,
+    E:Problem with MergeList /var/lib/apt/lists/mirrors.ubuntu.com_mirrors.txt_dists_trusty_restricted_i18n_Translation-en%5fU'
+
+As a temporary work-around, run these commands on the machine to fix:
+
+    sudo rm -r /var/lib/apt/lists/*
+    sudo apt-get update
+

--- a/source/manual/alerts/pagerduty-drill.html.md
+++ b/source/manual/alerts/pagerduty-drill.html.md
@@ -1,0 +1,24 @@
+---
+title: 'PagerDuty drill'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# PagerDuty drill
+
+Every week we test PagerDuty to make sure it can phone to alert us to
+any issues.
+
+Cron creates a file on disk. Icinga raises a critical alert when that
+file exists with an Icinga contact group set so that PagerDuty is
+notified. After a short amount of time, cron will remove the file to
+resolve the alert. The [code that does this is in
+Puppet](https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/pagerduty_drill.pp).
+
+You don't need to take any action for this alert. The primary in-office
+2nd line should escalate the call to the secondary who should escalate
+it to "escalations" to ensure that phone redirection is working. The
+person on "escalations" will resolve the PagerDuty alert to prevent
+anyone else being phoned.
+

--- a/source/manual/alerts/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/alerts/pingdom-bouncer-canary-check.html.md
@@ -1,0 +1,54 @@
+---
+title: 'Pingdom Bouncer canary check'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Pingdom Bouncer canary check
+
+Bouncer has a canary route at <https://www.direct.gov.uk/__canary__>
+which queries all the database tables which Bouncer uses to serve all
+responses to users and checks that those tables are not empty. The
+canary should return 200; if it doesn't then errors will be being served
+to users - see the table below for more details of the errors in each
+case.
+
+The application page for Bouncer and Transition [documents Bouncer's
+stack](applications/bouncer-and-transition.html#bouncer-s-stack).
+
+Possible causes of errors on the canary route include:
+
+-   DNS problems for `www.direct.gov.uk` or
+    `bouncer.publishing.service.gov.uk` - check [Bouncer's nginx
+    logs](https://kibana.publishing.service.gov.uk/kibana/#/dashboard/elasticsearch/Bouncer)
+    to see which requests are getting through
+-   CDN problems resulting in requests for `www.direct.gov.uk` not being
+    correctly passed to `https://bouncer.publishing.service.gov.uk`
+-   `bouncer-*` or `transition-postgresql-slave-1` machines being
+    unavailable
+-   Bouncer's dependencies being missing or having errors in its
+    configuration
+-   [memory](https://graphite.publishing.service.gov.uk/render/?width=600&height=300&target=alias(dashed(constantLine(6442450944)),%22critical%22)&target=alias(dashed(constantLine(4294967296)),%22warning%22)&target=bouncer-*_redirector.processes-app-bouncer.ps_rss&from=-2days)
+    leaks in Bouncer
+-   the app being unable to connect or authorise to the database
+-   the database or the required tables being missing or empty
+-   the `bouncer` role not having `SELECT` privileges on the required
+    tables
+
+The database tables checked by the canary route (in order) and the
+effect on requests for transitioned sites of errors when querying them:
+
+  Database table          HTTP status codes for requests for transitioned sites
+  ----------------------- -----------------------------------------------------------------------------------------------------------------------------
+  table name              when table inaccessible when table missing data
+  =====================   ================================================================================================ ==========================
+  `hosts`                 `500` for all requests `404` for all requests
+  `sites`                 `500` for all requests `500` for all requests
+  `mappings`              `500` for most requests `404` for most requests
+  `whitelisted_hosts`     `500` for requests which should redirect to non-`*.gov.uk`/`*.mod.uk`/`*.nhs.uk` domains `501` for those requests
+  `organisations`         `500` for most requests which should serve a 404 or 410 page `500` for those requests
+
+There are other tables in the `transition_production` database but they
+are only used by Transition and not by Bouncer.
+

--- a/source/manual/alerts/pingdom-homepage-check.html.md
+++ b/source/manual/alerts/pingdom-homepage-check.html.md
@@ -1,0 +1,30 @@
+---
+title: 'Pingdom homepage check'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Pingdom homepage check
+
+Pingdom monitors externally (from \~10 locations in Europe and America)
+that it can connect to <https://www.gov.uk/>. If this fails it could
+indicate that DNS for www.gov.uk is not working, our CDN has failed or
+GOV.UK (particularly the Frontend application) and all the static
+mirrors are inaccessible, which would probably qualify as a major
+incident.
+
+If you can confirm that GOV.UK is indeed globally inaccessible, then
+this is probably cause to first alert other people who may be able to
+help, then start troubleshooting to see if you can narrow down the
+failure.
+
+-   [Pingdom Twitter account](https://twitter.com/pingdom) - check if
+    they have announced issues
+-   [Fastly Service status](http://status.fastly.com/) - check if the
+    CDN has global issues
+-   [Carrenza status](https://servicedesk.carrenza.com/) - check if our
+    main provider has issues
+-   [Skyscape status](http://status.skyscapecloud.com/) - check if our
+    Licensing hosting provider has issues
+

--- a/source/manual/alerts/pingdom-search-check.html.md
+++ b/source/manual/alerts/pingdom-search-check.html.md
@@ -1,0 +1,22 @@
+---
+title: 'Pingdom search check'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Pingdom search check
+
+If Pingdom can't retrieve the search results page it means that while
+GOV.UK may be available (see check above), it is not possible to
+retrieve dynamic content. Assuming that the homepage check has not
+failed, the CDN is probably OK. It is possible for our main provider
+(Carrenza) to be down and for us to serve static content from a
+secondary mirror at a second supplier (Skyscape).
+
+This is not such a critical problem as you might assume, because a large
+amount of traffic comes direct to static content from external searches
+and can be served from the mirror. Debug as normal by walking backwards
+from the users perspective through the stack to find out where the
+failure is.
+

--- a/source/manual/alerts/postgresql-replication.html.md
+++ b/source/manual/alerts/postgresql-replication.html.md
@@ -1,0 +1,36 @@
+---
+title: 'PostgreSQL replication'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# PostgreSQL replication
+
+### 'replication on the postgres slave is too far behind master \[value in bytes\]'
+
+When this alert fires, the Postgres slave replication process may be
+struggling to keep up (due to load) or may have stopped altogether. Take
+a look at the graph linked by Nagios historical information.
+
+If one node is down (resulting in Graphite having NULL values for one
+metric) then the reported lag will jump to size of the XLOG position on
+the remaining node and raise a CRITICAL alert.
+
+If both nodes are down then Graphite will return no data and an UNKNOWN
+alert will be raised. This should correlate with other checks for server
+and database health.
+
+If the slave has fallen too far behind or is in an otherwise
+unrecoverable state then you may need to [resync
+it](../infrastructure/howto/setup-postgresql-replication.html#syncing-a-standby).
+
+If this is a new machine, the issue may be that PostgreSQL replication
+is set up and running correctly, but `collectd` needs to be restarted on
+either the primary or standby to ensure that Graphite is receiving the
+metrics it needs.
+
+The replication lag is measured by examining the difference in the [XLOG
+location in
+bytes](https://wiki.postgresql.org/wiki/Streaming_Replication).
+

--- a/source/manual/alerts/postgresql-s3-backups.html.md
+++ b/source/manual/alerts/postgresql-s3-backups.html.md
@@ -1,0 +1,61 @@
+---
+title: 'PostgreSQL S3 Backups'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# PostgreSQL S3 Backups
+
+There are two passive checks related to PostgreSQL S3 backups:
+
+-   PostgreSQL WAL-E base backup push
+-   PostgreSQL WAL-E archiving to S3
+
+### PostgreSQL WAL-E base backup push
+
+Every morning WAL-E will push a "base backup" to an S3 bucket. This base
+backup represents the point in time when, if a restore is required, the
+data is taken from. The WAL logs will be restored and replayed from that
+time.
+
+This means that if this base backup fails but the WAL archiving
+continues successfully, we aren't losing backup data, but it would take
+longer to restore and replay the WAL logs from an older checkpoint.
+
+If it fails check Kibana to see if you can see the error using the
+following query:
+
+    @fields.syslog_program:wal-e_postgres_base_backup_push
+
+There may be a problem with PostgreSQL or it may have trouble connecting
+to the S3 bucket.
+
+You can try to re-take the base backup. In theory this is a "hot"
+backup, which means it should not impact, but as it's running on the
+Primary machine some caution is advised. As detailed above, you could
+wait until the next morning for the backup to try again since we are not
+losing data due to the archiving process:
+
+sudo -iu postgres /usr/local/bin/wal-e\_postgres\_base\_backup\_push
+
+### PostgreSQL WAL-E archiving to S3
+
+[PostgreSQL has a concept of WAL
+archiving](http://www.postgresql.org/docs/9.3/static/continuous-archiving.html)
+which means it makes a copy of a WAL log to the chosen destination. If
+this job fails it means that archiving may not correctly be uploading to
+the S3 bucket.
+
+Fortunately if it is unable to correctly archive a log, it will not just
+"miss" the log, but will error until that log has been successfully
+archived. This means that we won't have missing data, but we won't have
+an offsite backup from the point that it errors, which subsequently
+means **the WAL archiving is more important to offsite backups than the
+base backup itself**.
+
+WAL logs will continue to write on the filesystem of the local server.
+Check the status of the archiving with the following Kibana query:
+
+    @message:"*wal-e_postgres_archiving_wrapper*"
+

--- a/source/manual/alerts/prolonged-gc-collection-times-check.html.md
+++ b/source/manual/alerts/prolonged-gc-collection-times-check.html.md
@@ -1,0 +1,62 @@
+---
+title: 'Prolonged GC collection times Check'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'Prolonged GC collection times' Check
+
+### What is 'Prolonged GC collection times' check?
+
+This checks when the elasticsearch JVM garbage collection times (in
+milliseconds) exceeds critical or warning levels. This is collected by
+graphite via collectd from the elasticsearch API.
+
+Currently the check uses graphite function to summarize over a time
+period of 5minutes and find the maximum value in that period.
+
+You can find the current value using curl if you SSH into the affected
+box:
+
+    curl localhost:9200/_nodes/stats/jvm?pretty
+
+You need to look for the `collection_time_in_millis`. There will be two
+values: `old` and `young`. Both are checked by nagios and correspond to
+different portions of the JVM heap. The lower these times are, the
+better. Another important value is `heap_used_percent`, again this
+should be low. If it gets too high it may prevent garbage collection
+completing.
+
+### Solutions
+
+Solving this problem largely depends on what the particular box is being
+used for.
+
+On boxes where the data in elasticsearch isn't critical (e.g. for
+ci-master and ci-agent, where it is only test data) freeing up heap
+space can be achieved by deleting indexes:
+
+    curl -XDELETE localhost:9200/<index name>
+
+to delete a specific index, or:
+
+    curl -XDELETE localhost:9200/_all
+
+to delete all indexes. Obviously run these with extreme care!
+
+### Places to investigate?
+
+-   Make sure this is not affecting the gov.uk site search if coming
+    from elasticsearch search boxes.
+-   Make sure not leading to loss of log lines if coming from
+    elasticsearch logging boxes.
+
+### Further reading
+
+If you are still struggling these links might help but they are very
+in-depth.
+
+-   [<http://www.oracle.com/technetwork/java/javase/memorymanagement-whitepaper-150215.pdf>](http://www.oracle.com/technetwork/java/javase/memorymanagement-whitepaper-150215.pdf)
+-   [<http://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.em4j.1.2/em4j/conf-heap-management.html>](http://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.em4j.1.2/em4j/conf-heap-management.html)
+

--- a/source/manual/alerts/rabbitmq-checks.html.md
+++ b/source/manual/alerts/rabbitmq-checks.html.md
@@ -1,0 +1,106 @@
+---
+title: 'RabbitMQ checks'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# RabbitMQ checks
+
+We run a RabbitMQ cluster, which is used to trigger events when
+documents are published. The general process is that messages are
+published onto "exchanges" in RabbitMQ. Applications create "queues"
+which listen to the exchanges, and gather the messages sent to the
+exchanges together. Applications then run "consumers" which receive
+messages from the queues.
+
+In order to ensure that our consumers remain active, we publish
+"heartbeat" messages to the exchanges every minute. This helps to avoid
+problems with consumers dropping their connections due to inactivity,
+but also allows us to monitor activity easily.
+
+### Sending heartbeats
+
+Heartbeat messages are sent every minute by cron. Currently, we only
+send heartbeat messages to one exchange: the `published_documents`
+exchange. These heartbeats are sent via a rake task in the
+`content-store` app.
+
+### Check for non-idle consumers
+
+We run a check that there is at least one non-idle consumer for a named
+RabbitMQ queue. (For example, for the `email_alert_service` queue.) The
+queue name should indicate the app responsible for consuming the queue.
+
+The check is performed by connecting to RabbitMQ's admin API, so the
+information given is from Rabbit's point of view.
+
+Since we send heartbeats every minute (from each instance of the content
+store), at least one of the consumers for each queue should be active
+every minute. To be conservative, the check checks that at least one
+consumer of the queue is running and has been active within the last 5
+minutes.
+
+If the check succeeds, it will return the most recent time at which
+activity happened on the queue.
+
+If the check fails due to no consumers having been active recently, it
+will report a critical failure, giving the most recent idle time, and
+the idle times of each consumer connected to RabbitMQ:
+
+    CRITICAL: No activity for X seconds: idle times are [X, Y, Z]
+
+If the check fails due to there being no consumers connected to the
+queue, it will report a critical failure:
+
+    CRITICAL: "No consumers listening to queue"
+
+### Consequences of idle consumers
+
+If consumers are idle, messages sent to the queue will not be being
+processed. This means that the actions which are meant to happen in
+response to the messages will not happen. For example, email alerts
+about updated content will not be sent if the `email_alert_sevice` queue
+isn't running.
+
+Unless there is a wider RabbitMQ failure, messages will not be lost -
+they will be processed once the problem is resolved.
+
+### RabbitMQ high watermark has been exceeded
+
+The RabbitMQ server detects the total amount of RAM installed on
+startup. By default, when the RabbitMQ server uses above 40% of the
+installed RAM, it raises a memory alarm and blocks all connections. Once
+the memory alarm has cleared (e.g. due to the server paging messages to
+disk or delivering them to clients) normal service resumes.
+
+If this alert is regularly triggered it is a sign that it is time to
+beef up the Rabbit boxes with more RAM. Alternatively, if you don't care
+about messages, you can try to purge messages or remove unused queues.
+
+Further information can be found
+[here](https://www.rabbitmq.com/memory.html).
+
+### Investigation
+
+RabbitMQ has an admin interface, which allows details of recent activity
+on the queues to be seen. To log in, [follow the
+instructions](rabbitmq).
+
+The admin interface allows you to see details (and graphs!) of the
+messages sent to each queue, and the number of messages held on the
+queues. Look at the queue for which the alert happened. If no messages
+have been sent to the queue over the last several minutes, the most
+likely failure is that the heartbeat messages are no longer being sent
+correctly. Look for recent changes to the [content
+store](https://github.com/alphagov/content-store).
+
+If messages have been received, and the queue has messages held on it
+and not being processed, the consumers have either got stuck or stopped
+running for some reason. Restarting the consumers for the relevant app
+will probably clear this up (but please make sure the team owning the
+app are also alerted, since this shouldn't normally happen). For
+example:
+
+    fab $environment class:backend app.restart:email-alert-service
+

--- a/source/manual/alerts/reboot-required-by-apt.html.md
+++ b/source/manual/alerts/reboot-required-by-apt.html.md
@@ -1,0 +1,30 @@
+---
+title: 'reboot required by apt'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# 'reboot required by apt'
+
+This check indicates that some packages have been installed but cannot
+be activated without rebooting the machines.
+
+See the [rebooting machines](rebooting-machines.html) for what to do.
+
+If there are a high number of machines requiring a reboot, including
+ones that are not part of database clusters (such as Mongo and MySQL
+machines) there may be a problem with the locking mechanism.
+
+Check if this is the case using fabric:
+
+    fab <environment> locksmith.status
+
+If there is a lock in place it will detail which machine holds the lock.
+You can remove it with:
+
+    fab <environment> locksmith.unlock:"<machine-name>"
+
+Machines which are safe to reboot should then do so at the scheduled
+time.
+

--- a/source/manual/alerts/rkhunter-warnings.html.md
+++ b/source/manual/alerts/rkhunter-warnings.html.md
@@ -1,0 +1,34 @@
+---
+title: 'rkhunter warnings'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# rkhunter warnings
+
+rkhunter (Rootkit Hunter) is software installed on our machines to
+detect potential rootkits and exploits. rkhunter runs every morning
+across our machines.
+
+In most cases you could verify that the warning is something we expect
+to be happening on our machines and then acknowledge it.
+
+If we miss the schedule on Integration (e.g. if Jenkins doesn't start
+the servers up on time), we get a 'freshness threshold' warning for each
+machine. It's possible to resolve this across all machines in an
+environment by running rkhunter via a fabric script, e.g.:
+
+    fab integration all rkhunter
+
+If this encounters an error while running, it's useful to continue
+running rkhunter only on those machines that are still reporting this
+warning.:
+
+    fab integration vm.nagios.loadhosts:rkhunter rkhunter
+
+If the warning shows `rkhunter definitions not updated`, then you need
+to update the definitions.:
+
+    fab integration all rkhunter.update
+

--- a/source/manual/alerts/root-filesystem-is-readonly.html.md
+++ b/source/manual/alerts/root-filesystem-is-readonly.html.md
@@ -1,0 +1,20 @@
+---
+title: 'root filesystem is readonly'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# root filesystem is readonly
+
+When Ubuntu is unable to write to disk it switches the filesystem to be
+read only. This could be caused by a cloud hosting provider having
+problems with their Storage Area Network (SAN).
+
+The machine will need to have a filesystem check forced on reboot. To do
+this log into the vCloud Director instance for the environment, find the
+affected machine and click on the 'console' image to bring up a web
+based console. Click the 'reset' icon in the top bar and then click to
+focus on the console. Press the 'f' key when prompted (or repeatedly if
+there's no output) to force a filesystem check.
+

--- a/source/manual/alerts/sidekiq-retries.html.md
+++ b/source/manual/alerts/sidekiq-retries.html.md
@@ -1,0 +1,28 @@
+---
+title: 'Sidekiq Retries'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Sidekiq Retries
+
+Many of our applications use
+[Sidekiq](https://github.com/mperham/sidekiq) for background job
+processing. Sidekiq has in built retry logic (turned on by default, but
+configurable). We graph Sidekiq job stats: successes, failures, job
+timings and retry counts. These can be found under the statsd Graphite
+namespace. i.e.:
+
+    stats.gauges.govuk.app.support.workers.retry_set_size
+
+    stats.govuk.app.whitehall.workers.SearchIndexAddWorker.failure
+
+Jobs do fail, this is not inherently bad and can happen for a number of
+reasons. When a job fails it gets retried with an exponential backoff
+(up to 21 days), as long as retries are enabled. A high number of
+retries signifies a bigger, less transient problem maybe occuring, and
+hence we alert on it. If this alert fires a good place to start
+investigation is the [Sidekiq
+monitor](applications/sidekiq-monitoring.html).
+

--- a/source/manual/alerts/unicorn-herder.html.md
+++ b/source/manual/alerts/unicorn-herder.html.md
@@ -1,0 +1,44 @@
+---
+title: 'Unicorn Herder'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Unicorn Herder
+
+### 'app unicornherder running'
+
+This alert means the Unicorn Herder process has disappeared for the
+named app, so the app is still running but we don't know about it and
+can't control it.
+
+At the moment, the fix is to run the fabric task vm.bodge\_unicorn for
+that app. (The name of the task should give a clue as to why I say "At
+the moment".)
+
+Within fabric-scripts repo, make sure you have a virtualenv and it is
+activated. If you don't have one, do this:
+
+    virtualenv .
+    . bin/activate
+
+virtualenv is installed with pip - if you don't have it, install it as
+such:
+
+    pip install virtualenv
+
+You'll also need a username in a .fabricrc file, if you haven't already
+got one:
+
+    echo 'user = YOURNAME' >> ~/.fabricrc
+
+Then, depending on the alert, look at which machine and which app it is
+that needs "bodging". For example, if the machine was
+whitehall-backend-1 and the app is whitehall, then the command you would
+run is:
+
+    fab $environment -H whitehall-backend-1.backend vm.bodge_unicorn:whitehall
+
+Job done. The Nagios alert should clear within a few minutes.
+

--- a/source/manual/alerts/upgrading-mysql.html.md
+++ b/source/manual/alerts/upgrading-mysql.html.md
@@ -1,0 +1,61 @@
+---
+title: 'Upgrading mysql'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Upgrading mysql
+
+Upgrading mysql will cause 500 errors on sites as the master and slave
+machines are restarted, so this procedure needs to be done at a suitable
+time on production - i.e outside of core business hours (9:00 - 18:00
+Monday to Friday)
+
+It is safe to reboot the \_backup and \_slave-2 machines on production
+as they are not actively used by sites and will not cause 500 errors
+
+The following puppet classes will need upgrading
+
+mysql cluster:
+
+> mysql\_backup
+>
+> mysql\_slave
+>
+> mysql\_master
+
+whitehall cluster:
+
+> whitehall\_mysql\_backup
+>
+> whitehall\_mysql\_slave
+>
+> whitehall\_mysql\_master
+
+To do the upgrade, use this fabric command
+
+`fab $environment -H <hostname> sdo:"apt-get install mysql-server-5.5"`
+
+Its best to do the backup machines first, followed by second slave,
+first slave and then the master.
+
+Before upgrading the master it is best to stop the slow query logs on
+the slaves. This can be done with the following fabric command (or a
+similar one replacing the classes for whitehall). Only do this on
+staging and integration -slow query logs are not enabled in production
+
+`fab $environment class:mysql_backup class:mysql_slave mysql.stop_slow_query_log`
+
+The upgrade task can then be run on the master. Stopping the slow query
+log should allow replication to continue - if alerts occur about
+replication not running, then run the following fabric task
+
+`fab $environment class:mysql_backup class:mysql_slave mysql.fix_replication_from_slow_query_log_after_upgrade`
+
+Once the master has safely upgraded and replication is running, then
+turn the slow query log back on - Only do this on staging and
+integration -slow query logs are not enabled in production
+
+`fab $environment class:mysql_backup class:mysql_slave mysql.start_slow_query_log`
+

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -1,0 +1,60 @@
+---
+title: 'Varnish port not responding'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Varnish port not responding
+
+Under high load, it is possible that the Varnish child process which
+handles connections will timeout on the healthcheck from the parent. If
+that happens and the replacement child process also fails to start,
+varnish can get in a state where it is not responsive.
+
+The 'varnish port not responding' check simply attempts to contact
+<http://localhost:7999/> and get a response. If it doesn't, then it will
+raise an urgent alert as this might lead to 1/3 of user requests
+failing.
+
+To diagnose, you should see messages like this:
+
+    $ fab $environment -H cache-3.router sdo:'grep varnishd /var/log/messages'
+    [cache-3.router] out: Jul  7 00:17:02 cache-3 varnishd[1620]: Child (1630) died signal=3
+    [cache-3.router] out: Jul  7 00:17:03 cache-3 varnishd[1620]: child (27973) Started
+    [cache-3.router] out: Jul  7 00:17:25 cache-3 varnishd[1620]: Child (27973) said Child starts
+    [cache-3.router] out: Jul  7 00:17:25 cache-3 varnishd[1620]: Child (27973) said Child dies
+    [cache-3.router] out: Jul  7 00:17:25 cache-3 varnishd[1620]: Child (27973) died status=1
+
+And you should see only one process called /usr/sbin/varnishd in the
+process table, with owner root. The child process if it exists will be
+owned by nobody:
+
+    $ fab $environment -H cache-3.router do:'ps -ef | grep [/]usr/sbin/varnishd'
+    [cache-3.router] out: root      8273     1  0 06:08 ?        00:00:00 /usr/sbin/varnishd -P /var/run/varnishd.pid -a :7999 -f /etc/varnish/default.vcl -T 127.0.0.1:6082 -t 900 -w 1,1000,120 -S /etc/varnish/secret -s malloc,5985M
+    [cache-3.router] out: nobody    8277  8273  1 06:08 ?        00:03:52 /usr/sbin/varnishd -P /var/run/varnishd.pid -a :7999 -f /etc/varnish/default.vcl -T 127.0.0.1:6082 -t 900 -w 1,1000,120 -S /etc/varnish/secret -s malloc,5985M
+
+And you can check whether there are any children of the current parent
+process (this check will fail where it succeeds below):
+
+    $ fab $environment -H cache-3.router do:'/usr/lib/nagios/plugins/check_procs -c 1:1 -C 'varnishd' -p `< /var/run/varnishd.pid`''
+    [cache-3.router] out: PROCS OK: 1 process with command name 'varnishd', PPID = 8273
+
+### To resolve varnish port not responding
+
+You just need to restart varnish on this machine:
+
+    $ fab $environment -H cache-3.router cache.restart
+
+### Varnish high memory consumption
+
+**Caution** Talk to someone from webops/infrastructure first.
+
+Varnish can be restarted with the fab task:
+
+fab \$environment cache.restart
+
+This isn't graceful and will stop and start varnish across the cache
+machines which can result in a spike in request volume to the
+applications and possibly errors.
+

--- a/source/manual/alerts/vpn-down.html.md
+++ b/source/manual/alerts/vpn-down.html.md
@@ -1,0 +1,22 @@
+---
+title: 'VPN down'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# VPN down
+
+We use VPNs to connect between datacentres. Please see
+GOV.UK and Virtual
+Private Networks (VPNs) &lt;/infrastructure/vpn&gt; for details of the
+VPNs we have and a description of the impact of each VPN failing.
+
+If a VPN is down, it is likely caused by a network issue due to a vendor
+incident or our own misconfiguration. If no changes have been made
+recently to our [network
+configuration](https://github.gds/gds/govuk-provisioning), the best
+action is to contact the vendors involved. If the VPN connects one
+vendor to another, you should open a ticket with each vendor as the
+problem could lie on either side.
+

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md
@@ -1,0 +1,33 @@
+---
+title: 'Whitehall scheduled publishing'
+parent: /manual.html
+layout: manual_layout
+section: Alerts
+---
+
+# Whitehall scheduled publishing
+
+### 'overdue publications in Whitehall'
+
+This alert means that there are scheduled editions which have passed
+their publication due date but haven't been published by the scheduled
+publishing workers. Scheduled publishing is performed by sidekiq workers
+picking up jobs from a scheduled queue.
+
+You can see whether sidekiq picked up the job for processing, and the
+current state of the job using [Sidekiq monitoring
+apps](applications/sidekiq-monitoring.html).
+
+You can verify that there are overdue published documents using:
+
+    $ fab $environment whitehall.overdue_scheduled_publications
+
+You'll see output like this:
+
+    ID  Scheduled date             Title
+
+If there are overdue publications you can publish by running the
+following:
+
+    $ fab $environment whitehall.schedule_publications
+


### PR DESCRIPTION
This imports the Nagios alert page: https://github.gds/pages/gds/opsmanual/2nd-line/nagios.html

The Nagios page contains information on how to respond to specific alerts on GOV.UK. They're linked from Icinga. Previously all information was on one page. This import splits them up to a page per alert.

https://trello.com/c/wWWH6YGr