### PR TITLE
Remove content-tools as owner for a bunch of apps

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -28,8 +28,6 @@
 
 - github_repo_name: maslow
   type: Publishing apps
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: panopticon
   retired: true
@@ -61,8 +59,6 @@
 
 - github_repo_name: short-url-manager
   type: Publishing apps
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: specialist-publisher
   type: Publishing apps
@@ -121,8 +117,6 @@
 
 - github_repo_name: govuk_need_api
   type: APIs
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: imminence
   type: APIs
@@ -156,8 +150,6 @@
 
 - github_repo_name: support-api
   type: APIs
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: hmrc-manuals-api
   type: APIs
@@ -172,8 +164,6 @@
 
 - github_repo_name: metadata-api
   type: APIs
-  team: "#content-tools"
-  product_manager: "@ben"
 
 # Support
 
@@ -193,8 +183,6 @@
 
 - github_repo_name: support
   type: Supporting apps
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: authenticating-proxy
   type: Supporting apps
@@ -234,13 +222,9 @@
 
 - github_repo_name: calculators
   type: Frontend apps
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: calendars
   type: Frontend apps
-  team: "#content-tools"
-  product_manager: "@ben"
 
 - github_repo_name: collections
   type: Frontend apps
@@ -291,8 +275,6 @@
 
 - github_repo_name: licence-finder
   type: Frontend apps
-  product_manager: "@ben"
-  team: "#content-tools"
 
 - github_repo_name: manuals-frontend
   type: Frontend apps


### PR DESCRIPTION
It's unclear who will own these applications, but it's not Ben / content tools.