### PR TITLE
Fix urls to rummager docs

### DIFF
--- a/source/apis/search/content.html.md.erb
+++ b/source/apis/search/content.html.md.erb
@@ -2,7 +2,7 @@
 layout: api_layout
 title: Content indexed in search and where it comes from
 parent: /search-api.html
-source_url: https://github.com/alphagov/rummager/blob/master/docs/content_overview.md
+source_url: https://github.com/alphagov/rummager/blob/master/doc/content_overview.md
 ---
 
-<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'docs/content_overview.md') %>
+<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'doc/content_overview.md') %>

--- a/source/apis/search/search-api.html.md.erb
+++ b/source/apis/search/search-api.html.md.erb
@@ -2,11 +2,11 @@
 layout: api_layout
 title: Search API
 parent: /apis.html
-source_url: https://github.com/alphagov/rummager/blob/master/docs/search-api.md
+source_url: https://github.com/alphagov/rummager/blob/master/doc/search-api.md
 ---
 
-> **This page was imported from the [docs directory](https://github.com/alphagov/rummager/blob/master/docs/) in the [rummager repo](https://github.com/alphagov/rummager/)**.
+> **This page was imported from the [docs directory](https://github.com/alphagov/rummager/blob/master/doc/) in the [rummager repo](https://github.com/alphagov/rummager/)**.
 
 > We're working on improving it.
 
-<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'docs/search-api.md') %>
+<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'doc/search-api.md') %>


### PR DESCRIPTION
docs/ was renamed to doc/

https://github.com/alphagov/rummager/commit/522250ae9a221414e5f1456fc6f48941f4817e79