### PR TITLE
Add smart-answers to list of apps

### DIFF
--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -13,7 +13,7 @@ allow us to automatically deploy application changes into a brand
 new Heroku app so that each Pull Request reviewer has a chance to see how it
 looks with live data.
 
-These are 2 examples of GOV.UK apps that have review apps enabled:
+These are examples of GOV.UK apps that have review apps enabled:
 
 - [collections](https://github.com/alphagov/collections)
 - [government-frontend](https://github.com/alphagov/government-frontend)

--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -17,6 +17,8 @@ These are 2 examples of GOV.UK apps that have review apps enabled:
 
 - [collections](https://github.com/alphagov/collections)
 - [government-frontend](https://github.com/alphagov/government-frontend)
+- [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs) - this project
+- [smart-answers](https://github.com/alphagov/smart-answers)
 
 Follow the steps below in order to enable review apps for your GOV.UK
 application.


### PR DESCRIPTION
Smart Answers is also using Heroku Review apps so should be listed.

The GOV.UK Developer Docs repo itself also uses it so should be added
to the list.