### PR TITLE
Fix Kibana queries and links

### DIFF
--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -5,14 +5,9 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/fastly-error-rate.md"
-last_reviewed_on: 2017-07-13
+last_reviewed_on: 2017-10-20
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/2nd-line/alerts/fastly-error-rate.md)
-
 
 ## Error rate alert
 
@@ -27,7 +22,8 @@ investigation is to examine the Fastly CDN logs.
 - `ssh logs-cdn-1.management.production`
 - `cd /mnt/logs_cdn` to access log files
 
-Alternatively you can look [in Kibana with the query `@fields.application:"govuk-cdn-logs-monitor"`](https://kibana.publishing.service.gov.uk/kibana#/dashboard/elasticsearch/GOV.UK%20CDN%20logs)
+Alternatively you can look in [Kibana](tools.html#kibana) with the query
+`application:"govuk-cdn-logs-monitor"`
 
 ## `Unknown` alert
 
@@ -37,8 +33,8 @@ The alert appears on `monitoring-1.management`. Collectd uses the Fastly API to 
 
 To prove collectd is the problem, use this query in Kibana:
 
-`@source_host:monitoring-1.management AND @fields.syslog_program:collectd`
+`syslog_hostname:monitoring-1.management AND syslog_program:collectd`
 
-You will see many reports simlilar to:
+You will see many reports similar to:
 
 `cdn_fastly plugin: Failed to query service`

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -5,17 +5,15 @@ layout: manual_layout
 parent: "/manual.html"
 section: Logging
 important: true
-last_reviewed_on: 2017-08-23
+last_reviewed_on: 2017-10-27
 review_in: 6 months
 ---
 
-All logs for GOV.UK are collected in Kibana:
+All logs for GOV.UK on all environments are collected in Kibana, which you can
+access through [Logit](logit.html).
 
-- <https://kibana.publishing.service.gov.uk>
-- <https://kibana.staging.publishing.service.gov.uk>
-- <https://kibana.integration.publishing.service.gov.uk>
-
-Kibana can be searched using the [Lucene search syntax][lucene].
+Kibana can be [searched using the Lucene search syntax or full JSON-based
+Elasticsearch queries][kibana-search].
 
 ## Examples
 
@@ -29,7 +27,7 @@ host:cache* AND @fields.status:[500 TO 504]
 
 ```rb
 # both agent and master
-syslog_program:puppet
+syslog_program:puppet*
 
 # agent only
 syslog_program:"puppet-agent"
@@ -102,10 +100,10 @@ application:"mongodb" AND message:"command"
 application:"syslog" AND syslog_program:"audispd"
 ```
 
-### Mirrrorer logs
+### Mirrorer logs
 
 ```rb
-syslog_program:"mirrorer"
+syslog_program:"govuk_sync_mirror"
 ```
 
 ### Publishing API timeouts
@@ -121,7 +119,7 @@ If you're looking for specific program outputs, use `syslog_program:FOO`:
 - `audispd`:	This is used to see all audit logs from various servers. You can refer to README for searching particular types of audit logs. The program name with combination of source_host and message can be helped for looking at various specific audit log lines on a server.
 - `clamd`	 
 - `cron`	 
-- `mirrorer`: Records information from govuk_mirrorer script. It contains INFO, WARN and ERROR information
+- `govuk_sync_mirror`: Records information from govuk_sync_mirror script
 - `puppet-agent`:	Records output for govuk_puppet script on various servers
 - `puppet-master`	 
 - `smokey`
@@ -130,8 +128,8 @@ If you're looking for specific program outputs, use `syslog_program:FOO`:
 
 - Score: does a aggregation of field on last 2000 results
 - Terms is not an aggregation of field, it is an aggregation of terms in the field across 1 recent indices
-- For more elaborate searching, [read about the Lucene syntax][lucene]
+- For more elaborate searching, [read about the Lucene and Elasticsearch syntax][kibana-search]
 - `@timestamp` of nginx log entries records [request end time is sometimes confusing][end]
 
-[lucene]: http://lucene.apache.org/core/old_versioned_docs/versions/2_9_1/queryparsersyntax.html
+[kibana-search]: https://www.elastic.co/guide/en/kibana/current/search.html
 [end]: http://serverfault.com/questions/438880/what-does-nginxs-time-local-logging-variable-mean-specifically/438891#438891

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -98,9 +98,9 @@ Our [deployment dashboards](deployment-dashboards.html) use Graphite extensively
 Graphite has a whole bunch of functions you can apply to your data to make it more useful: they’re listed out [in the Graphite docs](http://graphite.readthedocs.org/en/0.9.12/functions.html). One particularly useful one is `keepLastValue`: if your graphs come out nearly black with a few spots of colour in them, you probably want this one. Both views have an Apply Function button.
 ## Kibana
 
-<https://kibana.publishing.service.gov.uk/>
+You can access GOV.UK Kibana through [Logit](logit.html).
 
-Kibana is a log viewer and search engine. In Kibana, you can filter down log messages to show you just the ones you want. Say you’ve spotted a large number of errors coming from the content store related to MongoDB connections and you want to find out whether the MongoDB logs show anything strange. You can narrow down which log messages you want using the column browser on the left: `@source_host` and `@fields.application` are some particularly useful ones. The magnifying glass symbol next to each value lets you build up a query string and tinker with it.
+Kibana is a log viewer and search engine. In Kibana, you can filter down log messages to show you just the ones you want. Say you’ve spotted a large number of errors coming from the content store related to MongoDB connections and you want to find out whether the MongoDB logs show anything strange. You can narrow down which log messages you want using the column browser on the left: `@source_host` and `application` are some particularly useful ones. The magnifying glass symbol next to each value lets you build up a query string and tinker with it.
 
 You can tweak the time range manually with the drop down at the top or by dragging on the timeline.
 


### PR DESCRIPTION
This just fixes Kibana queries on three pages:
- Tools
- Kibana
- Fastly error rate

There are probably other pages which still use the old fields and syntax, but this is all I had time to review while on 2ndline.