### PR TITLE
Make review_by easier to work with

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'webmock', '~> 2.1'
 gem 'activesupport', '~> 5.0'
 gem 'govuk-lint', '~> 2.1'
 gem 'simplecov'
+gem 'chronic'
 
 # Middleman Gems
 gem 'middleman', '>= 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     chunky_png (1.3.8)
     coffee-script (2.4.1)
       coffee-script-source
@@ -236,6 +237,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.0)
   capybara
+  chronic
   faraday-http-cache (~> 2.0.0)
   faraday_middleware (~> 0.11.0)
   github-markdown

--- a/app/page_review.rb
+++ b/app/page_review.rb
@@ -1,0 +1,28 @@
+require 'chronic'
+
+class PageReview
+  attr_reader :page
+
+  def initialize(page)
+    @page = page
+  end
+
+  def reviewable?
+    page.data.review_in.present?
+  end
+
+  def expired?
+    reviewable? && Date.today > review_by
+  end
+
+  def expiring_soon?
+    reviewable? && Date.today > (review_by - 7.days)
+  end
+
+  def review_by
+    @review_by ||= Chronic.parse(
+      "in #{page.data.review_in}",
+      now: page.data.last_reviewed_at.to_time
+    ).to_date
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -51,6 +51,10 @@ helpers do
     ApplicationsByTeam.teams
   end
 
+  def page_review
+    @page_review ||= PageReview.new(current_page)
+  end
+
   require 'table_of_contents/helpers'
   include TableOfContents::Helpers
 end

--- a/lib/page_freshness.rb
+++ b/lib/page_freshness.rb
@@ -11,13 +11,13 @@ class PageFreshness
 
   def expired_pages
     sitemap.resources.select do |page|
-      page.data.review_by && Date.today > page.data.review_by
+      PageReview.new(page).expired?
     end
   end
 
   def expiring_soon
     soon = sitemap.resources.select do |page|
-      page.data.review_by && Date.today > (page.data.review_by - 7.days)
+      PageReview.new(page).expiring_soon?
     end
 
     soon - expired_pages
@@ -28,7 +28,7 @@ class PageFreshness
       {
         title: page.data.title,
         url: "https://docs.publishing.service.gov.uk#{page.url}",
-        review_by: page.data.review_by,
+        review_by: PageReview.new(page).review_by,
         owner_slack: page.data.owner_slack,
       }
     end

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -18,9 +18,9 @@
 
     <div class="app-pane__content toc-open-disabled">
       <main id="content" class="technical-documentation" data-module="anchored-headings">
-        <% if current_page.data.review_by && Date.today > current_page.data.review_by  %>
+        <% if page_review.expired? %>
           <div class='warning'>
-            This page was set to be reviewed before <%= current_page.data.review_by %>
+            This page was set to be reviewed before <%= page_review.review_by %>
             by the page owner: <%= current_page.data.owner_slack %>. This might mean the
             content is out of date. <%= link_to "Read how to review a page", "/manual/review-page.html" %>
           </div>

--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -1,10 +1,11 @@
 ---
 title: Run an A/B test
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Tools
 owner_slack: "@tijmen"
-review_by: 2017-06-01
+last_reviewed_at: 2016-12-01
+review_in: 6 months
 ---
 
 # Run an A/B test

--- a/source/manual/add-an-icinga-passive-check.md
+++ b/source/manual/add-an-icinga-passive-check.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-08
+owner_slack: "#2ndline"
 title: Add an Icinga passive check to a Jenkins job
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/add_a_passive_check_to_jenkins.md"
+last_reviewed_at: 2017-03-08
+review_in: 6 months
 ---
 
 

--- a/source/manual/add-deployment-dashboard.html.md
+++ b/source/manual/add-deployment-dashboard.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#search-team'
-review_by: 2017-10-27
+owner_slack: "#search-team"
 title: Add a deployment dashboard for an application
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-04-27
+review_in: 6 months
 ---
 
 # Add a deployment dashboard for an application

--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-08
+owner_slack: "#2ndline"
 title: Add a disk to a vCloud machine
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/adding-disks-in-vcloud.md"
+last_reviewed_at: 2017-04-08
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/asset-master-attachment-processing.html.md
+++ b/source/manual/alerts/asset-master-attachment-processing.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-11-01
-title: 'Asset master attachment processing'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Asset master attachment processing
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-05-01
+review_in: 6 months
 ---
 
 # asset master attachment processing

--- a/source/manual/alerts/aws-ses-email-quota.html.md
+++ b/source/manual/alerts/aws-ses-email-quota.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-13
-title: 'AWS SES quota usage higher than expected'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: AWS SES quota usage higher than expected
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-13
+review_in: 6 months
 ---
 
 # AWS SES quota usage higher than expected

--- a/source/manual/alerts/clamav-definitions-out-of-date.html.md
+++ b/source/manual/alerts/clamav-definitions-out-of-date.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-26
-title: 'ClamAV definitions out of date'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: ClamAV definitions out of date
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-26
+review_in: 6 months
 ---
 
 # ClamAV definitions out of date

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-17
+owner_slack: "#2ndline"
 title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/data-sync.md"
+last_reviewed_at: 2017-02-17
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/defined-cpu-type-does-not-match.html.md
+++ b/source/manual/alerts/defined-cpu-type-does-not-match.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-08
-title: 'defined cpu type does not match'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: defined cpu type does not match
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-08
+review_in: 6 months
 ---
 
 # defined cpu type does not match

--- a/source/manual/alerts/duplicate-ssh-host-keys.html.md
+++ b/source/manual/alerts/duplicate-ssh-host-keys.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-06
-title: 'duplicate SSH host keys'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: duplicate SSH host keys
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-06
+review_in: 6 months
 ---
 
 # 'duplicate SSH host keys'

