### PR TITLE
Add CSV export for apps data

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -28,11 +28,15 @@ class AppDocs
         puppet_name: puppet_name,
         links: {
           self: "https://docs.publishing.service.gov.uk/apps/#{app_name}.json",
-          html_url: "https://docs.publishing.service.gov.uk/apps/#{app_name}.html",
+          html_url: html_url,
           repo_url: repo_url,
           sentry_url: sentry_url,
         }
       }
+    end
+
+    def html_url
+      "https://docs.publishing.service.gov.uk/apps/#{app_name}.html"
     end
 
     def retired?

--- a/app/apps_csv.rb
+++ b/app/apps_csv.rb
@@ -1,0 +1,25 @@
+require 'csv'
+
+class AppsCSV
+  attr_reader :hash
+
+  def initialize(apps)
+    @apps = apps
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      csv << ["Name", "Product manager", "Team", "Docs URL", "Repo URL"]
+
+      @apps.each do |app|
+        csv << [
+          app.app_name,
+          app.product_manager,
+          app.team,
+          app.html_url,
+          app.repo_url,
+        ]
+      end
+    end
+  end
+end

--- a/source/apps.csv.erb
+++ b/source/apps.csv.erb
@@ -1,0 +1,1 @@
+<%= AppsCSV.new(active_app_pages).to_csv %>

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -6,6 +6,15 @@ title: Applications on GOV.UK
 The publishing platform of GOV.UK consists of at least <%= active_app_pages.size %>
 separate applications. Most of them are built using [Ruby on Rails][rails].
 
+You can [download this data as JSON](/apps.json), or [download this data as CSV](/apps.csv).
+In Google Spreadsheets, use the following formula:
+
+```
+=importData("https://docs.publishing.service.gov.uk/apps.csv")
+```
+
+## Infrastructure
+
 Applications are hosted on an infrastructure [configured using puppet][govuk-puppet].
 They are deployed using [capistrano scripts][govuk-app-deployment].
 


### PR DESCRIPTION
https://github.com/alphagov/govuk-developer-docs/pull/523 added CSV export for document types, this does the same for our applications. This will allow us to use the data in Google Spreadsheets. It will make it easier to do the [re-allocation of support work][1] in the beginning of the quarter

[1]: https://docs.google.com/spreadsheets/d/1r5Tc0ddDZpBzFGUJRIB2zPvvUjZed_0Ctk0YPAS4I0o/edit#gid=0

<img width="1345" alt="screen shot 2017-10-12 at 14 53 38" src="https://user-images.githubusercontent.com/233676/31499601-2a7f664a-af5d-11e7-9f3b-d5cf4993c9fd.png">
