### PR TITLE
Embed README into the application page

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -109,3 +109,8 @@
   height: 1px;
   overflow: hidden
 }
+
+.embedded-readme {
+  padding-left: $gutter-half;
+  border-left: 5px solid $grey-3;
+}

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -83,6 +83,14 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
 </ul>
 <% end %>
 
+<h2>Repo readme</h2>
+
+<p>Pulled in directly from <%= link_to "the repo", application.repo_url %>. Links might not function properly.</p>
+
+<div class='embedded-readme'>
+<%= ExternalDoc.fetch(repository: "alphagov/#{application.github_repo_name}", path: 'README.md') %>
+</div>
+
 <% end %>
 
 [app-yaml]: https://github.com/alphagov/govuk-developer-docs/edit/master/data/applications.yml


### PR DESCRIPTION
This is a bit beta, because the relative links might not work when the content is imported. Nevertheless, this surfaces the README of the repo (which should be good) when searching in the docs, which makes most of the relevant docs findable from the central location.

## Screenshots

![screen shot 2017-11-08 at 16 00 07](https://user-images.githubusercontent.com/233676/32558974-fc4193c4-c49d-11e7-8f68-2da46b64de41.png)
![screen shot 2017-11-08 at 16 00 29](https://user-images.githubusercontent.com/233676/32558975-fc673d22-c49d-11e7-94c2-6e9bdc2c9056.png)

## Examples

Once review app is deployed.
