### PR TITLE
Update links to development VM

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -15,12 +15,9 @@
 
     - name: Running on the VM
       sites:
-        - name: Using the GOV.UK Development VM
+        - name: The GOV.UK Development VM
           url: https://github.com/alphagov/govuk-puppet/tree/master/development-vm
-          description: How to get your development environment running
-        - name: gds/development
-          url: https://github.gds/gds/development
-          description: Tools to run GOV.UK apps in the VM
+          description: Tools and guide for running GOV.UK apps in the VM
 
       repos:
         - gds-boxen

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -91,12 +91,12 @@ Click on the Applications tab. Find the application that is being
 retired and click the "edit" button. Tick the box that says "This
 application is being retired", then save your changes.
 
-11. Remove from the [development repo][development] `Procfile` and `Pinfile`:
+11. Remove from the [development-vm repo][development] `Procfile` and `Pinfile`:
 
 Leave a comment in the `Procfile` indicating that the port used to be
 used by this app (eg <https://github.gds/gds/development/pull/149>)
 
-[development]: https://github.gds/gds/development
+[development]: https://github.com/alphagov/govuk-puppet/tree/master/development-vm
 
 12. Check the data replication scripts for anything specific to this application:
 

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -48,8 +48,8 @@ and elsewhere:
 
 ## Defining the app in the development repository
 
-You first need to add the app to the [development
-repository](https://github.gds/gds/development).
+You first need to add the app to the [development-vm
+configuration in puppet](https://github.com/alphagov/govuk-puppet/tree/master/development-vm).
 
 Add the app to the `Procfile` and assign it the next available port
 number.

--- a/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
+++ b/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
@@ -29,7 +29,7 @@ apps on our backend machines.
 
 -   Identify a port you want to allocate to the sidekiq-monitoring
     instance for your application and reserve it in
-    [development/Procfile](https://github.gds/gds/development/blob/master/Procfile).
+    [development-vm/Procfile](https://github.com/alphagov/govuk-puppet/blob/master/development-vm/Procfile).
 
 ## Adding configuration for your application in sidekiq-monitoring repository
 


### PR DESCRIPTION
The development VM repo has moved from github.gds to a subdirectory of govuk-puppet, so replace links to github.gds/gds/development with links to https://github.com/alphagov/govuk-puppet/tree/master/development-vm.

There's still one link to the old repo because it's to a PR. I don't think there's an equivalent PR in the new repo yet: https://github.gds/gds/development/pull/149