### PR TITLE
Check encrypted values are encrypted

### DIFF
--- a/.vale
+++ b/.vale
@@ -8,5 +8,5 @@ BasedOnStyles = vale, PlainLanguage
 # Set level for styles
 vale.GenderBias = warning
 
-PlainLanguage.Slash = warning
+PlainLanguage.Slash = NO
 PlainLanguage.Words = warning

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -171,16 +171,20 @@ modify encrypted Hiera data.
     Do not enclose it in single or double quotes as this will get
     interpreted as part of the secret.
 
-Once you have finished, save the file and quit the editor. The changes
-you made will be encrypted by Hiera eYAML. Should you encounter an
-error, please see the troubleshooting section below.
+    Once you have finished, save the file and quit the editor. The changes
+    you made will be encrypted by Hiera eYAML. Should you encounter an
+    error, please see the troubleshooting section below.
 
-> **NOTE**
->
-> When editing a Hiera key that has previously been encrypted, you will
-> notice a number enclosed in parentheses after the word GPG; for
-> example: DEC::GPG(1). You should not make any changes to the number as
-> this is used by Hiera eYAML GPG to identify existing encrypted data.
+    > **NOTE**
+    >
+    > When editing a Hiera key that has previously been encrypted, you will
+    > notice a number enclosed in parentheses after the word GPG; for
+    > example: DEC::GPG(1). You should not make any changes to the number as
+    > this is used by Hiera eYAML GPG to identify existing encrypted data.
+
+3. Check that the value is actually encrypted! If you make a typo in your markup, Hiera Eyaml doesn't always treat it as an error.
+
+    GIT_PAGER='less -S' git diff
 
 ## Managing access to encrypted Hiera data
 


### PR DESCRIPTION
Add a note about checking the output after encrypting, and simplify some of the language so the linter complains a bit less.

I've disabled one of the PlainLanguage linters because it triggers on repository names. There is also a lot of noise from the other PlainLanguage ones like `ComplexWords` and `PassiveVoice` but I've left these warnings in for now.