### PR TITLE
Disable the in-page navigation

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -7,7 +7,7 @@
 
   <% html = yield %>
 
-  <div class="app-pane__body" data-module="in-page-navigation">
+  <div class="app-pane__body">
     <div class="app-pane__toc">
       <%= partial "partials/search" %>
 

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -5,7 +5,7 @@
     </a>
   </div>
 
-  <div class="app-pane__body" data-module="in-page-navigation">
+  <div class="app-pane__body">
     <div class="app-pane__toc">
       <%= partial "partials/search" %>
 


### PR DESCRIPTION
This disables the automatic updating of the URL with the current fragment (/index.html#something) and the automatic highlighting in the sidebar. The in-page nav was designed for large pages like the PaaS docs (https://docs.cloud.service.gov.uk).

I've found that because we have very small pages, the URL updating is a bit distracting and doesn't add much. It also auto-updates on load, which will change the URL immediately. I've found myself removing the
fragment a lot when sharing a particular page.

Note that this doesn't prevent people from sharing specific headings, that's still possible.