### PR TITLE
Fix common 404

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -19,3 +19,10 @@ manual/alerts/publisher-app-health-check-not-ok.html: manual/alerts/publisher-ap
 manual/offsite-backup-and-restore.html: manual/restore-from-offsite-backups.html
 manual/redirecting-content-in-the-router.html: manual/redirect-routes.html
 manual/technical-setup.html: manual/on-call.html
+apis/search-api.html: apis/search/search-api.html
+manual/releasing-software.html: manual/deploying.html
+manual/mirror-fallback.html: manual/fall-back-to-mirror.html
+2nd-line/mirror-fallback.html: manual/fall-back-to-mirror.html
+manual/mirror-fallback.html: manual/fall-back-to-mirror.html
+manual/nagios.html: manual.html
+manual/alerts/applications/sidekiq-monitoring.html: manual/setting-up-new-sidekiq-monitoring-app.html

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -16,7 +16,7 @@ servers directly, they connect via the CDN. This is better because:
 - It reduces load on our origin. Fastly uses Varnish to cache responses.
 
 The CDN is responsible for retrying requests against the
-[static mirror](../2nd-line/mirror-fallback.html).
+[static mirror](/manual/fall-back-to-mirror.html).
 
 ![image](images/cdn-mirror-configuration.png)
 

--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -82,7 +82,7 @@ how serious the problem is and contact other people on GOV.UK if required.
 If you're phoned by somebody who works on GOV.UK it's likely that this is because:
 
 - There's a serious issue with the site which somebody else in government has noticed
-- Government has decided to do [emergency publishing](emergency-publishing.html)
+- Government has decided to do [emergency publishing](/manual/emergency-publishing.html)
 
 There's a separate process for urgent changes to content which doesn't require technical
 support (assuming everything is working).
@@ -90,6 +90,6 @@ support (assuming everything is working).
 ## Things you should read if you're on-call
 
 - [Stopping Nginx on the cache machines to fail to our static mirror](https://github.com/alphagov/fabric-scripts/blob/master/incident.py)
-- [Emergency publishing](emergency-publishing.html)
-- [Emergency publishing while origin is unavailable](mirror-fallback.html)
-- [Responding to an outage](outage-detail.html)
+- [Emergency publishing](/manual/emergency-publishing.html)
+- [Emergency publishing while origin is unavailable](/manual/fall-back-to-mirror.html)
+- [Responding to an outage](https://gov-uk.atlassian.net/wiki/display/PLOPS/GOV.UK+Incidents)

--- a/source/manual/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/pingdom-bouncer-canary-check.html.md
@@ -15,9 +15,6 @@ canary should return 200; if it doesn't then errors will be being served
 to users - see the table below for more details of the errors in each
 case.
 
-The application page for Bouncer and Transition [documents Bouncer's
-stack](applications/bouncer-and-transition.html#bouncer-s-stack).
-
 Possible causes of errors on the canary route include:
 
 -   DNS problems for `www.direct.gov.uk` or

--- a/source/manual/side-by-side-browser.html.md
+++ b/source/manual/side-by-side-browser.html.md
@@ -4,19 +4,17 @@ title: Side by Side Browser
 section: Transition
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual:  "https://github.digital.cabinet-office.gov.uk/pages/gds/opsmanual/infrastructure/side-by-side.html"
-last_reviewed_on: 2017-05-03
+last_reviewed_on: 2017-06-27
 review_in: 6 months
 ---
 
 The side-by-side browser is a tool to preview redirections for sites that are
 being transitioned to GOV.UK.
 
-[Github README]([https://github.com/alphagov/side-by-side-browser](https://github.com/alphagov/side-by-side-browser))
+- [Github repo](https://github.com/alphagov/side-by-side-browser)
+- [View the Side by Side Browser](http://www.apho.org.uk.side-by-side.alphagov.co.uk/__/#/)
 
-[View the Side by Side Browser](http://www.apho.org.uk.side-by-side.alphagov.co.uk/__/#/)
-
-## Deploying the side-by-side browser on AWS
+## Deploying the Side by Side browser on AWS
 
 [Instructions on the Wiki](https://gov-uk.atlassian.net/wiki/display/GOVUK/Bouncer+and+Transition) under 'Deploying the side-by-side browser on AWS'.
 
@@ -27,7 +25,7 @@ $ ssh side-by-side
 $ cd /data/side-by-side-browser
 ```
 
-There’s an etc/hosts.json file in the repo, but it’s periodically updated, so for now:
+There’s an `etc/hosts.json` file in the repo, but it’s periodically updated, so for now:
 
 ```
 $ sudo git stash
@@ -41,7 +39,7 @@ Restart the service:
 $ sudo /etc/init.d/side-by-side restart
 ```
 
-note, the command “service” doesn’t seem to work with the forever script :-(
+Note the command `service` doesn't seem to work with the forever script.
 
 Follow the logs, which are a bit too verbose:
 
@@ -49,7 +47,7 @@ Follow the logs, which are a bit too verbose:
 $ tail -f /var/log/side-by-side
 ```
 
-There’s a root cron job to check and fetch the hosts.json file every 15 minutes:
+There’s a root cron job to check and fetch the `hosts.json` file every 15 minutes:
 
 ```
 0,15,30,45 * * * * cd /data/side-by-side-browser/etc && curl -s -o temp-hosts.json https://transition.publishing.service.gov.uk/hosts.json && mv temp-hosts.json hosts.json >> /var/log/side-by-side-curl 2>&1


### PR DESCRIPTION
This fixes a number of pages that are currently 404'ing. Their sometimes caused by old links and incorrect relative links.

Found using kibana:

```
@fields.http_host:"docs.publishing.service.gov.uk" AND
@fields.status:404
```