### PR TITLE
Document how to whitelist site in Transition

### DIFF
--- a/source/manual/whitelist-site-in-transition.html.md
+++ b/source/manual/whitelist-site-in-transition.html.md
@@ -1,0 +1,18 @@
+---
+owner_slack: '#taxonomy'
+title: Whitelist site to allow redirection away from GOV.UK
+section: Transition
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2017-10-04
+review_in: 6 months
+related_applications: [transition]
+---
+
+To allow mappings redirecting away from GOV.UK, you'll need to add the site into
+a whitelist. This section exists in the Transition tool:
+[Redirection whitelist](redirection-whitelist)
+
+You'll need the `admin` permission for Transition to be able to see this page.
+
+[redirection-whitelist]: https://transition.publishing.service.gov.uk/admin/whitelisted_hosts


### PR DESCRIPTION
Without the admin permission for Transition, it is not obvious that
there is whitelisting functionality in the app. By documenting the fact
that such a feature exists, this should help others find some
information when a whitelist request comes in.