### PR TITLE
Update documentation on changing an organisation's slug

### DIFF
--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -4,11 +4,11 @@ title: Change an organisation's slug
 parent: "/manual.html"
 layout: manual_layout
 section: Routing
-last_reviewed_on: 2017-05-01
+last_reviewed_on: 2017-10-11
 review_in: 6 months
 ---
 
-> **NOTE:** for Worldwide Organisations, only Steps 1 and maybe 6 below need to
+> **NOTE:** for Worldwide Organisations, only Steps 1 and maybe 4 below need to
 > be performed.
 
 The organisation slug is used as a foreign key for organisations across
@@ -18,28 +18,7 @@ lots of apps. Changing it can be complex and time consuming.
 
 Create a data migration that uses the `DataHygiene::OrganisationReslugger` class, see [this PR for an example](https://github.com/alphagov/whitehall/pull/2245).
 
-### 2) Update the organisation in the Need API:
-
--   Pull the new organisation slug from Whitehall using the `organisations:import` rake task.
--   In the Rails console, update all needs with the new organisation:
-
-  ```rb
-  Need.where(organisation_ids: old_slug).each { |n| n.organisation_ids = (n.organisation_ids - [old_slug] + [new_slug]); n.save! }
-  ```
--   Use `Organisation.find(old_slug).destroy` to delete the old
-    organisation.
--   Re-index the needs in search via the `search:index_needs`
-    rake task.
-
-### 3)  Clear the organisation cache in Maslow:
-
-Restart the workers using Fabric:
-
-```
-fab $environment class:backend sdo:'service maslow reload'
-```
-
-### 4)  Update the organisation in Transition/transition-config:
+### 2)  Update the organisation in Transition/transition-config:
 
 The [transition-config repo](https://github.com/alphagov/transition-config) may contain slugs. Change any references to the old slug:
 
@@ -48,7 +27,7 @@ The [transition-config repo](https://github.com/alphagov/transition-config) may 
 - open a pull request, get it merged
 - merging will trigger the changes to be imported
 
-### 5) Update the organisation slug in Manuals Publisher
+### 3) Update the organisation slug in Manuals Publisher
 
 Repo: <https://github.com/alphagov/manuals-publisher>
 
@@ -63,6 +42,6 @@ ManualRecord.exists?(conditions: { organisation_slug: "old-slug" })
 If there are, create a migration to update the slugs. Republish all affected
 manuals after deploying your change.
 
-### 6) Update any best-bet searches in Search Admin
+### 4) Update any best-bet searches in Search Admin
 
 <https://search-admin.publishing.service.gov.uk/>


### PR DESCRIPTION
The Need API has been retired to gds-attic and the
cache of Organisation in Maslow is only an hour so
we can probably let this expire organically.