### PR TITLE
Commit missing page to fetch external doc

### DIFF
--- a/source/apis/search/faceted-search.html.md.erb
+++ b/source/apis/search/faceted-search.html.md.erb
@@ -1,0 +1,8 @@
+---
+layout: api_layout
+title: Faceted search, filters and aggregation
+parent: /apis/search/
+source_url: https://github.com/alphagov/rummager/blob/master/doc/public-api/faceted-search.md
+---
+
+<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'doc/public-api/faceted-search.md') %>


### PR DESCRIPTION
This should have been part of https://github.com/alphagov/govuk-developer-docs/pull/506