### PR TITLE
Add publishing components gem to dashboard

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -36,6 +36,7 @@
         - govuk_document_types
         - govuk_message_queue_consumer
         - govuk_navigation_helpers
+        - govuk_publishing_components
         - govuk_sidekiq
         - govuk_taxonomy_helpers
         - govuk-component-guide


### PR DESCRIPTION
A gem to document components in GOV.UK frontend applications
https://github.com/alphagov/govuk_publishing_components