--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-01
-title: 'Elasticsearch cluster health'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Elasticsearch cluster health
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-01
+review_in: 6 months
 ---
 
 # Elasticsearch cluster health

--- a/source/manual/alerts/elasticsearch-not-receiving-syslog.html.md
+++ b/source/manual/alerts/elasticsearch-not-receiving-syslog.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-08
+owner_slack: "#2ndline"
 title: 'Elasticsearch: not receiving syslog from logstash'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-08
+review_in: 6 months
 ---
 
 # Elasticsearch: not receiving syslog from logstash

--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-03
-title: 'Email Alerts'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Email Alerts
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-04-03
+review_in: 6 months
 ---
 
 # Email Alerts

--- a/source/manual/alerts/es-rotate.html.md
+++ b/source/manual/alerts/es-rotate.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-05
-title: 'es-rotate'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: es-rotate
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-01-05
+review_in: 6 months
 ---
 
 # es-rotate

--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-07
+owner_slack: "#2ndline"
 title: Fastly error rate for GOV.UK
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/fastly-error-rate.md"
+last_reviewed_at: 2017-01-07
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-24
-title: 'Fetch analytics data for search failed'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Fetch analytics data for search failed
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-24
+review_in: 6 months
 ---
 
 # Fetch analytics data for search failed

--- a/source/manual/alerts/free-memory-warning-on-backend.html.md
+++ b/source/manual/alerts/free-memory-warning-on-backend.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-11
-title: 'Free memory warning on backend'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Free memory warning on backend
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-11
+review_in: 6 months
 ---
 
 # Free memory warning on backend

--- a/source/manual/alerts/github-enterprise-connectivity.html.md
+++ b/source/manual/alerts/github-enterprise-connectivity.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-10
+owner_slack: "#2ndline"
 title: GitHub Enterprise connectivity
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/github-enterprise-connectivity.md"
+last_reviewed_at: 2017-03-10
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/gor.html.md
+++ b/source/manual/alerts/gor.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-16
+owner_slack: "#2ndline"
 title: Gor
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/gor.md"
+last_reviewed_at: 2017-03-16
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/high-disk-time.html.md
+++ b/source/manual/alerts/high-disk-time.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-18
-title: 'high disk time'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: high disk time
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-18
+review_in: 6 months
 ---
 
 # 'high disk time'

--- a/source/manual/alerts/high-zombie-procs.html.md
+++ b/source/manual/alerts/high-zombie-procs.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-05
-title: 'high zombie procs'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: high zombie procs
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-04-05
+review_in: 6 months
 ---
 
 # 'high zombie procs'

--- a/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
+++ b/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-05
-title: 'Logs are not being received from the CDN'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Logs are not being received from the CDN
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-05
+review_in: 6 months
 ---
 
 # Logs are not being received from the CDN

--- a/source/manual/alerts/low-available-disk-inodes.html.md
+++ b/source/manual/alerts/low-available-disk-inodes.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-29
-title: 'Low available disk inodes'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Low available disk inodes
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-29
+review_in: 6 months
 ---
 
 # Low available disk inodes

--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-16
-title: 'Low available disk space'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Low available disk space
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-16
+review_in: 6 months
 ---
 
 # Low available disk space

--- a/source/manual/alerts/mongod-replication-lag.html.md
+++ b/source/manual/alerts/mongod-replication-lag.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-27
-title: 'mongod replication lag'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: mongod replication lag
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-27
+review_in: 6 months
 ---
 
 # 'mongod replication lag'

--- a/source/manual/alerts/mongodb-rollback.html.md
+++ b/source/manual/alerts/mongodb-rollback.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-28
-title: 'MongoDB rollback'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: MongoDB rollback
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-28
+review_in: 6 months
 ---
 
 # MongoDB rollback

--- a/source/manual/alerts/mysql-replication-lag.html.md
+++ b/source/manual/alerts/mysql-replication-lag.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-20
+owner_slack: "#2ndline"
 title: 'MySQL: replication lag'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-20
+review_in: 6 months
 ---
 
 # MySQL: replication lag

--- a/source/manual/alerts/mysql-replication-running.html.md
+++ b/source/manual/alerts/mysql-replication-running.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-21
+owner_slack: "#2ndline"
 title: 'MySQL: replication running'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-21
+review_in: 6 months
 ---
 
 # MySQL: replication running

--- a/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
+++ b/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-06
-title: 'MySQL Xtrabackups to S3'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: MySQL Xtrabackups to S3
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-01-06
+review_in: 6 months
 ---
 
 # MySQL Xtrabackups to S3

--- a/source/manual/alerts/nginx-5xx-rate-too-high-for-many-apps-boxes.html.md
+++ b/source/manual/alerts/nginx-5xx-rate-too-high-for-many-apps-boxes.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-04
-title: 'nginx 5xx rate too high for many apps/boxes'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: nginx 5xx rate too high for many apps/boxes
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-04
+review_in: 6 months
 ---
 
 # "nginx 5xx rate too high" for many apps/boxes

--- a/source/manual/alerts/nginx-high-conn-writing-upstream-indicator-check.html.md
+++ b/source/manual/alerts/nginx-high-conn-writing-upstream-indicator-check.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-06
-title: 'nginx high conn writing -- upstream indicator Check'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: nginx high conn writing -- upstream indicator Check
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-01-06
+review_in: 6 months
 ---
 
 # 'nginx high conn writing -- upstream indicator' Check

