### PR TITLE
Add links from app pages to API docs

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -64,6 +64,10 @@ class AppDocs
       "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_#{puppet_name}.json"
     end
 
+    def api_docs_url
+      app_data["api_docs_url"]
+    end
+
     def type
       app_data.fetch("type")
     end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -95,6 +95,7 @@
   type: APIs
   product_manager: Antonia Simmons
   team: Holding Government To Account
+  api_docs_url: /apis/content-store.html
 
 - github_repo_name: email-alert-api
   type: APIs
@@ -129,16 +130,19 @@
   type: APIs
   product_manager: Antonia Simmons
   team: Holding Government To Account
+  api_docs_url: /apis/link-checker-api.html
 
 - github_repo_name: publishing-api
   type: APIs
   product_manager: Antonia Simmons
   team: Holding Government To Account
+  api_docs_url: /apis/publishing-api.html
 
 - github_repo_name: rummager
   type: APIs
   product_manager: Mark McLeod
   team: "Search: measure and monitor"
+  api_docs_url: /apis/search-api.html
 
 - github_repo_name: asset-manager
   type: APIs
@@ -161,6 +165,7 @@
   type: APIs
   product_manager: Mark McLeod
   team: "Search: measure and monitor"
+  api_docs_url: https://mapit.mysociety.org/docs/
 
 - github_repo_name: metadata-api
   type: APIs

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -39,6 +39,10 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   <li><%= link_to "Deploy scripts", application.deploy_url %></li>
   <li><%= link_to "Deployment dashboard", application.dashboard_url %> (warning: not all apps have a dashboard)</li>
 
+  <% if application.api_docs_url %>
+    <li><%= link_to "API docs", application.api_docs_url %></li>
+  <% end %>
+
   <% if application.production_url %>
     <li><%= link_to application.production_url.gsub('https://', ''), application.production_url %></li>
   <% end %>


### PR DESCRIPTION
Several applications have APIs which are documented separately. Make it easier for users to find docs for the relevant API from the application page.

Joe L was looking for the content-store API docs yesterday and couldn't find them from the app page. It would also have helped me when I was first using the docs - I didn't realise there were separate API docs.