### PR TITLE
Add section for Incidence Management Guidance

### DIFF
--- a/source/manual/incidence-management-guidance.html.md
+++ b/source/manual/incidence-management-guidance.html.md
@@ -1,0 +1,14 @@
+---
+owner_slack: "#2ndline"
+title: Incident management
+parent: "/manual.html"
+layout: manual_layout
+section: Support
+last_reviewed_on: 2017-11-03
+review_in: 6 months
+---
+
+You can find within the [GOV.UK Platform Operations wiki][1], a [section for GOV.UK incidents][2], where you will find guidance for writing incident reports and running post mortems, as well as general guidance about managing incidents on GOV.UK.
+
+[1]: https://gov-uk.atlassian.net/wiki/spaces/PLOPS/overview
+[2]: https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/33620002/Incident+management+guidance


### PR DESCRIPTION
We are not moving the content wiki into the Developers docs,
as there are plans to standardize this information before
making it public.

We have decided to add a link to the docs, so developers,
which are usually incident leads, can find easily this
information.