### PR TITLE
Link to gds tech blog

### DIFF
--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -110,3 +110,7 @@ We have processes in place to deploy if [either of the GitHubs are unavailable](
 The [release app](https://release.publishing.service.gov.uk/) tracks releases.
 
 You need to have a Signon account with appropriate permissions to access the release app.
+
+## On the blog
+
+- (Releasing applications to GOV.UK)[https://gdstechnology.blog.gov.uk/2014/09/10/releasing-applications-to-gov-uk/]

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -131,3 +131,7 @@ our jobs.
 With this configuration, in our jobs we can choose between 'GitHub' and 'GDS GitHub Enterprise' API endpoints to
 access the source code repository. The API endpoint name is referenced in Puppet to configure jobs automatically so
 we shouldn't update it.
+
+## On the blog
+
+- [Updating the GOV.UK Continuous Integration environment](https://gdstechnology.blog.gov.uk/2017/02/10/updating-the-gov-uk-continuous-integration-environment/)

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -128,3 +128,7 @@ Check the `app.py` class for different methods you can use. To run more specific
 `fab $environment class:backend sdo:"service contentapi reload"`
 
 For more information, check out the [Fabric scripts README](https://github.com/alphagov/fabric-scripts#readme>).
+
+## On the blog
+
+- [Monitoring the GOV.UK infrastructure](https://gdstechnology.blog.gov.uk/2016/03/30/monitoring-the-gov-uk-infrastructure/)


### PR DESCRIPTION
Adds an `On the blog` section to the bottom of these pages, with a link to a relevant article on the [GDS technology blog](https://gdstechnology.blog.gov.uk/)