### PR TITLE
Remove duplicate titles from manual pages

### DIFF
--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -1,4 +1,4 @@
-<% html = yield %>
+<% html = "<h1 id='header'>#{current_page.data.title}</h1>#{yield}" %>
 
 <% content_for :page_description, Snippet.generate(html) %>
 

--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-01
 review_in: 6 months
 ---
 
-# Run an A/B test
-
 ## 1. Overview
 
 There are two ways of doing A/B testing on GOV.UK. The first uses Javascript to change the contents on a page. The second uses our CDN to allow frontend applications to render different pages.

--- a/source/manual/add-an-icinga-passive-check.md
+++ b/source/manual/add-an-icinga-passive-check.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-08
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/add_a_passive_check_to_jenkins.md)
 
-
-# Add an Icinga passive check to a Jenkins job
 
 If you would like Icinga to raise an alert when a Jenkins job has not completed
 successfully in a while, you can add an Icinga passive check to the Jenkins

--- a/source/manual/add-deployment-dashboard.html.md
+++ b/source/manual/add-deployment-dashboard.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-27
 review_in: 6 months
 ---
 
-# Add a deployment dashboard for an application
-
 ## Update and Add Panels to Existing Dashboards
 
 [Deployment dashboards](deployment-dashboards.html) are configured in `govuk-puppet`. Each dashboard panel is configured by a .json.erb template in `modules/grafana/templates/dashboards/deployment_partials` and these are combined to generate the JSON config for each application dashboard.

--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-04-08
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/adding-disks-in-vcloud.md)
 
-
-# Add a disk to a vCloud machine
 
 > **note**
 

--- a/source/manual/alerts/asset-master-attachment-processing.html.md
+++ b/source/manual/alerts/asset-master-attachment-processing.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-05-01
 review_in: 6 months
 ---
 
-# asset master attachment processing
-
 When new assets get uploaded to asset-master-1, there is a script
 (/usr/local/bin/process-uploaded-attachment.sh) run by the assets user
 every minute in a cronjob. This kicks off a script (virus-scan-file.sh)

--- a/source/manual/alerts/aws-ses-email-quota.html.md
+++ b/source/manual/alerts/aws-ses-email-quota.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-13
 review_in: 6 months
 ---
 
-# AWS SES quota usage higher than expected
-
 Likely suspect for elevated email volumes is Errbit emailing too much errors.
 
 Other things that use the same SES account include Whitehall, Publisher, Signon, Licensing and machine email.

--- a/source/manual/alerts/clamav-definitions-out-of-date.html.md
+++ b/source/manual/alerts/clamav-definitions-out-of-date.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-26
 review_in: 6 months
 ---
 
-# ClamAV definitions out of date
-
 This could be because of a number of reasons. Check that the database is
 up to date by calling the freshclam command directly with verbose:
 

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-17
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/data-sync.md)
 
-
-# Data sync
 
 Data is synced from production to staging and integration every night.
 

--- a/source/manual/alerts/defined-cpu-type-does-not-match.html.md
+++ b/source/manual/alerts/defined-cpu-type-does-not-match.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-08
 review_in: 6 months
 ---
 
-# defined cpu type does not match
-
 We have two types of VM hosts that use either Intel or AMD processors.
 Some VMs have significant performance degradation when on the AMD CPUs
 and thus should live on the more performant Intel processor-based hosts.

--- a/source/manual/alerts/duplicate-ssh-host-keys.html.md
+++ b/source/manual/alerts/duplicate-ssh-host-keys.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-06
 review_in: 6 months
 ---
 
-# 'duplicate SSH host keys'
-
 This check indicates that more than one machine in an environment is
 using the same SSH host key. This is bad because it means that we can't
 verify the authenticity of a particular host and it could be used in a

--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-01
 review_in: 6 months
 ---
 
-# Elasticsearch cluster health
-
 Elasticsearch reports cluster health as one of three possible states, based on
 the state of its primary and replica shards.
 

--- a/source/manual/alerts/elasticsearch-not-receiving-syslog.html.md
+++ b/source/manual/alerts/elasticsearch-not-receiving-syslog.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-08
 review_in: 6 months
 ---
 
-# Elasticsearch: not receiving syslog from logstash
-
 The problem behind this warning is that logstash has stopped sending
 things. Restart logstash on logging-1.management with:
 

--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-03
 review_in: 6 months
 ---
 
-# Email Alerts
-
 GOV.UK sends out emails when certain publications are published. We have
 set up a check to verify that emails are sent for certain publication
 types (the drug and medical device alerts and travel advice updates).

--- a/source/manual/alerts/es-rotate.html.md
+++ b/source/manual/alerts/es-rotate.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-05
 review_in: 6 months
 ---
 
-# es-rotate
-
 This alert triggers when the es-rotate hasn't completed successfully.
 
 es-rotate is part of [es-tools](https://github.com/alphagov/estools).

--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-07
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/fastly-error-rate.md)
 
-
-# Fastly error rate for GOV.UK
 
 ## Error rate alert
 

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-24
 review_in: 6 months
 ---
 
-# Fetch analytics data for search failed
-
 This checks the latest build state of [a job in production
 Jenkins](https://deploy.publishing.service.gov.uk/job/search-fetch-analytics-data/)
 which runs every night and populates the search index with the latest data from

--- a/source/manual/alerts/free-memory-warning-on-backend.html.md
+++ b/source/manual/alerts/free-memory-warning-on-backend.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-11
 review_in: 6 months
 ---
 
-# Free memory warning on backend
-
 ### Background
 
 This is often caused by an application slowly leaking memory, which

--- a/source/manual/alerts/github-enterprise-connectivity.html.md
+++ b/source/manual/alerts/github-enterprise-connectivity.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-10
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/github-enterprise-connectivity.md)
 
