### PR TITLE
Correct link to deployment repo

### DIFF
--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -19,4 +19,5 @@ It hasn't been reviewed for accuracy yet.
 
 We use Heroku to host some non-critical applications.
 
-The credentials for Heroku are found in [gds/deployment](https://github.gds/gds/deployment/blob/master/pass/infra/heroku.gpg).
+The credentials for Heroku are found in
+[gds/deployment](https://github.gds/gds/deployment/blob/master/pass/2ndline/heroku.gpg).


### PR DESCRIPTION
heroku.gpg has moved to /2ndline.

I don't know if there's any other documentation we can link to here about using gpg.