### PR TITLE
Prevent `disk out of space` error when restoring from AWS

### DIFF
--- a/source/manual/restore-from-offsite-backups.html.md
+++ b/source/manual/restore-from-offsite-backups.html.md
@@ -120,6 +120,7 @@ On the machine where you'll be running the restore:
     ```bash
     duplicity restore --file-to-restore data/backups/whitehall-mysql-backup-1.backend.publishing.service.gov.uk/var/lib/automysqlbackup/latest.tbz2 s3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/govuk-datastores/ /tmp/latest.tbz2
     ```
+    * If you are running out of space in your VM, you could run the same command, but replacing `/tmp/latest.tbz2` with `--tempdir /var/govuk/tmp /var/govuk/tmp/latest.tbz2`
 
     * When this completes you may see the following 'error':
 


### PR DESCRIPTION
When restoring `mysql` from AWS with the command listed below you 
could get a `disk out of space` error if you have not enough space left.

```
duplicity restore --file-to-restore data/backups/whitehall-mysql-backup-1.backend.publishing.service.gov.uk/var/lib/automysqlbackup/latest.tbz2 s3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/govuk-datastores/ /tmp/latest.tbz2
```

But if you have enough space in the hosting machine, you could be 
specific about where to download the file, and what temporary folder to 
use. By using folders outside of the VM we overcome the disk space limitation
from the VM.

```
duplicity restore --file-to-restore data/backups/whitehall-mysql-backup-1.backend.publishing.service.gov.uk/var/lib/automysqlbackup/latest.tbz2 s3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/govuk-datastores/ --tempdir /var/govuk/tmp /var/govuk/tmp/latest.tbz2
```