-
-# GitHub Enterprise connectivity
 
 Some machines have a VPN connection to the GDS office so that they can
 clone repositories from GitHub Enterprise.

--- a/source/manual/alerts/gor.html.md
+++ b/source/manual/alerts/gor.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-16
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/gor.md)
 
-
-# Gor
 
 [Gor][gor-gh] is an open source tool for replaying HTTP traffic. We use it to
 replay traffic from production to staging to give us greater confidence that

--- a/source/manual/alerts/high-disk-time.html.md
+++ b/source/manual/alerts/high-disk-time.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-18
 review_in: 6 months
 ---
 
-# 'high disk time'
-
 This alert tells us that reads and/or writes to disk are taking longer
 than expected. In most cases this is only informational; you may not
 need to take any action, but it may explain the cause for other alerts.

--- a/source/manual/alerts/high-zombie-procs.html.md
+++ b/source/manual/alerts/high-zombie-procs.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-05
 review_in: 6 months
 ---
 
-# 'high zombie procs'
-
 You can check what the zombie processes are by SSHing onto the machine
 and running the command:
 

--- a/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
+++ b/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-05
 review_in: 6 months
 ---
 
-# Logs are not being received from the CDN
-
 Sometimes, we stop receiving either GOV.UK or Bouncer logs from Fastly
 to logs-cdn-1.management. We run Rsyslog on this machine, and Fastly
 send us logs using Syslog on their side to a port we have previously

--- a/source/manual/alerts/low-available-disk-inodes.html.md
+++ b/source/manual/alerts/low-available-disk-inodes.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-29
 review_in: 6 months
 ---
 
-# Low available disk inodes
-
 The inode usage on a box can be checked using:
 
     df -i

--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-16
 review_in: 6 months
 ---
 
-# Low available disk space
-
 ### Low available disk space on root
 
 You can try clearing out the APT cache:

--- a/source/manual/alerts/mongod-replication-lag.html.md
+++ b/source/manual/alerts/mongod-replication-lag.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-27
 review_in: 6 months
 ---
 
-# 'mongod replication lag'
-
 ### Investigating the problem
 
 There is a fabric task to show various mongo replication status

--- a/source/manual/alerts/mongodb-rollback.html.md
+++ b/source/manual/alerts/mongodb-rollback.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-28
 review_in: 6 months
 ---
 
