### PR TITLE
Update apps from taxonomy team

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -2,8 +2,8 @@
 
 - github_repo_name: collections-publisher
   type: Publishing apps
-  product_manager: Holly Garrett
-  team: Taxonomy and Content Transformation
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
 
 - github_repo_name: contacts-admin
   type: Publishing apps
@@ -13,8 +13,8 @@
 
 - github_repo_name: content-tagger
   type: Publishing apps
-  product_manager: Holly Garrett
-  team: Taxonomy and Content Transformation
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
 
 - github_repo_name: local-links-manager
   type: Publishing apps
@@ -47,8 +47,8 @@
 
 - github_repo_name: policy-publisher
   type: Publishing apps
-  product_manager: Holly Garrett
-  team: Taxonomy and Content Transformation
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
 
 - github_repo_name: publisher
   type: Publishing apps
@@ -66,8 +66,8 @@
 
 - github_repo_name: specialist-publisher
   type: Publishing apps
-  product_manager: Holly Garrett
-  team: Taxonomy and Content Transformation
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
 
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
@@ -195,13 +195,13 @@
 
 - github_repo_name: bouncer
   type: Supporting apps
-  product_manager: Holly Garrett
-  team: Navigation
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
 
 - github_repo_name: transition
   type: Supporting apps
-  product_manager: Holly Garrett
-  team: Navigation
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
 
 - github_repo_name: release
   type: Supporting apps
@@ -237,8 +237,6 @@
 
 - github_repo_name: collections
   type: Frontend apps
-  product_manager: Holly Garrett
-  team: Navigation
 
 - github_repo_name: contacts-frontend
   type: Frontend apps


### PR DESCRIPTION
We should also be using Slack usernames and channel names here so that people can easily find the correct person/team to ask about things.

Changes:

- Luke has taken over from Holly
- Transition & Bouncer are now in the taxonomy team
- The status of `collections` is unclear at the moment, more news later