### PR TITLE
Remove govuk-component-guide repo

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -39,7 +39,6 @@
         - govuk_publishing_components
         - govuk_sidekiq
         - govuk_taxonomy_helpers
-        - govuk-component-guide
         - plek
         - slimmer
 


### PR DESCRIPTION
This repo has moved to the attic.