### PR TITLE
Add admin-tasks.md to the publishing-api docs

### DIFF
--- a/app/publishing_api_docs.rb
+++ b/app/publishing_api_docs.rb
@@ -7,6 +7,7 @@ class PublishingApiDocs
     "pact_testing" => "Contract testing with Pact",
     "publishing-application-examples" => "Examples",
     "rabbitmq" => "Message queue",
+    "admin-tasks" => "Admin tasks",
   }.freeze
 
   def self.pages


### PR DESCRIPTION
The files in the `doc` directory of publishing-api currently need to be hardcoded into this repo. While this isn't ideal, this PR is just a quick fix to get all the publishing-api docs displaying for now.