### PR TITLE
Remove link to ci-puppet

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -69,7 +69,6 @@
     - name: Configuration
       repos:
         - govuk-puppet
-        - ci-puppet
         - fabric-scripts
 
     - name: Monitoring


### PR DESCRIPTION
This has moved to the attic, which breaks the build:

https://deploy.publishing.service.gov.uk/job/govuk-developer-docs/1730/console
