### PR TITLE
Review NTP drift docs

### DIFF
--- a/source/manual/alerts/ntp-drift-too-high.html.md
+++ b/source/manual/alerts/ntp-drift-too-high.html.md
@@ -4,7 +4,7 @@ title: ntp drift too high
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-01-02
+last_reviewed_on: 2017-07-05
 review_in: 6 months
 ---
 
@@ -12,4 +12,3 @@ There are tasks in fabric-scripts to make this less painful:
 
     fab $environment -H jumpbox-1.management ntp.status
     fab $environment -H jumpbox-1.management ntp.resync
-


### PR DESCRIPTION
I ran the `ntp.status` job on integration and it looked fine. I haven't tested `ntp.resync` but it looks correct.