### PR TITLE
Bump various page review dates

### DIFF
--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -4,8 +4,8 @@ title: Email alerts not sent
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-05-23
-review_in: 6 months
+last_reviewed_on: 2017-12-01
+review_in: 1 month
 ---
 
 GOV.UK sends out emails when certain publications are published. We have

--- a/source/manual/alerts/mongod-replication-lag.html.md
+++ b/source/manual/alerts/mongod-replication-lag.html.md
@@ -4,7 +4,7 @@ title: mongod replication lag
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-05-30
+last_reviewed_on: 2017-12-01
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/nginx-requests-too-low.html.md
+++ b/source/manual/alerts/nginx-requests-too-low.html.md
@@ -4,7 +4,7 @@ title: Nginx requests too low
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-05-30
+last_reviewed_on: 2017-12-01
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/root-filesystem-is-readonly.html.md
+++ b/source/manual/alerts/root-filesystem-is-readonly.html.md
@@ -4,8 +4,8 @@ title: root filesystem is readonly
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-05-30
-review_in: 6 months
+last_reviewed_on: 2017-12-01
+review_in: 1 month
 ---
 
 When Ubuntu is unable to write to disk it switches the filesystem to be

--- a/source/manual/alerts/user-monitor.html.md
+++ b/source/manual/alerts/user-monitor.html.md
@@ -4,7 +4,7 @@ title: Check that correct users have access
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-05-25
+last_reviewed_on: 2017-12-01
 review_in: 6 months
 ---
 

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -4,7 +4,7 @@ title: Get started on GOV.UK
 description: Guide for new developers on GOV.UK
 layout: manual_layout
 section: Basics
-last_reviewed_on: 2017-08-26
+last_reviewed_on: 2017-12-01
 review_in: 3 months
 ---
 

--- a/source/manual/resync-mongo-db.html.md
+++ b/source/manual/resync-mongo-db.html.md
@@ -4,7 +4,7 @@ title: Resync a MongoDB database
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-05-30
+last_reviewed_on: 2017-12-01
 review_in: 6 months
 ---
 


### PR DESCRIPTION
Mainly just review date bumps, but also a couple of changes to next review date for:

* email alerts, due to ongoing email changes; and
* filesystem readonly alerts, due to AWS migration.