### PR TITLE
Correct source URL and sorting to rummager fields reference

### DIFF
--- a/app/search_api_docs.rb
+++ b/app/search_api_docs.rb
@@ -4,7 +4,8 @@ class SearchApiReference
       field_definitions_url,
     )
 
-    JSON.parse(contents)
+    fields = JSON.parse(contents)
+    fields.sort_by { |name, definition| [definition["type"], name] }
   end
 
   def self.field_definitions_url

--- a/source/apis/search/fields.html.md.erb
+++ b/source/apis/search/fields.html.md.erb
@@ -2,7 +2,7 @@
 layout: api_layout
 title: Search API field reference
 parent: /search-api.html
-source_url: https://github.com/alphagov/rummager/master/config/schema/field_definitions.json
+source_url: https://github.com/alphagov/rummager/blob/master/config/schema/field_definitions.json
 ---
 
 Documents in an elasticsearch index have a type, and each type can have different fields.


### PR DESCRIPTION
- Github URLs contain /blob/
- It's helpful to see similar kinds of fields together