### PR TITLE
Update "Edit an existing route in the Router"

### DIFF
--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -4,9 +4,16 @@ title: Edit an existing route in the Router
 section: Routing
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-08-15
-review_in: 6 months
+last_reviewed_on: 2018-01-02
+review_in: 3 months
 ---
+
+The Router API database is populated from the Publishing API, and also
+the deprecated router-data tool. Changes to routes should be made in
+the Publishing API as this is the authoritive source of the data,
+however, it can be helpful to make short term changes to routes
+manually, when going through the Publishing API would take to long,
+for example during an incident.
 
 If there's a need to edit a Route in the database, follow these
 instructions:
@@ -15,14 +22,14 @@ instructions:
     $ govuk_app_console router-api
     > r = Route.where(incoming_path: '/path-to-item').first
 
-manipulate the `r` object directly (see the
+Manipulate the `r` object directly (see the
 [documentation](https://github.com/alphagov/router#data-structure) for
 available options), eg:
 
     > r.route_type = 'exact'
     > r.save!
 
-once you've edited the Route appropriately and saved it, you need to
+Once you've edited the Route appropriately and saved it, you need to
 reload the router:
 
     > RouterReloader.reload


### PR DESCRIPTION
Drop the review time, as I'm not sure when production will move to
AWS, and thus a different way of accessing the relevant machine will
be needed.

Add a paragraph to make it clearer when manually editing routes is
appropriate, and that it's only a short term fix/change.

Also, improve some capitalisation.