### PR TITLE
Review and update "Data sync" manual page

### DIFF
--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -5,7 +5,7 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/data-sync.md"
-last_reviewed_on: 2017-02-17
+last_reviewed_on: 2017-07-25
 review_in: 6 months
 ---
 
@@ -18,3 +18,11 @@ Data is synced from production to staging and integration every night.
 
 Check the output of the production Jenkins job to see which part of
 the data sync failed. It may be safe to re-run part of the sync.
+
+The Jenkins jobs included in the sync are:
+
+* Copy Data to Staging
+* Copy Data to integration
+* Copy Licensify Data to staging
+
+See the [source code](https://github.com/alphagov/env-sync-and-backup/tree/master/jobs) of the jobs for more information about how they work.

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -5,7 +5,7 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/data-sync.md"
-last_reviewed_on: 2017-07-25
+last_reviewed_on: 2017-08-30
 review_in: 6 months
 ---
 
@@ -18,6 +18,8 @@ Data is synced from production to staging and integration every night.
 
 Check the output of the production Jenkins job to see which part of
 the data sync failed. It may be safe to re-run part of the sync.
+
+Warning: the mysql backup will cause signon in staging to point to production until the `Data Sync Complete` job runs and renames the hostnames copied from production to back to their staging equivalents.  This means that any deploys to staging that rely on GDS API Adapters are likely to fail due to to authentication failures.
 
 The Jenkins jobs included in the sync are:
 


### PR DESCRIPTION
Update the "Data sync" manual page to use the word "Copy"

The jobs that perform the data sync are called "Copy ...." if you
search the manual with the name of the job you'd never find this page
because the word "copy" doesn't appear anywhere.