### PR TITLE
Remove warnings about opsmanual import

### DIFF
--- a/source/manual/add-an-icinga-passive-check.html.md
+++ b/source/manual/add-an-icinga-passive-check.html.md
@@ -4,11 +4,9 @@ title: Add an Icinga passive check to a Jenkins job
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/add_a_passive_check_to_jenkins.md"
 last_reviewed_on: 2017-09-12
 review_in: 6 months
 ---
-
 
 If you would like Icinga to raise an alert when a Jenkins job has not completed
 successfully in a while, you can add an Icinga passive check to the Jenkins

--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -4,7 +4,6 @@ title: Add a disk to a vCloud machine
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/adding-disks-in-vcloud.md"
 last_reviewed_on: 2017-09-04
 review_in: 6 months
 ---

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -4,15 +4,9 @@ title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/data-sync.md"
 last_reviewed_on: 2017-08-30
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/2nd-line/alerts/data-sync.md)
-
 
 Data is synced from production to staging and integration every night.
 

--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -4,7 +4,6 @@ title: Fastly error rate for GOV.UK
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/fastly-error-rate.md"
 last_reviewed_on: 2017-10-20
 review_in: 6 months
 ---

--- a/source/manual/alerts/gor.html.md
+++ b/source/manual/alerts/gor.html.md
@@ -4,7 +4,6 @@ title: Gor
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/gor.md"
 last_reviewed_on: 2017-09-13
 review_in: 6 months
 ---

--- a/source/manual/alerts/redis.html.md
+++ b/source/manual/alerts/redis.html.md
@@ -4,7 +4,6 @@ title: Redis alerts
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/redis.md"
 last_reviewed_on: 2017-10-09
 review_in: 6 months
 ---

--- a/source/manual/alerts/ruby-version.html.md
+++ b/source/manual/alerts/ruby-version.html.md
@@ -4,7 +4,6 @@ title: App isn't running the expected Ruby version
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/ruby-version.md"
 last_reviewed_on: 2017-06-26
 review_in: 6 months
 ---

--- a/source/manual/alerts/virus-scanning.html.md
+++ b/source/manual/alerts/virus-scanning.html.md
@@ -4,7 +4,6 @@ title: Fix stuck virus scanning
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/alerts/virus-scanning.md"
 last_reviewed_on: 2017-07-05
 review_in: 6 months
 related_applications: [whitehall]

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -4,7 +4,6 @@ title: 'Assets: how they work'
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/architecture/assets.md"
 last_reviewed_on: 2017-06-13
 review_in: 6 months
 related_applications: [asset-manager]

--- a/source/manual/attachments.html.md
+++ b/source/manual/attachments.html.md
@@ -4,7 +4,6 @@ title: Attachment backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/backups/attachments.md"
 last_reviewed_on: 2017-07-11
 review_in: 6 months
 related_applications: [whitehall]

--- a/source/manual/blocking-apps-from-release.html.md
+++ b/source/manual/blocking-apps-from-release.html.md
@@ -4,7 +4,6 @@ title: Block apps from being deployed
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/blocking-apps-from-release.md"
 last_reviewed_on: 2017-11-07
 review_in: 6 months
 related_applications: [release]

--- a/source/manual/cache-flush.html.md
+++ b/source/manual/cache-flush.html.md
@@ -4,7 +4,6 @@ title: Purge a page from cache
 section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/cache-flush.md"
 important: true
 last_reviewed_on: 2017-08-15
 review_in: 6 months
@@ -122,7 +121,7 @@ To flush our origin run the following Fabric command::
     fab $environment cache.ban_all
 
 Once this is done move on to Fastly. This can only be done through the
-Fastly UI - the credentials are in the 2nd line store. If possible, 
+Fastly UI - the credentials are in the 2nd line store. If possible,
 speak to a member of the senior tech team before doing this, to
 evaluate the risk.
 

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -4,7 +4,6 @@ title: Check for a `gone` route
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/check-for-gone-route.md"
 last_reviewed_on: 2017-09-14
 review_in: 6 months
 ---

--- a/source/manual/clone-mysql-slave.html.md
+++ b/source/manual/clone-mysql-slave.html.md
@@ -4,15 +4,9 @@ title: Clone a MySQL instance from one slave to another
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/clone-mysql-slave.md"
 last_reviewed_on: 2017-06-28
 review_in: 7 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/howto/clone-mysql-slave.md)
