### PR TITLE
Update docs for deploying when Github is down

### DIFF
--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -5,8 +5,8 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/github-unavailable.md"
-last_reviewed_on: 2017-05-09
-review_in: 6 months
+last_reviewed_on: 2017-10-05
+review_in: 1 months
 ---
 
 ## Public GitHub (application code)
@@ -15,41 +15,28 @@ Many of the Git repositories which make up GOV.UK are hosted on public GitHub. W
 need to deploy changes at any time, and GitHub.com is a Software as a Service (SaaS)
 product which we don't control the availability of.
 
-GDS Internal IT host GitHub Enterprise which we can use to deploy from if public
-GitHub is unavailable.
+We mirror all our repositories to GitLab.com every two hours using the
+[`govuk-repo-mirror`](https://github.com/alphagov/govuk-repo-mirror) scripts. This is run
+from the [`Mirror_Repositories`](https://ci.integration.publishing.service.gov.uk/job/Mirror_Repositories/) CI job
+In the event of Github being down, we can deploy the code from the [govuk team](https://gitlab.com/govuk/)
+on GitLab.com.
 
-During a normal production application deployment the app code is pushed to the
-[`gds-production-backup`](https://github.digital.cabinet-office.gov.uk/gds-production-backup/) organisation
-on GitHub Enterprise.
+### Deploying from GitLab.com
 
-We copy to GitHub Enterprise after a production deployment so we know that we're
-only mirroring trusted code.
-
-### Deploying from GitHub Enterprise
-
-Use the normal deployment job but check the box to deploy from GitHub Enterprise.
-
-In integration and staging the job will fail because it doesn't have access to push
-branches and tags back to the repository in `gds-production-backup`.
+Use the normal deployment job but check the box to deploy from GitLab.com.
 
 ### Making changes before deployment
 
-Push to a new branch on the production backup repo and then deploy that code. Ideally
-we wouldn't make changes to the production backup repo and only use it as a backup,
-but sometimes we need to (in exceptional circumstances when we can't work in public).
+GOV.UK Tech Leads are owners on the `govuk` team on GitLab.com. Thy can give access to
+developers who need to make changes to the code before deployment. This may be necessary
+if we need to work in private, for example to fix a security vulnerability without
+disclosing it to the public. To do this, push to a new branch on GitLab.com and then deploy that code.
 
-## GitHub Enterprise (secrets)
+### Deploying if you can't authenticate with Jenkins
 
-If [GitHub Enterprise](github-enterprise.html) becomes unavailable, GDS internal IT will switch to
-a disaster recovery instance. Failing over to the DR machine may take some time.
+If GitHub.com is down, we may not be able to log in to Jenkins. We haven't yet looked into this problem,
+2ndline is due to Gameday this scenario soon. Possible options:
 
-Depending on the nature of the outage, we may need to change our `govuk_ghe_vpn`
-configuration to point to `vpndr.digital.cabinet-office.gov.uk`.
-
-In order to deploy this change, first disable Puppet on the Jenkins machine.
-
-```
-fab $environment -H jenkins-1.management puppet.disable:"Switching to disaster recovery VPN"
-```
-
-Then update the VPN host in `/etc/init/openconnect.conf` on that machine.
+1. Run the Capistrano deployment scripts from a developer's laptop. This may require them to have access to the `deploy` user.
+2. [Bypass Jenkins authentication](https://jenkins.io/doc/book/system-administration/security/#disabling-security)
+3. Add break-glass credentials to Jenkins to use instead of GitHub OAuth.


### PR DESCRIPTION
We now use Gitlab instead of Github Enterprise. Set a short review time
as 2ndline should be Gamedaying this soon.

Actual change in https://github.com/alphagov/govuk-puppet/pull/6586