--- a/source/manual/alerts/nginx-requests-too-low.html.md
+++ b/source/manual/alerts/nginx-requests-too-low.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-20
-title: 'nginx requests too low'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: nginx requests too low
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-20
+review_in: 6 months
 ---
 
 # 'nginx requests too low'

--- a/source/manual/alerts/ntp-drift-too-high.html.md
+++ b/source/manual/alerts/ntp-drift-too-high.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-02
-title: 'ntp drift too high'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: ntp drift too high
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-01-02
+review_in: 6 months
 ---
 
 # 'ntp drift too high'

--- a/source/manual/alerts/offsite-backups.html.md
+++ b/source/manual/alerts/offsite-backups.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-15
-title: 'Offsite backups'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Offsite backups
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-15
+review_in: 6 months
 ---
 
 # Offsite backups

--- a/source/manual/alerts/onsite-backups.html.md
+++ b/source/manual/alerts/onsite-backups.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-06
-title: 'Onsite backups'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Onsite backups
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-06
+review_in: 6 months
 ---
 
 # Onsite backups

--- a/source/manual/alerts/outstanding-security-updates.html.md
+++ b/source/manual/alerts/outstanding-security-updates.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-17
-title: 'Outstanding security updates'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Outstanding security updates
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-17
+review_in: 6 months
 ---
 
 # 'Outstanding security updates'

--- a/source/manual/alerts/pagerduty-drill.html.md
+++ b/source/manual/alerts/pagerduty-drill.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-30
-title: 'PagerDuty drill'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: PagerDuty drill
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-01-30
+review_in: 6 months
 ---
 
 # PagerDuty drill

--- a/source/manual/alerts/pingdom-homepage-check.html.md
+++ b/source/manual/alerts/pingdom-homepage-check.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-17
-title: 'Pingdom homepage check'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Pingdom homepage check
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-17
+review_in: 6 months
 ---
 
 # Pingdom homepage check

--- a/source/manual/alerts/pingdom-search-check.html.md
+++ b/source/manual/alerts/pingdom-search-check.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-04
-title: 'Pingdom search check'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Pingdom search check
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-04
+review_in: 6 months
 ---
 
 # Pingdom search check

--- a/source/manual/alerts/postgresql-replication-too-far-behind.html.md
+++ b/source/manual/alerts/postgresql-replication-too-far-behind.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-14
+owner_slack: "#2ndline"
 title: 'PostgreSQL: replication too far behind'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-14
+review_in: 6 months
 ---
 
 # PostgreSQL: replication too far behind

--- a/source/manual/alerts/postgresql-s3-backups.html.md
+++ b/source/manual/alerts/postgresql-s3-backups.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-09
+owner_slack: "#2ndline"
 title: 'PostgreSQL: S3 Backups'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-09
+review_in: 6 months
 ---
 
 # PostgreSQL: S3 Backups

--- a/source/manual/alerts/prolonged-gc-collection-times-check.html.md
+++ b/source/manual/alerts/prolonged-gc-collection-times-check.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-11
-title: 'Prolonged GC collection times Check'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Prolonged GC collection times Check
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-11
+review_in: 6 months
 ---
 
 # 'Prolonged GC collection times' Check

--- a/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-04
-title: 'publisher app health check not ok'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: publisher app health check not ok
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-04
+review_in: 6 months
 ---
 
 # 'publisher app health check not ok'

--- a/source/manual/alerts/rabbitmq-high-watermark.html.md
+++ b/source/manual/alerts/rabbitmq-high-watermark.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-29
+owner_slack: "#2ndline"
 title: 'RabbitMQ: high watermark has been exceeded'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-29
+review_in: 6 months
 ---
 
 # RabbitMQ: high watermark has been exceeded

--- a/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
+++ b/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-10
+owner_slack: "#2ndline"
 title: 'RabbitMQ: No consumers listening to queue'
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-10
+review_in: 6 months
 ---
 
 # RabbitMQ: No consumers listening to queue

--- a/source/manual/alerts/reboot-required-by-apt.html.md
+++ b/source/manual/alerts/reboot-required-by-apt.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-12
-title: 'reboot required by apt'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: reboot required by apt
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-12
+review_in: 6 months
 ---
 
 # 'reboot required by apt'

--- a/source/manual/alerts/redis.html.md
+++ b/source/manual/alerts/redis.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-12
+owner_slack: "#2ndline"
 title: Redis alerts
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/redis.md"
+last_reviewed_at: 2017-03-12
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/rkhunter-warnings.html.md
+++ b/source/manual/alerts/rkhunter-warnings.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-27
-title: 'rkhunter warnings'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: rkhunter warnings
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-27
+review_in: 6 months
 ---
 
 # rkhunter warnings

--- a/source/manual/alerts/root-filesystem-is-readonly.html.md
+++ b/source/manual/alerts/root-filesystem-is-readonly.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-27
-title: 'root filesystem is readonly'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: root filesystem is readonly
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-27
+review_in: 6 months
 ---
 
 # root filesystem is readonly

--- a/source/manual/alerts/ruby-version.html.md
+++ b/source/manual/alerts/ruby-version.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-24
+owner_slack: "#2ndline"
 title: App isn't running the expected Ruby version
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/ruby-version.md"
+last_reviewed_at: 2016-12-24
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/search-benchmarking.html.md
+++ b/source/manual/alerts/search-benchmarking.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#search-team'
-review_by: 2017-06-26
-title: 'Benchmark search queries failed'
-parent: /manual.html
+owner_slack: "#search-team"
+title: Benchmark search queries failed
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-26
+review_in: 6 months
 ---
 
 # Benchmark search queries failed