-
 
 This tutorial documents the process behind adding a new slave to a MySQL
 senvironment where an existing slave may or may not already exist. The

--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -4,15 +4,9 @@ title: Debian packaging
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/debian-packaging.md"
 last_reviewed_on: 2017-06-27
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/debian-packaging.md)
-
 
 This page explains how we're managing our Debian packaging.
 

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -4,7 +4,6 @@ title: Edit an existing route in the Router
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/editing-an-existing-route.md"
 last_reviewed_on: 2017-08-15
 review_in: 6 months
 ---

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -4,15 +4,9 @@ title: GOV.UK's environments (training, integration, staging, production)
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/architecture/environments.md"
 last_reviewed_on: 2017-07-25
 review_in: 3 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/architecture/environments.md)
-
 
 GOV.UK has several environments with different purposes.
 

--- a/source/manual/gds-hubot.html.md
+++ b/source/manual/gds-hubot.html.md
@@ -4,7 +4,6 @@ title: Update Hubot (Slack bot)
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/gds-hubot.md"
 last_reviewed_on: 2017-08-15
 review_in: 6 months
 ---

--- a/source/manual/generate-csr.html.md
+++ b/source/manual/generate-csr.html.md
@@ -4,7 +4,6 @@ title: Generate a Certificate Signing Request (CSR) for GOV.UK
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/generate-csr.md"
 last_reviewed_on: 2017-10-09
 review_in: 6 months
 ---

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -4,7 +4,6 @@ title: Deploy when GitHub is unavailable
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/releasing-software/github-unavailable.md"
 last_reviewed_on: 2017-10-13
 review_in: 1 months
 ---

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -4,13 +4,9 @@ title: Upload HMRC PAYE files
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/hmrc-paye-files.md"
 last_reviewed_on: 2017-07-31
 review_in: 6 months
 ---
-
-
-## Preamble
 
 HMRC have a [desktop application to submit
 PAYE](https://www.gov.uk/basic-paye-tools). This is available on Windows,

--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -4,7 +4,6 @@ title: Remove an asset
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/howto-manually-remove-assets.md"
 last_reviewed_on: 2017-09-04
 review_in: 6 months
 ---

--- a/source/manual/howto-switch-off-app.html.md
+++ b/source/manual/howto-switch-off-app.html.md
@@ -4,15 +4,9 @@ title: Switch an app off
 layout: manual_layout
 section: Packaging
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/howto-switch-off-app.md"
 last_reviewed_on: 2017-06-08
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/2nd-line/howto-switch-off-app.md)
-
 
 In the event of a security incident an app may need to be switched off until it
 can be patched.

--- a/source/manual/howto-upload-an-asset-to-asset-manager.html.md
+++ b/source/manual/howto-upload-an-asset-to-asset-manager.html.md
@@ -4,7 +4,6 @@ title: Upload an asset to asset-manager
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/howto-upload-an-asset-to-asset-manager.md"
 last_reviewed_on: 2017-10-09
 review_in: 6 months
 ---

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -4,7 +4,6 @@ title: How logging works on GOV.UK
 section: Logging
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/logging/index.md"
 last_reviewed_on: 2017-10-02
 review_in: 6 months
 ---

--- a/source/manual/mysql.html.md
+++ b/source/manual/mysql.html.md
@@ -4,7 +4,6 @@ title: MySQL backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/backups/mysql.md"
 last_reviewed_on: 2017-08-09
 review_in: 6 months
 ---

--- a/source/manual/packer-vagrant-image-creation.html.md
+++ b/source/manual/packer-vagrant-image-creation.html.md
@@ -4,7 +4,6 @@ title: Packer Vagrant Dev VM / Image Creation
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/packer-vagrant-image-creation.md"
 last_reviewed_on: 2017-08-09
 review_in: 6 months
 ---

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -4,7 +4,6 @@ title: Pact Broker
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/introductions/pact_broker.md"
 last_reviewed_on: 2017-11-06
 review_in: 6 months
 ---

--- a/source/manual/postgresql.html.md
+++ b/source/manual/postgresql.html.md
@@ -4,7 +4,6 @@ title: PostgreSQL backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/backups/postgresql.md"
 last_reviewed_on: 2017-08-31
 review_in: 6 months
 ---

