### PR TITLE
Link to the correct source for Get started page

### DIFF
--- a/source/getting-started.html.md.erb
+++ b/source/getting-started.html.md.erb
@@ -2,6 +2,7 @@
 layout: getting_started_layout
 title: Get started
 description: Guide for new developers on GOV.UK
+source_url: https://github.com/alphagov/govuk-puppet/blob/master/development-vm/README.md
 ---
 
 # Get started


### PR DESCRIPTION
This should link to the puppet repo so the "View source" page works.