### PR TITLE
Expose puppet name in API

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -25,6 +25,7 @@ class AppDocs
         app_name: app_name,
         product_manager: product_manager,
         team: team,
+        puppet_name: puppet_name,
         links: {
           self: "https://docs.publishing.service.gov.uk/apps/#{app_name}.json",
           html_url: "https://docs.publishing.service.gov.uk/apps/#{app_name}.html",


### PR DESCRIPTION
We'll need this to build something in https://github.com/alphagov/govuk-sentry-config/pull/1.

https://trello.com/c/Yxm08KR7