### PR TITLE
Redirect offsite back to new file

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -16,3 +16,4 @@ manual/elasticsearch.html: manual/elasticsearch-dumps.html
 manual/emergency-publishing-redis.html: manual/emergency-publishing.html
 manual/alerts/whitehall-app-health-check-not-ok.html: manual/alerts/whitehall-app-healthcheck-not-ok.html
 manual/alerts/publisher-app-health-check-not-ok.html: manual/alerts/publisher-app-healthcheck-not-ok.html
+manual/offsite-backup-and-restore.html: manual/restore-from-offsite-backups.html


### PR DESCRIPTION
This file was renamed during https://github.com/alphagov/govuk-developer-docs/pull/260/files
This commit aims to redirect the page to the location.