### PR TITLE
Suggest using our airbrake fork when upgrading to rails 5

### DIFF
--- a/source/manual/upgrade-rails.html.md
+++ b/source/manual/upgrade-rails.html.md
@@ -29,8 +29,15 @@ will ensure the classes are loaded in both production and development. See
 
 ### Airbrake
 
-Upgrading to Rails 5 requires upgrading the Airbrake gem. This breaks some compatibility with
+Upgrading to Rails 5 requires upgrading the Airbrake gem to avoid deprecation 
+warnings about middleware. However, Airbrake 5 breaks some compatibility with
 our Errbit installation, namely that deployments are no longer recorded.
+
+Instead of upgrading to a released version of the Airbrake 5 gem you can use
+[a branch in our fork of Airbrake](https://github.com/alphagov/airbrake/tree/silence-dep-warnings-for-rails-5).
+This is 4.3.8 of the gem with a small change to silence the warnings:
+
+    gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 
 ### Don't include ActionCable or Puma configs
 


### PR DESCRIPTION
We have forked airbrake and made a branch from the last release of 4.x that includes a fix to silence the deprecation warnings you get when using rails 5 and airbrake 4.x.  This way we can keep the deployment recording functionality in errbit.