### PR TITLE
Review search docs

### DIFF
--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -4,8 +4,8 @@ title: Elasticsearch cluster health
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-06-07
-review_in: 3 months
+last_reviewed_on: 2017-09-12
+review_in: 6 months
 ---
 
 Elasticsearch reports cluster health as one of three possible states, based on
@@ -38,7 +38,7 @@ to help you diagnose any problems.
 
 #### Find hosts in an elasticsearch cluster
 
-We use different elasticsearch clusters for different applications. For example, the `logs-elasticsearch` cluster is used for logging, and the `api-elasticsearch` cluster powers the GOV.UK search API.
+We use different elasticsearch clusters for different applications. For example, the `logs-elasticsearch` cluster is used for logging, and the `rummager-elasticsearch` cluster powers the GOV.UK search API.
 
 You can find hostnames by running:
 

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -4,8 +4,8 @@ title: 'Backup and restore Elasticsearch indices'
 parent: "/manual.html"
 layout: manual_layout
 section: Backups
-last_reviewed_on: 2017-06-07
-review_in: 3 months
+last_reviewed_on: 2017-09-12
+review_in: 2 months
 ---
 
 ## Creating a backup
@@ -56,6 +56,9 @@ The [search analytics jenkins job](https://deploy.publishing.service.gov.uk/job/
 - government-$timestamp
 - page-traffic-$timestamp
 - metasearch-$timestamp
+
+After restoring a backup, consider [replaying traffic](/manual/rummager-traffic-replay.html)
+to bring the search index back in sync with the publishing apps.
 
 ### Restoring other indexes (without aliases)
 


### PR DESCRIPTION
The cluster health one looks good, I've just updated a reference to
api-elasticsearch, because we'll shortly be replacing it with
rummager-elasticsearch, which runs a newer version.

I've linked the elasticsearch backup/restore to traffic replay.  We're
currently changing the indexing process so this is likely to change -
I've shortened the review time to reflect that.