### PR TITLE
Show page section in page title

### DIFF
--- a/helpers/meta_tag_helpers.rb
+++ b/helpers/meta_tag_helpers.rb
@@ -37,7 +37,7 @@ module MetaTagHelpers
   end
 
   def page_title
-    locals[:title] || current_page.data.title
+    locals[:title] || [current_page.data.title, current_page.data.section].compact.join(' - ')
   end
 
 private


### PR DESCRIPTION
When sharing docs, this makes it easier to see what the page is about. If there's no `section`, nothing will be shown.