### PR TITLE
Add doc on logit

### DIFF
--- a/source/manual/alerts/puppet-last-run-errors.html.md
+++ b/source/manual/alerts/puppet-last-run-errors.html.md
@@ -10,7 +10,12 @@ review_in: 6 months
 
 This alert triggers when there's an error while running Puppet on a machine.
 
-To investigate, SSH into the machine and look at `syslog`:
+To view the errors in Kibana, first login to [Logit](/manual/logit.html), and then
+run the following query (where `$hostname` is the hostname linked to the alert):
+
+`syslog_program:'puppet-agent' AND host:$hostname`
+
+You may also SSH into the machine and look at `syslog`:
 
 ```
 tail /var/log/syslog

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -47,6 +47,13 @@ $ fab $environment -H cache-3.router do:'/usr/lib/nagios/plugins/check_procs -c 
 [cache-3.router] out: PROCS OK: 1 process with command name 'varnishd', PPID = 8273
 ```
 
+### Related Kibana query
+
+You can view the number of 5xx errors by [logging into Logit](/manual/logit.html),
+and using this query:
+
+`host:cache* AND @fields.status:[500 TO 599]`
+
 ### To resolve Varnish port not responding
 
 You just need to restart Varnish on this machine:

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -13,12 +13,12 @@ handles connections will timeout on the healthcheck from the parent. If
 that happens and the replacement child process also fails to start,
 Varnish can get in a state where it is not responsive.
 
-The 'varnish port not responding' check simply attempts to contact
+The 'varnish port not responding' check attempts to contact
 <http://localhost:7999/> and get a response. If it doesn't, then it will
 raise an urgent alert as this might lead to 1/3 of user requests
 failing.
 
-To diagnose, you should see messages like this:
+To diagnose, check for messages like this:
 
 ```
 $ fab $environment -H cache-3.router sdo:'grep varnishd /var/log/messages'
@@ -29,7 +29,7 @@ $ fab $environment -H cache-3.router sdo:'grep varnishd /var/log/messages'
 [cache-3.router] out: Jul  7 00:17:25 cache-3 varnishd[1620]: Child (27973) died status=1
 ```
 
-And you should see only one process called `/usr/sbin/varnishd` in the
+You may see only one process called `/usr/sbin/varnishd` in the
 process table, with owner root. The child process if it exists will be
 owned by nobody:
 
@@ -39,8 +39,8 @@ $ fab $environment -H cache-3.router do:'ps -ef | grep [/]usr/sbin/varnishd'
 [cache-3.router] out: nobody    8277  8273  1 06:08 ?        00:03:52 /usr/sbin/varnishd -P /var/run/varnishd.pid -a :7999 -f /etc/varnish/default.vcl -T 127.0.0.1:6082 -t 900 -w 1,1000,120 -S /etc/varnish/secret -s malloc,5985M
 ```
 
-And you can check whether there are any children of the current parent
-process (this check will fail where it succeeds below):
+Check whether there are any children of the current parent process (this check
+will fail where it succeeds below):
 
 ```
 $ fab $environment -H cache-3.router do:'/usr/lib/nagios/plugins/check_procs -c 1:1 -C 'varnishd' -p `< /var/run/varnishd.pid`''
@@ -56,7 +56,7 @@ and using this query:
 
 ### To resolve Varnish port not responding
 
-You just need to restart Varnish on this machine:
+Restart Varnish on this machine:
 
 ```
 $ fab $environment -H cache-3.router cache.restart

--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -1,0 +1,64 @@
+---
+owner_slack: "#2ndline"
+title: How to use Logit for GOV.UK
+section: Logging
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2017-10-02
+review_in: 6 months
+---
+
+## How GOV.UK use Logit
+
+GOV.UK use [Logit](https://logit.io) to provide our [ELK Stack](https://www.elastic.co/webinars/introduction-elk-stack).
+
+This is in line with [The GDS Way](https://gds-way.cloudapps.digital/) guidance
+on [logging](https://gds-way.cloudapps.digital/standards/logging.html).
+
+## Logging in to Logit
+
+We use a Google App to authenticate users with Logit. Login to your GDS Google account in Chrome
+(for example, when in https://mail.google.com), and click on the 9 small dots at the top
+right of the Chrome browser.
+
+Go to the bottom of the selection of apps and you should find one for "Logit".
+
+Clicking on this should log you in.
+
+### Adding your user to the right team
+
+After you have logged in, if you are unable to see any "stacks", please speak to
+a GOV.UK Logit administrator. This will normally be your Tech Lead, or a member of
+the Infrastructure team.
+
+## Viewing Kibana
+
+Click on the "Kibana" button next to the stack you wish to view.
+
+When you are viewing a Kibana instance for a specific stack, if you open any direct
+links externally they will take you to this stack.
+
+At present we are unable to link directly to a stack, or view multiple stacks
+at the same time. This is on the Logit roadmap.
+
+## Administration guide
+
+### Adding users to GOV.UK Stacks
+
+1. Go to "People", and click "Manage".
+2. Click "Teams", then "Assign members" on the "GOV.UK" team.
+3. Add the new members of the team, and click "Update team members".
+
+### Updating Logstash configuration
+
+At present there is no automated way to configure Logstash configuration.
+
+1. Click the "Settings" button next to the stack you wish to configure.
+2. Go to "Logstash Filters"
+3. Amend the configuration
+4. Click "Validate"
+5. If correctly validated, click "Apply"
+
+We store our configuration in the [govuk-logitio](https://github.com/alphagov/govuk-logitio)
+repository. Any changes to the configuration should be stored in here, and they
+should be consistent across stacks.


### PR DESCRIPTION
I included this in a previous PR, but I'd like to merge it early as I intend to sneakily redirect people to this document when they try to browse the old Kibana URL while testing.

https://trello.com/c/YrTOpoq7/746-logit-migration

I have also included some queries as I have given up trying to pass in a direct link to Icinga for Kibana 5/Logit.