### PR TITLE
Generate nicer snippets for sharing

### DIFF
--- a/app/snippet.rb
+++ b/app/snippet.rb
@@ -1,0 +1,10 @@
+class Snippet
+  def self.generate(html)
+    html
+      .split('</h1>')[1..-1].join # make sure we skip anything before <h1>
+      .gsub(/<h.+?>.+?<\/h.>/, "") # remove headings
+      .gsub(/<\/?[^>]*>/, "") # remove other HTML but keep the contents
+      .squish # remove whitespace
+      .truncate(300) # http://stackoverflow.com/questions/8914476/facebook-open-graph-meta-tags-maximum-content-length
+  end
+end

--- a/helpers/meta_tag_helpers.rb
+++ b/helpers/meta_tag_helpers.rb
@@ -33,7 +33,7 @@ module MetaTagHelpers
   end
 
   def page_description
-    locals[:description] || current_page.data.description || config[:tech_docs][:description]
+    locals[:description] || current_page.data.description || yield_content(:page_description) || config[:tech_docs][:description]
   end
 
   def page_title

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -1,5 +1,7 @@
 <% html = yield %>
 
+<% content_for :page_description, Snippet.generate(html) %>
+
 <% content_for :sidebar do %>
   <a href='/manual.html'>&lsaquo; Manual</a>
   <%= table_of_contents html, max_level: 3 %>

--- a/spec/app/snippet_spec.rb
+++ b/spec/app/snippet_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Snippet do
+  describe '.generate' do
+    it 'generates a proper snippet without the opsmanual warning' do
+      html = <<~html
+        <blockquote>
+        <p><strong>This page was imported from <a href="https://github.gds/gds/opsmanual">the opsmanual on github.gds</a></strong>.
+        It hasn&rsquo;t been reviewed for accuracy yet.
+        <a href="https://github.gds/gds/opsmanual/tree/master/2nd-line/howto-manually-remove-assets.md">View history in old opsmanual</a></p>
+        </blockquote>
+        <h1 id='remove-an-asset'>Remove an asset</h1>
+        <p>If you need to remove an asset manually from <code>assets.publishing.sevice.gov.uk</code>,
+        follow these steps:</p>
+      html
+
+      snippet = Snippet.generate(html)
+
+      expect(snippet).to eql("If you need to remove an asset manually from assets.publishing.sevice.gov.uk, follow these steps:")
+    end
+
+    it 'removes headings' do
+      html = <<~html
+        <h1 id='deploy-an-application-to-govuk'>Deploy an application to GOV.UK</h1>
+        <h2 id='introduction'>Introduction</h2>
+        <p>2nd line is responsible for:</p>
+
+        <ul>
+        <li>ensuring that software is released to GOV.UK responsibly</li>
+        <li>providing access to deploy software for teams who can&rsquo;t deploy it themselves</li>
+        </ul>
+
+        <p>As far as possible, teams are responsible for deploying their own work. We believe that
+        <a href="https://gds.blog.gov.uk/2012/11/02/regular-releases-reduce-risk/">regular releases minimise the risk of major problems</a> and
+        improve recovery time.</p>
+      html
+
+      snippet = Snippet.generate(html)
+
+      expect(snippet).to eql("2nd line is responsible for: ensuring that software is released to GOV.UK responsibly providing access to deploy software for teams who can&rsquo;t deploy it themselves As far as possible, teams are responsible for deploying their own work. We believe that regular releases minimise the risk of ma...")
+    end
+  end
+end


### PR DESCRIPTION
The manual pages currently fall back to the default description "Documentation for developers working on GOV.UK". That's not super informative.

This generates a 300 character snippet from the page HTML. The goal is to generate a representative piece of text from the body, so:

- Only text after the h1 (to skip the "This page was imported" text)
- No HTML
- No headings