### PR TITLE
Add two new component guides

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -87,6 +87,10 @@ class AppDocs
       app_data["api_docs_url"]
     end
 
+    def component_guide_url
+      app_data["component_guide_url"]
+    end
+
     def type
       app_data.fetch("type")
     end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -261,6 +261,7 @@
   type: Frontend apps
   product_manager: "@gansenthi"
   team: "#frontend-design"
+  component_guide_url: https://govuk-collections.herokuapp.com/component-guide
 
 - github_repo_name: contacts-frontend
   type: Frontend apps
@@ -289,6 +290,7 @@
   type: Frontend apps
   team: "#publishing-frontend"
   product_manager: "@humin_miah"
+  component_guide_url: https://finder-frontend.herokuapp.com/component-guide
 
 - github_repo_name: frontend
   type: Frontend apps
@@ -299,6 +301,7 @@
   type: Frontend apps
   team: "#publishing-frontend"
   product_manager: "@humin_miah"
+  component_guide_url: https://government-frontend.herokuapp.com/component-guide
 
 - github_repo_name: info-frontend
   type: Frontend apps
@@ -343,3 +346,4 @@
   type: Frontend apps
   team: "#publishing-frontend"
   product_manager: "@humin_miah"
+  component_guide_url: https://govuk-static.herokuapp.com/component-guide

--- a/source/manual/components.html.md
+++ b/source/manual/components.html.md
@@ -18,6 +18,8 @@ Find components in these guides:
 
 * [static component guide](https://govuk-static.herokuapp.com/component-guide/)
 * [government-frontend component guide](https://government-frontend.herokuapp.com/component-guide/)
+* [collections component guide](https://govuk-collections.herokuapp.com/component-guide/)
+* [finder-frontend component guide](https://finder-frontend.herokuapp.com/component-guide/)
 
 ## Building components
 

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -44,6 +44,10 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
     <li><%= link_to "API docs", application.api_docs_url %></li>
   <% end %>
 
+  <% if application.component_guide_url %>
+    <li><%= link_to "Component guide", application.component_guide_url %></li>
+  <% end %>
+
   <% if application.production_url %>
     <li><%= link_to application.production_url.gsub('https://', ''), application.production_url %></li>
   <% end %>


### PR DESCRIPTION
Collections and finder-frontend now use the govuk_publishing_components gem and have Heroku review apps and pipelines set up.