### PR TITLE
Remove references to the Content API

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -107,10 +107,13 @@
   product_manager: Rob Rankin
 
 - github_repo_name: govuk_content_api
+  retired: true
   type: APIs
   puppet_name: contentapi
-  product_manager: Holly Garrett
-  team: Navigation
+  description: |
+    API that used to store and serve published content to the rendering applications
+    for display from public-facing URLs. This has now been superceded by the
+    [content-store](/apps/content-store.html).
 
 - github_repo_name: govuk_need_api
   type: APIs

--- a/source/manual/creating-a-new-environment.html.md
+++ b/source/manual/creating-a-new-environment.html.md
@@ -239,36 +239,35 @@ of deployment matters and might have changed since this was written.
 Here is the order that was used for building the Carrenza preview
 environment:
 
-> 1.  errbit
-> 2.  router
-> 3.  router-api
-> 4.  whitehall
-> 5.  publisher
-> 6.  rummager
-> 7.  signon
-> 8.  smartanswers
-> 9.  release
-> 10. external\_link\_tracker
-> 11. govuk\_content\_api
-> 12. govuk\_need\_api
-> 13. asset-manager
-> 14. designprinciples
-> 15. feedback
-> 16. support
-> 17. travel-advice-publisher
-> 18. transaction-wrappers
-> 19. frontend
-> 20. static
-> 21. govuk-delivery
-> 22. transition
-> 23. licencefinder
-> 24. imminence
-> 25. kibana
-> 26. maslow
-> 27. bouncer
-> 28. calculators
-> 29. calendars
-> 30. licensify (it has separete Jenkins jobs)
+> 0. errbit
+> 0. router
+> 0. router-api
+> 0. whitehall
+> 0. publisher
+> 0. rummager
+> 0. signon
+> 0. smartanswers
+> 0. release
+> 0. external\_link\_tracker
+> 0. govuk\_need\_api
+> 0. asset-manager
+> 0. designprinciples
+> 0. feedback
+> 0. support
+> 0. travel-advice-publisher
+> 0. transaction-wrappers
+> 0. frontend
+> 0. static
+> 0. govuk-delivery
+> 0. transition
+> 0. licencefinder
+> 0. imminence
+> 0. kibana
+> 0. maslow
+> 0. bouncer
+> 0. calculators
+> 0. calendars
+> 0. licensify (it has separete Jenkins jobs)
 
 ## Other environment setup
 

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -85,7 +85,7 @@ To build a graph, you can add one or more graph targets in the composer by eithe
 Some useful targets are:
 
 - `stats.cache-?_router.nginx_logs.www-origin.http_5xx` to graph the rate of HTTP errors from all cache machines (note the question mark to pattern-match multiple data series: * also works).
-- `stats.backend-?_backend.nginx_logs.contentapi_publishing_service_gov_uk.http_5xx` to show HTTP errors for a specific app on all backend machines.
+- `stats.backend-?_backend.nginx_logs.content-store_publishing_service_gov_uk.http_5xx` to show HTTP errors for a specific app on all backend machines.
 
 The composer offers tab completion, although it doesn’t handle patterns very well.
 
@@ -105,7 +105,7 @@ Graphite has a whole bunch of functions you can apply to your data to make it mo
 
 <https://kibana.publishing.service.gov.uk/>
 
-Kibana is a log viewer and search engine. In Kibana, you can filter down log messages to show you just the ones you want. Say you’ve spotted a large number of errors coming from the content API related to MongoDB connections and you want to find out whether the MongoDB logs show anything strange. You can narrow down which log messages you want using the column browser on the left: `@source_host` and `@fields.application` are some particularly useful ones. The magnifying glass symbol next to each value lets you build up a query string and tinker with it.
+Kibana is a log viewer and search engine. In Kibana, you can filter down log messages to show you just the ones you want. Say you’ve spotted a large number of errors coming from the content store related to MongoDB connections and you want to find out whether the MongoDB logs show anything strange. You can narrow down which log messages you want using the column browser on the left: `@source_host` and `@fields.application` are some particularly useful ones. The magnifying glass symbol next to each value lets you build up a query string and tinker with it.
 
 You can tweak the time range manually with the drop down at the top or by dragging on the timeline.
 
@@ -115,13 +115,13 @@ Check out some of the [useful Kibana queries](kibana.html) to get an idea of wha
 
 <https://github.com/alphagov/fabric-scripts/>
 
-The Fabric scripts are useful for running something on a set of machines. For instance, to restart all instances of the content API on backend boxes:
+The Fabric scripts are useful for running something on a set of machines. For instance, to restart all instances of the content store on backend boxes:
 
-`fab $environment class:backend app.reload:contentapi`
+`fab $environment class:backend app.reload:content-store`
 
 Check the `app.py` class for different methods you can use. To run more specific commands you can run the following (`sdo` for sudo):
 
-`fab $environment class:backend sdo:"service contentapi reload"`
+`fab $environment class:backend sdo:"service content-store reload"`
 
 For more information, check out the [Fabric scripts README](https://github.com/alphagov/fabric-scripts#readme>).
 

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -60,7 +60,7 @@ If it goes down, these things will happen:
    unreachable hosts in GOV.UK monitoring
 
 Applying for a licence should remain available because
-the connection between GOV.UK (the router and contentapi) and the Licensify organisation is made
+the connection between GOV.UK (the router and content store) and the Licensify organisation is made
 over the internet rather than over the VPN.
 
 [carrenza-secure]: howto/connect-carrenza-il2.html


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api