### PR TITLE
Note file size changes in HMRC PAYE files docs

### DIFF
--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -88,7 +88,7 @@ the previous version of the software.
     works fine, the new edition of the [mainstream content
     item](https://www.gov.uk/basic-paye-tools) and [Welsh
     translation](https://www.gov.uk/lawrlwytho-offer-twe-sylfaenol-cthem)
-    can be prepped by the content team with the new links and version
+    can be prepped by the content team with the new links, file sizes and version
     number, ready to publish at the launch time.
 
 8.  When the launch time comes (which should be specified in the Zendesk


### PR DESCRIPTION
Note the file sizes may change when new HMRC PAYE files are made available to upload. If this is the case they will need to be reflected in the content pages too.