### PR TITLE
Add section on transition to dashboard

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -214,16 +214,6 @@
   product_manager: "@martinlugton"
   team: "#publishing-platform"
 
-- github_repo_name: bouncer
-  type: Supporting apps
-  product_manager: "@lukemalcher"
-  team: "#taxonomy"
-
-- github_repo_name: transition
-  type: Supporting apps
-  product_manager: "@lukemalcher"
-  team: "#taxonomy"
-
 - github_repo_name: release
   type: Supporting apps
   product_manager: "@robrankin"
@@ -347,3 +337,15 @@
   team: "#start-pages"
   product_manager: "@humin_miah"
   component_guide_url: https://govuk-static.herokuapp.com/component-guide
+
+# Transition
+
+- github_repo_name: bouncer
+  type: Transition apps
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"
+
+- github_repo_name: transition
+  type: Transition apps
+  product_manager: "@lukemalcher"
+  team: "#taxonomy"

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -102,6 +102,29 @@
         - release
         - govuk-app-deployment
 
+- name: Transition
+  sections:
+    - name: Transition apps
+    - name: Supporting transition
+      repos:
+        - alphagov/transition-config
+        - alphagov/optic14n
+        - alphagov/assets-directgov
+        - alphagov/assets-businesslink
+        - alphagov/side-by-side-browser
+      sites:
+        - name: pre-transition-stats
+          url: https://github.com/alphagov/pre-transition-stats
+          description: |
+            Processes statistics from sites before they transition to GOV.UK.
+            It creates an intermediate aggregate TSV file from web server logs
+            suitable for import into Transition.
+        - name: transition-stats
+          url: https://github.com/alphagov/transition-stats
+          description: |
+            Daily aggregate statistics gleaned from the GOV.UK redirector
+            Fastly logfiles.
+
 - name: Team tools
   sections:
     - name: Misc


### PR DESCRIPTION
`bouncer` and `transition` are apps that we use to support sites
transitioning to gov.uk, but there are a handful of other tools we use as
aprt of this process.  We collect them all here in a new "Transition"
section on the dashboard.  The repos were found via [the
`govuk-transition` topic on github][govuk-transition].  Some of the repos
we link to are private, so they have to be added as sites.

[govuk-transition]: https://github.com/search?q=topic%3Agovuk-transition+org%3Aalphagov&type=Repositories