### PR TITLE
Retire business-support-api

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -83,9 +83,13 @@
 # api
 
 - github_repo_name: business-support-api
+  retired: true
   type: APIs
   product_manager: Antonia Simmons
   team: Holding Government To Account
+  description: |
+    API that was used to populate the "business support finder". In May 2017,
+    it was replaced with the publishing-api and content-store.
 
 - github_repo_name: content-store
   type: APIs


### PR DESCRIPTION
Mark the `business-support-api` as retired and add a description of what it used to do.