### PR TITLE
Update create-a-gpg-key.html.md

### DIFF
--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -52,6 +52,7 @@ Send your key to a keyserver by doing:
 ```
 gpg --send-keys $KEYID
 ```
+If you are having problems uploading your key, it's worth trying another keyserver. Ultimately the uploaded key will be synced to the other keyservers so it doesn't matter which one you chose.
 
 You now should be able to find your key on <http://keys.gnupg.net/>
 


### PR DESCRIPTION
I followed the docs but got the following error when sending to the default keyserver (from gpgtools):

```
gpg: sending key XXXX to hkps server hkps.pool.sks-keyservers.net
gpgkeys: HTTP post error 60: SSL certificate problem: Invalid certificate chain
```

Updates the docs with a hint for anyone else running into this...