### PR TITLE
Reference GitLab for security incident deployments

### DIFF
--- a/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
+++ b/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
@@ -4,16 +4,15 @@ title: Deploy fixes for a security vulnerability
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-08-10
+last_reviewed_on: 2017-10-12
 review_in: 3 months
 ---
 
 When responding to a security incident, we should review the changes in private
 before deploying them, so that we don't accidentally disclose the vulnerability.
 
-To do this, push branches to the [GitHub Enterprise backup](github-unavailable.html)
+To do this, push branches to the [GitLab backup](github-unavailable.html)
 of the repository, rather than the normal repository on github.com.
-The repository will be in the [`gds-production-backup`](https://github.digital.cabinet-office.gov.uk/gds-production-backup/) organisation, not the `gds` one.
 
 This repository should be up to date as of the previous release, but will be
 missing any unreleased commits that are on github.com master.
@@ -24,13 +23,13 @@ This is fine as you don't want to deploy these.
 1. Ensure nobody else deploys the app until you've confirmed the vulnerability
    is fixed.
 
-1. Review the pull request on GitHub Enterprise
+1. Review the pull request on GitLab
 
 1. Create a release tag manually in git. This should follow the standard format
    `release_X`. Tag the branch directly instead of merging it.
 
 1. Don't use the release app. Go directly to the `deploy_app` Jenkins job, and
-   check "DEPLOY_FROM_GITHUB_ENTERPRISE".
+   check "DEPLOY_FROM_GITLAB".
 
 ## After deploying
 


### PR DESCRIPTION
This updates the references to github enterprise to instead reference
gitlab.