--- a/source/manual/alerts/search-spelling-suggestions.html.md
+++ b/source/manual/alerts/search-spelling-suggestions.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#search-team'
-review_by: 2017-06-26
-title: 'Check for spelling suggestions failed'
-parent: /manual.html
+owner_slack: "#search-team"
+title: Check for spelling suggestions failed
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-26
+review_in: 6 months
 ---
 
 # Check for spelling suggestions failed

--- a/source/manual/alerts/unicorn-herder.html.md
+++ b/source/manual/alerts/unicorn-herder.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-30
-title: 'Unicorn Herder'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Unicorn Herder
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-12-30
+review_in: 6 months
 ---
 
 # Unicorn Herder

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-16
-title: 'Varnish port not responding'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Varnish port not responding
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2016-11-16
+review_in: 6 months
 ---
 
 # Varnish port not responding

--- a/source/manual/alerts/virus-scanning.html.md
+++ b/source/manual/alerts/virus-scanning.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-27
+owner_slack: "#2ndline"
 title: Fix stuck virus scanning
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/virus-scanning.md"
+last_reviewed_at: 2016-12-27
+review_in: 6 months
 ---
 
 

--- a/source/manual/alerts/vpn-down.html.md
+++ b/source/manual/alerts/vpn-down.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-11
-title: 'VPN down'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: VPN down
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-11
+review_in: 6 months
 ---
 
 # VPN down

--- a/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-24
-title: 'whitehall app health check not ok'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: whitehall app health check not ok
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-02-24
+review_in: 6 months
 ---
 
 # whitehall app health check not ok

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-19
-title: 'Whitehall scheduled publishing'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Whitehall scheduled publishing
+parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
+last_reviewed_at: 2017-03-19
+review_in: 6 months
 ---
 
 # Whitehall scheduled publishing

--- a/source/manual/archiving-and-redirecting-content.html.md
+++ b/source/manual/archiving-and-redirecting-content.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-24
+owner_slack: "#2ndline"
 title: Archive and redirect mainstream content to other pages on GOV.UK
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/archiving-and-redirecting-content.md"
+last_reviewed_at: 2017-03-24
+review_in: 6 months
 ---
 
 

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-26
-title: "Assets: how they work"
+owner_slack: "#2ndline"
+title: 'Assets: how they work'
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/architecture/assets.md"
+last_reviewed_at: 2017-03-26
+review_in: 6 months
 ---
 
 

--- a/source/manual/attachments.html.md
+++ b/source/manual/attachments.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-08
+owner_slack: "#2ndline"
 title: Attachment backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/backups/attachments.md"
+last_reviewed_at: 2017-01-08
+review_in: 6 months
 ---
 
 # Attachment backups

--- a/source/manual/blocking-apps-from-release.html.md
+++ b/source/manual/blocking-apps-from-release.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-03
+owner_slack: "#2ndline"
 title: Block apps from being deployed
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/blocking-apps-from-release.md"
+last_reviewed_at: 2016-11-03
+review_in: 6 months
 ---
 
 

--- a/source/manual/cache-flush.html.md
+++ b/source/manual/cache-flush.html.md
@@ -1,12 +1,13 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-08
+owner_slack: "#2ndline"
 title: Purge a page from cache
 section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/cache-flush.md"
 important: true
+last_reviewed_at: 2017-01-08
+review_in: 6 months
 ---
 
 

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-01
+owner_slack: "#2ndline"
 title: Our content delivery network (CDN)
 section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-04-01
+review_in: 6 months
 ---
 
 # Our content delivery network (CDN)

--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-11-01
+owner_slack: "#2ndline"
 title: Change an organisation's slug
 parent: "/manual.html"
 layout: manual_layout
 section: Routing
+last_reviewed_at: 2017-05-01
+review_in: 6 months
 ---
 
 # Change an organisation's slug

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-15
+owner_slack: "#2ndline"
 title: Check for a `gone` route
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/check-for-gone-route.md"
+last_reviewed_at: 2017-03-15
+review_in: 6 months
 ---
 
 

--- a/source/manual/clone-mysql-slave.html.md
+++ b/source/manual/clone-mysql-slave.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-15
+owner_slack: "#2ndline"
 title: Clone a MySQL instance from one slave to another
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/clone-mysql-slave.md"
+last_reviewed_at: 2016-11-15
+review_in: 6 months
 ---
 
 

--- a/source/manual/content-preview.html.md
+++ b/source/manual/content-preview.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-04
+owner_slack: "#2ndline"
 title: How the draft stack works
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Publishing
+last_reviewed_at: 2017-01-04
+review_in: 6 months
 ---
 
 # How the draft stack works

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-01
+owner_slack: "#2ndline"
 title: Create a GPG key
 parent: "/manual.html"
 layout: manual_layout
 section: Support
+last_reviewed_at: 2017-04-01
+review_in: 6 months
 ---
 
 # Create a GPG key

--- a/source/manual/create-a-new-open-source-project.html.md
+++ b/source/manual/create-a-new-open-source-project.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-30
+owner_slack: "#2ndline"
 title: Create a new open source project
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/create-a-new-open-source-project.md"
+last_reviewed_at: 2017-01-30
+review_in: 6 months
 ---
 
 

--- a/source/manual/create-page.html.md
+++ b/source/manual/create-page.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-09
+owner_slack: "#2ndline"
 title: Create a page in this manual
 section: Manual
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-02-09
+review_in: 6 months
 ---
 
 # Create a page in this manual

--- a/source/manual/creating-a-new-environment.html.md
+++ b/source/manual/creating-a-new-environment.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#infrastructure'
-review_by: 2019-01-01
+owner_slack: "#infrastructure"
 title: Create a new environment for GOV.UK
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2018-07-01
+review_in: 6 months
 ---
 
 > It's possible this page is out of date, but it's is still relevant if we ever need to rebuild a VMWare vCloud environment somewhere.

