### PR TITLE
Use private env-sync-and-backup repo

### DIFF
--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -45,5 +45,5 @@ $ es_dump_restore http://localhost:9200/ <indexname> dumpfile.zip
 ```
 
 Given a directory of dumps named after their respective indices, you can
-use the [elasticsearch-restore.sh](https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/blob/master/scripts/elasticsearch-restore.sh)
+use the [elasticsearch-restore.sh](https://github.com/alphagov/env-sync-and-backup/blob/master/scripts/elasticsearch-restore.sh)
 script to restore them.

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -113,7 +113,7 @@ used by this app (eg <https://github.digital.cabinet-office.gov.uk/gds/developme
 Check the data replication scripts for anything specific to this application.
 
 Some applications have special case details in
-<https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/>. Any relating to the
+<https://github.com/alphagov/env-sync-and-backup/>. Any relating to the
 application should be removed.
 
 ## 12. Update DNS


### PR DESCRIPTION
The env-sync-and-backup repository is now in github (rather than GHE).
This updates links to use its new location: https://github.com/alphagov/env-sync-and-backup