### PR TITLE
Use commit SHA to reference line in code

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -135,7 +135,7 @@ at us by the organisation. For hostnames which can have a `CNAME`
 record, this is `redirector-cdn.production.govuk.service.gov.uk`.
 Domains at the root of their zone can't be CNAMEd, so must use an `A`
 record and point at one of the [Fastly GOV.UK IP
-addresses](https://github.com/alphagov/transition/blob/master/app/models/host.rb#L18).
+addresses](https://github.com/alphagov/transition/blob/016c3d30e190c41eaa912ed554384a49f3418a91/app/models/host.rb#L22).
 
 ### 8) Get the organisation to monitor the traffic data in the Transition app
 


### PR DESCRIPTION
The Host model in Transition has been modified since this documentation was first written, which means that the link that references a particular line in the code is not longer highlighting the correct part. We should use a particular point in time to ensure that this doesn't happen in the future.