### PR TITLE
Update the Publishing to Puppet Forge docs

### DIFF
--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -16,35 +16,39 @@ It hasn't been reviewed for accuracy yet.
 
 ## Logging in to the Forge
 
-Credentials for the GDS Operations account can be found in the
-`alphagov/govuk-secrets:creds/infra_team` secure store.
+Credentials for the GDS Operations account can be found in `packages/puppet_forge`
+in the 2ndline password store.
 
 The URL for our account is: <http://forge.puppetlabs.com/gdsoperations>
 
 ## Checks before releasing a new or updated module
 
-1)  Ensure that all tests pass and that the project conforms to our
+1.  Ensure that all tests pass and that the project conforms to our
     [Open Source
     Guidelines](https://gds-operations.github.io/guidelines/).
-2)  Choose a new version number in accordance with [Semantic
+2.  Choose a new version number in accordance with [Semantic
     Versioning](http://semver.org/).
-3)  Add a new release entry to the `CHANGELOG`.
-4)  Update the `version` field in `Modulefile`.
-5)  Create a pull request with these changes.
+3.  Add a new release entry to the `CHANGELOG`.
+4.  Update the `version` field in `Modulefile`.
+5.  Create a pull request with these changes.
 
 ## Releasing a new or updated module
 
-1)  Build the module with `bundle exec puppet module build`.
-2)  Click [Publish](https://forge.puppetlabs.com/upload).
-3)  Submit the tarball you just built from the `pkg/` directory.
+### Via the Forge website
 
-Alternatively, use the
+1.  Build the module with `bundle exec puppet module build`.
+2.  Click [Publish](https://forge.puppetlabs.com/upload).
+3.  Submit the tarball you just built from the `pkg/` directory.
+
+### Via the command line
+
+The web UI is the preferred method, but it is also possible to use the
 [puppet-blacksmith](https://github.com/maestrodev/puppet-blacksmith) gem
 to push from the command line.
 
 If publishing to the Forge was successful, create a tag on the
 repository:
 
-1)  Tag the release prefixed with a `v`, eg: `git tag v0.1.2`. Ensure
+1.  Tag the release prefixed with a `v`, eg: `git tag v0.1.2`. Ensure
     you tag the merge commit, not the branch commit.
-2)  Push the commit and tag to the repo: `git push --tags origin master`
+2.  Push the commit and tag to the repo: `git push --tags origin master`


### PR DESCRIPTION
- Use `pass` instead of the credstore.
- The password for the Puppet Forge account has moved to the 2ndline
  password store.
- Render numbered lists properly, delimited with `.` instead of `)`.
- Split the "Releasing" section into two - via the website, or via the
  command line, to make it clearer that they're not linked.