### PR TITLE
Update review date for email not sent page

### DIFF
--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -4,7 +4,7 @@ title: Email alerts not sent
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-01-04
+last_reviewed_on: 2018-01-04
 review_in: 1 month
 ---
 


### PR DESCRIPTION
This was meant to be 2018 rather than 2017.