### PR TITLE
Add link to Grafana dashboard for Sidekiq monitoring

### DIFF
--- a/source/manual/monitor-sidekiq-workers.html.md
+++ b/source/manual/monitor-sidekiq-workers.html.md
@@ -4,7 +4,7 @@ title: Monitor sidekiq queues for your application
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-05-03
+last_reviewed_on: 2017-06-28
 review_in: 6 months
 ---
 
@@ -19,6 +19,8 @@ $ ssh backend-1.backend.integration -CNL 9000:127.0.0.1:80
 ```
 
 Then visit [http://127.0.0.1:9000](http://127.0.0.1:9000) to see a list of [Sidekiq] configurations you can monitor.
+
+You can also monitor Sidekiq queue lengths using [this Grafana dashboard](https://grafana.publishing.service.gov.uk/dashboard/file/sidekiq.json).
 
 See also: [Add sidekiq-monitoring to your application](setting-up-new-sidekiq-monitoring-app.html).
 

--- a/source/manual/monitor-sidekiq-workers.html.md
+++ b/source/manual/monitor-sidekiq-workers.html.md
@@ -12,13 +12,13 @@ review_in: 6 months
 
 We have restricted public access as the Web UI allows modifying the state of [Sidekiq] queues.
 
-To gain access you should setup SSH port forwarding to a backend box belonging to the environment you wish to monitor when connected to the Bardeen wireless network or the VPN: 
+To gain access you should setup SSH port forwarding to a backend box belonging to the environment you wish to monitor when connected to the Bardeen wireless network or the VPN:
 
 ```bash
-$ ssh backend-1.backend.integration -CNL 9000:127.0.0.1:80 
+$ ssh backend-1.backend.integration -CNL 9000:127.0.0.1:80
 ```
 
-Then visit [http://127.0.0.1:9000](http://127.0.0.1:9000) to see a list of [Sidekiq] configurations you can monitor. 
+Then visit [http://127.0.0.1:9000](http://127.0.0.1:9000) to see a list of [Sidekiq] configurations you can monitor.
 
 See also: [Add sidekiq-monitoring to your application](setting-up-new-sidekiq-monitoring-app.html).
 


### PR DESCRIPTION
The Grafana dashboard doesn't show as much information as Sidekiq::Web, but it is handy for quickly viewing multiple queues and it allows you to view historical queue lengths.

Also clean up trailing whitespace in a separate commit.