### PR TITLE
Add deployment dashboard links

### DIFF
--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -13,6 +13,8 @@ parent: "/manual.html"
 
 There are a number of applications with a dashboard showing useful information for the deployment process.
 
+They can be found in [Grafana](tools.html#grafana), and they are all named "Deployment dashboard - application name", such as [Deployment dashboard - whitehall](https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json).
+
 The existing deployment dashboards are written by puppet every 30 minutes and loaded when Grafana starts. Don’t change them directly.
 
 You can also see further tips on [how we use Graphite](graphite-and-deployment-dashboards.html) to present the data below.

--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -101,4 +101,4 @@ Graph showing the response time by controller over the dashboard time range.
 
 ## Deploy the Dashboards
 
-Please refer to [add a deployment dashboards](add-deployment-dashboard.html) for details on adding/updating dashboards.
+Please refer to [add a deployment dashboard](add-deployment-dashboard.html) for details on adding/updating dashboards.

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -74,6 +74,7 @@ Useful Grafana dashboards:
 
 - [Origin health](https://grafana.publishing.service.gov.uk/#/dashboard/file/origin_health.json)
 - [Edge health](https://grafana.publishing.service.gov.uk/#/dashboard/file/edge_health.json)
+- [Application deployment dashboards](deployment-dashboards.html)
 
 The full list of Grafana dashboards is [stored in the Puppet repo][dashboards]
 


### PR DESCRIPTION
Fix a typo and add a couple of links to help people find the deployment dashboards.