### PR TITLE
Follow design community guidance for dates in deploying manual

### DIFF
--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -32,7 +32,7 @@ multiple teams are involved in the release, pick one.
 
 ## Experimental deployment process
 
-As a response to [RFC-70](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=130703581) starting 15th May we are experimenting with a process which allows us to remove the need to book a deployment slot. If you think there's something wrong with the process during the experiment speak up as soon as possible.
+As a response to [RFC-70](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=130703581) starting 15 May 2017 we are experimenting with a process which allows us to remove the need to book a deployment slot. If you think there's something wrong with the process during the experiment speak up as soon as possible.
 
 Deployment communications are in the `#govuk-deploy` Slack channel. If you are on 2ndline you should add yourself to that channel. As before, releases can start from 9:30am and must be finished by 5pm, or 4pm on Fridays.
 


### PR DESCRIPTION
https://www.gov.uk/service-manual/design/dates#how-to-write-dates