### PR TITLE
Review docs on search benchmark alerts

### DIFF
--- a/source/manual/alerts/search-benchmarking.html.md
+++ b/source/manual/alerts/search-benchmarking.html.md
@@ -4,8 +4,8 @@ title: Benchmark search queries failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2016-12-26
-review_in: 6 months
+last_reviewed_on: 2017-06-27
+review_in: 3 months
 ---
 
 Indicates that the Jenkins [search_benchmark healthcheck job]
@@ -19,7 +19,3 @@ only fail if something actually goes wrong. For example, if a request to the
 search API fails.
 
 Check the output of the job on the relevant environment for more information.
-
-It's common to see 'freshness threshold exceeded' alerts in integration on a
-Monday morning for this check, because integration is switched off over the
-weekend so the job has not been run for a couple of days.

--- a/source/manual/alerts/search-spelling-suggestions.html.md
+++ b/source/manual/alerts/search-spelling-suggestions.html.md
@@ -4,8 +4,8 @@ title: Check for spelling suggestions failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2016-12-26
-review_in: 6 months
+last_reviewed_on: 2017-06-27
+review_in: 3 months
 ---
 
 Indicates that the Jenkins [search_test_spelling_suggestions healthcheck job]
@@ -20,7 +20,3 @@ only fail if something actually goes wrong. For example, if a request to the
 search API fails.
 
 Check the output of the job on the relevant environment for more information.
-
-It's common to see 'freshness threshold exceeded' alerts in integration on a
-Monday morning for this check, because integration is switched off over the
-weekend so the job has not been run for a couple of days.


### PR DESCRIPTION
Remove warning about weekend failures on integration. These jobs have now been configured to only run on weekdays, so weekend failures should no longer occur.

Set a review date for three months' time because we expect to make changes to the search benchmarking in the next quarter.