### PR TITLE
Make context of Icinga alert pages clearer

### DIFF
--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -7,7 +7,7 @@
 
 <% wrap_layout :layout_with_sidebar do %>
   <% if current_page.data.section == "Icinga alerts" %>
-    <div class="icinga-alert-backlink">
+    <div class="information-callout">
       This page describes what to do in case of an
       <a href='https://docs.publishing.service.gov.uk/manual/tools.html#icinga'>Icinga alert</a>.
       For more information you could

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -6,5 +6,16 @@
 <% end %>
 
 <% wrap_layout :layout_with_sidebar do %>
+  <% if current_page.data.section == "Icinga alerts" %>
+    <div class="icinga-alert-backlink">
+      This page describes what to do in case of an
+      <a href='https://docs.publishing.service.gov.uk/manual/tools.html#icinga'>Icinga alert</a>.
+      For more information you could
+      <a href='https://github.com/alphagov/govuk-puppet/search?utf8=%E2%9C%93&q=<%= File.basename(current_page.path, ".*") %>'>
+        search the govuk-puppet repo for the source of the alert
+      </a>
+    </div>
+  <% end %>
+
   <%= html %>
 <% end %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -27,12 +27,9 @@
   background-color: $govuk-blue;
   color: $page-colour;
 
-  a:link {
-    color: $page-colour;
-  }
-
+  a:link,
   a:visited {
-    color: $page-colour;
+    color: inherit;
   }
 
   a:hover {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -19,3 +19,27 @@
   border: 1px solid $error-colour;
   color: $error-colour;
 }
+
+.icinga-alert-backlink {
+  padding: $gutter;
+  margin-top: $gutter;
+  margin-bottom: $gutter;
+  background-color: $govuk-blue;
+  color: $page-colour;
+
+  a:link {
+    color: $page-colour;
+  }
+
+  a:visited {
+    color: $page-colour;
+  }
+
+  a:hover {
+    color: $link-hover-colour;
+  }
+
+  a:active {
+    color: $link-active-colour;
+  }
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -20,7 +20,7 @@
   color: $error-colour;
 }
 
-.icinga-alert-backlink {
+.information-callout {
   padding: $gutter;
   margin-top: $gutter;
   margin-bottom: $gutter;


### PR DESCRIPTION
The pages in the "Icinga alerts" section [like this one][1]  are linked from the Icinga UI:

![screen shot 2017-04-12 at 17 15 40](https://cloud.githubusercontent.com/assets/233676/24968012/c4c03eea-1fa3-11e7-8495-46baff56c22a.png)

However, when you visit the page the context isn't really made clear. 

![screen shot 2017-04-12 at 17 18 39](https://cloud.githubusercontent.com/assets/233676/24968110/146a7514-1fa4-11e7-94c0-4d0c03d8bfcd.png)

This PR adds a block to 1) communicate that this is a page that deals with a specific alert, 2) links back to govuk-puppet, so that the user can find out what triggered the alert. See [these search results for example][2].

![screen shot 2017-04-12 at 17 19 08](https://cloud.githubusercontent.com/assets/233676/24968130/282cb0f8-1fa4-11e7-932f-c6d451f52fb9.png)

cc @nickcolley @fofr because I'm randomly adding a new UI element here, what do you think?

[1]: https://docs.publishing.service.gov.uk/manual/alerts/rabbitmq-high-watermark.html
[2]: https://github.com/alphagov/govuk-puppet/search?utf8=%E2%9C%93&q=rabbitmq-high-watermark