### PR TITLE
Rename govuk-sentry-config to govuk-saas-config

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -77,7 +77,7 @@
         - govuk-tagging-monitor
         - kibana-gds
         - sidekiq-monitoring
-        - govuk-sentry-config
+        - govuk-saas-config
         - govuk_app_config
 
       sites:

--- a/source/manual/error-reporting.html.md
+++ b/source/manual/error-reporting.html.md
@@ -14,9 +14,9 @@ When exceptions occur in production environments we need to be notified. We use 
 
 ## Configuring Sentry
 
-We configure Sentry using [govuk-sentry-config][]. It reads from the docs and makes sure all the configuration is set up correctly.
+We configure Sentry using [govuk-saas-config][]. It reads from the docs and makes sure all the configuration is set up correctly.
 
 [Errbit]: https://errbit.com/docs/master/
 [Sentry]: https://sentry.io/govuk
-[govuk-sentry-config]: https://github.com/alphagov/govuk-sentry-config
+[govuk-saas-config]: https://github.com/alphagov/govuk-saas-config
 [Sentry.io]: https://sentry.io/about

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -214,9 +214,9 @@ To complete the setup, do the following.
 
 ### Create the app in Sentry
 
-Run the appropriate rake task in [govuk-sentry-config][].
+Run the appropriate rake task in [govuk-saas-config][].
 
-[govuk-sentry-config]: https://github.com/alphagov/govuk-sentry-config
+[govuk-saas-config]: https://github.com/alphagov/govuk-saas-config
 
 ### Update Puppet to include the environment variables for airbrake
 


### PR DESCRIPTION
We've renamed this repo so that we can also put other scripts there (to configure GitHub for example).