### PR TITLE
Update elasticsearch backup guidance

### DIFF
--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -1,18 +1,20 @@
 ---
-owner_slack: "#2ndline"
+owner_slack: "#search-team"
 title: 'Elasticsearch: dump and restore indices'
 parent: "/manual.html"
 layout: manual_layout
 section: Backups
-last_reviewed_on: 2017-04-06
-review_in: 6 months
+last_reviewed_on: 2017-06-07
+review_in: 3 months
 ---
 
 ## Creating a dump
 
 Sometimes you may need to take a backup of Elasticsearch before a
-critical operation and all Elasticsearch servers create their own
-nightly backups via the following cronjob:
+critical operation. You can use [es_dump_restore](https://github.com/patientslikeme/es_dump_restore) for this.
+
+All Elasticsearch servers create their own
+nightly backups using a cronjob, which shows how to run it:
 
 ```bash
 $ sudo crontab -lu elasticsearch
@@ -20,22 +22,48 @@ $ sudo crontab -lu elasticsearch
 ```
 
 The first argument is the Elasticsearch instance and the second is the
-directory in which to store the output. The user running the dump needs
-permission to write to this directory.
+directory in which to store the output. The user running the dump needs permission to write to this directory.
 
 ## Restoring a dump
 
+Before restoring a backup, make sure you are [monitoring the cluster](/manual/alerts/elasticsearch-cluster-health.html).
+
 Restoring to an index which exists is additive - it doesn't replace the
 existing data or delete any documents which don't exist in the dump.
-This means that:
+This means that if the import fails (as it sometimes does), you can simply re-run the command.
 
-If you want to replace something, you have to delete it first:
+### Restoring GOV.UK search indexes (with aliases)
+
+Given a directory of dumps named after their respective indices, you can restore them using the same steps as the environment data sync script, [elasticsearch-restore.sh](https://github.com/alphagov/env-sync-and-backup/blob/master/scripts/elasticsearch-restore.sh).
+
+```
+backupfile="government.zip"
+alias_name=$(basename $backupfile .zip)
+iso_date="$(date --iso-8601=seconds|cut --byte=-19|tr [:upper:] [:lower:])z"
+real_name="$alias_name-$(date --iso-8601=seconds|cut --byte=-19|tr [:upper:] [:lower:])z-00000000-0000-0000-0000-000000000000"
+
+es_dump_restore restore_alias "http://localhost:9200/" "$alias_name" "$real_name" "$backupfile" '{}' $BATCH_SIZE
+```
+
+This will restore each backup into a new index, and then move the alias to point to it.
+
+If you need to change the alias back for any reason, you can run the rummager rake task `rummager:switch_to_named_index[foo-2017-01-01...]`, where `foo-2017-01-01...` is the name of the index you want to point the alias to. The task will automatically determine the correct alias name from the index name.
+
+The [search analytics jenkins job](https://deploy.publishing.service.gov.uk/job/search-fetch-analytics-data/) runs overnight and will automatically clean up search indexes that no longer have an alias pointing to them. It looks for indices with any of these names:
+
+- mainstream-$timestamp
+- detailed-$timestamp
+- government-$timestamp
+- page-traffic-$timestamp
+- metasearch-$timestamp
+
+### Restoring other indexes (without aliases)
+
+If you want to replace something, you have to delete it first.
 
 ```
 $ curl -XDELETE 'http://localhost:9200/indexname/'
 ```
-
-If the import fails (as it sometimes does), you can simply re-run the command.
 
 Given a dump, which will typically be a zipfile, then it can be restored
 into Elasticsearch:
@@ -43,7 +71,3 @@ into Elasticsearch:
 ```
 $ es_dump_restore http://localhost:9200/ <indexname> dumpfile.zip
 ```
-
-Given a directory of dumps named after their respective indices, you can
-use the [elasticsearch-restore.sh](https://github.com/alphagov/env-sync-and-backup/blob/master/scripts/elasticsearch-restore.sh)
-script to restore them.


### PR DESCRIPTION
I want to make sure we can follow this guidance for managing GOV.UK
search (the api-elasticsearch cluster) so I've assigned our team as
owner.

I think this is still out of date for logs-elasticsearch because we now
store snapshots on s3 using
https://www.elastic.co/guide/en/elasticsearch/reference/1.7/modules-snapshots.html
but I've left it out of this PR.

Review this in 3 months because we're likely to setup s3 backups for
api-elasticsearch too at some point.