### PR TITLE
Move Link Checker to HGTA

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -121,7 +121,7 @@
 - github_repo_name: link-checker-api
   type: APIs
   product_manager: Antonia Simmons
-  team: Content History
+  team: Holding Government To Account
 
 - github_repo_name: publishing-api
   type: APIs


### PR DESCRIPTION
This keeps it consistent with other apps maintained by Content History team since that's all done with the Holding Government to Account grouping