### PR TITLE
Add an "API" for page freshness

### DIFF
--- a/lib/page_freshness.rb
+++ b/lib/page_freshness.rb
@@ -5,13 +5,17 @@ class PageFreshness
     @sitemap = sitemap
   end
 
+  def to_json
+    { expired_pages: expired_pages, expiring_soon: expiring_soon }.to_json
+  end
+
   def expired_pages
     expired = sitemap.resources.select do |page|
       page.data.review_by && Date.today > page.data.review_by
     end
 
     expired.map do |page|
-      { title: page.data.title, url: page.url, expired_at: page.data.review_by }
+      export(page)
     end
   end
 
@@ -21,9 +25,18 @@ class PageFreshness
     end
 
     pages = soon.map do |page|
-      { title: page.data.title, url: page.url, expired_at: page.data.review_by }
+      export(page)
     end
 
     pages - expired_pages
+  end
+
+  def export(page)
+    {
+      title: page.data.title,
+      url: "https://docs.publishing.service.gov.uk#{page.url}",
+      review_by: page.data.review_by,
+      owner_slack: page.data.owner_slack,
+    }
   end
 end

--- a/source/api/page-freshness.json.erb
+++ b/source/api/page-freshness.json.erb
@@ -1,0 +1,1 @@
+<%= page_freshness.to_json %>

--- a/spec/app/page_freshness_spec.rb
+++ b/spec/app/page_freshness_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe PageFreshness do
+  describe "#to_json" do
+    it "returns JSON" do
+      sitemap = double(resources: [
+        double(url: "/a", data: double(title: "A thing", owner_slack: "#2ndline", review_by: Date.yesterday)),
+        double(url: "/b", data: double(title: "B thing", owner_slack: "#2ndline", review_by: Date.tomorrow)),
+      ])
+
+      json = PageFreshness.new(sitemap).to_json
+
+      expect(JSON.parse(json)).to eql(
+        "expired_pages" => [{ "title" => "A thing", "url" => "https://docs.publishing.service.gov.uk/a", "review_by" => Date.yesterday.to_s, "owner_slack" => "#2ndline" }],
+        "expiring_soon" => [{ "title" => "B thing", "url" => "https://docs.publishing.service.gov.uk/b", "review_by" => Date.tomorrow.to_s, "owner_slack" => "#2ndline" }]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This JSON endpoint can be called by a hypothetical bot that announces soon to expire pages to Slack.

https://trello.com/c/ZUd0ITTZ