### PR TITLE
Update reboot required docs

### DIFF
--- a/source/manual/alerts/reboot-required-by-apt.html.md
+++ b/source/manual/alerts/reboot-required-by-apt.html.md
@@ -11,6 +11,9 @@ review_in: 6 months
 This check indicates that some packages have been installed but cannot
 be activated without rebooting the machines.
 
+The check contains a list of apps that require a reboot (click into the warning
+for the list)
+
 See the [rebooting machines](/manual/rebooting-machines.html) for what to do.
 
 If there are a high number of machines requiring a reboot, including


### PR DESCRIPTION
From the existing documentation it isn't clear that the list of apps that require rebooting is actually in the check. This commit adds a line to that effect.