### PR TITLE
API docs for Link Checker API

### DIFF
--- a/source/apis/link-checker-api.html.md.erb
+++ b/source/apis/link-checker-api.html.md.erb
@@ -1,0 +1,8 @@
+---
+layout: api_layout
+title: Link Checker API
+parent: /apis.html
+source_url: https://github.com/alphagov/link-checker-api/blob/master/docs/api.md
+---
+
+<%= ExternalDoc.fetch(repository: 'alphagov/link-checker-api', path: 'docs/api.md') %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -10,6 +10,7 @@
       </ul>
     </li>
     <li><%= link_to 'Content Store', '/apis/content-store.html' %></li>
+    <li><%= link_to 'Link Checker API', '/apis/link-checker-api.html' %></li>
   </ul>
 <% end %>
 

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -1,6 +1,7 @@
 <% content_for :sidebar do %>
   <ul>
-    <li><%= sidebar_link 'Search API', '/apis/search-api.html' %></li>
+    <li><%= link_to 'Content Store', '/apis/content-store.html' %></li>
+    <li><%= link_to 'Link Checker API', '/apis/link-checker-api.html' %></li>
     <li>
       <%= sidebar_link 'Publishing API', '/apis/publishing-api.html' %>
       <ul>
@@ -9,8 +10,7 @@
         <% end %>
       </ul>
     </li>
-    <li><%= link_to 'Content Store', '/apis/content-store.html' %></li>
-    <li><%= link_to 'Link Checker API', '/apis/link-checker-api.html' %></li>
+    <li><%= sidebar_link 'Search API', '/apis/search-api.html' %></li>
   </ul>
 <% end %>
 


### PR DESCRIPTION
Imports [https://github.com/alphagov/link-checker-api/blob/master/docs/api.md] into the docs

Also re-orders the API layout sidebar to be alphabetical.

These don't quite render correctly (the `<details>` disclosures) because of a lack of parity with the end-of-life github-markdown and common mark that github uses now. This will be fixed when https://github.com/jch/html-pipeline/pull/274 is merged into https://github.com/jch/html-pipeline - or if we want to use it sooner I have [a branch](https://github.com/alphagov/govuk-developer-docs/tree/commonmark) using that rendering