### PR TITLE
Avoid double encoding in snippets

### DIFF
--- a/app/snippet.rb
+++ b/app/snippet.rb
@@ -1,10 +1,14 @@
 class Snippet
   def self.generate(html)
-    html
+    body_text = html
       .split('</h1>')[1..-1].join # make sure we skip anything before <h1>
       .gsub(/<h.+?>.+?<\/h.>/, "") # remove headings
       .gsub(/<\/?[^>]*>/, "") # remove other HTML but keep the contents
       .squish # remove whitespace
-      .truncate(300) # http://stackoverflow.com/questions/8914476/facebook-open-graph-meta-tags-maximum-content-length
+
+    # unescape HTML entities to avoid double encoding
+    unescaped_text = Nokogiri::HTML.parse(body_text).text
+
+    unescaped_text.truncate(300) # http://stackoverflow.com/questions/8914476/facebook-open-graph-meta-tags-maximum-content-length
   end
 end

--- a/spec/app/snippet_spec.rb
+++ b/spec/app/snippet_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Snippet do
 
       snippet = Snippet.generate(html)
 
-      expect(snippet).to eql("2nd line is responsible for: ensuring that software is released to GOV.UK responsibly providing access to deploy software for teams who can&rsquo;t deploy it themselves As far as possible, teams are responsible for deploying their own work. We believe that regular releases minimise the risk of ma...")
+      expect(snippet).to eql("2nd line is responsible for: ensuring that software is released to GOV.UK responsibly providing access to deploy software for teams who can’t deploy it themselves As far as possible, teams are responsible for deploying their own work. We believe that regular releases minimise the risk of major pr...")
     end
   end
 end


### PR DESCRIPTION
Characters like quotes are escaped in this payload, but also when they're inserted into the page (with the `tag` helper). By unescaping here we avoid showing html entities to users:

<img width="825" alt="screen shot 2017-05-05 at 13 29 28" src="https://cloud.githubusercontent.com/assets/233676/25745492/05111064-3197-11e7-8b59-dadb445afda3.png">

