### PR TITLE
Update docs link for transition logs processing error

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -5,6 +5,7 @@ getting-started.html: manual/get-started.html
 guides.html: manual.html
 manual/alerts/applications/sidekiq-monitoring.html: manual/setting-up-new-sidekiq-monitoring-app.html
 manual/alerts/publisher-app-health-check-not-ok.html: manual/alerts/publisher-app-healthcheck-not-ok.html
+manual/alerts/data-sources-for-transition.html: manual/transition-architecture.html
 manual/alerts/whitehall-app-health-check-not-ok.html: manual/alerts/whitehall-app-healthcheck-not-ok.html
 manual/archiving-and-redirecting-content.html: manual/redirect-routes.html
 manual/bouncer.html: manual/transition-architecture.html


### PR DESCRIPTION
The link to the documentation page from Icinga was not redirecting to the correct page.