-# MongoDB rollback
-
 ### What is a rollback
 
 Explanation from the [MongoDB

--- a/source/manual/alerts/mysql-replication-lag.html.md
+++ b/source/manual/alerts/mysql-replication-lag.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-20
 review_in: 6 months
 ---
 
-# MySQL: replication lag
-
 Checks the value of `Seconds_Behind_Master` to a threshold. As described
 in the MySQL documentation:
 

--- a/source/manual/alerts/mysql-replication-running.html.md
+++ b/source/manual/alerts/mysql-replication-running.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-21
 review_in: 6 months
 ---
 
-# MySQL: replication running
-
 Checks whether `Slave_IO_Running` and `Slave_SQL_Running` both return
 `Yes` to indicate that replication is currently active. As described in
 the MySQL documentation:

--- a/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
+++ b/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-06
 review_in: 6 months
 ---
 
-# MySQL Xtrabackups to S3
-
 We send backups to an Amazon S3 bucket every 15 minutes. This is
 performed using a nightly "base" backup and "incremental" backups which
 run every 15 minutes, which are linked to the base backup.

--- a/source/manual/alerts/nginx-5xx-rate-too-high-for-many-apps-boxes.html.md
+++ b/source/manual/alerts/nginx-5xx-rate-too-high-for-many-apps-boxes.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-04
 review_in: 6 months
 ---
 
-# "nginx 5xx rate too high" for many apps/boxes
-
 If the message is "UNKNOWN: INTERNAL ERROR: RuntimeError: no valid
 datapoints" or "UNKNOWN: INTERNAL ERROR: RuntimeError: no data returned
 for target", it probably means that statsd or collectd stopped

--- a/source/manual/alerts/nginx-high-conn-writing-upstream-indicator-check.html.md
+++ b/source/manual/alerts/nginx-high-conn-writing-upstream-indicator-check.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-06
 review_in: 6 months
 ---
 
-# 'nginx high conn writing -- upstream indicator' Check
-
 ### What is the 'nginx high conn writing -- upstream indicator' check?
 
 -   If you see this alert it may be that we are having or about to have

--- a/source/manual/alerts/nginx-requests-too-low.html.md
+++ b/source/manual/alerts/nginx-requests-too-low.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-20
 review_in: 6 months
 ---
 
-# 'nginx requests too low'
-
 -   An Icinga check that alerts when the number of Nginx requests drops
     below a critical threshold.
 -   We have seen misconfigured firewall configs on our vSE.

--- a/source/manual/alerts/ntp-drift-too-high.html.md
+++ b/source/manual/alerts/ntp-drift-too-high.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-02
 review_in: 6 months
 ---
 
-# 'ntp drift too high'
-
 There are tasks in fabric-scripts to make this less painful:
 
     fab $environment -H jumpbox-1.management ntp.status

--- a/source/manual/alerts/offsite-backups.html.md
+++ b/source/manual/alerts/offsite-backups.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-15
 review_in: 6 months
 ---
 
-# Offsite backups
-
 All of our offsite backups use duplicity. Most, but not all, are
 encrypted using GPG.
 

--- a/source/manual/alerts/onsite-backups.html.md
+++ b/source/manual/alerts/onsite-backups.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-06
 review_in: 6 months
 ---
 
-# Onsite backups
-
 The backup machine (e.g. backup-1.management.integration) collects
 backups from the various data stores.
 

--- a/source/manual/alerts/outstanding-security-updates.html.md
+++ b/source/manual/alerts/outstanding-security-updates.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-17
 review_in: 6 months
 ---
 
-# 'Outstanding security updates'
-
 Most security updates should be automagically applied overnight by
 [unattended-upgrades](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package)
 and our Nagios check accounts for that by delaying alerts for up to

--- a/source/manual/alerts/pagerduty-drill.html.md
+++ b/source/manual/alerts/pagerduty-drill.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-30
 review_in: 6 months
 ---
 
-# PagerDuty drill
-
 Every week we test PagerDuty to make sure it can phone to alert us to
 any issues.
 

--- a/source/manual/alerts/pingdom-homepage-check.html.md
+++ b/source/manual/alerts/pingdom-homepage-check.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-17
 review_in: 6 months
 ---
 
-# Pingdom homepage check
-
 Pingdom monitors externally (from \~10 locations in Europe and America)
 that it can connect to <https://www.gov.uk/>. If this fails it could
 indicate that DNS for www.gov.uk is not working, our CDN has failed or

--- a/source/manual/alerts/pingdom-search-check.html.md
+++ b/source/manual/alerts/pingdom-search-check.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-04
 review_in: 6 months
 ---
 
-# Pingdom search check
-
 If Pingdom can't retrieve the search results page it means that while
 GOV.UK may be available (see check above), it is not possible to
 retrieve dynamic content. Assuming that the homepage check has not

--- a/source/manual/alerts/postgresql-replication-too-far-behind.html.md
+++ b/source/manual/alerts/postgresql-replication-too-far-behind.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-14
 review_in: 6 months
 ---
 
-# PostgreSQL: replication too far behind
-
 > "replication on the postgres slave is too far behind master [value in bytes]"
 
 When this alert fires, the Postgres slave replication process may be

--- a/source/manual/alerts/postgresql-s3-backups.html.md
+++ b/source/manual/alerts/postgresql-s3-backups.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-09
 review_in: 6 months
 ---
 
-# PostgreSQL: S3 Backups
-
 There are two passive checks related to PostgreSQL S3 backups:
 
 -   PostgreSQL WAL-E base backup push

--- a/source/manual/alerts/prolonged-gc-collection-times-check.html.md
+++ b/source/manual/alerts/prolonged-gc-collection-times-check.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-11
 review_in: 6 months
 ---
 
-# 'Prolonged GC collection times' Check
-
 ### What is 'Prolonged GC collection times' check?
 
 This checks when the elasticsearch JVM garbage collection times (in

--- a/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-04
 review_in: 6 months
 ---
 
-# 'publisher app health check not ok'
-
 If the message is a warning about `scheduled_queue`, eg '71 scheduled
 edition(s); 3 item(s) queued', this alert means that the number of
 editions in the database which are scheduled to be published in the

--- a/source/manual/alerts/rabbitmq-high-watermark.html.md
+++ b/source/manual/alerts/rabbitmq-high-watermark.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-29
 review_in: 6 months
 ---
 
-# RabbitMQ: high watermark has been exceeded
-
 The RabbitMQ server detects the total amount of RAM installed on
 startup. By default, when the RabbitMQ server uses above 40% of the
 installed RAM, it raises a memory alarm and blocks all connections. Once

--- a/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
+++ b/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-10
 review_in: 6 months
 ---
 
-# RabbitMQ: No consumers listening to queue
-
 [Read more about how we use RabbitMQ](/manual/rabbitmq.html)
 
 We run a check that there is at least one non-idle consumer for a named

--- a/source/manual/alerts/reboot-required-by-apt.html.md
+++ b/source/manual/alerts/reboot-required-by-apt.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-12
 review_in: 6 months
 ---
 
-# 'reboot required by apt'
-
 This check indicates that some packages have been installed but cannot
 be activated without rebooting the machines.
 

--- a/source/manual/alerts/redis.html.md
+++ b/source/manual/alerts/redis.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-12
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/redis.md)
 
-
-# Redis alerts
 
 We have a few monitoring checks for Redis:
 

--- a/source/manual/alerts/rkhunter-warnings.html.md
+++ b/source/manual/alerts/rkhunter-warnings.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-27
 review_in: 6 months
 ---
 
-# rkhunter warnings
-
 rkhunter (Rootkit Hunter) is software installed on our machines to
 detect potential rootkits and exploits. rkhunter runs every morning
 across our machines.

--- a/source/manual/alerts/root-filesystem-is-readonly.html.md
+++ b/source/manual/alerts/root-filesystem-is-readonly.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-27
 review_in: 6 months
 ---
 
-# root filesystem is readonly
-
 When Ubuntu is unable to write to disk it switches the filesystem to be
 read only. This could be caused by a cloud hosting provider having
 problems with their Storage Area Network (SAN).

--- a/source/manual/alerts/ruby-version.html.md
+++ b/source/manual/alerts/ruby-version.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-24
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/ruby-version.md)
 
-
-# App isn't running the expected Ruby version
 
 When a `.ruby-version` file is updated, a standard app reload won't pick
 up the change, and the application will be left running under the old

--- a/source/manual/alerts/search-benchmarking.html.md
+++ b/source/manual/alerts/search-benchmarking.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-26
 review_in: 6 months
 ---
 
