### PR TITLE
Document search field definitions

### DIFF
--- a/app/search_api_docs.rb
+++ b/app/search_api_docs.rb
@@ -1,0 +1,13 @@
+class SearchApiReference
+  def self.fetch_field_definitions
+    contents = HTTP.get(
+      field_definitions_url,
+    )
+
+    JSON.parse(contents)
+  end
+
+  def self.field_definitions_url
+    "https://raw.githubusercontent.com/alphagov/rummager/master/config/schema/field_definitions.json"
+  end
+end

--- a/source/apis/search/fields.html.md.erb
+++ b/source/apis/search/fields.html.md.erb
@@ -1,0 +1,13 @@
+---
+layout: api_layout
+title: Search API field reference
+parent: /search-api.html
+source_url: https://github.com/alphagov/rummager/master/config/schema/field_definitions.json
+---
+
+Documents in an elasticsearch index have a type, and each type can have different fields.
+
+In Search API, the field is named `elasticsearch_type` to avoid confusion with [content_store_document_type](/document-types.html).
+
+## All fields
+<%= table_of_properties(SearchApiReference.fetch_field_definitions) %>

--- a/source/apis/search/search-api.html.md.erb
+++ b/source/apis/search/search-api.html.md.erb
@@ -5,4 +5,8 @@ parent: /apis.html
 source_url: https://github.com/alphagov/rummager/blob/master/docs/search-api.md
 ---
 
+> **This page was imported from the [docs directory](https://github.com/alphagov/rummager/blob/master/docs/) in the [rummager repo](https://github.com/alphagov/rummager/)**.
+
+> We're working on improving it.
+
 <%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'docs/search-api.md') %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -10,7 +10,10 @@
         <% end %>
       </ul>
     </li>
-    <li><%= sidebar_link 'Search API', '/apis/search-api.html' %></li>
+    <li><%= sidebar_link 'Search API', '/apis/search/search-api.html' %></li>
+    <ul>
+      <li><%= sidebar_link "Field reference", "/apis/search/fields.html" %></li>
+    </ul>
   </ul>
 <% end %>
 


### PR DESCRIPTION
This is a first stab at making the documentation better for rummager. I've added an autogenerated list of document fields.

This pulls descriptions out of the JSON file that configures the rummager schema.

I've also put a notice on the search api page itself as it's quite wordy and hasn't been updated for a long time. I'd like to split this information out into shorter pages, eg a quickstart for using the api, and a guide to using filters and facets.

I'm also wondering if the README itself would make a better landing page for the search API?
https://github.com/alphagov/rummager/blob/master/README.md