### PR TITLE
Fix doc urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby File.read('.ruby-version').chomp
 
+gem 'capybara'
 gem 'rake'
 gem 'rspec', '~> 3.5'
 gem 'webmock', '~> 2.1'
@@ -20,6 +21,8 @@ gem 'middleman-search_engine_sitemap', '~> 1.4'
 
 gem 'table_of_contents', git: 'https://github.com/alphagov/table_of_contents.git', ref: 'f6d37fe1e837cebf7354abafd891f755148e7efa'
 
+gem 'github-markdown'
+gem 'html-pipeline'
 gem 'redcarpet', '~> 3.3.2'
 
 gem 'govuk_schemas', '~> 2.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,13 @@ GEM
       execjs
     backports (3.6.8)
     builder (3.2.3)
+    capybara (2.12.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     chunky_png (1.3.8)
     coffee-script (2.4.1)
       coffee-script-source
@@ -59,6 +66,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.0)
     ffi (1.9.18)
+    github-markdown (0.6.9)
     govuk-lint (2.0.0)
       rubocop (~> 0.43.0)
       scss_lint
@@ -70,6 +78,9 @@ GEM
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.2)
     hashie (3.5.5)
+    html-pipeline (2.5.0)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (2.0.3)
@@ -132,6 +143,9 @@ GEM
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -155,6 +169,8 @@ GEM
       rack (>= 0.9.1)
     rack-livereload (0.3.16)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
@@ -211,16 +227,21 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport (~> 5.0)
+  capybara
   faraday-http-cache (~> 2.0.0)
   faraday_middleware (~> 0.11.0)
+  github-markdown
   govuk-lint (~> 2.0)
   govuk_schemas (~> 2.1.1)
+  html-pipeline
   middleman (>= 4.0.0)
   middleman-autoprefixer (~> 2.7.0)
   middleman-compass (>= 4.0.0)
@@ -241,4 +262,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.1
+   1.14.6

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -95,7 +95,7 @@ class AppDocs
     end
 
     def github_repo_data
-      @github_repo_data ||= GitHub.client.repo(github_repo_name)
+      @github_repo_data ||= GitHubRepoFetcher.client.repo(github_repo_name)
     end
   end
 end

--- a/app/dashboard.rb
+++ b/app/dashboard.rb
@@ -52,7 +52,7 @@ class Dashboard
 
     def repos
       data['repos'].to_a.map do |app_name|
-        repo = GitHub.client.repo(app_name)
+        repo = GitHubRepoFetcher.client.repo(app_name)
         Repo.new(repo)
       end
     end

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -1,13 +1,138 @@
+require 'html/pipeline'
+require 'uri'
+
 class ExternalDoc
-  def self.fetch(url_to_markdown)
-    markdown = HTTP.get(url_to_markdown)
+  def self.fetch(repository:, path:)
+    contents = HTTP.get(
+      "https://raw.githubusercontent.com/#{repository}/master/#{path}",
+    )
 
-    # remove the own title of the page
-    markdown = markdown.lines[2..-1].join.strip
+    context = {
+      base_url: URI.join(
+        'https://github.com',
+        "#{repository}/blob/master/",
+      ),
 
-    # Make sure we link to the pages hosted here
-    markdown = markdown.gsub('.md', '.html')
+      image_base_url: URI.join(
+        'https://raw.githubusercontent.com',
+        "#{repository}/master/",
+      ),
+    }
 