--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-09
+owner_slack: "#2ndline"
 title: Debian packaging
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/debian-packaging.md"
+last_reviewed_at: 2016-12-09
+review_in: 6 months
 ---
 
 

--- a/source/manual/deploy-puppet.html.md
+++ b/source/manual/deploy-puppet.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-09
+owner_slack: "#2ndline"
 title: Deploy Puppet
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/deploy-puppet.md"
+last_reviewed_at: 2017-02-09
+review_in: 6 months
 ---
 
 

--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-02
+owner_slack: "#2ndline"
 title: Deploy an application to GOV.UK
 parent: "/manual.html"
 layout: manual_layout
 section: Deployment
 important: true
+last_reviewed_at: 2017-02-02
+review_in: 6 months
 ---
 
 # Deploy an application to GOV.UK

--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#search-team'
-review_by: 2017-10-27
+owner_slack: "#search-team"
 title: Monitor your app during deployment
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-04-27
+review_in: 6 months
 ---
 
 # Monitor your app during deployment

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-04
+owner_slack: "#2ndline"
 title: Domain Name System (DNS) records
 section: DNS
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/dns.md"
+last_reviewed_at: 2016-11-04
+review_in: 6 months
 ---
 
 # Domain Name System (DNS) records

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-10
+owner_slack: "#2ndline"
 title: Edit an existing route in the Router
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/editing-an-existing-route.md"
+last_reviewed_at: 2017-02-10
+review_in: 6 months
 ---
 
 

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-06
-title: "Elasticsearch: dump and restore indices"
+owner_slack: "#2ndline"
+title: 'Elasticsearch: dump and restore indices'
 parent: "/manual.html"
 layout: manual_layout
 section: Backups
+last_reviewed_at: 2017-04-06
+review_in: 6 months
 ---
 
 # Elasticsearch: dump and restore indices

--- a/source/manual/emergency-publishing-redis.html.md
+++ b/source/manual/emergency-publishing-redis.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-17
+owner_slack: "#2ndline"
 title: Deploy emergency publishing banners with Redis
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 important: true
+last_reviewed_at: 2017-02-17
+review_in: 6 months
 ---
 
 # Deploy emergency publishing banners

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-17
+owner_slack: "#2ndline"
 title: Deploy emergency publishing banners
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 important: true
+last_reviewed_at: 2017-02-17
+review_in: 6 months
 ---
 
 # Deploy emergency publishing banners

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-13
+owner_slack: "#2ndline"
 title: Handle encrypted hieradata
 parent: "/manual.html"
 layout: manual_layout
 section: Deployment
+last_reviewed_at: 2017-01-13
+review_in: 6 months
 ---
 # Handle encrypted hieradata
 

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-11
+owner_slack: "#2ndline"
 title: GOV.UK's environments (integration, staging, production)
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/architecture/environments.md"
+last_reviewed_at: 2017-02-11
+review_in: 6 months
 ---
 
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -1,10 +1,11 @@
 ---
-title: "Fall back to the static mirrors"
+title: Fall back to the static mirrors
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-owner_slack: '#2ndline'
-review_by: 2017-10-01
+owner_slack: "#2ndline"
+last_reviewed_at: 2017-04-01
+review_in: 6 months
 ---
 
 # Fall back to the static mirrors

--- a/source/manual/gds-hubot.html.md
+++ b/source/manual/gds-hubot.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-13
+owner_slack: "#2ndline"
 title: Update Hubot (Slack bot)
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/gds-hubot.md"
+last_reviewed_at: 2017-02-13
+review_in: 6 months
 ---
 
 

--- a/source/manual/generate-csr.html.md
+++ b/source/manual/generate-csr.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-24
+owner_slack: "#2ndline"
 title: Generate a Certificate Signing Request (CSR) for GOV.UK
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/generate-csr.md"
+last_reviewed_at: 2017-02-24
+review_in: 6 months
 ---
 
 

--- a/source/manual/github-enterprise.html.md
+++ b/source/manual/github-enterprise.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-08
+owner_slack: "#2ndline"
 title: GitHub Enterprise
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/github-enterprise/index.md"
+last_reviewed_at: 2017-03-08
+review_in: 6 months
 ---
 
 

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-18
+owner_slack: "#2ndline"
 title: Deploy when GitHub is unavailable
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/github-unavailable.md"
+last_reviewed_at: 2016-12-18
+review_in: 6 months
 ---
 
 

--- a/source/manual/graphite-and-deployment-dashboards.html.md
+++ b/source/manual/graphite-and-deployment-dashboards.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-09
-title: "Graphite and deployment dashboards"
+owner_slack: "#2ndline"
+title: Graphite and deployment dashboards
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-03-09
+review_in: 6 months
 ---
 
 # Graphite and deployment dashboards

--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2018-01-01
+owner_slack: "#2ndline"
 title: Access apps on the shared Heroku account
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-07-01
+review_in: 6 months
 ---
 
 # Access apps on the shared Heroku account

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-22
+owner_slack: "#2ndline"
 title: Upload HMRC PAYE files
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/hmrc-paye-files.md"
+last_reviewed_at: 2016-11-22
+review_in: 6 months
 ---
 
 

--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-28
+owner_slack: "#2ndline"
 title: Remove an asset
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/howto-manually-remove-assets.md"
+last_reviewed_at: 2017-02-28
+review_in: 6 months
 ---
 
 

