### PR TITLE
Explain how to configure Fastly dictionaries in A/B tests

### DIFF
--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -85,9 +85,11 @@ If the original request did not have the `ABTest-Example` cookie, Fastly will se
 Follow these steps:
 
 1. Get your cookie listed on the [cookies page](https://www.gov.uk/help/cookies). Raise a ticket on [Gov.uk Zendesk](https://govuk.zendesk.com) and assign it to the content team's 2nd line Gov.uk content triage. They need to know the name of the cookie that you will be using, a description and the expiry time.
-2. Add the details for your test to the [ab_tests configuration file][configuration-file] in the [fastly-configure][fastly-configure] repo. You will need to set the name, the percentage of users to be given the b variant and the expiry time for the cookie.
-3. Use the [govuk\_ab\_testing gem][govuk_ab_testing] to serve different versions to your users.
+2. If you want to use Google Analytics to monitor the A/B test, talk to a performance analyst and pick a [GA dimension][analytics-dimensions] to use for your test. There is a range of dimensions from 40-49 blocked out for A/B tests. These can be reused when an A/B test has ended.
+3. Add the details for your test to the [ab_tests configuration file][configuration-file] in the [fastly-configure][fastly-configure] repo. You will need to set the name, the percentage of users to be given the b variant and the expiry time for the cookie.
+4. Use the [govuk\_ab\_testing gem][govuk_ab_testing] to serve different versions to your users. It can be configured with the analytics dimension selected in step 2.
 
+[analytics-dimensions]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Analytics+on+GOV.UK
 [govuk_ab_testing]: https://github.com/alphagov/govuk_ab_testing
 [configuration-file]: https://github.com/alphagov/fastly-configure/blob/master/ab_tests/ab_tests.yaml
 [fastly-configure]: https://github.com/alphagov/fastly-configure

--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -56,6 +56,8 @@ Fastly appends the `GOVUK-ABTest-Example` header to the request for downstream a
 - If the request already has a cookie, use the value of that
 - If not, randomly assign the user to a test variant and set it value based on that
 
+Fastly looks up the weighting for the random assignment in a [Fastly dictionary](https://docs.fastly.com/guides/edge-dictionaries/) configured for our A/B tests.
+
 Fastly will then try to get a response from its cache. The `Vary: GOVUK-ABTest-Example` header on previously cached responses will ensure that the right version is returned to the user.
 
 If there's nothing in Fastly's cache, it'll send the request down the stack to GOV.UK.
@@ -86,10 +88,18 @@ Follow these steps:
 
 1. Get your cookie listed on the [cookies page](https://www.gov.uk/help/cookies). Raise a ticket on [Gov.uk Zendesk](https://govuk.zendesk.com) and assign it to the content team's 2nd line Gov.uk content triage. They need to know the name of the cookie that you will be using, a description and the expiry time.
 2. If you want to use Google Analytics to monitor the A/B test, talk to a performance analyst and pick a [GA dimension][analytics-dimensions] to use for your test. There is a range of dimensions from 40-49 blocked out for A/B tests. These can be reused when an A/B test has ended.
-3. Add the details for your test to the [ab_tests configuration file][configuration-file] in the [fastly-configure][fastly-configure] repo. You will need to set the name, the percentage of users to be given the b variant and the expiry time for the cookie.
-4. Use the [govuk\_ab\_testing gem][govuk_ab_testing] to serve different versions to your users. It can be configured with the analytics dimension selected in step 2.
+3. Configure the A/B test in [the cdn-configs repo][cdn-configs]. Add your test to the following files:
+  - `active_ab_tests.yaml`: This controls whether the test is active or not. You may want to configure your test to be inactive at first, so that you can activate it at a later date.
+  - `ab_test_b_percentages.yaml`: The percentage of users who should see the B version of your test. This can be changed at a later date to expand the test to more users, but note that there will be some lag because users who have already visited the site will stay in their A/B test bucket until their cookie expires.
+  - `ab_test_expiries.yaml`: The lifetime of the A/B test cookie. The value you choose depends on what kind of change you are making. If it is important that users always see a consistent version of the site (e.g. because you are making large changes to the navigation) then choose a lifetime which is significantly longer than the duration of your A/B test, such as 1 year. On the other hand, a shorter lifetime (such as 1 day) causes less lag when changing the B percentage, and might be more appropriate when testing something where consistency is less important from day-to-day, such as changing the order of search results.
+4. Deploy the cdn-configs changes to staging and production using the `Update_CDN_Dictionaries` Jenkins job. The `vhost` must be set to `www`, and the credentials are in the deployment repo.
+5. Add your test to the [ab_tests configuration file][configuration-file] in the [fastly-configure][fastly-configure] repo. The test name must match the name configured in the cdn-configs repo in step 3.
+6. Deploy the Fastly configuration to staging and production using the `Deploy_CDN` Jenkins job. Use the same parameters as in step 4. You can test it on staging by visiting https://www.staging.publishing.service.gov.uk/. Changes should appear almost immediately - there is no caching of the CDN config.
+7. Use the [govuk\_ab\_testing gem][govuk_ab_testing] to serve different versions to your users. It can be configured with the analytics dimension selected in step 2.
+8. To activate or deactivate the test, or to change the B percentage, update your test in the cdn-configs repo and deploy the change.
 
 [analytics-dimensions]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Analytics+on+GOV.UK
+[cdn-configs]: https://github.digital.cabinet-office.gov.uk/gds/cdn-configs
 [govuk_ab_testing]: https://github.com/alphagov/govuk_ab_testing
 [configuration-file]: https://github.com/alphagov/fastly-configure/blob/master/ab_tests/ab_tests.yaml
 [fastly-configure]: https://github.com/alphagov/fastly-configure


### PR DESCRIPTION
- Add Google Analytics instructions for A/B tests
- Document the changes to A/B test deployment, which make it easier to activate A/B tests and update the B percentage.

https://trello.com/c/HOV2ChJ9/104-simplify-a-b-test-cdn-configuration

Marked as DO NOT MERGE until alphagov/govuk-cdn-config#53 is merged.