-    markdown
+    context[:subpage_url] =
+      URI.join(context[:base_url], File.join('.', File.dirname(path), '/'))
+
+    context[:image_subpage_url] =
+      URI.join(context[:image_base_url], File.join('.', File.dirname(path), '/'))
+
+    filters = [
+      HTML::Pipeline::MarkdownFilter,
+      HTML::Pipeline::AbsoluteSourceFilter,
+      PrimaryHeadingFilter,
+      HeadingFilter,
+      AbsoluteLinkFilter,
+      MarkdownLinkFilter,
+    ]
+
+    HTML::Pipeline
+      .new(filters)
+      .to_html(contents, context)
+  end
+
+private
+
+  # When we import external documentation it can contain relative links to
+  # source files within the repository that the documentation resides. We need
+  # to filter out these types of links and make them absolute so that they
+  # continue to work when rendered as part of GOV.UK Developer Docs.
+  #
+  # For example a link to `lib/link_expansion.rb` would be rewritten to
+  # https://github.com/alphagov/publishing-api/blob/master/lib/link_expansion.rb
+  class AbsoluteLinkFilter < HTML::Pipeline::Filter
+    def call
+      doc.search('a').each do |element|
+        next if element['href'].nil? || element['href'].empty?
+
+        href = element['href'].strip
+        uri = URI.parse(href)
+        path = uri.path
+
+        unless uri.scheme || href.start_with?('#') || path.end_with?('.md')
+          base = if path.start_with? '/'
+                   base_url
+                 else
+                   subpage_url
+                 end
+
+          element['href'] = URI.join(base, href).to_s
+        end
+      end
+
+      doc
+    end
+
+    def subpage_url
+      context[:subpage_url]
+    end
+  end
+
+  # When we import external documentation formatted with Markdown it can
+  # contain links to other pages of documentation also formatted with Markdown.
+  # When the documentation is rendered as part of GOV.UK Developer Docs we
+  # render it as HTML so we need to rewrite the links so that they have a .html
+  # extension to match out routing.
+  #
+  # For example a link to `link-expansion.md` would be rewritten to
+  # `link-expansion.html`
+  class MarkdownLinkFilter < HTML::Pipeline::Filter
+    def call
+      doc.search('a').each do |element|
+        next if element['href'].nil? || element['href'].empty?
+
+        href = element['href'].strip
+        uri = URI.parse(href)
+
+        if uri.path.end_with?('.md')
+          uri.path.sub!(/.md$/, '.html')
+          element['href'] = uri.to_s
+        end
+      end
+
+      doc
+    end
+  end
+
+  # Removes the H1 from the page so that we can choose our own title
+  class PrimaryHeadingFilter < HTML::Pipeline::Filter
+    def call
+      doc.at('h1:first-of-type').unlink
+      doc
+    end
+  end
+
+  # This adds a unique ID to each header element so that we can reference
+  # each section of the document when we build our table of contents navigation.
+  class HeadingFilter < HTML::Pipeline::Filter
+    def call
+      headers = Hash.new(0)
+
+      doc.css('h1, h2, h3, h4, h5, h6').each do |node|
+        text = node.text
+        id = text
+               .downcase # lower case
+               .gsub(/<[^>]*>/, '') # crudely remove html tags
+               .gsub(/[^\w\- ]/, '') # remove any non-word characters
+               .tr(' ', '-') # replace spaces with hyphens
+
+        uniq = (headers[id] > 0) ? "-#{headers[id]}" : ''
+        headers[id] += 1
+
+        if header_content = node.children.first
+          node[:id] = id
+        end
+      end
+
+      doc
+    end
   end
 end

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -1,6 +1,6 @@
 require 'octokit'
 
-class GitHub
+class GitHubRepoFetcher
   # Fetch a repo from GitHub.
   #
   # If the app_name is just a repo name we'll assume that it's in the alphagov
@@ -18,7 +18,7 @@ class GitHub
   end
 
   def self.client
-    @client ||= GitHub.new
+    @client ||= GitHubRepoFetcher.new
   end
 
 private

--- a/app/publishing_api_docs.rb
+++ b/app/publishing_api_docs.rb
@@ -21,12 +21,12 @@ class PublishingApiDocs
       @title = title
     end
 
-    def source_url
-      "https://github.com/alphagov/publishing-api/blob/master/doc/#{filename}.md"
+    def path
+      "/doc/#{filename}.md"
     end
 
-    def raw_source
-      "https://raw.githubusercontent.com/alphagov/publishing-api/master/doc/#{filename}.md"
+    def repository
+      'alphagov/publishing-api'
     end
   end
 end

--- a/source/apis/search-api.html.md.erb
+++ b/source/apis/search-api.html.md.erb
@@ -5,4 +5,4 @@ parent: /apis.html
 source_url: https://github.com/alphagov/rummager/blob/master/docs/search-api.md
 ---
 
-<%= ExternalDoc.fetch('https://raw.githubusercontent.com/alphagov/rummager/master/docs/search-api.md') %>
+<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'docs/search-api.md') %>

