### PR TITLE
Add tips on dealing with a broken bowl

### DIFF
--- a/source/manual/fix-problems-with-vagrant.html.md
+++ b/source/manual/fix-problems-with-vagrant.html.md
@@ -36,6 +36,51 @@ $ cd /var/govuk/govuk-puppet/development-vm
 $ foreman start rummager
 ```
 
+Most apps also have a `startup.sh` script in their root folder, and you can
+run that directly too:
+
+```shell
+$ cd /var/govuk/rummager
+$ ./startup.sh
+````
+
+## Using `bowl` fails with bundler error
+
+Sometimes the `bowl` command is not correctly installed on the VM.  If you
+get an error like:
+
+```shell
+$ bowl frontend
+bash: bowl: command not found
+```
+
+In other ruby applications this type of error can be solved by running the
+command via `bundle exec` which load the application's `Gemfile` and makes
+sure all the commands from the dependencies listed in there are available.
+In this case however, `bowl` should be globally available, and running it via
+`bundle exec` means we can't change the ruby version it will use to run each
+different app.  Leading to errors like:
+
+```
+/usr/lib/rbenv/versions/2.4.0/bin/bundle:22:in `load': cannot load such file -- /usr/lib/rbenv/versions/1.9.3-p550/lib/ruby/gems/1.9.1/gems/bundler-1.7.4/lib/gems/bundler-1.7.4/bin/bundle (LoadError)
+````
+
+or
+
+```
+/usr/lib/rbenv/versions/1.9.3-p550/lib/ruby/gems/1.9.1/gems/bundler-1.7.4/lib/bundler/source/git.rb:188:in `rescue in load_spec_files': https://github.com/alphagov/mongoid_rails_migrations (at avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix) is not yet checked out. Run `bundle install` first. (Bundler::GitError)
+```
+
+To make `bowl` globally available reinstall it:
+
+```shell
+$ cd /var/govuk/govuk-puppet/development-vm
+$ sudo gem install bowler
+$ rbenv rehash
+```
+
+You should now be able to use `bowl` to run the apps correctly.
+
 ## Can't connect to Mongo
 
 This is probably happening because your VM didn't shut down cleanly.

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -161,6 +161,8 @@ If you don't need an optional dependency, you can pass the `-w` option:
 
     dev$ bowl whitehall -w mapit
 
+If these `bowl` commands fail, try the troubleshooting guide on [how to fix a broken bowl](/manual/fix-problems-with-vagrant.html#using-bowl-fails-with-bundler-error).
+
 ## 9. Keep your VM up to date
 
 There are a few scripts that should be run regularly to keep your VM up to date. In `govuk-puppet/development-vm` there is `update-git.sh` and `update-bundler.sh` to help with this. Also, `govuk_puppet` should be run from anywhere on the VM regularly.


### PR DESCRIPTION
Sometimes the VM ends up created without a fully working `bowl` command
so the advice in the getting started guide about running apps seems like
it is out of date.  The resolution is to manually install the bowler gem
rather than trying to use `bundle exec bowl` or ignoring `bowl` in favour
of using `startup.sh` in each app folder directly.

It's not clear to me why some VMs get into this state, and others don't,
but it's happened enough that some docs on solving it wouldn't go amiss.

[Fixes #424]