### PR TITLE
Add puppet_name for asset-manager

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -148,6 +148,7 @@
 - github_repo_name: asset-manager
   type: APIs
   team: "#2ndline"
+  puppet_name: asset-manager
 
 - github_repo_name: router-api
   type: APIs


### PR DESCRIPTION
This fixes the broken link to the Deployment dashboard on the
apps/asset-manager.html page.

The link changes from:

  https://grafana.publishing.service.gov.uk/dashboard/file/deployment_asset_manager.json

to:

  https://grafana.publishing.service.gov.uk/dashboard/file/deployment_asset-manager.json

I've tried this locally and have confirmed that the new link works as
expected.