-# Benchmark search queries failed
-
 Indicates that the Jenkins [search_benchmark healthcheck job]
 (https://deploy.publishing.service.gov.uk/job/search_benchmark/) has failed.
 

--- a/source/manual/alerts/search-spelling-suggestions.html.md
+++ b/source/manual/alerts/search-spelling-suggestions.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-26
 review_in: 6 months
 ---
 
-# Check for spelling suggestions failed
-
 Indicates that the Jenkins [search_test_spelling_suggestions healthcheck job]
 (https://deploy.publishing.service.gov.uk/job/search_test_spelling_suggestions/)
 has failed.

--- a/source/manual/alerts/unicorn-herder.html.md
+++ b/source/manual/alerts/unicorn-herder.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-30
 review_in: 6 months
 ---
 
-# Unicorn Herder
-
 ### 'app unicornherder running'
 
 This alert means the Unicorn Herder process has disappeared for the

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-16
 review_in: 6 months
 ---
 
-# Varnish port not responding
-
 Under high load, it is possible that the Varnish child process which
 handles connections will timeout on the healthcheck from the parent. If
 that happens and the replacement child process also fails to start,

--- a/source/manual/alerts/virus-scanning.html.md
+++ b/source/manual/alerts/virus-scanning.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-27
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/alerts/virus-scanning.md)
 
-
-# Fix stuck virus scanning
 
 Documents uploaded to asset-master are scanned asynchronously through
 a virus scanner, as explained in <https://github.gds/pages/gds/opsmanual/2nd-line/applications/whitehall.html?highlight=whitehall#virus-scanning-of-uploaded-files>

--- a/source/manual/alerts/vpn-down.html.md
+++ b/source/manual/alerts/vpn-down.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-11
 review_in: 6 months
 ---
 
-# VPN down
-
 We use VPNs to connect between datacentres. Please see
 GOV.UK and Virtual
 Private Networks (VPNs) &lt;/infrastructure/vpn&gt; for details of the

--- a/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-24
 review_in: 6 months
 ---
 
-# whitehall app health check not ok
-
 If the message is a warning about `scheduled_queue`, eg '850 scheduled
 edition(s); 840 job(s) queued', this alert means that the number of
 editions in the database which are scheduled to be published in the

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-19
 review_in: 6 months
 ---
 
-# Whitehall scheduled publishing
-
 ### 'overdue publications in Whitehall'
 
 This alert means that there are scheduled editions which have passed

--- a/source/manual/archiving-and-redirecting-content.html.md
+++ b/source/manual/archiving-and-redirecting-content.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-24
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/archiving-and-redirecting-content.md)
 
-
-# Archive and redirect mainstream content to other pages on GOV.UK
 
 Sometimes there is a need to remove existing content and redirect the
 slug to another internal location. This can happen when content is

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-26
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/architecture/assets.md)
 
-
-# Assets: how they work
 
 Assets are stylesheets (CSS), JavaScript (JS) and image files which
 make GOV.UK look the way it does. When we use the term assets we

--- a/source/manual/attachments.html.md
+++ b/source/manual/attachments.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-01-08
 review_in: 6 months
 ---
 
-# Attachment backups
-
 We sync all the data to both an Amazon S3 bucket (using [Duplicity], from
 asset-slave-1.backend) and [S3] (using [s3cmd], from asset-slave-2.backend).
 

--- a/source/manual/blocking-apps-from-release.html.md
+++ b/source/manual/blocking-apps-from-release.html.md
@@ -9,13 +9,9 @@ last_reviewed_on: 2017-04-28
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/releasing-software/blocking-apps-from-release.md)
 
-
-# Block apps from being deployed
 
 Sometimes the master branch of an app might contain a feature which cannot
 be released to production. This is usually because it is coupled to the release of

--- a/source/manual/bouncer.html.md
+++ b/source/manual/bouncer.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-05-03
 review_in: 6 months
 ---
 
-# Bouncer
-
 [Bouncer](https://github.com/alphagov/bouncer) is a Ruby/Rack web app that receives requests for the URLs of government sites that have either been transitioned to GOV.UK, archived or removed. It queries the database it shares with Transition and replies with a
 redirect, an archive page or a 404 page. It also handles `/robots.txt`
 and `/sitemap.xml` requests.

--- a/source/manual/cache-flush.html.md
+++ b/source/manual/cache-flush.html.md
@@ -10,14 +10,10 @@ last_reviewed_on: 2017-01-08
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/cache-flush.md)
 
-
-# Purge a page from cache
 
 The `www.gov.uk` domain is served through Fastly, which honours the
 cache control headers sent by Varnish.

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-01
 review_in: 6 months
 ---
 
-# Our content delivery network (CDN)
-
 GOV.UK uses Fastly as a CDN. Citizen users aren't accessing GOV.UK
 servers directly, they connect via the CDN. This is better because:
 

--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-05-01
 review_in: 6 months
 ---
 
-# Change an organisation's slug
-
 > **NOTE:** for Worldwide Organisations, only Steps 1, 6 and maybe 7 below need
 > to be performed.
 

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-15
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/check-for-gone-route.md)
 
-
-# Check for a `gone` route
 
 When a Whitehall document fails to appear on the frontend, and the user
 is shown a 'Gone' page, follow these instructions:

--- a/source/manual/clone-mysql-slave.html.md
+++ b/source/manual/clone-mysql-slave.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-11-15
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/clone-mysql-slave.md)
 
-
-# Clone a MySQL instance from one slave to another
 
 This tutorial documents the process behind adding a new slave to a MySQL
 senvironment where an existing slave may or may not already exist. The

--- a/source/manual/content-preview.html.md
+++ b/source/manual/content-preview.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-04
 review_in: 6 months
 ---
 
-# How the draft stack works
-
 ## Overview
 
 The Content Preview site, also known as Draft GOV.UK, is intended to be

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-01
 review_in: 6 months
 ---
 
-# Create a GPG key
-
 ## Prerequisites
 
 Install gpg if you don't already have it. [GPGtools](https://gpgtools.org/) is recommended if you are on a Mac.

