### PR TITLE
Retire Need API

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -118,9 +118,14 @@
     [content-store](/apps/content-store.html).
 
 - github_repo_name: govuk_need_api
+  retired: true
   type: APIs
   puppet_name: need_api
   team: "#survey-and-support"
+  description: |
+    A JSON read and write API for information about user needs on GOV.UK. It was a Rails
+    app which was part of the GOV.UK Publishing Platform. The need information is now
+    stored in the Publishing API, and available in the Content Store.
 
 - github_repo_name: imminence
   type: APIs


### PR DESCRIPTION
Mark `govuk_need_api` as retired and add a description.

For: https://trello.com/c/ClCFMBlG/217-retire-need-api