### PR TITLE
Add example of querying CDN logs in Kibana

### DIFF
--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -64,6 +64,12 @@ Nginx logs for frontend:
 
 Note: the `@timestamp` field records the request END time. To calculate request start time subtract `@fields.request_time`.
 
+### CDN logs
+
+```rb
+@fields.application:"govuk-cdn-logs-monitor"
+```
+
 ### Application upstart logs
 
 ```rb


### PR DESCRIPTION
This query is also available on
https://docs.publishing.service.gov.uk/manual/alerts/fastly-error-rate.html#errr-rate-alert
but I didn't find it on that page when trying to work out how to query the CDN
logs. Adding it as an example here should hopefully make it easier for other
people to work out how to do it in future.