--- a/source/manual/create-a-new-open-source-project.html.md
+++ b/source/manual/create-a-new-open-source-project.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-30
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/create-a-new-open-source-project.md)
 
-
-# Create a new open source project
 
 We try to [code in the
 open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/) by default

--- a/source/manual/create-page.html.md
+++ b/source/manual/create-page.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-09
 review_in: 6 months
 ---
 
-# Create a page in this manual
-
 ## Create a page
 
 1. Add a page in Github to the [/source/manual](https://github.com/alphagov/govuk-developer-docs/tree/master/source/manual) directory.
@@ -43,8 +41,6 @@ Bad examples:
 > Data sync
 
 > Ruby (too vague: what about Ruby?)
-
-
 Don't use:
 
 - "how to" at the start
@@ -85,8 +81,6 @@ Don't say:
 > Data can be exported to CSV.
 
 ### Acronyms
-
-
 Spell out acronyms the first time they're used on the page unless they're very widely known.
 
 Examples of widely known acronyms:

--- a/source/manual/creating-a-new-environment.html.md
+++ b/source/manual/creating-a-new-environment.html.md
@@ -10,8 +10,6 @@ review_in: 6 months
 
 > It's possible this page is out of date, but it's is still relevant if we ever need to rebuild a VMWare vCloud environment somewhere.
 
-# Create a new environment for GOV.UK
-
 ## Manual steps to ask of the IaaS provider
 
 Ask the IaaS provider to:

--- a/source/manual/data-sources-for-transition.html.md
+++ b/source/manual/data-sources-for-transition.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-05-03
 review_in: 6 months
 ---
 
-# Data sources for Transition
-
 Site configuration is automatically imported on an hourly basis via
 [deploy.publishing](https://deploy.publishing.service.gov.uk/job/Transition_load_site_config/) from
 [transition-config](https://github.com/alphagov/transition-config).

--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-09
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/debian-packaging.md)
 
-
-# Debian packaging
 
 This page explains how we're managing our Debian packaging.
 

--- a/source/manual/deploy-puppet.html.md
+++ b/source/manual/deploy-puppet.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-09
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/deploy-puppet.md)
 
-
-# Deploy Puppet
 
 ## Basic Steps
 

--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-02-02
 review_in: 6 months
 ---
 
-# Deploy an application to GOV.UK
-
 ## Introduction
 
 2nd line is responsible for:

--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-27
 review_in: 6 months
 ---
 
-# Monitor your app during deployment
-
 ## Deployment Dashboards
 
 There are a number of applications with a dashboard showing useful information for the deployment process.

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2016-11-04
 review_in: 6 months
 ---
 
-# Domain Name System (DNS) records
-
 The GOV.UK Infrastructure team is responsible for managing several DNS zones.
 
 By default, zones are managed using DynDNS.

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-10
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/editing-an-existing-route.md)
 
-
-# Edit an existing route in the Router
 
 If there's a need to edit a Route in the database, follow these
 instructions:

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-06
 review_in: 6 months
 ---
 
-# Elasticsearch: dump and restore indices
-
 ## Creating a dump
 
 Sometimes you may need to take a backup of Elasticsearch before a

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-02-17
 review_in: 6 months
 ---
 
-# Deploy emergency publishing banners
-
 There are three types of events that would lead GOV.UK to add an emergency banner to the top of each page on the web site. Each type of event is detailed below.
 
 The GOV.UK on-call escalations contact will tell you when you need to publish an emergency banner. They will ensure that the event is legitimate and provide you with the text for the emergency banner.

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -7,8 +7,6 @@ section: Deployment
 last_reviewed_on: 2017-01-13
 review_in: 6 months
 ---
-# Handle encrypted hieradata
-
 [Hiera](https://docs.puppetlabs.com/hiera/1/) is a key/value lookup tool
 that we use for storing [Puppet](https://docs.puppetlabs.com/puppet/)
 configuration data. We use [Hiera eYAML

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -14,8 +14,6 @@ It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/architecture/environments.md)
 
 
-# GOV.UK's environments (integration, staging, production)
-
 GOV.UK has several environments with different purposes.
 
 ## Continuous integration (CI)

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-01
 review_in: 6 months
 ---
 
-# Fall back to the static mirrors
-
 We maintain a static copy of most of the site which is used by the content delivery
 network (CDN) whenever origin (the application server) times out or serves an error
 response.

--- a/source/manual/gds-hubot.html.md
+++ b/source/manual/gds-hubot.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-13
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/gds-hubot.md)
 
-
-# Update Hubot (Slack bot)
 
 Hubot is a bot on our Slack channel.
 

--- a/source/manual/generate-csr.html.md
+++ b/source/manual/generate-csr.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-24
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/generate-csr.md)
 
-
-# Generate a Certificate Signing Request (CSR) for GOV.UK
 
 When buying an SSL certificate for a GOV.UK domain, a certificate
 signing request is required.

--- a/source/manual/github-enterprise.html.md
+++ b/source/manual/github-enterprise.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-08
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/github-enterprise/index.md)
 
-
-# GitHub Enterprise
 
 Our GitHub Enterprise installation lives at https://github.gds/ and is manged
 by the GDS service desk.

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-18
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/releasing-software/github-unavailable.md)
 
-
-# Deploy when GitHub is unavailable
 
 ## Public GitHub (application code)
 

--- a/source/manual/graphite-and-deployment-dashboards.html.md
+++ b/source/manual/graphite-and-deployment-dashboards.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-09
 review_in: 6 months
 ---
 
-# Graphite and deployment dashboards
-
 ## How Graphite is used with deployment dashboards
 
 Graphite is a data storage application for time stream data that is used to store data performance data, error counts and other statistics about gov.uk servers.

