### PR TITLE
Add CSV export for document types

### DIFF
--- a/app/document_types.rb
+++ b/app/document_types.rb
@@ -19,6 +19,10 @@ class DocumentTypes
     end
   end
 
+  def self.to_csv
+    DocumentTypesCsv.new(pages).to_csv
+  end
+
   def self.coverage_percentage
     ((pages.sum(&:total_count) / facet_query.fetch("total").to_f) * 100).round(1)
   end
@@ -38,6 +42,10 @@ class DocumentTypes
       @name = name
       @total_count = total_count
       @examples = examples
+    end
+
+    def url
+      "https://docs.publishing.service.gov.uk/document-types/#{name}.html"
     end
 
     def search_url

--- a/app/document_types_csv.rb
+++ b/app/document_types_csv.rb
@@ -1,0 +1,41 @@
+require 'csv'
+
+class DocumentTypesCsv
+  def initialize(pages)
+    @pages = pages
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      row = [
+        "Name",
+        "Docs URL",
+        "Number of pages",
+        "Example URL",
+      ]
+
+      Supertypes.all.each do |supertype|
+        row << supertype.name
+      end
+
+      csv << row
+
+      @pages.each do |page|
+        example_url = page.examples.first ? "https://www.gov.uk" + page.examples.first['link'] : nil
+
+        row = [
+          page.name,
+          page.url,
+          page.total_count,
+          example_url,
+        ]
+
+        Supertypes.all.each do |supertype|
+          row << supertype.for_document_type(page.name)
+        end
+
+        csv << row
+      end
+    end
+  end
+end

--- a/source/document-types.csv.erb
+++ b/source/document-types.csv.erb
@@ -1,0 +1,1 @@
+<%= DocumentTypes.to_csv %>

--- a/source/document-types.html.md.erb
+++ b/source/document-types.html.md.erb
@@ -10,6 +10,12 @@ all document types have been indexed in search yet. This means some types are
 missing from the list on the left. At the moment the list covers types for
 <%= DocumentTypes.coverage_percentage %>% of the pages in search index.
 
+You can [download this data as CSV too](/document-types.csv). In Google Spreadsheets, use the following formula:
+
+```
+=importData("https://docs.publishing.service.gov.uk/document-types.csv")
+```
+
 > The data for the list is generated [by running a facet query against search][query].
 
 ## Supertypes

--- a/spec/app/document_types_csv_spec.rb
+++ b/spec/app/document_types_csv_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe DocumentTypesCsv do
+  describe ".to_csv" do
+    it "returns document types" do
+      stub_request(:get, "https://www.gov.uk/api/search.json?count=0&facet_content_store_document_type=500,examples:10,example_scope:global").
+        to_return(
+          body: File.read("spec/fixtures/rummager-app-search-response.json"),
+          headers: {
+            content_type: "application/json"
+          }
+        )
+
+      stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml").
+        to_return(body: File.read("spec/fixtures/allowed-document-types-fixture.json"))
+
+      stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk_document_types/master/data/supertypes.yml").
+        to_return(body: File.read("spec/fixtures/supertypes.yml"))
+
+      csv = DocumentTypes.to_csv
+
+      expect(csv).to eql(File.read('spec/fixtures/document-types-export.csv'))
+    end
+  end
+end

--- a/spec/fixtures/document-types-export.csv
+++ b/spec/fixtures/document-types-export.csv
@@ -1,0 +1,5 @@
+Name,Docs URL,Number of pages,Example URL,Navigation document type
+announcement,https://docs.publishing.service.gov.uk/document-types/announcement.html,10439,https://www.gov.uk/government/news/credit-reports-available-online-for-all-consumers,other
+answer,https://docs.publishing.service.gov.uk/document-types/answer.html,737,https://www.gov.uk/apply-apprenticeship,guidance
+asylum_support_decision,https://docs.publishing.service.gov.uk/document-types/asylum_support_decision.html,0,,other
+authored_article,https://docs.publishing.service.gov.uk/document-types/authored_article.html,249,https://www.gov.uk/government/speeches/i-want-an-exit-that-will-work-for-all-of-us-article-by-theresa-may,other


### PR DESCRIPTION
We're going to be working a lot with document types again this quarter. For analysis and design it's useful to have a CSV of the document type data we have. This CSV can be used in Google Spreadsheets too.

The export looks like this:

<img width="1254" alt="screen shot 2017-10-12 at 11 54 00" src="https://user-images.githubusercontent.com/233676/31492690-166c6f22-af44-11e7-8c28-d6cf8aad638a.png">
