### PR TITLE
Replace all mentions of opsmanual_layout

### DIFF
--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -1,7 +1,7 @@
 ---
 title: Change an organisation's slug
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 section: Routing
 ---
 

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -1,7 +1,7 @@
 ---
 title: Create a GPG key
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 section: Support
 ---
 

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -1,7 +1,7 @@
 ---
 title: "Elasticsearch: dump and restore indices"
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 sections: Backups
 ---
 

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -1,7 +1,7 @@
 ---
 title: Handle encrypted hieradata
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 section: Deployment
 ---
 # Handle encrypted hieradata

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -1,7 +1,7 @@
 ---
 title: Jenkins CI infrastructure
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 section: Testing
 ---
 

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -1,7 +1,7 @@
 ---
 title: MongoDB backups
-layout: opsmanual_layout
-parent: "/opsmanual.html"
+layout: manual_layout
+parent: "/manual.html"
 section: Backups
 ---
 

--- a/source/manual/releasing-software.html.md
+++ b/source/manual/releasing-software.html.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy something to GOV.UK
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 section: Deployment
 ---
 

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -1,7 +1,7 @@
 ---
 title: Remove a machine
-parent: /opsmanual.html
-layout: opsmanual_layout
+parent: "/manual.html"
+layout: manual_layout
 section: Environments
 ---
 


### PR DESCRIPTION
A few pages still had the layout as "opsmanual_layout" and the page
parent as the opsmanual instead of the new names for these. This was
causing the build to fail and these pages not to display.