--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-07-01
 review_in: 6 months
 ---
 
-# Access apps on the shared Heroku account
-
 We use Heroku to host some non-critical applications like the [monitoring-screen][].
 
 The credentials for Heroku are found in

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -10,8 +10,6 @@ review_in: 6 months
 ---
 
 
-# Upload HMRC PAYE files
-
 ## Preamble
 
 HMRC have a [desktop application to submit

--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-28
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/howto-manually-remove-assets.md)
 
-
-# Remove an asset
 
 If you need to remove an asset manually from `assets.publishing.sevice.gov.uk`,
 follow these steps:

--- a/source/manual/howto-switch-off-app.html.md
+++ b/source/manual/howto-switch-off-app.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-06
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/howto-switch-off-app.md)
 
-
-# Switch an app off
 
 In the event of a security incident an app may need to be switched off until it
 can be patched.

--- a/source/manual/howto-transition-a-site-to-govuk.html.md
+++ b/source/manual/howto-transition-a-site-to-govuk.html.md
@@ -10,14 +10,10 @@ last_reviewed_on: 2017-01-26
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/howto-transition-a-site-to-govuk.md)
 
-
-# Transition a site to GOV.UK
 
 When a site is going to move to GOV.UK, there are broadly two ways that
 the old site can be redirected. They can do it themselves, or they can

--- a/source/manual/howto-update-pingdom-ip-ranges.html.md
+++ b/source/manual/howto-update-pingdom-ip-ranges.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-31
 review_in: 6 months
 ---
 
-# Update Pingdom IP Ranges
-
 There is a task that runs daily of "Check_Pingdom_IP_Ranges" which checks
 whether the IP addresses we have stored for Pingdom match the ones they
 are actually using.

--- a/source/manual/howto-upload-an-asset-to-asset-manager.html.md
+++ b/source/manual/howto-upload-an-asset-to-asset-manager.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-23
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/howto-upload-an-asset-to-asset-manager.md)
 
-
-# Upload an asset to asset-manager
 
 Some publishing apps such as Mainstream Publisher do not provide the facility for editors to upload
 assets such as images and PDFs. In these rare cases, we can upload assets to asset-manager manually

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-28
 review_in: 6 months
 ---
 
-# Jenkins CI infrastructure
-
 ## Introduction
 
 Our CI environment provides the infrastructure and services to cover the

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-01-30
 review_in: 6 months
 ---
 
-# Keeping software current
-
 One of our core values is to use secure and up to date software. This document lays out the recommendations for keeping our Ruby on Rails software current.
 
 ## Introduction

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-02-18
 review_in: 6 months
 ---
 
-# Useful Kibana queries
-
 All logs for GOV.UK are collected in Kibana:
 
 - <https://kibana.publishing.service.gov.uk>

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-21
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/logging/index.md)
 
-
-# How logging works on GOV.UK
 
 ## Syslog
 

--- a/source/manual/manage-sign-on-accounts.html.md
+++ b/source/manual/manage-sign-on-accounts.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-11
 review_in: 6 months
 ---
 
-# Manage signon accounts
-
 ## Accounts in different environments
 
 User accounts from production are synced to staging every morning, so any

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-04
 review_in: 6 months
 ---
 
-# MongoDB backups
-
 # automongodbbackup
 
 This is how MongoDB backups have traditionally been taken on the GOV.UK Infrastructure.

--- a/source/manual/monitor-sidekiq-workers.html.md
+++ b/source/manual/monitor-sidekiq-workers.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-05-03
 review_in: 6 months
 ---
 
-# Monitor Sidekiq queues for your application
-
 [Sidekiq] comes with a web application, [`Sidekiq::Web`](https://github.com/mperham/sidekiq/wiki/Monitoring) that can display the current state of a [Sidekiq] installation. We have [configured this](https://github.com/alphagov/sidekiq-monitoring) to monitor multiple [Sidekiq] configurations used throughout [GOV.UK].
 
 We have restricted public access as the Web UI allows modifying the state of [Sidekiq] queues.

--- a/source/manual/mysql.html.md
+++ b/source/manual/mysql.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-02-04
 review_in: 6 months
 ---
 
-# MySQL backups
-
 ## automysqlbackup
 
 This is how MySQL backups have traditionally been taken on the GOV.UK Infrastructure.

--- a/source/manual/nagios-nrpe-connection-failures.html.md
+++ b/source/manual/nagios-nrpe-connection-failures.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-12
 review_in: 6 months
 ---
 
-# Nagios NRPE connection failures
-
 Nagios uses a protocol called NRPE (Nagios Remote Plugin Executor) to perform
 checks on remote machines. Monitored machines run an 'NRPE agent' which
 listens for requests to execute monitoring checks.

--- a/source/manual/offsite-backup-and-restore.html.md
+++ b/source/manual/offsite-backup-and-restore.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-28
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/offsite-backup-and-restore.md)
 
-
-# Offsite backups
 
 We use [duplicity](http://duplicity.nongnu.org/) to perform offsite backups. Some
 backups are encrypted with GPG before being shipped to an Amazon S3 bucket.

--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-20
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/on-call.md)
 
-
-# Out of hours support (on-call)
 
 GOV.UK developers and web operations staff are part of an on-call rota
 to keep GOV.UK running at night, on the weekends and on public holidays.

--- a/source/manual/packer-vagrant-image-creation.html.md
+++ b/source/manual/packer-vagrant-image-creation.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-13
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/packer-vagrant-image-creation.md)
 
-
-# Packer Vagrant Dev VM / Image Creation
 
 This is a stub page that links to the real documentation for this task.
 

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -9,13 +9,9 @@ last_reviewed_on: 2017-04-28
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/introductions/pact_broker.md)
 
