### PR TITLE
[DO NOT MERGE] Add email test docs

### DIFF
--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -55,6 +55,10 @@ Deployment communications are in the `#govuk-deploy` Slack channel. If you are o
 
 An alert for the start and end of your deployment will appear in the channel. Jenkins will still enforce sequential deployments per environment across all applications, so you may end up in a queue.
 
+### Testing email alerts
+
+See [testing email](testing-email.md) if the changes you are deploying may affect email. Deploying Travel Advice Publisher should always include testing email alerts.
+
 ### Holding deployment of other applications
 
 If you need to hold deployments of applications during your deploy say so in your announcement post and add it to the channel topic (along with your name). Post again and remove from the topic when you release your hold.

--- a/source/manual/testing-email.md
+++ b/source/manual/testing-email.md
@@ -1,0 +1,29 @@
+---
+owner_slack: "#email"
+title: Testing Email
+parent: "/manual.html"
+layout: manual_layout
+section: Deployment
+important: true
+last_reviewed_on: 2017-11-29
+review_in: 1 month
+---
+
+## Introduction
+
+When deploying an application that sends email alerts we need to test that functionality.
+
+### Testing email alerts
+
+A courtesy copy of all email sent from the integration, staging and production 
+environments is sent to [a google group](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies).
+Integration and staging emails will have a subject prefixed by the environmnent.
+
+If you need to test the process of subscribing to an email alert you can subscribe
+with govuk-email-courtesy-copies@digital.cabinet-office.gov.uk. You should then
+see two copies of the email at that address when you perform an action that triggers
+an email alert (the courtesy copy and the subscriber one).
+
+Our integration and staging environments only allow email to be sent to a small
+number of email addresses so you cannot test using your own email address in these
+environments.

--- a/source/manual/testing-email.md
+++ b/source/manual/testing-email.md
@@ -24,6 +24,22 @@ with govuk-email-courtesy-copies@digital.cabinet-office.gov.uk. You should then
 see two copies of the email at that address when you perform an action that triggers
 an email alert (the courtesy copy and the subscriber one).
 
+The process for triggering an alert varies by publishing application, but it
+usually involves creating a new edition of some content, then publishing it with
+a 'major' update type. The change note you enter should appear in the email that
+gets sent.
+
+A useful debug step if you're not sure if an email has been sent is to check
+`email-alert-api` to see if it has created records in its database, e.g.
+
+```ruby
+$ govuk_app_console email-alert-api
+> ContentChange.last
+> Email.last
+> DeliveryAttempt.last
+```
+
+Emails won't be sent if no one is subscribed, so you'll need to do that first.
 Our integration and staging environments only allow email to be sent to a small
 number of email addresses so you cannot test using your own email address in these
 environments.


### PR DESCRIPTION
This PR adds documentation for testing email alerts on integration and staging. Only members of the Notify account can receive email in these environments so we have a courtesy copy address that can be used for testing.

Marked DNM as it isn't possible to subscribe to Notify based alerts yet.

[Trello](https://trello.com/c/WG5ZrPfb/375-define-an-approach-for-handling-email-sending-in-staging-integration)