### PR TITLE
Add a note about size of files in support-api

### DIFF
--- a/source/manual/alerts/asset-master-slave-disk-space-comparison.html.md
+++ b/source/manual/alerts/asset-master-slave-disk-space-comparison.html.md
@@ -38,3 +38,5 @@ If the disk usage is slowly increasing, the most likely cause of the alert is
 that a large volume of files has been uploaded to Whitehall. In this case the
 alert will only resolve itself when the daily sync job runs so the alert is a
 false alarm and can be acknowledged.
+
+It is worth checking the `support-api/csvs` directory as any reports generated against zendesk get created here, if the report is poorly constrained this can be large (>1GB). These files will be synced daily as part of the `rsync-uploads` task. Use `ls -hltr` to check if any of the recent files are particularly large.


### PR DESCRIPTION
The disk comparison check between assets slave & master can fail if
large reports have been compiled against zendesk. This adds a note to
this effect.