### PR TITLE
Mark specialist-frontend as retired

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -243,7 +243,7 @@
   description: |
    contacts-frontend used to render the HMRC contacts pages. Since April 2017
    these are rendered by government-frontend.
-   
+
 - github_repo_name: design-principles
   type: Frontend apps
   team: Template consolidation
@@ -307,8 +307,10 @@
 
 - github_repo_name: specialist-frontend
   type: Frontend apps
-  team: Template consolidation
-  product_manager: Humin Miah
+  retired: true
+  description: |
+    specialist-frontend was used to render specialist documents. Those were moved
+    to government-frontend in April 2017.
 
 - github_repo_name: static
   type: Frontend apps

--- a/source/apis/content-store.html.md.erb
+++ b/source/apis/content-store.html.md.erb
@@ -55,7 +55,7 @@ or index page for this item.
 editing it. Examples include "whitehall", "specialist-publisher".
 
 `rendering_app`: The frontend app that is responsible for displaying this
-content. Examples include "government-frontend", "specialist-frontend".
+content. Examples include "government-frontend", "manuals-frontend".
 
 `locale`: The language of the content, eg "en", "ar".
 


### PR DESCRIPTION
specialist-frontend was used to render specialist documents. Those were moved to government-frontend in April 2017.

Part of https://trello.com/c/UM7aecOQ/194-final-stage-decomission-specialist-frontend-2