### PR TITLE
Update elasticsearch reboot documentation

### DIFF
--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -115,9 +115,7 @@ The general approach for rebooting machines in a MongoDB cluster is:
 
 To reboot an Elasticsearch machine, run the following command:
 
-    fab $environment class:elasticsearch numbered:N elasticsearch.safe_reboot
-
-(you will also need to do this for `class:logs_elasticsearch`).
+    fab $environment -H '<machine-to-reboot>' elasticsearch.safe_reboot
 
 This will prevent you from rebooting a machine in a cluster which
 doesn't have a green cluster health status.


### PR DESCRIPTION
This makes the reboot instructions for elasticsearch consistent with the
other types of servers and is easier to follow as it's hard to know what
machines will be affected by the previous command.