### PR TITLE
Add more stuff about GitHub

### DIFF
--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -1,0 +1,35 @@
+---
+title: Configure a GitHub repo
+parent: /manual.html
+layout: manual_layout
+section: Tools
+owner_slack: "#2ndline"
+last_reviewed_on: 2017-10-05
+review_in: 6 months
+---
+
+Repositories in GOV.UK must:
+
+- Be accessible to the [GOV.UK team][team]
+- Have a good description
+- Link to relevant documentation
+- Be tagged with [`govuk`](https://github.com/search?q=topic:govuk)
+- Have a [good README](/manual/readmes.html)
+
+Almost all repos should:
+
+- Have [branch protection](https://help.github.com/articles/about-protected-branches) on master
+- Have [Jenkins CI](/manual/testing-projects.html) configured
+- Have [GitHub Trello Poster](https://github.com/emmabeynon/github-trello-poster) enabled
+
+[team]: https://github.com/orgs/alphagov/teams/gov-uk/members
+
+## Auto configuration
+
+When your repo is tagged with `govuk`, it will be auto-configured by [govuk-saas-config][]. This will take care of the settings, branch protection and web hooks.
+
+If you create a new repo [kick off a build of the Jenkins job][jj] and everything will be done for you.
+
+[govuk-saas-config]: https://github.com/alphagov/govuk-saas-config/tree/master/github
+[jj]: https://deploy.integration.publishing.service.gov.uk/job/configure-github-repos
+[alphagov]: https://github.com/alphagov

--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -3,6 +3,9 @@ title: How we use GitHub
 parent: /manual.html
 layout: manual_layout
 section: Tools
+owner_slack: "#2ndline"
+last_reviewed_on: 2017-10-05
+review_in: 6 months
 ---
 
 # How we use GitHub
@@ -14,6 +17,8 @@ This can sometimes make it hard to find repositories that belong to our team. We
 GitHub "topics" to organise the repos. All repos owned by us should be tagged with
 [`govuk`](https://github.com/search?q=topic:govuk).
 
+We use [govuk-saas-config][] to configure our repositories.
+
 ## Topics on GitHub
 
 <% AppDocs.topics_on_github.each do |topic| %>
@@ -21,3 +26,4 @@ GitHub "topics" to organise the repos. All repos owned by us should be tagged wi
 <% end %>
 
 [alphagov]: https://github.com/alphagov
+[govuk-saas-config]: https://github.com/alphagov/govuk-saas-config/tree/master/github


### PR DESCRIPTION
We now use https://github.com/alphagov/govuk-saas-config to configure repos. This adds some info on that, as well as a page on how to configure your GitHub repo.