### PR TITLE
New manual index page

### DIFF
--- a/app/manual_index_page.rb
+++ b/app/manual_index_page.rb
@@ -1,0 +1,55 @@
+class ManualIndexPage
+  ICINGA_ALERTS = "Icinga alerts".freeze
+
+  attr_reader :sitemap
+
+  def initialize(sitemap)
+    @sitemap = sitemap
+  end
+
+  def columns
+    [
+      first_column,
+      in_two_groups[0],
+      in_two_groups[1],
+    ]
+  end
+
+private
+
+  def first_column
+    {
+      "Top tasks" => most_important_pages,
+      "Manual" => manual_pages.select { |page| page.data.section == "Manual" },
+      "Expired pages" => page_freshness.expired_pages,
+      "Pages due for review this week" => page_freshness.expiring_soon,
+      ICINGA_ALERTS => manual_pages.select { |page| page.data.section == ICINGA_ALERTS },
+    }
+  end
+
+  def page_freshness
+    PageFreshness.new(sitemap)
+  end
+
+  def in_two_groups
+    slice_size = (manual_pages_grouped_by_section.size / 2.0).ceil
+    manual_pages_grouped_by_section.each_slice(slice_size).to_a
+  end
+
+  def manual_pages_grouped_by_section
+    manual_pages
+      .reject { |page| page.data.section.in?([ICINGA_ALERTS, "Manual"]) } # these go into the 1st column
+      .group_by { |page| page.data.section || "Uncategorised" }
+      .sort_by(&:first)
+  end
+
+  def most_important_pages
+    manual_pages.select { |page| page.data.important }
+  end
+
+  def manual_pages
+    sitemap.resources
+      .select { |page| page.path.start_with?('manual/') && page.path.end_with?('.html') }
+      .sort_by { |page| page.data.title.try(:downcase).to_s }
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -43,28 +43,12 @@ helpers do
     AppDocs.pages.reject(&:retired?).sort_by(&:app_name)
   end
 
-  def manual_pages_grouped_by_section
-    manual_pages
-      .group_by { |page| page.data.section || "Uncategorised" }
-      .sort_by(&:first)
-  end
-
-  def most_important_pages
-    manual_pages.select { |page| page.data.important }
-  end
-
-  def manual_pages
-    sitemap.resources
-      .select { |page| page.path.start_with?('manual/') && page.path.end_with?('.html') }
-      .sort_by { |page| page.data.title.try(:downcase).to_s }
+  def manual_index_page
+    ManualIndexPage.new(sitemap)
   end
 
   def teams
     ApplicationsByTeam.teams
-  end
-
-  def page_freshness
-    PageFreshness.new(sitemap)
   end
 
   require 'table_of_contents/helpers'

--- a/lib/page_freshness.rb
+++ b/lib/page_freshness.rb
@@ -6,16 +6,12 @@ class PageFreshness
   end
 
   def to_json
-    { expired_pages: expired_pages, expiring_soon: expiring_soon }.to_json
+    { expired_pages: export(expired_pages), expiring_soon: export(expiring_soon) }.to_json
   end
 
   def expired_pages
-    expired = sitemap.resources.select do |page|
+    sitemap.resources.select do |page|
       page.data.review_by && Date.today > page.data.review_by
-    end
-
-    expired.map do |page|
-      export(page)
     end
   end
 
@@ -24,19 +20,17 @@ class PageFreshness
       page.data.review_by && Date.today > (page.data.review_by - 7.days)
     end
 
-    pages = soon.map do |page|
-      export(page)
-    end
-
-    pages - expired_pages
+    soon - expired_pages
   end
 
-  def export(page)
-    {
-      title: page.data.title,
-      url: "https://docs.publishing.service.gov.uk#{page.url}",
-      review_by: page.data.review_by,
-      owner_slack: page.data.owner_slack,
-    }
+  def export(pages)
+    pages.map do |page|
+      {
+        title: page.data.title,
+        url: "https://docs.publishing.service.gov.uk#{page.url}",
+        review_by: page.data.review_by,
+        owner_slack: page.data.owner_slack,
+      }
+    end
   end
 end

--- a/source/api/page-freshness.json.erb
+++ b/source/api/page-freshness.json.erb
@@ -1,1 +1,1 @@
-<%= page_freshness.to_json %>
+<%= PageFreshness.new(sitemap).to_json %>

--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -3,69 +3,28 @@ layout: false
 title: Dev manual
 ---
 
