### PR TITLE
Remove reference to content-api

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -106,15 +106,6 @@
   team: Worldwide Publishing
   product_manager: Rob Rankin
 
-- github_repo_name: govuk_content_api
-  retired: true
-  type: APIs
-  puppet_name: contentapi
-  description: |
-    API that used to store and serve published content to the rendering applications
-    for display from public-facing URLs. This has now been superceded by the
-    [content-store](/apps/content-store.html).
-
 - github_repo_name: govuk_need_api
   type: APIs
   team: Publisher Data and Content Tools


### PR DESCRIPTION
This app has now been removed.

Trello: https://trello.com/c/2MF97xce/154-retire-content-api
Paired with: @Rosa-Fox