-
-# Pact Broker
 
 [Pact Broker](https://github.com/bethesque/pact_broker#readme) is a repository
 for consumer contracts created by the [pact

--- a/source/manual/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/pingdom-bouncer-canary-check.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-08
 review_in: 6 months
 ---
 
-# Pingdom Bouncer canary check
-
 Bouncer has a canary route at <https://www.direct.gov.uk/__canary__>
 which queries all the database tables which Bouncer uses to serve all
 responses to users and checks that those tables are not empty. The

--- a/source/manual/postgresql.html.md
+++ b/source/manual/postgresql.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-02-18
 review_in: 6 months
 ---
 
-# PostgreSQL backups
-
 ## autopostgresqlbackup
 
 This is how PostgreSQL backups have traditionally been taken on the GOV.UK Infrastructure.

--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-30
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/publish-to-puppet-forge.md)
 
-
-# Publish to Puppet Forge
 
 ## Logging in to the Forge
 

--- a/source/manual/puppet-class-assignment.html.md
+++ b/source/manual/puppet-class-assignment.html.md
@@ -8,14 +8,10 @@ last_reviewed_on: 2017-02-22
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/puppet-class-assignment.md)
 
-
-# Puppet Class Assignment
 
 ## High level overview
 

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-02-25
 review_in: 6 months
 ---
 
-# RabbitMQ
-
 ## How we run RabbitMQ
 
 We run a RabbitMQ cluster, which is used to trigger events when
@@ -31,8 +29,6 @@ Heartbeat messages are sent every minute by cron. Currently, we only
 send heartbeat messages to one exchange: the `published_documents`
 exchange. These heartbeats are sent via a rake task in the
 `content-store` app.
-
-
 ## Connecting to the RabbitMQ web control panel
 
 1.  Create an SSH tunnel to access the web control panel

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -10,14 +10,10 @@ last_reviewed_on: 2017-02-14
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/rebooting-machines.md)
 
-
-# Reboot a machine
 
 ## Rules of rebooting
 

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-12
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/redirect-routes.md)
 
-
-# Redirect a route
 
 To find if there is a redirect route for a particular path:
 

--- a/source/manual/redirecting-content-in-the-router.html.md
+++ b/source/manual/redirecting-content-in-the-router.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-16
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/redirecting-content-in-the-router.md)
 
-
-# Redirect content in the Router
 
 Sometimes there is a need to manually redirect existing URLs to another
 internal location, usually due to content being archived or because the

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-22
 review_in: 6 months
 ---
 
-# Remove a machine
-
 If you need to remove/decommission individual machines or a class of machines,
 there are several steps you need to go through.
 

--- a/source/manual/reprovision.html.md
+++ b/source/manual/reprovision.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-29
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/reprovision.md)
 
-
-# Reprovision a machine in vCloud Director
 
 Make sure you are aware what the consequences will be of removing a
 machine from the rotation and consider who needs to be aware of

--- a/source/manual/resync-mongo-db.html.md
+++ b/source/manual/resync-mongo-db.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-11-18
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/resync-mongo-db.md)
 
-
-# Resync a Mongo database
 
 To
 [resync](https://docs.mongodb.org/v2.4/tutorial/resync-replica-set-member/)

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-05-03
 review_in: 6 months
 ---
 
-# Retire an application
-
 To remove an application from our infrastructure take the following
 steps:
 

--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-20
 review_in: 6 months
 ---
 
-# Set up Heroku review apps for pull requests
-
 [Review apps](https://devcenter.heroku.com/articles/github-integration-review-apps)
 allow us to automatically deploy application changes into a brand
 new Heroku app so that each Pull Request reviewer has a chance to see how it

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-02-09
 review_in: 6 months
 ---
 
-# Review a page in this manual
-
 How to review pages in this manual.
 
 ## Questions to ask

--- a/source/manual/rotate-offsite-backup-gpg-keys.html.md
+++ b/source/manual/rotate-offsite-backup-gpg-keys.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-25
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/rotate-offsite-backup-gpg-keys.md)
 
-
-# Rotate offsite backup GPG keys
 
 To encrypt our offsite backups, we use GPG keys which are valid for a year. For
 good security practice we rotate these keys each year.

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-09
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/ruby.md)
 
-
-# Add a new Ruby version
 
 The Ruby language is a core part of GOV.UK - most of our applications
 are written in it.

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -10,14 +10,10 @@ last_reviewed_on: 2016-12-21
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/running-rake-tasks.md)
 
-
-# Run a rake task
 
 There is a Jenkins job that can be used to run any rake task:
 

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-14
 review_in: 6 months
 ---
 
-# Monitoring screens
-
 Most teams in GOV.UK have screens set up to show data about pull requests and
 releases.
 

--- a/source/manual/setting-up-new-mirror.html.md
+++ b/source/manual/setting-up-new-mirror.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-12
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/setting-up-new-mirror.md)
 
-
-# Set up a new mirror for GOV.UK
 
 We mirror GOV.UK on a number of providers which run independently of
 each other in order to ensure availability and integrity. In this

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-16
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/setting-up-new-rails-app.md)
 
-
-# Set up a new Rails app
 
 Getting a new Rails app configured and deployed to the integration and
 production infrastructure involves several steps across multiple

--- a/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
+++ b/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-28
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/setting-up-new-sidekiq-monitoring-app.md)
 
