### PR TITLE
Add additional suggestion to get bowler working

### DIFF
--- a/source/manual/fix-problems-with-vagrant.html.md
+++ b/source/manual/fix-problems-with-vagrant.html.md
@@ -81,6 +81,12 @@ $ rbenv rehash
 
 You should now be able to use `bowl` to run the apps correctly.
 
+However, if you are seeing an error such as
+`rbenv: cannot rehash: /usr/lib/rbenv/shims/.rbenv-shim exists` but the
+`.rbenv-shim` file doesn't exist, try rebooting the VM. Use `vagrant halt`,
+`vagrant up` and then `vagrant ssh` and hopefully `bowl` should be globally
+available.
+
 ## Can't connect to Mongo
 
 This is probably happening because your VM didn't shut down cleanly.


### PR DESCRIPTION
Sometimes `bowl` fails to execute even after reinstalling the gem and
running `rbenv rehash`.

`rbenv` thinks that a rehash is in progress, usually indicated by a
temporary file `.rbenv-shim`. However, such file doesn't exist.

The solution to this has been to restart vagrant.