### PR TITLE
Lutgendorff != null

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -27,6 +27,7 @@
 
 - github_repo_name: maslow
   type: Publishing apps
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
 
 - github_repo_name: panopticon
@@ -59,6 +60,7 @@
 
 - github_repo_name: short-url-manager
   type: Publishing apps
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
 
 - github_repo_name: specialist-publisher
@@ -123,6 +125,7 @@
   retired: true
   type: APIs
   puppet_name: need_api
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
   description: |
     A JSON read and write API for information about user needs on GOV.UK. It was a Rails
@@ -164,6 +167,7 @@
 
 - github_repo_name: support-api
   type: APIs
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
 
 - github_repo_name: hmrc-manuals-api
@@ -179,6 +183,7 @@
 - github_repo_name: metadata-api
   retired: true
   type: APIs
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
   description: |
     API written in Go that was used to get user need information about given URLs
@@ -207,6 +212,7 @@
 
 - github_repo_name: support
   type: Supporting apps
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
 
 - github_repo_name: authenticating-proxy
@@ -295,6 +301,7 @@
 
 - github_repo_name: info-frontend
   type: Frontend apps
+  product_manager: "@lutgendorff"
   team: "#survey-and-support"
 
 - github_repo_name: licence-finder


### PR DESCRIPTION
When asking "who owns short-url-manager" in slack, unless you have a product
manager defined you get:

> short-url-manager is owned by `null` (#survey-and-support)