### PR TITLE
Link to other pages in the same section on manual pages

### DIFF
--- a/app/manual_index_page.rb
+++ b/app/manual_index_page.rb
@@ -15,6 +15,10 @@ class ManualIndexPage
     ]
   end
 
+  def other_pages_from_section(other_page)
+    manual_pages.select { |page| page.data.section == other_page.data.section } - [other_page]
+  end
+
 private
 
   def first_column

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -18,14 +18,6 @@
 
     <div class="app-pane__content toc-open-disabled">
       <main id="content" class="technical-documentation" data-module="anchored-headings">
-        <% if page_review.expired? %>
-          <div class='warning'>
-            This page was set to be reviewed before <%= page_review.review_by %>
-            by the page owner: <%= current_page.data.owner_slack %>. This might mean the
-            content is out of date. <%= link_to "Read how to review a page", "/manual/review-page.html" %>
-          </div>
-        <% end %>
-
         <%= yield %>
         <%= partial 'partials/source' %>
       </main>

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -19,5 +19,33 @@
     </div>
   <% end %>
 
+  <% if page_review.expired? %>
+    <div class='warning'>
+      This page was set to be reviewed before <%= page_review.review_by %>
+      by the page owner: <%= current_page.data.owner_slack %>. This might mean the
+      content is out of date. <%= link_to "Read how to review a page", "/manual/review-page.html" %>
+    </div>
+  <% end %>
+
   <%= html %>
+
+  <div>
+    <% if current_page.data.related_applications %>
+      <h2 id='related-applications'>Related applications</h2>
+
+      <ul>
+      <% current_page.data.related_applications.to_a.each do |app| %>
+        <li><%= link_to app, "/apps/#{app}.html" %></li>
+      <% end %>
+      </ul>
+    <% end %>
+  </div>
+
+  <% if page_review.reviewable? %>
+    This page is owned by <%= current_page.data.owner_slack %>
+    and <%= link_to "needs to be reviewed", "/manual/review-page.html" %>
+    <time data-module="datetime-relative" datetime="<%= page_review.review_by %>">
+      <%= page_review.review_by %>
+    </time>
+  <% end %>
 <% end %>

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -29,23 +29,37 @@
 
   <%= html %>
 
-  <div>
-    <% if current_page.data.related_applications %>
-      <h2 id='related-applications'>Related applications</h2>
+  <div class='grid-row'>
+    <div class='column-half'>
+      <% if current_page.data.related_applications %>
+        <h3>Related applications</h3>
+
+        <ul>
+        <% current_page.data.related_applications.to_a.each do |app| %>
+          <li><%= link_to "#{app} application", "/apps/#{app}.html" %></li>
+        <% end %>
+        </ul>
+      <% end %>
+    </div>
+
+    <div class='column-half'>
+      <h3>More about <%= current_page.data.section %></h3>
 
       <ul>
-      <% current_page.data.related_applications.to_a.each do |app| %>
-        <li><%= link_to app, "/apps/#{app}.html" %></li>
+      <% manual_index_page.other_pages_from_section(current_page).each do |page| %>
+        <li><%= link_to page.data.title, page.url %></li>
       <% end %>
       </ul>
-    <% end %>
+    </div>
   </div>
 
   <% if page_review.reviewable? %>
-    This page is owned by <%= current_page.data.owner_slack %>
-    and <%= link_to "needs to be reviewed", "/manual/review-page.html" %>
-    <time data-module="datetime-relative" datetime="<%= page_review.review_by %>">
-      <%= page_review.review_by %>
-    </time>
+    <div class='review-status'>
+      This page is owned by <%= current_page.data.owner_slack %>
+      and <%= link_to "needs to be reviewed", "/manual/review-page.html" %>
+      <time data-module="datetime-relative" datetime="<%= page_review.review_by %>">
+        <%= page_review.review_by %>
+      </time>
+    </div>
   <% end %>
 <% end %>

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,25 +1,6 @@
-<div>
-  <% if current_page.data.related_applications %>
-    <h2 id='related-applications'>Related applications</h2>
-
-    <ul>
-    <% current_page.data.related_applications.to_a.each do |app| %>
-      <li><%= link_to app, "/apps/#{app}.html" %></li>
-    <% end %>
-    </ul>
-  <% end %>
-</div>
 
 <div class="meta-links">
   <%= link_to "View source", view_source_url %>
   <%= link_to "Report problem", report_issue_url %>
   <%= link_to "GitHub Repo", "https://github.com/alphagov/govuk-developer-docs" %>
 </div>
-
-<% if page_review.reviewable? %>
-  This page is owned by <%= current_page.data.owner_slack %>
-  and <%= link_to "needs to be reviewed", "/manual/review-page.html" %>
-  <time data-module="datetime-relative" datetime="<%= page_review.review_by %>">
-    <%= page_review.review_by %>
-  </time>
-<% end %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -42,12 +42,20 @@
   }
 }
 
+.review-status {
+  margin-top: $gutter;
+}
+
 .grid-row {
   @extend %grid-row;
 }
 
 .column-third {
   @include grid-column( 1/3 );
+}
+
+.column-half {
+  @include grid-column( 1/2 );
 }
 
 .technical-documentation.full-width {


### PR DESCRIPTION
Pages in the same section are often relevant when browsing the docs. This commit adds a column with the other pages in the same section. Also does some reshuffling of elements on the page to make it clearer.

## Before, without related apps

![screen shot 2017-10-17 at 17 36 46](https://user-images.githubusercontent.com/233676/31677161-d95703d2-b361-11e7-9862-da1c2db675ab.png)

## After, without related apps

![screen shot 2017-10-17 at 17 36 48](https://user-images.githubusercontent.com/233676/31677171-dd03d7c6-b361-11e7-843e-941f8b6d5ec6.png)

## Before, with related apps

![screen shot 2017-10-17 at 17 38 58](https://user-images.githubusercontent.com/233676/31677253-151895e8-b362-11e7-9047-bda11fa062f4.png)

## After, with related apps

![screen shot 2017-10-17 at 17 38 42](https://user-images.githubusercontent.com/233676/31677259-19dae5d6-b362-11e7-86c5-2f2c6785e489.png)


