### PR TITLE
Update URL for the dns-config repo to github.com

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -54,7 +54,7 @@ job uses [Terraform](https://www.terraform.io/) and pushes changes to the
 selected provider.
 
 To make a change to this zone, begin by adding the records to the yaml file for
-the zone held in the [DNS config repo](https://github.digital.cabinet-office.gov.uk/gds/govuk-dns-config).
+the zone held in the [DNS config repo](https://github.com/alphagov/govuk-dns-config).
 
 When this has been reviewed and merged, you can deploy the changes using [the
 "Deploy DNS "Jenkins job](https://deploy.publishing.service.gov.uk/job/Deploy_DNS/).


### PR DESCRIPTION
As part of the migration from GHE move govuk-dns-config to a github private repo