### PR TITLE
Add shared frontend repos

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -114,5 +114,7 @@
         - govuk_prototype_kit
         - govuk_template
         - govuk_elements
+        - govuk_elements_rails
         - govuk_frontend_toolkit
         - govuk_frontend_toolkit_gem
+        - govuk_frontend_toolkit_npm


### PR DESCRIPTION
Add govuk_elements_rails - a gem wrapper around govuk_elements
and govuk_frontend_toolkit_npm, a npm package for alphagov/govuk_frontend_toolkit