### PR TITLE
Override puppet_name for inconsistently named apps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,3 +48,10 @@ task :verify_deployable_apps do
     puts missing_app
   end
 end
+
+desc "Check all puppet names are valid, will error when not"
+task :check_puppet_names do
+  AppDocs.pages.reject(&:retired?).each do |app|
+    HTTP.get(app.puppet_url)
+  end
+end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -245,6 +245,7 @@
   type: Frontend apps
   team: "#publishing-frontend"
   product_manager: "@humin_miah"
+  puppet_name: designprinciples
 
 - github_repo_name: email-alert-frontend
   type: Frontend apps

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -119,6 +119,7 @@
 
 - github_repo_name: govuk_need_api
   type: APIs
+  puppet_name: need_api
 
 - github_repo_name: imminence
   type: APIs
@@ -277,6 +278,7 @@
 
 - github_repo_name: licence-finder
   type: Frontend apps
+  puppet_name: licencefinder
 
 - github_repo_name: manuals-frontend
   type: Frontend apps
@@ -294,6 +296,7 @@
   type: Frontend apps
   team: "#content-tools"
   product_manager: "@ben"
+  puppet_name: smartanswers
 
 - github_repo_name: service-manual-frontend
   team: "#servicemanual"


### PR DESCRIPTION
These apps have a different puppet name then their repo name implies, so the default (`repo_name.underscore`) doesn't work here. Having the correct puppet name will make the application page link correctly (https://docs.publishing.service.gov.uk/apps/smart-answers.html now leads to a 404).

https://trello.com/c/iTFRLCaM