### PR TITLE
Add instructions on processing virus scanning queue

### DIFF
--- a/source/manual/alerts/virus-scanning.html.md
+++ b/source/manual/alerts/virus-scanning.html.md
@@ -5,22 +5,84 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/virus-scanning.md"
-last_reviewed_on: 2016-12-27
+last_reviewed_on: 2017-07-05
 review_in: 6 months
 ---
 
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/2nd-line/alerts/virus-scanning.md)
-
-
 Documents uploaded to asset-master are scanned asynchronously through
-a virus scanner, as explained in <https://github.digital.cabinet-office.gov.uk/pages/gds/opsmanual/2nd-line/applications/whitehall.html?highlight=whitehall#virus-scanning-of-uploaded-files>
+a virus scanner, as explained below.
 
 If the number of documents is too high, users can experience long waiting times
-until they see the documents available. There is a Grafana [dashboard](https://grafana.publishing.service.gov.uk/dashboard/file/asset_master_virus_scan_speed.json) that helps to
-visualise the number of documents that have been processed and the waiting time since the file
-has been placed on disk until it is scanned.
+until they see the documents available. There is a Grafana [dashboard](https://grafana.publishing.service.gov.uk/dashboard/file/asset_master_virus_scan_speed.json)
+that helps to visualise the number of documents that have been processed and the
+waiting time since the file has been placed on disk until it is scanned.
 
-If the waiting time is too long, you can follow the [instructions](https://github.digital.cabinet-office.gov.uk/pages/gds/opsmanual/2nd-line/applications/whitehall.html?highlight=whitehall#quickly-processing-a-backlog-of-files-awaiting-av-scan) to quickly process a backlog of files
-awaiting the scan.
+# Virus scanning process
+
+## Incoming files
+
+All files uploaded through Whitehall (including both attachment documents and
+images) are asynchronously run through a virus scanner (ClamAV) before being
+made available to view.  This process runs on the asset master
+(`asset-master-1`).
+
+The AV scan process is as follows:
+
+1. Publisher uploads file, which gets written to a sub-directory within
+   `/mnt/uploads/whitehall/incoming/`, with the full path based on the
+   type of the upload and the ID of the edition being edited.
+2. Every minute, a cron job runs as the `assets` user and triggers the
+   [process-uploaded-attachments.sh](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb)
+   script.
+3. Each file currently found within the `incoming` directory is
+   scanned using ClamAV via the
+   [virus-scan-file.sh](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_asset_base/virus-scan-file.sh)
+   script.
+4. If the file is clean, it is moved to the `/mnt/uploads/whitehall/clean/`
+   directory, and is then available for users to view. It also writes the file
+   name to a list, which gets put into a temporary directory. If the file is
+   found to have an infection, it is moved to the
+   `/mnt/uploads/whitehall/infected` directory.
+5. Independent to this process, another cronjob runs every minute and triggers
+   the
+   [copy-attachments-to-slaves](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb)
+   script. This script copies each file found in the list (produced by the
+   previous task) to each asset slave and an Amazon S3 bucket.
+
+All scripts write to syslog, so you can check on the current processing as
+follows:
+
+    $ tail -f /var/log/syslog | grep "process_uploaded_attachment\|virus_scan\|copy_attachment"
+
+## Detecting new viruses
+
+A [separate script](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_asset_base/virus_scan.sh)
+regularly rescans *all* the previously uploaded files in both clean and
+draft-clean to catch any newly-released virus signatures.
+
+The script is configured in cron to run every hour, but actually takes over 2
+days to complete. It starts under a lock so that only one scan runs at a time.
+
+# Quickly process a backlog of files awaiting AV scan
+
+The AV scan process is currently quite slow (usually taking between 10-12
+seconds per file), and we get a lot of files to check.  If there's a large
+backlog, publishers can be waiting for hours for their files to be scanned.
+You can scan everything in the backlog in one go as follows:
+
+    $ find /mnt/uploads/whitehall/incoming -type f | xargs clamscan
+
+This shouldn't take more than a minute, unless there's a huge (>500 files)
+backlog.  The reason this is so much quicker than the per-file scan is that
+we're only starting `clamscan` once, rather than once per file.
+
+The output of that scan will tell you how many files are infected.  Assuming
+they are all clean (`Infected files: 0`), you can make all these available
+immediately by running:
+
+    $ sudo -u assets rsync -rav /mnt/uploads/whitehall/incoming/* /mnt/uploads/whitehall/clean/
+
+Note that this doesn't actually clear the queue: it simply shortcuts it.  Each
+file will still be scanned individually, and then copied to the asset slaves
+appropriately.  This means that any new uploads will still be at the back of
+the queue.


### PR DESCRIPTION
Two of the links in this guide were broken because they linked to the old Ops Manual. To fix this, copy two sections from https://github.digital.cabinet-office.gov.uk/attic/opsmanual/blob/master/2nd-line/applications/whitehall.rst:

- Background on how attachments are uploaded and processed by the ClamAV virus scanner
- Instructions on how to bypass the queue and publish all clean files immediately

---

I've tested that the links work and that the directories still exist. I haven't actually tested the command to process the backlog.

I'd appreciate a review from someone who knows about asset uploading - the content I've copied from the ops manual is very whitehall-specific but it sounds like it might apply to other publishing apps too. Is that right?