### PR TITLE
Cross-link application pages with manual

### DIFF
--- a/app/manual.rb
+++ b/app/manual.rb
@@ -1,0 +1,14 @@
+class Manual
+  attr_reader :sitemap
+
+  def initialize(sitemap)
+    @sitemap = sitemap
+  end
+
+  def pages_for_application(app_name)
+    sitemap.resources
+      .select { |page| page.path.start_with?('manual/') && page.path.end_with?('.html') && page.data.title }
+      .select { |page| page.data.related_applications.to_a.include?(app_name) }
+      .sort_by { |page| page.data.title.downcase }
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -47,6 +47,10 @@ helpers do
     ManualIndexPage.new(sitemap)
   end
 
+  def manual
+    Manual.new(sitemap)
+  end
+
   def teams
     ApplicationsByTeam.teams
   end

--- a/source/manual/alerts/virus-scanning.html.md
+++ b/source/manual/alerts/virus-scanning.html.md
@@ -7,6 +7,7 @@ parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/virus-scanning.md"
 last_reviewed_on: 2017-07-05
 review_in: 6 months
+related_applications: [whitehall]
 ---
 
 Documents uploaded to asset-master are scanned asynchronously through

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -7,6 +7,7 @@ parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/architecture/assets.md"
 last_reviewed_on: 2017-06-13
 review_in: 6 months
+related_applications: [asset-manager]
 ---
 
 There are two types of asset files.

--- a/source/manual/attachments.html.md
+++ b/source/manual/attachments.html.md
@@ -7,6 +7,7 @@ parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/infrastructure/backups/attachments.md"
 last_reviewed_on: 2017-07-11
 review_in: 6 months
+related_applications: [whitehall]
 ---
 
 We sync all the data to two [S3] buckets:

--- a/source/manual/blocking-apps-from-release.html.md
+++ b/source/manual/blocking-apps-from-release.html.md
@@ -7,6 +7,7 @@ parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/blocking-apps-from-release.md"
 last_reviewed_on: 2017-04-28
 review_in: 6 months
+related_applications: [release]
 ---
 
 > **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.

--- a/source/manual/howto-transition-a-site-to-govuk.html.md
+++ b/source/manual/howto-transition-a-site-to-govuk.html.md
@@ -8,6 +8,7 @@ parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/howto-transition-a-site-to-govuk.md"
 last_reviewed_on: 2017-01-26
 review_in: 6 months
+related_applications: [bouncer, transition]
 ---
 
 > **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -6,6 +6,7 @@ layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2017-06-19
 review_in: 6 months
+related_applications: [short-url-manager]
 ---
 
 Sometimes, there is a need to manually redirect existing URLs to another

--- a/source/manual/rescan-infected-file.html.md
+++ b/source/manual/rescan-infected-file.html.md
@@ -6,6 +6,7 @@ layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2017-05-18
 review_in: 12 months
+related_applications: [whitehall]
 ---
 
 If you suspect that a file has been incorrectly marked as "infected" in Whitehall,

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -6,6 +6,7 @@ section: Publishing
 owner_slack: "#taxonomy"
 last_reviewed_on: 2017-03-01
 review_in: 6 months
+related_applications: [content-tagger]
 ---
 
 GOV.UK's "single subject taxonomy" will describe all content on GOV.UK. It is being developed theme-by-theme, starting with education.

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,3 +1,15 @@
+<div>
+  <% if current_page.data.related_applications %>
+    <h2 id='related-applications'>Related applications</h2>
+
+    <ul>
+    <% current_page.data.related_applications.to_a.each do |app| %>
+      <li><%= link_to app, "/apps/#{app}.html" %></li>
+    <% end %>
+    </ul>
+  <% end %>
+</div>
+
 <div class="meta-links">
   <%= link_to "View source", view_source_url %>
   <%= link_to "Report problem", report_issue_url %>

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -58,6 +58,16 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
 </ul>
 <% end %>
 
+<% if manual.pages_for_application(application.app_name) %>
+<h3>Relevant manual pages</h3>
+
+<ul>
+<% manual.pages_for_application(application.app_name).each do |page| %>
+  <li><%= link_to page.data.title, page.url %></li>
+<% end %>
+</ul>
+<% end %>
+
 <% if application.example_rendered_pages %>
 <h3>Example pages rendered by <%= application.app_name %></h3>
 


### PR DESCRIPTION
This allows us to specify "related applications" in manual pages. Doing that will generate a link in the footer to the application and link back from the application page to the manual.

## Screens

![screen shot 2017-07-18 at 10 01 10](https://user-images.githubusercontent.com/233676/28309064-1a650518-6ba0-11e7-9808-91f6e88c7493.png)
![screen shot 2017-07-18 at 10 01 30](https://user-images.githubusercontent.com/233676/28309065-1a6649a0-6ba0-11e7-9781-503f01be2afd.png)
