### PR TITLE
Use "manual" throughout

### DIFF
--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -1,7 +1,7 @@
 <% html = yield %>
 
 <% content_for :sidebar do %>
-  <a href='/manual.html'>&lsaquo; Dev manual</a>
+  <a href='/manual.html'>&lsaquo; Manual</a>
   <%= table_of_contents html, max_level: 3 %>
 <% end %>
 

--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -1,6 +1,6 @@
 ---
 layout: false
-title: Dev manual
+title: Manual
 ---
 
 <% wrap_layout :header_footer_only do %>

--- a/source/manual/dictionary.html.erb
+++ b/source/manual/dictionary.html.erb
@@ -8,7 +8,7 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/di
 <% content_for :sidebar do %>
   <ul>
     <li>
-      <a href='/manual.html'>&lsaquo; Dev manual</a>
+      <a href='/manual.html'>&lsaquo; Manual</a>
       <%= link_to 'Dictionary', '/manual/dictionary.html' %>
       <ul>
       <% data.dictionary.each do |entry| %>

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -9,7 +9,7 @@ parent: "/manual.html"
 
 # Review a page in this manual
 
-How to review pages in the dev manual.
+How to review pages in this manual.
 
 ## Questions to ask
 


### PR DESCRIPTION
Manual is probably vague enough to accommodate all uses. Allows us to circumvent discussions around the naming of this particular section of the docs.

Supersedes https://github.com/alphagov/govuk-developer-docs/pull/144. 