### PR TITLE
Set parent page for apps by team page

### DIFF
--- a/source/apps/by-team.html.md.erb
+++ b/source/apps/by-team.html.md.erb
@@ -2,7 +2,7 @@
 layout: application_layout
 title: Application ownership by team
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
-parent: "/manual.html"
+parent: "/apps.html"
 ---
 
 <% unless ApplicationsByTeam.no_known_owner.empty? %>

--- a/source/apps/by-team.html.md.erb
+++ b/source/apps/by-team.html.md.erb
@@ -2,6 +2,7 @@
 layout: application_layout
 title: Application ownership by team
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
+parent: "/manual.html"
 ---
 
 <% unless ApplicationsByTeam.no_known_owner.empty? %>


### PR DESCRIPTION
This will highlight the "Apps" link in the main navigation.