### PR TITLE
Add a guide about the concept of stacks

### DIFF
--- a/source/manual/concept-of-stacks.html.md
+++ b/source/manual/concept-of-stacks.html.md
@@ -1,0 +1,36 @@
+---
+owner_slack: "#govuk-infrastructure"
+title: Stacks in AWS
+section: AWS
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2017-12-13
+review_in: 1 month
+---
+
+When designing the infrastructure for GOV.UK in AWS we built in the concept of
+being able to deploy multiple "stacks" within a single environment.
+
+The implementation detail is described in the [related ADR](https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0015-dns-infrastructure.md).
+
+## Definition of a stack
+
+A stack is a namespace for a piece of infrastructure. It is not used at an application level and
+should not be visible to end users.
+
+For example, you could build an entire infrastructure within an [Amazon VPC](https://aws.amazon.com/vpc)
+using the "stackname" of "blue".
+
+This would deploy configuration based upon namespaced data found in [govuk-aws-data](https://github.com/alphagov/govuk-aws-data).
+
+If you wished to upgrade a piece of infrastructure without interrupting the current service,
+you could deploy something using the "green" stackname.
+
+For instance, you may wish to deploy a new [Amazon RDS](https://aws.amazon.com/rds/)
+instance with a newer version of a database server.
+
+You could then specifically test this implementation by pointing an application
+at the stack specific endpoint.
+
+When you are happy with the results, you could then switch top level DNS over
+and remove the older RDS instance.

--- a/source/manual/govuk-in-aws.html.md
+++ b/source/manual/govuk-in-aws.html.md
@@ -62,7 +62,7 @@ calculators-frontend.blue.integration.govuk-internal.digital has address 10.1.5.
 calculators-frontend.blue.integration.govuk-internal.digital has address 10.1.6.27
 ```
 
-The service name will first resolve the top level environment domain name (`integration.govuk-internal.digital`), which will be a [CNAME record](https://en.wikipedia.org/wiki/CNAME_record) to a stack specific DNS record. Please see the documentation about [the concept of stacks in the infrastructure]().
+The service name will first resolve the top level environment domain name (`integration.govuk-internal.digital`), which will be a [CNAME record](https://en.wikipedia.org/wiki/CNAME_record) to a stack specific DNS record. Please see the documentation about [the concept of stacks in the infrastructure](concept-of-stacks.html).
 
 GOV.UK applications use [Plek](https://github.com/alphagov/plek) for service discovery. Plek will return the fully-qualified domain name (FQDN) of the service it is discovering. To ensure that all internal traffic is routed internally, we must set [specific overrides for Plek to ensure internal names are resolved](https://github.com/alphagov/govuk-puppet/blob/6d19af8a266eaa1680a6a3b54f9b4fc7af943c20/modules/govuk/manifests/deploy/config.pp#L103-L117):
 


### PR DESCRIPTION
The concept of stacks is something which is fundamentally different in the AWS architecture. This is a small, high level view on what their use case is, and how they may be used.

The ADR needs to be updated to present a clearer view on the implementation of the stacks and how DNS works with them.