### PR TITLE
Document GitHub enterprise deploy

### DIFF
--- a/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
+++ b/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
@@ -1,0 +1,43 @@
+---
+owner_slack: "#2ndline"
+title: Deploy fixes for a security vulnerability
+section: Deployment
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2017-05-09
+review_in: 3 months
+---
+
+When responding to a security incident, we should review the changes in private
+before deploying them, so that we don't accidentally disclose the vulnerability.
+
+To do this, push branches to the [GitHub Enterprise backup](github-unavailable.html)
+of the repository, rather than the normal repository on github.com.
+The repository will be in the [`gds-production-backup`](https://github.digital.cabinet-office.gov.uk/gds-production-backup/) organisation, not the `gds` one.
+
+This repository should be up to date as of the previous release, but will be
+missing any unreleased commits that are on github.com master.
+This is fine as you don't want to deploy these.
+
+## Deploy process
+
+1. Ensure nobody else deploys the app until you've confirmed the vulnerability
+   is fixed.
+
+1. Review the pull request on Github Enterprise
+
+1. Create a release tag manually in git. This should follow the standard format
+   `release_X`. Tag the branch directly instead of merging it.
+
+1. Don't use the release app. Go directly to the `deploy_app` jenkins job, and
+   check "DEPLOY_FROM_GITHUB_ENTERPRISE".
+
+## After deploying
+
+1. Ensure the vulnerability is fixed.
+
+1. Push the branch and tag to github.com.
+
+1. Merge the branch into master.
+
+1. Record the missing deployment in the release app.

--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -69,6 +69,12 @@ the previous team isn't going to have to roll back their release.
 
 ### Deployment
 
+#### Security fixes
+
+If you are responding to a security incident, follow the steps in [Deploy fixes for a security vulnerability](deploy-fixes-for-a-security-vulnerability.html).
+
+#### Regular code changes
+
 1.  Check any notes against the application in the [Release app][release].
 1.  Acquire the badger
 1.  Ensure the badger is not tagged with the application you are deploying,

--- a/source/manual/github-enterprise.html.md
+++ b/source/manual/github-enterprise.html.md
@@ -5,20 +5,19 @@ section: Tools
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/github-enterprise/index.md"
-last_reviewed_on: 2017-03-08
-review_in: 6 months
+last_reviewed_on: 2017-05-09
+review_in: 2 months
 ---
 
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/github-enterprise/index.md)
+Our GitHub Enterprise installation lives at [https://github.digital.cabinet-office.gov.uk]() and is managed by the GDS service desk.
 
+It's used for:
 
-Our GitHub Enterprise installation lives at https://github.digital.cabinet-office.gov.uk/ and is manged
-by the GDS service desk.
-
-On GOV.UK we use GitHub Enterprise to store repositories that we're not comfortable
-maintaining as private repositories on public GitHub.
+- [Backups](github-unavailable.html) of our [public repositories](https://alphagov.github.io/gds-tech/source-code.html)
+- Older private repositories that haven't been moved to github.com
+- Authentication with Jenkins CI ([ci.integration.publishing.service.gov.uk](https://ci.integration.publishing.service.gov.uk))
 
 GOV.UK data on GitHub Enterprise should be encrypted in the repository (for example
 using a list of GOV.UK GPG keys).
+
+GitHub Enterprise should not be used for new repositories or OAuth authentication.

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -5,14 +5,9 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/github-unavailable.md"
-last_reviewed_on: 2016-12-18
+last_reviewed_on: 2017-05-09
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/2nd-line/releasing-software/github-unavailable.md)
-
 
 ## Public GitHub (application code)
 
@@ -45,12 +40,16 @@ but sometimes we need to (in exceptional circumstances when we can't work in pub
 
 ## GitHub Enterprise (secrets)
 
-If GitHub Enterprise becomes unavailable, GDS internal IT will switch to
-a disaster recovery instance. Internal IT have previously estimated that failing
-over to the DR machine may take some time.
+If [GitHub Enterprise](github-enterprise.html) becomes unavailable, GDS internal IT will switch to
+a disaster recovery instance. Failing over to the DR machine may take some time.
 
 Depending on the nature of the outage, we may need to change our `govuk_ghe_vpn`
 configuration to point to `vpndr.digital.cabinet-office.gov.uk`.
 
-In order to deploy this change, you may first need to disable Puppet on the Jenkins
-machine and make the change manually.
+In order to deploy this change, first disable Puppet on the Jenkins machine.
+
+```
+fab $environment -H jenkins-1.management puppet.disable:"Switching to disaster recovery VPN"
+```
+
+Then update the VPN host in `/etc/init/openconnect.conf` on that machine.


### PR DESCRIPTION
Update the github enterprise docs and add a guide for using it to deploy security fixes.

This is completely made up by me, so please flag anything that looks like the wrong thing to do.

The domain for GHE is changing on Thursday so I've updated the links as well. Don't merge until then.

Trello: https://trello.com/c/w2yA4dy6/60-document-how-to-deploy-security-fixes-action-item-from-2nd-line-incident