### PR TITLE
Update the location of router-data

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -56,10 +56,7 @@
         - fastly-configure
         - govuk-cdn-config
         - router
-      sites:
-        - name: gds/router-data
-          url: https://github.digital.cabinet-office.gov.uk/gds/router-data
-          description: Send routes directly to the router-api (deprecated)
+        - router-data
       sites:
         - name: gds/cdn-configs
           url: https://github.digital.cabinet-office.gov.uk/gds/cdn-configs

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -53,8 +53,8 @@ the Publishing API, then [router-data][router-data] can be
 used. Follow the [README](router-data-README) to create your redirects
 in a new branch and open a pull request.
 
-[router-data]: https://github.digital.cabinet-office.gov.uk/gds/router-data
-[router-data-README]: https://github.digital.cabinet-office.gov.uk/gds/router-data#router-data
+[router-data]: https://github.com/alphagov/router-data
+[router-data-README]: https://github.com/alphagov/router-data#router-data
 
 ## Fixing incorrect Corporate Information page redirects
 


### PR DESCRIPTION
The repository has moved from GitHub Enterprise, to a private
repository on GitHub.