### PR TITLE
Stop redirects from showing up on manual page

### DIFF
--- a/app/manual_index_page.rb
+++ b/app/manual_index_page.rb
@@ -49,7 +49,7 @@ private
 
   def manual_pages
     sitemap.resources
-      .select { |page| page.path.start_with?('manual/') && page.path.end_with?('.html') }
-      .sort_by { |page| page.data.title.try(:downcase).to_s }
+      .select { |page| page.path.start_with?('manual/') && page.path.end_with?('.html') && page.data.title }
+      .sort_by { |page| page.data.title.downcase }
   end
 end


### PR DESCRIPTION
Redirects are also showing up on the homepage. Because they don't have a title they're displayed as an empty list item. This commit makes sure we don't include things without titles. This then enables us to be less defensive in the `sort_by` block.

## Before

![screen shot 2017-05-03 at 17 39 48](https://cloud.githubusercontent.com/assets/233676/25671421/e5deddf4-3027-11e7-98ff-d50ceb0eaec7.png)

## After

![screen shot 2017-05-03 at 17 39 44](https://cloud.githubusercontent.com/assets/233676/25671423/e9957d0e-3027-11e7-97a1-ad427e68f7cf.png)

