### PR TITLE
Add links to application deployment dashboards

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -60,6 +60,10 @@ class AppDocs
       "https://github.com/alphagov/govuk-app-deployment/blob/master/#{github_repo_name}/config/deploy.rb"
     end
 
+    def dashboard_url
+      "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_#{puppet_name}.json"
+    end
+
     def type
       app_data.fetch("type")
     end

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -37,6 +37,7 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   <li><%= link_to "GitHub repo", application.repo_url %></li>
   <li><%= link_to "Puppet configuration", application.puppet_url %></li>
   <li><%= link_to "Deploy scripts", application.deploy_url %></li>
+  <li><%= link_to "Deployment dashboard", application.dashboard_url %> (warning: not all apps have a dashboard)</li>
 
   <% if application.production_url %>
     <li><%= link_to application.production_url.gsub('https://', ''), application.production_url %></li>


### PR DESCRIPTION
Link to Grafana dashboard from app pages.

Include warning that not all apps have dashboards. Once the an internal Grafana hostname has been configured, the plan is to only show this link if a dashboard has been created for that application.

https://trello.com/c/6954MV1K/48-link-to-dashboards-from-app-pages-in-the-developer-docs