### PR TITLE
Add a redirect for the virus scanning page that Google has indexed

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -11,3 +11,4 @@ opsmanual/kibana.html: manual/kibana.html
 opsmanual/screens.html: manual/screens.html
 opsmanual/taxonomy.html: manual/taxonomy.html
 manual/docs-styleguide.html: manual/creating-pages.html
+manual/virus-scanning.html: manual/alerts/virus-scanning.html


### PR DESCRIPTION
- Google has indexed the old URL (`manual/virus-scanning.html`) and so
  it 404s. Redirect to what appears to be the actual page.