### PR TITLE
Update to emergency publishing manual

### DIFF
--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -55,6 +55,7 @@ $ . ~/venv/fabric-scripts/bin/activate
 ```
 export environment=integration
 ```
+> **NOTE:** You must remember to [unset your Fabric environment variable](#unset-your-environment-variable-and-deactivate-your-virtual-environment) once you have finished running your tasks.
 
 4) If you'd like to double check the environment you have set:
 ```


### PR DESCRIPTION
It is a good idea to make a note that the Fabric environment variable needs to be unset, especially for new starters to prevent them from accidentally running things in the wrong environment if switching between jobs.