### PR TITLE
Add Algolia DocSearch

### DIFF
--- a/source/layouts/header_footer_only.erb
+++ b/source/layouts/header_footer_only.erb
@@ -15,6 +15,7 @@
     <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
 
     <link rel="canonical" href="<%= canonical_url %>">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css"/>
 
     <%= stylesheet_link_tag :print, media: 'print' %>
     <%= javascript_include_tag :application %>
@@ -79,6 +80,15 @@
 
       <%= yield %>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
+    <script>
+      docsearch({
+        apiKey: '7acf46aa10b80bb6f92e7138f84bfacf',
+        indexName: 'publishing_service_gov_uk',
+        inputSelector: '#tech-docs-search'
+      });
+    </script>
 
     <% if config[:tech_docs][:ga_tracking_id].is_a?(String) && !config[:tech_docs][:ga_tracking_id].empty? %>
       <script>

--- a/source/partials/_search.html.erb
+++ b/source/partials/_search.html.erb
@@ -2,6 +2,6 @@
   <form action="https://www.google.co.uk/search" method="get" role="search">
     <input type="hidden" name="as_sitesearch" value="<%= config[:tech_docs][:host] %>"/>
     <label for="tech-docs-search"  class="visually-hidden">Search (via Google)</label>
-    <input type="search" id="tech-docs-search" name="q" placeholder="Search (via Google)" class="form-control">
+    <input type="search" id="tech-docs-search" name="q" placeholder="Search" class="form-control" />
   </form>
 </div>

--- a/source/stylesheets/modules/_search.scss
+++ b/source/stylesheets/modules/_search.scss
@@ -22,9 +22,21 @@
       }
     }
 
+    // Override to make sure the search box doesn't get overlapped by the content section
     .algolia-autocomplete {
       position: absolute !important;
       z-index: 10000;
+    }
+
+    // Default contrast is too low for current selection highlight
+    .algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion:not(.suggestion-layout-simple) .algolia-docsearch-suggestion--content {
+      background-color: $focus-colour;
+    }
+
+    // Default contrast is too low for the chapters
+    .algolia-autocomplete .algolia-docsearch-suggestion--category-header,
+    .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
+      color: $text-colour;
     }
   }
 }

--- a/source/stylesheets/modules/_search.scss
+++ b/source/stylesheets/modules/_search.scss
@@ -6,6 +6,7 @@
   .search {
     @include core-16;
     margin-bottom: $gutter-half;
+    height: 40px;
 
     .form-control {
       @include box-sizing(border-box);
@@ -19,6 +20,11 @@
         outline: 3px solid $focus-colour;
         outline-offset: 0;
       }
+    }
+
+    .algolia-autocomplete {
+      position: absolute !important;
+      z-index: 10000;
     }
   }
 }

--- a/source/stylesheets/modules/_search.scss
+++ b/source/stylesheets/modules/_search.scss
@@ -38,6 +38,14 @@
     .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
       color: $text-colour;
     }
+
+    // Default search term highlighting is low contrast and doesn't work with
+    // the yellow curreny-highlighting.
+    .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+      color: $text-colour;
+      text-decoration: underline;
+      background: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
This adds [Algolia DocSearch][al]. It's a free service used by prominent projects such as React, Stripe and Scala. We have an account set up, which is configured in https://github.com/algolia/docsearch-configs/blob/master/configs/publishing_service_gov_uk.json.

We previously discussed this in https://github.com/alphagov/govuk-developer-docs/pull/128. We didn't go for this then because there were questions about accessibility. I think it would make sense to implement it now after all because the Google is very slow, causing new pages to be indexed weeks after first being published. 

![oct-11-2017 13-57-42](https://user-images.githubusercontent.com/233676/31441847-56ce2988-ae8c-11e7-813e-e0af97fb46d0.gif)

[al]: https://community.algolia.com/docsearch