### PR TITLE
Show command to SSH into an app machine

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -13,6 +13,16 @@ class AppDocs
     pages.reject(&:retired?).flat_map(&:topics).sort.uniq
   end
 
+  def self.aws_machines
+    @common ||= HTTP.get_yaml('https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml')
+    @common["node_class"]
+  end
+
+  def self.carrenza_machines
+    @common ||= HTTP.get_yaml('https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml')
+    @common["node_class"]
+  end
+
   class App
     attr_reader :app_data
 
@@ -33,6 +43,22 @@ class AppDocs
           sentry_url: sentry_url,
         }
       }
+    end
+
+    def aws_puppet_class
+      AppDocs.aws_machines.each do |puppet_class, keys|
+        if keys["apps"].include?(app_name)
+          return puppet_class
+        end
+      end
+    end
+
+    def carrenza_machine
+      AppDocs.carrenza_machines.each do |puppet_class, keys|
+        if keys["apps"].include?(app_name)
+          return puppet_class
+        end
+      end
     end
 
     def html_url

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -53,6 +53,28 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   <% end %>
 </ul>
 
+<h3>SSH access</h3>
+
+This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
+
+To SSH to one of these machines:
+
+```
+ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
+ssh -A -t jumpbox.staging.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
+ssh -A -t jumpbox.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
+```
+
+<h3>AWS SSH access</h3>
+
+This application lives on `<%= application.aws_puppet_class %>` machines on the integration environment in AWS.
+
+To SSH to one of these machines [via the jumpbox](https://docs.publishing.service.gov.uk/manual/howto-ssh-to-machines-in-aws.html), use this command:
+
+```
+ssh -A -t jumpbox.integration.govuk.digital 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
+```
+
 <% if application.example_published_pages %>
 <h3>Example pages published by <%= application.app_name %></h3>
 


### PR DESCRIPTION
This PR adds a section to all application pages with the command to SSH into the machine where the application lives. It works by fetching the YAML file that contains the mapping between machine "classes" and applications.

Some examples:

<img width="817" alt="screen shot 2017-12-20 at 14 52 40" src="https://user-images.githubusercontent.com/233676/34212824-7605ac00-e595-11e7-9da5-cb31e3531a6f.png">