-<% content_for :sidebar do %>
-  <ul>
-    <li>
-      <a href="/manual.html">Dev manual</a>
-    <ul>
-    <li>
-      <% manual_pages_grouped_by_section.each do |section, pages| %>
-        <li><a href='#'><%= section %></a>
-        <ul>
-          <% pages.each do |page| %>
-            <li><%= link_to page.data.title, page.path %></li>
-          <% end %>
-        </ul>
-        </li>
-      <% end %>
-    </li>
-    </ul>
-  </li>
-  </ul>
-<% end %>
+<% wrap_layout :header_footer_only do %>
+  <div class="app-pane__body">
+    <div class="app-pane__content">
+      <main id="content" class="technical-documentation full-width">
+        <%= partial 'partials/header' %>
 
-<% wrap_layout :layout_with_sidebar do %>
-  <%= partial 'partials/header' %>
+        <%= partial "partials/search" %>
 
-  <blockquote>
-    <strong>Work in progress</strong><br/><br/>
-
-    We're currently moving <a href='https://github.gds/pages/gds/opsmanual'>
-    the opsmanual</a> to this site. Follow along
-    <a href='https://trello.com/b/pWnVP4wF'>on our Trello board</a>.
-  </blockquote>
-
-  <h2>Top tasks</h2>
-
-  <ul>
-    <% most_important_pages.each do |page| %>
-      <li><%= link_to page.data.title, page.path %></li>
-    <% end %>
-  </ul>
-
-  <h2>Keeping the opsmanual up to date</h2>
-
-  <p>Everyone on GOV.UK is responsible for keeping the opsmanual up to date. To ensure
-  this, every page should have a named owner.</p>
-
-
-  <% if page_freshness.expiring_soon.any? %>
-    <h3>Pages to be reviewed soon</h3>
-
-    <ul>
-    <% page_freshness.expiring_soon.each do |page| %>
-      <li><%= link_to page[:title], page[:url] %></li>
-    <% end %>
-    </ul>
-  <% end %>
-
-  <% if page_freshness.expired_pages.any? %>
-    <h3>Expired pages</h3>
-
-    <ul>
-    <% page_freshness.expired_pages.each do |page| %>
-      <li><%= link_to page[:title], page[:url] %></li>
-    <% end %>
-    </ul>
-  <% end %>
+        <% manual_index_page.columns.each do |column_pages| %>
+          <div class='column-third'>
+            <% column_pages.each do |section_name, pages| %>
+              <% next unless pages.any? %>
+              <h4><%= section_name %></h4>
+              <ul>
+                <% pages.each do |page| %>
+                  <li><%= link_to page.data.title, page.path %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -41,3 +41,16 @@
     color: $link-active-colour;
   }
 }
+
+.column-third {
+  @include grid-column( 1/3 );
+}
+
+.technical-documentation.full-width {
+  max-width: 1024px;
+}
+
+.top-tasks {
+  background-color: $canvas-colour;
+  padding: 0 20px 20px 20px;
+}

--- a/spec/app/manual_index_page.rb
+++ b/spec/app/manual_index_page.rb
@@ -1,0 +1,17 @@
+RSpec.describe ManualIndexPage do
+  describe '#columns' do
+    it "returns the correct groups" do
+      sitemap = double(resources: [
+        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo")),
+        double(path: "manual/foo.html", data: double(title: "Foo", important: true, review_by: Date.today, section: "Foo")),
+        double(path: "manual/bar.html", data: double(title: "Bar", important: true, review_by: Date.today, section: "Bar")),
+      ])
+
+      columns = ManualIndexPage.new(sitemap).columns
+
+      expect(columns[0].keys).to eql(["Top tasks", "Manual", "Expired pages", "Pages due for review this week", "Icinga alerts"])
+      expect(columns[1].map(&:first)).to eql(["Bar"])
+      expect(columns[2].map(&:first)).to eql(["Foo"])
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt at a new index page for the manual. We currently show all pages in the sidebar. 

The goal of this version is to make it easy to understand the "shape" of all the documentation we have and to make it easy to scan the pages.

Feedback very welcome. 

## Before

![screen shot 2017-04-13 at 12 03 09](https://cloud.githubusercontent.com/assets/233676/25002224/2be7f872-2041-11e7-9243-11e84e498481.png)

## After

![screen shot 2017-04-13 at 12 03 02](https://cloud.githubusercontent.com/assets/233676/25002233/31a18044-2041-11e7-9956-3bd5a48f04b3.png)

## Rendered

👉 https://govuk-tech-docs-pr-131.herokuapp.com/manual.html