### PR TITLE
Add frontend memcache clear step and echo env instructions

### DIFF
--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -56,6 +56,11 @@ $ . ~/venv/fabric-scripts/bin/activate
 export environment=integration
 ```
 
+4) If you'd like to double check the environment you have set:
+```
+echo $environment
+```
+
 ### Deploy the banner using Jenkins
 
 The data for the emergency banner is stored in Redis. Jenkins is used to set the variables.
@@ -83,13 +88,15 @@ static:
 fab $environment campaigns.clear_cached_templates
 ```
 
-2) Clear the cache for whitehall-frontend by restarting memcached:
+2) Clear the cache for whitehall-frontend and frontend by restarting memcached:
 
 ```
 fab $environment class:whitehall_frontend app.restart:memcached
+fab $environment class:frontend app.restart:memcached
 ```
 
 You may also need to restart `government-frontend` for Whitehall and Travel Advice pages:
+(Note for the reader: This step may not be necessary anymore due to the addition of the memcache clear above, if this is the case please remove this step as part of your 2ndline testing)
 
 ```shell
 fab $environment class:frontend app.restart:government-frontend


### PR DESCRIPTION
We've added a step to check your environment, hopefully this will help
people in a high stress situation to double check they're in the right environment.

We've also added a step to clear the memcache for the frontend class since government-frontend
now uses Dalli (memcache based) for it's caching, enabling a quicker update.

There is also a note left for the next 2ndline to see if a government-frontend restart is still required.

Thanks to @bevanloon for the memcache spelunking