### PR TITLE
Mark govuk-delivery as retired

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,8 +38,6 @@ task :verify_deployable_apps do
     errbit
     kibana-gds
     sidekiq-monitoring
-
-    govuk-delivery
   ]
 
   puts "Deployables is not included in applications.yml:"

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -104,9 +104,14 @@
   product_manager: "@martinlugton"
 
 - github_repo_name: govuk-delivery
+  retired: true
   type: APIs
   team: "#email"
   product_manager: "@martinlugton"
+  description: |
+    API that was once used to handle Whitehall email notifications and the 
+    translation of Whitehall feed URLs into Govdelivery topics. Retired in favour
+    of email-alert-api in September 2017.
 
 - github_repo_name: govuk_content_api
   retired: true

--- a/source/manual/creating-a-new-environment.html.md
+++ b/source/manual/creating-a-new-environment.html.md
@@ -258,7 +258,6 @@ environment:
 > 0. transaction-wrappers
 > 0. frontend
 > 0. static
-> 0. govuk-delivery
 > 0. transition
 > 0. licencefinder
 > 0. imminence


### PR DESCRIPTION
Also removes some other references to govuk-delivery. We have retired
this app as it is no longer used.

[Trello](https://trello.com/c/xHgvQXOX/137-archive-and-remove-govuk-delivery)