### PR TITLE
Fix Mongoid command for Reslugging docs

### DIFF
--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -36,7 +36,7 @@ Find out if any manuals are published by this organisation.
 Run the following in manuals-publisher Rails console:
 
 ```ruby
-ManualRecord.exists?(conditions: { organisation_slug: "old-slug" })
+ManualRecord.where(organisation_slug: "old-slug").exists?
 ```
 
 If there are, create a migration to update the slugs. Republish all affected


### PR DESCRIPTION
The provided command to check for existing manuals belonging to the
organisation being reslugged does not work. This change updates the
documentation to have a command that works.