### PR TITLE
Healthcheck usage

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -14,3 +14,5 @@ manual/docs-styleguide.html: manual/creating-pages.html
 manual/virus-scanning.html: manual/alerts/virus-scanning.html
 manual/elasticsearch.html: manual/elasticsearch-dumps.html
 manual/emergency-publishing-redis.html: manual/emergency-publishing.html
+manual/alerts/whitehall-app-health-check-not-ok.html: manual/alerts/whitehall-app-healthcheck-not-ok.html
+manual/alerts/publisher-app-health-check-not-ok.html: manual/alerts/publisher-app-healthcheck-not-ok.html

--- a/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#2ndline"
-title: publisher app health check not ok
+title: publisher app healthcheck not ok
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts

--- a/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#2ndline"
-title: Whitehall app health check not ok
+title: Whitehall app healthcheck not ok
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts


### PR DESCRIPTION
This tries to make the alerts related to /healthcheck fails more consistent. It's a big can of worms deciding whether the compound or non compound usage of "health check" makes sense, but this just takes the lead from https://github.com/alphagov/govuk-developer-docs/blob/master/source/manual/alerts/app-healthcheck-failed.html.md

Related to https://github.com/alphagov/govuk-puppet/pull/5985