### PR TITLE
Add intro text to docs homepage

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,6 +14,9 @@ set :markdown,
 
 configure :development do
   activate :livereload
+
+  # Disable Google Analytics in development
+  config[:tech_docs][:ga_tracking_id] = nil
 end
 
 activate :autoprefixer

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,0 @@
-<a href='https://docs.publishing.service.gov.uk/'>Go to docs.publishing.service.gov.uk</a>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -22,7 +22,9 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/da
 <% end %>
 
 <% wrap_layout :layout_with_sidebar do %>
-  <%= partial 'partials/header' %>
+  <h1 class="page-title">GOV.UK developer docs</h1>
+
+  <%= partial 'partials/intro' %>
 
   <% dashboard.chapters.each do |chapter| %>
     <h2 id='<%= chapter.id %>'><%= chapter.name %></h2>

--- a/source/partials/_intro.html.md
+++ b/source/partials/_intro.html.md
@@ -1,0 +1,7 @@
+This is the technical documentation for [GOV.UK][], built by the
+[Government Digital Service (GDS)][GDS]. For other projects built by GDS, see
+the [Service Toolkit][].
+
+[GDS]: https://gds.blog.gov.uk/about/
+[GOV.UK]: https://www.gov.uk/
+[Service Toolkit]: https://www.gov.uk/service-toolkit


### PR DESCRIPTION
This intro is intended to show that the docs on this site are related to GOV.UK publishing, and not other "GOV.UK" branded products like Verify and Notify.

Also removes some cruft and disables GA in development.