### PR TITLE
Improve Sidekiq monitoring docs

### DIFF
--- a/source/manual/monitor-sidekiq-workers.html.md
+++ b/source/manual/monitor-sidekiq-workers.html.md
@@ -4,19 +4,25 @@ title: Monitor sidekiq queues for your application
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_at: 2017-04-28
+last_reviewed_at: 2017-05-03
 review_in: 6 months
 ---
 
-# Monitor sidekiq queues for your application
+# Monitor Sidekiq queues for your application
 
-Sidekiq [monitoring applications](https://github.com/mperham/sidekiq/wiki/Monitoring) are sinatra applications that ship with the [sidekiq gem](http://sidekiq.org/). We have configured these to run as [standalone](https://github.com/mperham/sidekiq/wiki/Monitoring#standalone) apps on our backend machines.
+[Sidekiq] comes with a web application, [`Sidekiq::Web`](https://github.com/mperham/sidekiq/wiki/Monitoring) that can display the current state of a [Sidekiq] installation. We have [configured this](https://github.com/alphagov/sidekiq-monitoring) to monitor multiple [Sidekiq] configurations used throughout [GOV.UK].
 
-An nginx vhost called `sidekiq-monitoring` hosts each of these standalone apps at various locations. For example, Whitehall's sidekiq monitoring app on integration is available at `sidekiq-monitoring.integration.publishing.service.gov.uk/whitehall`.
+We have restricted public access as the Web UI allows modifying the state of [Sidekiq] queues.
 
-These vhost are blocked for public access, as they allow modifying the state of sidekiq queues. You can setup ssh port forwarding to access these apps. To access sidekiq monitoring apps running on integration:
+To gain access you should setup SSH port forwarding to a backend box belonging to the environment you wish to monitor when connected to the Bardeen wireless network or the VPN: 
 
-* on the command line enter: `ssh backend-1.backend.integration -CNL 9000:127.0.0.1:80`
-* open [http://127.0.0.1:9000](http://127.0.0.1:9000)
+```bash
+$ ssh backend-1.backend.integration -CNL 9000:127.0.0.1:80 
+```
 
-Also see [how to set up](setting-up-new-sidekiq-monitoring-app.html) sidekiq monitoring for your app
+Then visit [http://127.0.0.1:9000](http://127.0.0.1:9000) to see a list of [Sidekiq] configurations you can monitor. 
+
+See also: [Add sidekiq-monitoring to your application](setting-up-new-sidekiq-monitoring-app.html).
+
+[gov.uk]: https://www.gov.uk/
+[sidekiq]: http://sidekiq.org/


### PR DESCRIPTION
The information about the NGINX configuration was incorrect, we have one NGINX Server Block and run a `Sidekiq::Web` process for each GOV.UK Sidekiq application we want to monitor – https://github.com/alphagov/sidekiq-monitoring

Also removes unnecessary detail about some of the technologies used to make this work.