### PR TITLE
Make navigation more compact

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -8,11 +8,11 @@ description: Documentation for developers working on GOV.UK
 
 header_links:
   Dashboard: /
-  Getting started: /getting-started.html
-  Applications: /apps.html
-  Dev manual: /manual.html
-  API docs: /apis.html
-  Content schemas: /content-schemas.html
+  Get started: /getting-started.html
+  Apps: /apps.html
+  Manual: /manual.html
+  APIs: /apis.html
+  Schemas: /content-schemas.html
   Document types: /document-types.html
 
 ga_tracking_id: UA-91585274-1


### PR DESCRIPTION
The navigation bar contains too many things, making it wrap at ~1200px.

This changes the words to make it more compact. The page can now be viewed at ~1000px and not wrap.

<img width="925" alt="screen shot 2017-04-20 at 10 25 18" src="https://cloud.githubusercontent.com/assets/233676/25223652/e057a466-25b3-11e7-819f-476b32df871c.png">

![screen shot 2017-04-20 at 10 25 36](https://cloud.githubusercontent.com/assets/233676/25223693/fdc050ac-25b3-11e7-9171-f4cc3bf77d92.png)
