### PR TITLE
Add page about where to find what documentation

### DIFF
--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -1,0 +1,40 @@
+---
+owner_slack: '#2ndline'
+review_by: 2017-06-01
+title: Where to find what documentation?
+section: Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+# Where to find what documentation?
+
+## Individual repos
+
+- GOV.UK projects on GitHub should [conform to the README styleguide][readme]
+- Additional docs should be [put in the /docs folder][docs-folder]
+
+## Developer docs (this site)
+
+<https://docs.publishing.service.gov.uk>
+
+- Uses content from GitHub and public APIs to generate documentation
+- Contains content on architecture, common tasks and alerts
+
+## Confluence Wiki
+
+<https://gov-uk.atlassian.net/wiki> (private)
+
+- The [Platform Operations wiki][plops] contains information about 2nd line and incident management
+- The [Product documentation][prod-docs] contains documentation about the features of the platform
+
+## Opsmanual
+
+<https://github.gds/pages/gds/opsmanual> (private)
+
+- Contains private information on operations, such as phone numbers and account IDs
+
+[readme]: https://github.com/alphagov/styleguides/blob/master/use-of-READMEs.md
+[docs-folder]: https://github.com/alphagov/publishing-api/tree/master/doc
+[plops]: https://gov-uk.atlassian.net/wiki/display/PLOPS/GOV.UK+Platform+Operations+Home
+[prod-docs]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Product+documentation

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -27,6 +27,7 @@ parent: "/manual.html"
 
 - The [Platform Operations wiki][plops] contains information about 2nd line and incident management
 - The [Product documentation][prod-docs] contains documentation about the features of the platform
+- The [RFCs section][rfcs] contains ideas and proposals for GOV.UK
 
 ## Opsmanual
 
@@ -38,3 +39,4 @@ parent: "/manual.html"
 [docs-folder]: https://github.com/alphagov/publishing-api/tree/master/doc
 [plops]: https://gov-uk.atlassian.net/wiki/display/PLOPS/GOV.UK+Platform+Operations+Home
 [prod-docs]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Product+documentation
+[rfcs]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Request+for+comments+-+RFC


### PR DESCRIPTION
In this page we write down the new "system" for docs on GOV.UK. Its purpose is to show where things should live.