--- a/source/getting-started.html.md.erb
+++ b/source/getting-started.html.md.erb
@@ -6,5 +6,4 @@ description: Guide for new developers on GOV.UK
 
 # Get started
 
-<% url = "https://raw.githubusercontent.com/alphagov/govuk-puppet/master/development-vm/README.md" %>
-<%= ExternalDoc.fetch(url) %>
+<%= ExternalDoc.fetch(repository: 'alphagov/govuk-puppet', path: 'development-vm/README-dev.md') %>

--- a/source/templates/publishing_api_template.html.erb
+++ b/source/templates/publishing_api_template.html.erb
@@ -4,4 +4,4 @@ parent: /apis.html
 hide_from_sitemap: true
 ---
 
-<%= ExternalDoc.fetch(page.raw_source) %>
+<%= ExternalDoc.fetch(repository: page.repository, path: page.path) %>

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -1,20 +1,41 @@
+require 'capybara/rspec'
+
 RSpec.describe ExternalDoc do
   describe '.fetch' do
-    subject(:markdown) { described_class.fetch(url) }
+    subject(:html) do
+      Capybara.string(described_class.fetch(repository: repository, path: path))
+    end
 
-    let(:url) { 'https://example.org/markdown.md' }
+    let(:repository) { 'example/lipsum' }
+    let(:path) { 'markdown.md' }
 
     before do
-      stub_request(:get, url).
+      stub_request(:get, 'https://raw.githubusercontent.com/example/lipsum/master/markdown.md').
         to_return(body: File.read('spec/fixtures/markdown.md'))
     end
 
     it 'removes the title of the page' do
-      expect(markdown).to start_with('## tl;dr')
+      expect(html).not_to have_selector('h1', text: 'Lorem ipsum')
     end
 
     it 'rewrites links to markdown pages' do
-      expect(markdown).to include('[turpis ultrices](/ultrices.html)')
+      expect(html).to have_link('turpis ultrices', href: '/ultrices.html')
+    end
+
+    it 'rewrites relative images' do
+      expect(html).to have_css('img[src="https://raw.githubusercontent.com/example/lipsum/master/suspendisse_iaculis.png"]')
+    end
+
+    it 'rewrites relative URLs' do
+      expect(html).to have_link('tincidunt leo', href: 'https://github.com/example/lipsum/blob/master/lib/tincidunt_leo.rb')
+    end
+
+    it 'maintains anchor links' do
+      expect(html).to have_link('Suspendisse iaculis', href: '#suspendisse-iaculis')
+    end
+
+    it 'adds an id attribute to all headers so they can be accessed from a table of contents' do
+      expect(html).to have_selector('h2#tldr')
     end
   end
 end

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe GitHub do
+RSpec.describe GitHubRepoFetcher do
   describe "#repo" do
     it "returns a repo if the user is specified" do
       stub_request(:get, "https://api.github.com/repos/some-user/some-repo").
         to_return(body: "{}", headers: { content_type: "application/json" })
 
-      repo = GitHub.new.repo("some-user/some-repo")
+      repo = GitHubRepoFetcher.new.repo("some-user/some-repo")
 
       expect(repo).not_to be_nil
     end
@@ -14,7 +14,7 @@ RSpec.describe GitHub do
         to_return(body: "[]", headers: { content_type: "application/json" })
 
       expect {
-        GitHub.new.repo("something-not-here")
+        GitHubRepoFetcher.new.repo("something-not-here")
       }.to raise_error(StandardError)
     end
   end

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -3,5 +3,11 @@
 ## tl;dr
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam efficitur lacus in
-neque consequat porta. Sed et [turpis ultrices](/ultrices.md), imperdiet eros
-ut, tincidunt leo.
+neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
+[turpis ultrices](/ultrices.md), imperdiet eros ut, [tincidunt leo].
+
+## Suspendisse iaculis
+
+![Suspendisse iaculis](suspendisse_iaculis.png)
+
+[tincidunt leo]: ./lib/tincidunt_leo.rb


### PR DESCRIPTION
Adds a number of filters that ensure external markdown docs render correctly:

- Loads external sources
- Rewrites relative links to work in this context
- Rewrites links to other markdown links to their dev docs equivalent

We have had to duplicate some of the TOC logic as this is only applied to markdown templates. Ideally we could do this for all ERB templates.

https://trello.com/c/nGPt3dpG