--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -4,7 +4,6 @@ title: Publish to Puppet Forge
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/publish-to-puppet-forge.md"
 last_reviewed_on: 2017-10-09
 review_in: 6 months
 ---

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -4,7 +4,6 @@ title: RabbitMQ
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/rabbitmq.md"
 last_reviewed_on: 2017-10-04
 review_in: 6 months
 ---

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -4,12 +4,10 @@ title: Reboot a machine
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/rebooting-machines.md"
 important: true
 last_reviewed_on: 2017-08-15
 review_in: 6 months
 ---
-
 
 ## Rules of rebooting
 

--- a/source/manual/reprovision.html.md
+++ b/source/manual/reprovision.html.md
@@ -4,7 +4,6 @@ title: Reprovision a machine in vCloud Director
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/reprovision.md"
 last_reviewed_on: 2017-08-09
 review_in: 6 months
 ---

--- a/source/manual/restore-from-offsite-backups.html.md
+++ b/source/manual/restore-from-offsite-backups.html.md
@@ -4,7 +4,6 @@ title: Restore from offsite backups
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/offsite-backup-and-restore.md"
 last_reviewed_on: 2017-10-09
 review_in: 6 months
 ---

--- a/source/manual/resync-mongo-db.html.md
+++ b/source/manual/resync-mongo-db.html.md
@@ -4,7 +4,6 @@ title: Resync a MongoDB database
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/resync-mongo-db.md"
 last_reviewed_on: 2017-05-30
 review_in: 6 months
 ---

--- a/source/manual/rotate-offsite-backup-gpg-keys.html.md
+++ b/source/manual/rotate-offsite-backup-gpg-keys.html.md
@@ -4,15 +4,9 @@ title: Rotate offsite backup GPG keys
 section: Backups
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/rotate-offsite-backup-gpg-keys.md"
 last_reviewed_on: 2017-09-07
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/howto/rotate-offsite-backup-gpg-keys.md)
-
 
 To encrypt our offsite backups, we use GPG keys which are valid for a year. For
 good security practice we rotate these keys each year.

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -4,15 +4,9 @@ title: Add a new Ruby version
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/ruby.md"
 last_reviewed_on: 2017-06-12
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/ruby.md)
-
 
 The Ruby language is a core part of GOV.UK - most of our applications
 are written in it.

--- a/source/manual/setting-up-new-mirror.html.md
+++ b/source/manual/setting-up-new-mirror.html.md
@@ -4,7 +4,6 @@ title: Set up a new mirror for GOV.UK
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setting-up-new-mirror.md"
 last_reviewed_on: 2017-10-09
 review_in: 6 months
 ---

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -4,7 +4,6 @@ title: Set up a new Rails app
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setting-up-new-rails-app.md"
 last_reviewed_on: 2017-07-31
 review_in: 6 months
 ---

--- a/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
+++ b/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
@@ -4,15 +4,9 @@ title: Add sidekiq-monitoring to your application
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setting-up-new-sidekiq-monitoring-app.md"
 last_reviewed_on: 2017-10-04
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/howto/setting-up-new-sidekiq-monitoring-app.md)
-
 
 [Sidekiq monitoring
 applications](https://github.com/mperham/sidekiq/wiki/Monitoring) are

--- a/source/manual/setup-postgresql-replication.html.md
+++ b/source/manual/setup-postgresql-replication.html.md
@@ -4,15 +4,9 @@ title: Set up PostgreSQL replication
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/howto/setup-postgresql-replication.md"
 last_reviewed_on: 2017-10-04
 review_in: 6 months
 ---
-
-> **This page was imported from [the opsmanual on GitHub Enterprise](https://github.com/alphagov/govuk-legacy-opsmanual)**.
-It hasn't been reviewed for accuracy yet.
-[View history in old opsmanual](https://github.com/alphagov/govuk-legacy-opsmanual/tree/master/infrastructure/howto/setup-postgresql-replication.md)
-
 
 This how-to guide explains how to set-up PostgreSQL replication.
 

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -4,7 +4,6 @@ title: 'Tools: Icinga, Grafana and Graphite, Kibana and Fabric'
 section: Tools
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/2nd-line/tools.md"
 last_reviewed_on: 2017-09-25
 review_in: 6 months
 ---

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -4,7 +4,6 @@ title: GOV.UK and Virtual Private Networks (VPNs)
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-old_path_in_opsmanual: "../opsmanual/infrastructure/vpn.md"
 last_reviewed_on: 2017-08-31
 review_in: 6 months
 ---


### PR DESCRIPTION
These pages have been updated since we imported the opsmanual. We don't need the warnings and the old paths anymore.