--- a/source/manual/howto-switch-off-app.html.md
+++ b/source/manual/howto-switch-off-app.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-06
+owner_slack: "#2ndline"
 title: Switch an app off
 layout: manual_layout
 section: Packaging
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/howto-switch-off-app.md"
+last_reviewed_at: 2016-12-06
+review_in: 6 months
 ---
 
 

--- a/source/manual/howto-transition-a-site-to-govuk.html.md
+++ b/source/manual/howto-transition-a-site-to-govuk.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-26
+owner_slack: "#2ndline"
 title: Transition a site to GOV.UK
 section: Transition
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/howto-transition-a-site-to-govuk.md"
+last_reviewed_at: 2017-01-26
+review_in: 6 months
 ---
 
 

--- a/source/manual/howto-update-pingdom-ip-ranges.html.md
+++ b/source/manual/howto-update-pingdom-ip-ranges.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-31
+owner_slack: "#2ndline"
 title: Update Pingdom IP Ranges
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-01-31
+review_in: 6 months
 ---
 
 # Update Pingdom IP Ranges

--- a/source/manual/howto-upload-an-asset-to-asset-manager.html.md
+++ b/source/manual/howto-upload-an-asset-to-asset-manager.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-23
+owner_slack: "#2ndline"
 title: Upload an asset to asset-manager
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/howto-upload-an-asset-to-asset-manager.md"
+last_reviewed_at: 2017-03-23
+review_in: 6 months
 ---
 
 

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-28
+owner_slack: "#2ndline"
 title: Jenkins CI infrastructure
 parent: "/manual.html"
 layout: manual_layout
 section: Testing
+last_reviewed_at: 2016-12-28
+review_in: 6 months
 ---
 
 # Jenkins CI infrastructure

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-30
+owner_slack: "#2ndline"
 title: Keeping software current
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Tools
+last_reviewed_at: 2017-01-30
+review_in: 6 months
 ---
 
 # Keeping software current

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-18
+owner_slack: "#2ndline"
 title: Useful Kibana queries
 layout: manual_layout
 parent: "/manual.html"
 section: Logging
 important: true
+last_reviewed_at: 2017-02-18
+review_in: 6 months
 ---
 
 # Useful Kibana queries

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-21
+owner_slack: "#2ndline"
 title: How logging works on GOV.UK
 section: Logging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/logging/index.md"
+last_reviewed_at: 2017-02-21
+review_in: 6 months
 ---
 
 

--- a/source/manual/manage-sign-on-accounts.html.md
+++ b/source/manual/manage-sign-on-accounts.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-11
+owner_slack: "#2ndline"
 title: Manage sign on accounts
 section: Support
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2016-12-11
+review_in: 6 months
 ---
 
 # Manage signon accounts

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-04
+owner_slack: "#2ndline"
 title: MongoDB backups
 layout: manual_layout
 parent: "/manual.html"
 section: Backups
+last_reviewed_at: 2016-12-04
+review_in: 6 months
 ---
 
 # MongoDB backups

--- a/source/manual/mysql.html.md
+++ b/source/manual/mysql.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-04
+owner_slack: "#2ndline"
 title: MySQL backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/backups/mysql.md"
+last_reviewed_at: 2017-02-04
+review_in: 6 months
 ---
 
 # MySQL backups

--- a/source/manual/nagios-nrpe-connection-failures.html.md
+++ b/source/manual/nagios-nrpe-connection-failures.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-12
+owner_slack: "#2ndline"
 title: Nagios NRPE connection failures
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-02-12
+review_in: 6 months
 ---
 
 # Nagios NRPE connection failures

--- a/source/manual/offsite-backup-and-restore.html.md
+++ b/source/manual/offsite-backup-and-restore.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-28
+owner_slack: "#2ndline"
 title: Offsite backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/offsite-backup-and-restore.md"
+last_reviewed_at: 2017-01-28
+review_in: 6 months
 ---
 
 

--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-20
+owner_slack: "#2ndline"
 title: Out of hours support (on-call)
 section: Support
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/on-call.md"
+last_reviewed_at: 2017-03-20
+review_in: 6 months
 ---
 
 

--- a/source/manual/packer-vagrant-image-creation.html.md
+++ b/source/manual/packer-vagrant-image-creation.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-13
+owner_slack: "#2ndline"
 title: Packer Vagrant Dev VM / Image Creation
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/packer-vagrant-image-creation.md"
+last_reviewed_at: 2017-01-13
+review_in: 6 months
 ---
 
 

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-04
+owner_slack: "#2ndline"
 title: Pact Broker
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/introductions/pact_broker.md"
+last_reviewed_at: 2016-11-04
+review_in: 6 months
 ---
 
 

--- a/source/manual/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/pingdom-bouncer-canary-check.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-08
-title: 'Pingdom Bouncer canary check'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Pingdom Bouncer canary check
+parent: "/manual.html"
 layout: manual_layout
 section: Monitoring
+last_reviewed_at: 2017-02-08
+review_in: 6 months
 ---
 
 # Pingdom Bouncer canary check

--- a/source/manual/postgresql.html.md
+++ b/source/manual/postgresql.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-18
+owner_slack: "#2ndline"
 title: PostgreSQL backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/backups/postgresql.md"
+last_reviewed_at: 2017-02-18
+review_in: 6 months
 ---
 
 # PostgreSQL backups

--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-30
+owner_slack: "#2ndline"
 title: Publish to Puppet Forge
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/publish-to-puppet-forge.md"
+last_reviewed_at: 2017-03-30
+review_in: 6 months
 ---
 
 

--- a/source/manual/puppet-class-assignment.html.md
+++ b/source/manual/puppet-class-assignment.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-22
+owner_slack: "#2ndline"
 title: Puppet Class Assignment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/puppet-class-assignment.md"
