### PR TITLE
A11Y, Spacing fixes

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -98,7 +98,7 @@
 
 - name: Team tools
   sections:
-    - name: Team tools
+    - name: Misc
       repos:
         - gds-hubot
         - binaryberry/seal

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -30,12 +30,18 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/da
     <% chapter.sections.each do |section| %>
       <h3 id='<%= section.id %>'><%= section.name %></h3>
 
-      <% section.entries.each do |entry| %>
-        <div class='entry'>
-          <a href='<%= entry.url %>'><%= entry.name %></a>
-          <small><%= entry.description %></small>
-        </div>
-      <% end %>
+      <ul class='entry-list'>
+        <% section.entries.each do |entry| %>
+        <li class='entry-list__item'>
+          <a class='entry-list__key' href='<%= entry.url %>'>
+            <%= entry.name %>
+          </a>
+          <small class='entry-list__value' >
+            <%= entry.description %>
+          </small>
+        </li>
+        <% end %>
+      </ul>
     <% end %>
   <% end %>
 <% end %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -9,9 +9,8 @@
 
   <div class="app-pane__body">
     <div class="app-pane__toc">
-      <%= partial "partials/search" %>
-
       <div class="toc" data-module="table-of-contents">
+        <%= partial "partials/search" %>
         <a href="#" class="toc__close js-toc-close" aria-controls="toc" aria-label="Hide table of contents"></a>
         <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
           <%=

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -7,9 +7,8 @@
 
   <div class="app-pane__body">
     <div class="app-pane__toc">
-      <%= partial "partials/search" %>
-
       <div class="toc" data-module="table-of-contents">
+        <%= partial "partials/search" %>
         <a href="#" class="toc__close js-toc-close" aria-controls="toc" aria-label="Hide table of contents"></a>
         <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
           <%= yield_content :sidebar %>

--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -11,19 +11,21 @@ title: Dev manual
 
         <%= partial "partials/search" %>
 
-        <% manual_index_page.columns.each do |column_pages| %>
-          <div class='column-third'>
-            <% column_pages.each do |section_name, pages| %>
-              <% next unless pages.any? %>
-              <h4><%= section_name %></h4>
-              <ul>
-                <% pages.each do |page| %>
-                  <li><%= link_to page.data.title, page.path %></li>
-                <% end %>
-              </ul>
-            <% end %>
-          </div>
-        <% end %>
+        <div class='grid-row'>
+          <% manual_index_page.columns.each do |column_pages| %>
+            <div class='column-third'>
+              <% column_pages.each do |section_name, pages| %>
+                <% next unless pages.any? %>
+                <h2><%= section_name %></h2>
+                <ul>
+                  <% pages.each do |page| %>
+                    <li><%= link_to page.data.title, page.path %></li>
+                  <% end %>
+                </ul>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/source/partials/_search.html.erb
+++ b/source/partials/_search.html.erb
@@ -1,6 +1,7 @@
 <div class="search" data-module="search">
   <form action="https://www.google.co.uk/search" method="get" role="search">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
-    <input type="search" name="q" placeholder="Search (via Google)" class="form-control">
+    <label for="tech-docs-search"  class="visually-hidden">Search (via Google)</label>
+    <input type="search" id="tech-docs-search" name="q" placeholder="Search (via Google)" class="form-control">
   </form>
 </div>

--- a/source/stylesheets/modules/_search.scss
+++ b/source/stylesheets/modules/_search.scss
@@ -1,7 +1,11 @@
 @include screen {
+  .page-title + .search {
+    margin-top: $gutter;
+  }
+
   .search {
     @include core-16;
-    padding: $gutter-half;
+    margin-bottom: $gutter-half;
 
     .form-control {
       @include box-sizing(border-box);

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -54,3 +54,37 @@
   background-color: $canvas-colour;
   padding: 0 20px 20px 20px;
 }
+
+.technical-documentation {
+  .entry-list {
+    list-style: none;
+    padding-left: 0;
+  }
+  .entry-list__item {
+    margin-top: 0;
+    margin-bottom: $gutter-half;
+  }
+  .entry-list__key {
+    display: block;
+  }
+  @include media(tablet) {
+    .entry-list {
+      display: table;
+    }
+    .entry-list__item {
+      display: table-row;
+    }
+    .entry-list__key,
+    .entry-list__value {
+      display: table-cell;
+    }
+    .entry-list__key {
+      width: 1%;
+      white-space: nowrap;
+      padding-right: $gutter;
+    }
+    .entry-list__value {
+      width: 100%;
+    }
+  }
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -85,10 +85,10 @@
     .entry-list__key {
       width: 1%;
       white-space: nowrap;
-      padding-right: $gutter;
     }
     .entry-list__value {
       width: 100%;
+      padding-left: $gutter;
     }
   }
 }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -42,6 +42,10 @@
   }
 }
 
+.grid-row {
+  @extend %grid-row;
+}
+
 .column-third {
   @include grid-column( 1/3 );
 }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -92,3 +92,12 @@
     }
   }
 }
+
+.visually-hidden {
+  position: absolute;
+  left: -9999em;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden
+}


### PR DESCRIPTION
- Aligns grid columns by adding `grid-row` class
- Adds label to search input for assistive tech
- Moves search input into the navigation so it uses the same padding and aligns, means it's hidden in the table contents dropdown smaller screens though 🤔 
- Update team tools sub heading so the IDs do not conflict

Before:

![screen shot 2017-04-19 at 11 47 07](https://cloud.githubusercontent.com/assets/2445413/25176712/0ece3c50-24f7-11e7-8439-3becd9b0b47c.png)

After:

![screen shot 2017-04-19 at 11 46 54](https://cloud.githubusercontent.com/assets/2445413/25176711/0ecb2272-24f7-11e7-8715-c34447ec41f8.png)

---

Before:

![screen shot 2017-04-19 at 11 50 23](https://cloud.githubusercontent.com/assets/2445413/25176713/0eceb5a4-24f7-11e7-80bd-25953e85e817.png)

After:

![screen shot 2017-04-19 at 11 50 12](https://cloud.githubusercontent.com/assets/2445413/25176715/0ecec940-24f7-11e7-98fc-5b12a2e31e95.png)

---

Before:

![screen shot 2017-04-19 at 11 53 51](https://cloud.githubusercontent.com/assets/2445413/25176714/0ece76ac-24f7-11e7-8393-0bf56e36dfac.png)

After:

![screen shot 2017-04-19 at 11 53 57](https://cloud.githubusercontent.com/assets/2445413/25176716/0ed01e4e-24f7-11e7-86a9-50aa72ccb706.png)
