### PR TITLE
Add info about listing locks for puppet last run docs

### DIFF
--- a/source/manual/alerts/puppet-last-run-errors.html.md
+++ b/source/manual/alerts/puppet-last-run-errors.html.md
@@ -4,7 +4,7 @@ title: Puppet last run errors
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-05-18
+last_reviewed_on: 2017-08-31
 review_in: 6 months
 ---
 
@@ -20,4 +20,10 @@ You can also try running Puppet again and check the output:
 
 ```
 govuk_puppet --test
+```
+
+Sometimes this alert means that there is a puppet lock on the machine, so puppet won't be run. You can list current locks by running:
+
+```
+govuk_puppet -l
 ```


### PR DESCRIPTION
Sometimes the reason for this alert is that there is a puppet lock on the machine, so add a note about it.