+last_reviewed_at: 2017-02-22
+review_in: 6 months
 ---
 
 

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-25
+owner_slack: "#2ndline"
 title: RabbitMQ
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/rabbitmq.md"
+last_reviewed_at: 2017-02-25
+review_in: 6 months
 ---
 
 # RabbitMQ

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -1,12 +1,13 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-14
+owner_slack: "#2ndline"
 title: Reboot a machine
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/rebooting-machines.md"
 important: true
+last_reviewed_at: 2017-02-14
+review_in: 6 months
 ---
 
 

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-12
+owner_slack: "#2ndline"
 title: Redirect a route
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/redirect-routes.md"
+last_reviewed_at: 2016-12-12
+review_in: 6 months
 ---
 
 

--- a/source/manual/redirecting-content-in-the-router.html.md
+++ b/source/manual/redirecting-content-in-the-router.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-16
+owner_slack: "#2ndline"
 title: Redirect content in the Router
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/redirecting-content-in-the-router.md"
+last_reviewed_at: 2016-12-16
+review_in: 6 months
 ---
 
 

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-22
+owner_slack: "#2ndline"
 title: Remove a machine
 parent: "/manual.html"
 layout: manual_layout
 section: Environments
+last_reviewed_at: 2017-03-22
+review_in: 6 months
 ---
 
 # Remove a machine

--- a/source/manual/reprovision.html.md
+++ b/source/manual/reprovision.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-29
+owner_slack: "#2ndline"
 title: Reprovision a machine in vCloud Director
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/reprovision.md"
+last_reviewed_at: 2017-01-29
+review_in: 6 months
 ---
 
 

--- a/source/manual/resync-mongo-db.html.md
+++ b/source/manual/resync-mongo-db.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-18
+owner_slack: "#2ndline"
 title: Resync a Mongo database
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/resync-mongo-db.md"
+last_reviewed_at: 2016-11-18
+review_in: 6 months
 ---
 
 

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-01
+owner_slack: "#2ndline"
 title: Retire an application
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/retiring-an-application.md"
+last_reviewed_at: 2017-03-01
+review_in: 6 months
 ---
 
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.

--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-20
+owner_slack: "#2ndline"
 title: Set up Heroku review apps for pull requests
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2016-11-20
+review_in: 6 months
 ---
 
 # Set up Heroku review apps for pull requests

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-09
+owner_slack: "#2ndline"
 title: Review a page in this manual
 section: Manual
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-02-09
+review_in: 6 months
 ---
 
 # Review a page in this manual

--- a/source/manual/rotate-offsite-backup-gpg-keys.html.md
+++ b/source/manual/rotate-offsite-backup-gpg-keys.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-25
+owner_slack: "#2ndline"
 title: Rotate offsite backup GPG keys
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/rotate-offsite-backup-gpg-keys.md"
+last_reviewed_at: 2016-12-25
+review_in: 6 months
 ---
 
 

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-09
+owner_slack: "#2ndline"
 title: Add a new Ruby version
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/ruby.md"
+last_reviewed_at: 2016-12-09
+review_in: 6 months
 ---
 
 

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -1,12 +1,13 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-21
+owner_slack: "#2ndline"
 title: Run a rake task
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/running-rake-tasks.md"
 important: true
+last_reviewed_at: 2016-12-21
+review_in: 6 months
 ---
 
 

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-14
+owner_slack: "#2ndline"
 title: Monitoring screens
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Tools
+last_reviewed_at: 2017-03-14
+review_in: 6 months
 ---
 
 # Monitoring screens

--- a/source/manual/setting-up-new-mirror.html.md
+++ b/source/manual/setting-up-new-mirror.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-12
+owner_slack: "#2ndline"
 title: Set up a new mirror for GOV.UK
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setting-up-new-mirror.md"
+last_reviewed_at: 2017-03-12
+review_in: 6 months
 ---
 
 

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-16
+owner_slack: "#2ndline"
 title: Set up a new Rails app
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setting-up-new-rails-app.md"
+last_reviewed_at: 2017-01-16
+review_in: 6 months
 ---
 
 

--- a/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
+++ b/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-31
+owner_slack: "#2ndline"
 title: Add sidekiq-monitoring to your application
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setting-up-new-sidekiq-monitoring-app.md"
+last_reviewed_at: 2017-02-28
+review_in: 6 months
 ---
 
 

--- a/source/manual/setting-up-request-tracing.html.md
+++ b/source/manual/setting-up-request-tracing.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-13
+owner_slack: "#2ndline"
 title: Set up request tracing
 section: Logging
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-04-13
+review_in: 6 months
 ---
 
 # Set up request tracing

--- a/source/manual/setup-postgresql-replication.html.md
+++ b/source/manual/setup-postgresql-replication.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-08-26
+owner_slack: "#2ndline"
 title: Set up PostgreSQL replication
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setup-postgresql-replication.md"
+last_reviewed_at: 2017-02-26
+review_in: 6 months
 ---
 
 

--- a/source/manual/sidekiq-retries.html.md
+++ b/source/manual/sidekiq-retries.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-07
-title: 'Sidekiq'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Sidekiq
+parent: "/manual.html"
 layout: manual_layout
 section: Tools
+last_reviewed_at: 2016-11-07
+review_in: 6 months
 ---
 
 # Sidekiq

--- a/source/manual/smokey-smoke-tests.html.md
+++ b/source/manual/smokey-smoke-tests.html.md
@@ -1,10 +1,11 @@
 ---
-title: "Smoke testing with smokey"
+title: Smoke testing with smokey
 section: Testing
 layout: manual_layout
 parent: "/manual.html"
