### PR TITLE
Change GPG Key server address

### DIFF
--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -52,9 +52,10 @@ Send your key to a keyserver by doing:
 ```
 gpg --send-keys $KEYID
 ```
-If you are having problems uploading your key, it's worth trying another keyserver. Ultimately the uploaded key will be synced to the other keyservers so it doesn't matter which one you chose.
+If you are having problems uploading your key, it's worth trying another keyserver. Those trying to receive your key may be connecting to a different keyserver than the one you sent your key to. This is fine, as the keyservers synchronise, but this may take some time to happen.
 
-You now should be able to find your key on <http://keys.gnupg.net/>
+You now should be able to find your key on <http://keys.gnupg.net:11371/>
 
-It occasionally takes a while for the keyserver to display pushed keys
-due to caching.
+It occasionally takes a while for the keyserver to display pushed keys due to caching.
+
+You can find an overview of the GPG keyserver pools [here](https://sks-keyservers.net/overview-of-pools.php)


### PR DESCRIPTION
Port number is required to send the user to the search page for that particular key server.

Also added a link to an overview about GPG key server pools.