### PR TITLE
Don't use h1 tags in manual pages 

### DIFF
--- a/source/manual/alerts/asset-master-slave-disk-space-comparison.html.md
+++ b/source/manual/alerts/asset-master-slave-disk-space-comparison.html.md
@@ -24,7 +24,7 @@ usage should be very similar.
 A difference in the disk usage triggers the alert: "Asset master and slave are
 using about the same amount of disk space".
 
-# Investigation
+## Investigation
 
 Check that the asset-manager cron job is syncing new asset data correctly by
 graphing `asset-slave-*_backend*.df-mnt-uploads.df_complex-used` in [Graphite or

--- a/source/manual/alerts/virus-scanning.html.md
+++ b/source/manual/alerts/virus-scanning.html.md
@@ -17,9 +17,9 @@ until they see the documents available. There is a Grafana [dashboard](https://g
 that helps to visualise the number of documents that have been processed and the
 waiting time since the file has been placed on disk until it is scanned.
 
-# Virus scanning process
+## Virus scanning process
 
-## Incoming files
+### Incoming files
 
 All files uploaded through Whitehall (including both attachment documents and
 images) are asynchronously run through a virus scanner (ClamAV) before being
@@ -54,7 +54,7 @@ follows:
 
     $ tail -f /var/log/syslog | grep "process_uploaded_attachment\|virus_scan\|copy_attachment"
 
-## Detecting new viruses
+### Detecting new viruses
 
 A [separate script](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_asset_base/virus_scan.sh)
 regularly rescans *all* the previously uploaded files in both clean and
@@ -63,7 +63,7 @@ draft-clean to catch any newly-released virus signatures.
 The script is configured in cron to run every hour, but actually takes over 2
 days to complete. It starts under a lock so that only one scan runs at a time.
 
-# Quickly process a backlog of files awaiting AV scan
+## Quickly process a backlog of files awaiting AV scan
 
 The AV scan process is currently quite slow (usually taking between 10-12
 seconds per file), and we get a lot of files to check.  If there's a large

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -8,7 +8,9 @@ last_reviewed_on: 2017-12-12
 review_in: 6 months
 ---
 
-# automongodbbackup
+We have 2 ways of taking MongoDB backups. 
+
+## automongodbbackup
 
 This is how MongoDB backups have traditionally been taken on the GOV.UK Infrastructure.
 
@@ -24,7 +26,7 @@ To restore from this method:
  - Unzip the file. This will produce a directory of data.
  - `mongo restore --drop <directory>`
 
-# mongodumps to S3
+## mongodumps to S3
 
 We also take backups that are sent to an Amazon S3 bucket. The timings are defined by parameters [set in the manifest](https://github.com/alphagov/govuk-puppet/blob/master/modules/mongodb/manifests/s3backup/cron.pp),
 but for important MongoDB clusters these may be taken every 15 minutes. The machines which take the backups are defined in hiera node classes.

--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -25,5 +25,11 @@ Dir.glob("source/manual/**/*.md").each do |filename|
     it "has the correct suffix" do
       expect(filename).to match(/\.html\.md$/)
     end
+
+    unless filename.in?(%w[source/manual/readmes.html.md source/manual/kibana.html.md])
+      it "doesn't use H1 tags (the page title is already an H1)" do
+        expect(raw).not_to match(/\n#\s/)
+      end
+    end
   end
 end


### PR DESCRIPTION
We shouldn't use `h1` tags in manual pages, because there's already a h1 present on the page. Adds tests.