### PR TITLE
Fix section tag for elasticsearch page

### DIFF
--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -4,7 +4,7 @@ review_by: 2017-10-06
 title: "Elasticsearch: dump and restore indices"
 parent: "/manual.html"
 layout: manual_layout
-sections: Backups
+section: Backups
 ---
 
 # Elasticsearch: dump and restore indices


### PR DESCRIPTION
This was a typo, causing the page to be uncategorised.