-
-# Add sidekiq-monitoring to your application
 
 [Sidekiq monitoring
 applications](https://github.com/mperham/sidekiq/wiki/Monitoring) are

--- a/source/manual/setting-up-request-tracing.html.md
+++ b/source/manual/setting-up-request-tracing.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-13
 review_in: 6 months
 ---
 
-# Set up request tracing
-
 Request tracing makes it easier to understand how requests originating from
 users of publishing apps make their way through the system. For example, if a
 user publishes a piece of content, request tracing will "connect the dots"

--- a/source/manual/setup-postgresql-replication.html.md
+++ b/source/manual/setup-postgresql-replication.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-02-26
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/howto/setup-postgresql-replication.md)
 
-
-# Set up PostgreSQL replication
 
 This how-to guide explains how to set-up PostgreSQL replication.
 

--- a/source/manual/side-by-side-browser.html.md
+++ b/source/manual/side-by-side-browser.html.md
@@ -9,8 +9,6 @@ last_reviewed_on: 2017-05-03
 review_in: 6 months
 ---
 
-# Side by Side Browser
-
 The side-by-side browser is a tool to preview redirections for sites that are
 being transitioned to GOV.UK.
 

--- a/source/manual/sidekiq-retries.html.md
+++ b/source/manual/sidekiq-retries.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-5-02
 review_in: 6 months
 ---
 
-# Sidekiq
-
 Many of our applications use
 [Sidekiq](https://github.com/mperham/sidekiq) for background job
 processing.

--- a/source/manual/smokey-smoke-tests.html.md
+++ b/source/manual/smokey-smoke-tests.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-07-01
 review_in: 6 months
 ---
 
-# Smoke testing with smokey
-
 We have [smoke tests][smokey] running against our infrastructure to verify
 that core functionality of the site is working.
 

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-03-01
 review_in: 6 months
 ---
 
-# Taxonomy
-
 GOV.UK's "single subject taxonomy" will describe all content on GOV.UK. It is being developed theme-by-theme, starting with education.
 
 ## 1. Editing taxonomy

--- a/source/manual/technical-setup.html.md
+++ b/source/manual/technical-setup.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2016-12-22
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/technical-setup.md)
 
-
-# Technical setup
 
 ## Production Access
 

--- a/source/manual/testing-projects.html.md
+++ b/source/manual/testing-projects.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-07-01
 review_in: 6 months
 ---
 
-# Test & build a project on Jenkins CI
-
 Application tests run in a continuous integration (CI) environment.
 
 https://ci.integration.publishing.service.gov.uk/

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-03-09
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/2nd-line/tools.md)
 
-
-# Tools: Icinga, Grafana and Graphite, Kibana and Fabric
 
 ## Icinga
 
@@ -42,8 +38,6 @@ navigation):
 [recovery_image]: images/icinga/recovery.png
 [unknown_image]: images/icinga/unknown.png
 [flapping_image]: images/icinga/flapping.gif
-
-
 ### External URLs
 
 A service may have two additional URLs associated with it which will assist
@@ -61,8 +55,6 @@ these icons:
 
 They will appear next to the service name in the service overview page or on
 the top-right of the page when viewing a specific service.
-
-
 ### Digging deeper
 
 If you want to dig a little deeper into the history of a specific alert click on it in the "Unhandled Services" view. In the top left of the main window there a few links. "View Alert Histogram For This Service" and "View Trends For This Service" are particularly useful.
@@ -109,8 +101,6 @@ Our [deployment dashboards](deployment-dashboards.html) use Graphite extensively
 ### Applying Functions
 
 Graphite has a whole bunch of functions you can apply to your data to make it more useful: they’re listed out [in the Graphite docs](http://graphite.readthedocs.org/en/0.9.12/functions.html). One particularly useful one is `keepLastValue`: if your graphs come out nearly black with a few spots of colour in them, you probably want this one. Both views have an Apply Function button.
-
-
 ## Kibana
 
 <https://kibana.publishing.service.gov.uk/>

--- a/source/manual/troubleshooting-vagrant.html.md
+++ b/source/manual/troubleshooting-vagrant.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-11-25
 review_in: 6 months
 ---
 
-# Troubleshooting Vagrant
-
 ## loading the Vagrantfile
 
 If you're encountering errors loading the `Vagrantfile`, check you're running the right version:

--- a/source/manual/upgrade-rails.html.md
+++ b/source/manual/upgrade-rails.html.md
@@ -8,8 +8,6 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-# Upgrade Rails
-
 When upgrading our apps between Rails major and minor versions, follow the [official Rails guides][guide]
 
 ## Gotchas for upgrading to Rails 5.0

--- a/source/manual/upgrading-mysql.html.md
+++ b/source/manual/upgrading-mysql.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2017-04-03
 review_in: 6 months
 ---
 
-# Upgrading mysql
-
 Upgrading mysql will cause 500 errors on sites as the master and slave
 machines are restarted, so this procedure needs to be done at a suitable
 time on production - i.e outside of core business hours (9:00 - 18:00

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -9,14 +9,10 @@ last_reviewed_on: 2017-01-31
 review_in: 6 months
 ---
 
-
-
 > **This page was imported from [the opsmanual on github.gds](https://github.gds/gds/opsmanual)**.
 It hasn't been reviewed for accuracy yet.
 [View history in old opsmanual](https://github.gds/gds/opsmanual/tree/master/infrastructure/vpn.md)
 
-
-# GOV.UK and Virtual Private Networks (VPNs)
 
 GOV.UK uses several VPNs to connect environments. This page explains what they
 are and what happens if they stop working.

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2016-12-01
 review_in: 6 months
 ---
 
-# Where to find what documentation?
-
 ## Individual repos
 
 - GOV.UK projects on GitHub should [conform to the README styleguide][readme]


### PR DESCRIPTION
We currently have to add the title of the page to the frontmatter as well as the body text. This is a bit error prone and needless. This PR makes it so we have to specify the title once, and removes the duplicate titles.