-owner_slack: '#2ndline'
-review_by: 2018-01-01
+owner_slack: "#2ndline"
+last_reviewed_at: 2017-07-01
+review_in: 6 months
 ---
 
 # Smoke testing with smokey

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -1,10 +1,11 @@
 ---
 title: Taxonomy
-parent: /manual.html
+parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 owner_slack: "#taxonomy"
-review_by: 2017-09-01
+last_reviewed_at: 2017-03-01
+review_in: 6 months
 ---
 
 # Taxonomy

--- a/source/manual/technical-setup.html.md
+++ b/source/manual/technical-setup.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-22
+owner_slack: "#2ndline"
 title: Technical setup
 section: Support
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/technical-setup.md"
+last_reviewed_at: 2016-12-22
+review_in: 6 months
 ---
 
 

--- a/source/manual/testing-projects.html.md
+++ b/source/manual/testing-projects.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2018-01-01
+owner_slack: "#2ndline"
 title: Test & build a project on Jenkins CI
 section: Testing
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2017-07-01
+review_in: 6 months
 ---
 
 # Test & build a project on Jenkins CI

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-09-09
-title: "Tools: Icinga, Grafana and Graphite, Kibana and Fabric"
+owner_slack: "#2ndline"
+title: 'Tools: Icinga, Grafana and Graphite, Kibana and Fabric'
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/tools.md"
+last_reviewed_at: 2017-03-09
+review_in: 6 months
 ---
 
 

--- a/source/manual/troubleshooting-vagrant.html.md
+++ b/source/manual/troubleshooting-vagrant.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-05-25
+owner_slack: "#2ndline"
 title: Troubleshooting Vagrant
 section: Support
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2016-11-25
+review_in: 6 months
 ---
 
 # Troubleshooting Vagrant

--- a/source/manual/upgrading-mysql.html.md
+++ b/source/manual/upgrading-mysql.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-10-03
-title: 'Upgrading mysql'
-parent: /manual.html
+owner_slack: "#2ndline"
+title: Upgrading mysql
+parent: "/manual.html"
 layout: manual_layout
 section: Databases
+last_reviewed_at: 2017-04-03
+review_in: 6 months
 ---
 
 # Upgrading mysql

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -1,11 +1,12 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-07-31
+owner_slack: "#2ndline"
 title: GOV.UK and Virtual Private Networks (VPNs)
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/vpn.md"
+last_reviewed_at: 2017-01-31
+review_in: 6 months
 ---
 
 

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -1,10 +1,11 @@
 ---
-owner_slack: '#2ndline'
-review_by: 2017-06-01
+owner_slack: "#2ndline"
 title: Where to find what documentation?
 section: Manual
 layout: manual_layout
 parent: "/manual.html"
+last_reviewed_at: 2016-12-01
+review_in: 6 months
 ---
 
 # Where to find what documentation?

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -4,10 +4,10 @@
   <%= link_to "Create new page", "/manual/create-page.html" %>
 </div>
 
-<% if current_page.data.owner_slack && current_page.data.review_by %>
+<% if page_review.reviewable? %>
   This page is owned by <%= current_page.data.owner_slack %>
   and <%= link_to "needs to be reviewed", "/manual/review-page.html" %>
-  <time data-module="datetime-relative" datetime="<%= current_page.data.review_by %>">
-    <%= current_page.data.review_by %>
+  <time data-module="datetime-relative" datetime="<%= page_review.review_by %>">
+    <%= page_review.review_by %>
   </time>
 <% end %>

--- a/spec/app/page_freshness_spec.rb
+++ b/spec/app/page_freshness_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe PageFreshness do
   describe "#to_json" do
     it "returns JSON" do
       sitemap = double(resources: [
-        double(url: "/a", data: double(title: "A thing", owner_slack: "#2ndline", review_by: Date.yesterday)),
-        double(url: "/b", data: double(title: "B thing", owner_slack: "#2ndline", review_by: Date.tomorrow)),
+        double(url: "/a", data: double(title: "A thing", owner_slack: "#2ndline", last_reviewed_at: Date.yesterday, review_in: "0 days")),
+        double(url: "/b", data: double(title: "B thing", owner_slack: "#2ndline", last_reviewed_at: Date.yesterday, review_in: "2 days")),
       ])
 
       json = PageFreshness.new(sitemap).to_json

--- a/spec/app/review_by_spec.rb
+++ b/spec/app/review_by_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe PageReview do
+  describe '#review_by' do
+    it "calculates it correctly" do
+      review_by = PageReview.new(
+        double(data: double(last_reviewed_at: Date.parse("2016-01-01"), review_in: "6 months"))
+      )
+
+      expect(review_by.review_by).to eql(Date.parse("2016-07-01"))
+    end
+  end
+end

--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -8,8 +8,10 @@ Dir.glob("source/manual/**/*.md").each do |filename|
       expect(frontmatter['owner_slack'][0]).to be_in(%[# @]), "`owner_slack` should be a @username or #channel"
     end
 
-    it "has a review_by date" do
-      expect(frontmatter['review_by']).to be_a(Date)
+    it "has a valid review date" do
+      review_by = PageReview.new(double(data: double(frontmatter)))
+
+      expect(review_by.review_by).to be_a(Date)
     end
 
     it "has a title" do


### PR DESCRIPTION
Since the `review_by` date was introduced I've seen a few questions come up around what a good review date is (https://github.com/alphagov/govuk-developer-docs/pull/183 for example). I've also noticed that I find it hard to pick a good date (since it involves some arithmetic).

This PR tries make it easier by replacing `review_by` with `last_reviewed_at` and `review_in`. The idea is that you don't have to think about the dates anymore, just insert todays date.

Thoughts?