### PR TITLE
Review Rummager publishing fixes

### DIFF
--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -63,7 +63,7 @@ to bring the search index back in sync with the publishing apps.
 ### Replaying rummager traffic
 
 Once an index is restored we need to re-run all traffic that occurred after the snapshot was taken for the 'government', 'detailed' and
-'mainstream' indicies. We have setup `GOR` logging for `POST` and `GET` requests so that we can replay this traffic, this way we don't need
+'mainstream' indices. We have setup `GOR` logging for `POST` and `GET` requests so that we can replay this traffic, this way we don't need
 to resend the traffic from individual publishing application.
 
 > The `govuk` index can be restored by resending data directly from the publishing API as it is not updated directly from the publishing applications.

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -4,28 +4,32 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 owner_slack: "#search-team"
-last_reviewed_on: 2017-08-18
+last_reviewed_on: 2017-11-23
 review_in: 3 months
 related_applications: [rummager]
 ---
 
-Rummager (the search API) often gets out of sync with publishing
-applications. This affects any part of the site using it, including navigation
-pages and related links.
+[Rummager](/apps/rummager.html) (the search API) often gets out of sync with
+publishing applications. This affects any part of the site using it, including
+navigation pages and related links.
 
 ### Root cause
 
+For most document formats (those that have not been [migrated to the new
+index](https://github.com/alphagov/rummager/blob/master/config/govuk_index/migrated_formats.yaml)),
 Rummager depends on requests from publishing apps to stay
 up to date. This is usually a "fire and forget" task that doesn't block
 the user's publishing action, and if anything goes wrong, the search data
 will stay unchanged until the next time an update is made to the document.
 
-The search team are working on improving this.
+The search team are [working on improving
+this](https://github.com/alphagov/rummager/blob/master/doc/arch/adr-004-transition-mainstream-to-publishing-api-index.md).
 
 ### Check if search is the problem
 
 A page with URL [/council-tax](https://www.gov.uk/council-tax) can be queried using [/api/search.json?filter_link=/council-tax](https://www.gov.uk/api/search.json?filter_link=/council-tax). You can quickly
-switch between the two using the GOV.UK chrome plugin.
+switch between the two using the [GOV.UK chrome
+plugin](https://github.com/alphagov/govuk-toolkit-chrome).
 
 You can compare the data returned with the publishing app to check if it's up
 to date. An empty response means search has never received the content.


### PR DESCRIPTION
Add extra links.

Keep a review time of three months because we expect to have migrated most of the formats to the new index by that point, and this will change the republishing process.

I took a brief look at the Elasticsearch backup docs too, but I haven't bumped the review date because it will need to be updated in the next couple of days once we've reconfigured the background jobs.