### PR TITLE
Review search team stuff

### DIFF
--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 title: Elasticsearch cluster health
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/alerts/enhanced-ecommerce.html.md
+++ b/source/manual/alerts/enhanced-ecommerce.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 title: Enhanced ecommerce data export
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -1,22 +1,23 @@
 ---
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 title: Fetch analytics data for search failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-06-27
+last_reviewed_on: 2018-01-08
 review_in: 6 months
 ---
 
 This checks the latest build state of [a job in production
 Jenkins](https://deploy.publishing.service.gov.uk/job/search-fetch-analytics-data/)
-which runs every night and populates the search index with the latest data from
+which runs every night and updates all documents in the search index with pageview data from
 Google Analytics.
 
 The only downside of this not running is that the popularity data is slightly
 out of date. The search index is locked while it runs so it shouldn’t be re-run
 whilst people are publishing.
 
+The popularity data is used to promote more popular pages in search results.
+
 If the job is failing often, make sure the team currently responsible for search
 are aware of the problem.
-

--- a/source/manual/alerts/search-benchmarking.html.md
+++ b/source/manual/alerts/search-benchmarking.html.md
@@ -1,11 +1,11 @@
 ---
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 title: Benchmark search queries failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-10-02
-review_in: 3 months
+last_reviewed_on: 2018-01-08
+review_in: 6 months
 ---
 
 Indicates that the Jenkins [search_benchmark healthcheck job] (https://deploy.publishing.service.gov.uk/job/search_benchmark/) has failed.

--- a/source/manual/alerts/search-spelling-suggestions.html.md
+++ b/source/manual/alerts/search-spelling-suggestions.html.md
@@ -1,22 +1,19 @@
 ---
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 title: Check for spelling suggestions failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-10-02
-review_in: 3 months
+last_reviewed_on: 2018-01-08
+review_in: 6 months
 ---
 
 Indicates that the Jenkins [search_test_spelling_suggestions healthcheck job]
 (https://deploy.publishing.service.gov.uk/job/search_test_spelling_suggestions/)
 has failed.
 
-The healthcheck sends queries to the search API and checks that the response
+This job sends queries to the search API and checks that the response
 contains the expected spelling suggestions.
 
-The Jenkins job will still succeed even if the search results are poor and will
-only fail if something actually goes wrong. For example, if a request to the
-search API fails.
-
-Check the output of the job on the relevant environment for more information.
+It will only fail if something actually goes wrong, like if a request to the
+search API fails. The actual score will be less than 100%.

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -1,23 +1,22 @@
 ---
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 title: 'Backup and restore Elasticsearch indices'
 parent: "/manual.html"
 layout: manual_layout
 section: Backups
-last_reviewed_on: 2017-11-28
+last_reviewed_on: 2018-01-08
 review_in: 2 months
 ---
+The elasticsearch indexes used for search are backed up to disk using [es_dump_restore](https://github.com/patientslikeme/es_dump_restore).
+
+**Note: this will change to S3 snapshots when production is moved to AWS**
 
 ## Creating a backup
 
-Sometimes you may need to take a backup of Elasticsearch before a
-critical operation. You can use [es_dump_restore](https://github.com/patientslikeme/es_dump_restore) for this.
-
-All Elasticsearch servers create their own
-nightly backups using a cronjob, which shows how to run it:
+Sometimes you may need to take a backup before a
+critical operation. To do this, run:
 
 ```bash
-$ sudo crontab -lu elasticsearch
 /usr/bin/es_dump http://localhost:9200 /var/es_dump
 ```
 
@@ -31,8 +30,6 @@ Before restoring a backup, make sure you are [monitoring the cluster](/manual/al
 Restoring to an index which exists is additive - it doesn't replace the
 existing data or delete any documents which don't exist in the dump.
 This means that if the import fails (as it sometimes does), you can simply re-run the command.
-
-### Restoring GOV.UK search indexes (with aliases)
 
 Given a directory of dumps named after their respective indices, you can restore them using the same steps as the environment data sync script, [elasticsearch-restore.sh](https://github.com/alphagov/env-sync-and-backup/blob/master/scripts/elasticsearch-restore.sh).
 
@@ -51,45 +48,9 @@ If you need to change the alias back for any reason, you can run the rummager ra
 
 Once backups have been restored it is necessary to manually delete the old indices as otherwise elasticsearch will run out of disk space and memory. This can be done by running the rummager task: `rummager:clean`.
 
-After restoring a backup, consider [replaying traffic](/manual/rummager-traffic-replay.html)
-to bring the search index back in sync with the publishing apps.
-
 ### Replaying rummager traffic
 
-Once an index is restored we need to re-run all traffic that occurred after the snapshot was taken for the 'government', 'detailed' and
-'mainstream' indices. We have setup `GOR` logging for `POST` and `GET` requests so that we can replay this traffic, this way we don't need
-to resend the traffic from individual publishing application.
+By restoring an older backup, you will lose any documents that have been updated since the backup was taken.
 
-> The `govuk` index can be restored by resending data directly from the publishing API as it is not updated directly from the publishing applications.
-
-The logs are stored on the rummager servers (1 file per server) location at:
-
-```
-/var/logs/gor_dump
-```
-
-A copy of the file should be taken for the restore, as the restore requests will be logged to the file. The following command can be used to run the restore:
-
-```
-sudo gor --input-file "20171031.log|6000%" --stats --output-http-stats --output-http "http://localhost:3009/|6000%" -verbose
-```
-
-This runs the restore at 60x the speed it was saved so each hour of logs takes 1min to process.
-
-> This processed failed when running on the rummager server, but was successful when run locally with port forwarding.
-> This may be an issue with the `GOR` version on the server.
-
-### Restoring other indexes (without aliases)
-
-If you want to replace something, you have to delete it first.
-
-```
-$ curl -XDELETE 'http://localhost:9200/indexname/'
-```
-
-Given a dump, which will typically be a zipfile, then it can be restored
-into Elasticsearch:
-
-```
-$ es_dump_restore http://localhost:9200/ <indexname> dumpfile.zip
-```
+After restoring a backup, follow [Replaying traffic to correct an out of sync search index](/manual/rummager-traffic-replay.html)
+to bring the search index back in sync with the publishing apps.

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -3,7 +3,7 @@ title: Content that doesn't show up correctly in search or list pages
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#search-team"
+owner_slack: "#2ndline"
 last_reviewed_on: 2017-11-23
 review_in: 3 months
 related_applications: [rummager]

--- a/source/manual/rummager-traffic-replay.html.md
+++ b/source/manual/rummager-traffic-replay.html.md
@@ -1,33 +1,41 @@
 ---
-owner_slack: "#search-team"
-title: 'Replay search indexing traffic after restoring a backup'
+owner_slack: "#2ndline"
+title: 'Replaying traffic to correct an out of sync search index'
 parent: "/manual.html"
 layout: manual_layout
 section: Backups
-last_reviewed_on: 2017-09-05
+last_reviewed_on: 2018-01-08
 review_in: 3 months
 ---
 
-If the index should fail and we need to [restore from backup](https://docs.publishing.service.gov.uk/manual/elasticsearch-dumps.html) we can then replay this traffic rather than trying to resend from the source applications.
+If the data in the search index is out of sync with the publishing API,
+(for example, after [restoring a backup](https://docs.publishing.service.gov.uk/manual/elasticsearch-dumps.html)),
+then any `publish` and `unpublish` messages that have not been processed need to be resent.
 
-We are using [GOR](https://github.com/buger/goreplay) to store POST and DELETED requests made to the rummager servers.
+#### `govuk` index
+Content in the `govuk` index is populated from the [publishing API message queue](https://github.com/alphagov/rummager/blob/master/doc/new-indexing-process.md). Missing documents can be recovered by resending the content to the message queue, for example by running `represent_downstream:document_type[:document_type]` rake task in publishing API.
 
-Data for each of the rummager machine is stored locally on the machine at:
+#### `government`/`detailed` indexes ####
+
+**This will not be neccessary after whitehall content has been moved to the `govuk` index.**
+
+These indexes are populated by whitehall calling an HTTP API in Rummager.
+
+We have also setup [GOR](https://github.com/buger/goreplay) logging for `POST` and `GET` requests so that we can replay the traffic.
+
+The logs are stored on the rummager servers (1 file per server) location at:
 
 ```
-/var/log/gor_dumps
+/var/logs/gor_dump
 ```
 
-Traffic will needs to be replayed from each server using the command:
+A copy of the file should be taken for the restore, as the restore requests will be logged to the file. The following command can be used to run the restore:
 
 ```
-sudo GODEBUG="netdns=go" /usr/local/bin/gor --input-file "/var/log/gor_dump/*.log|1000%" --output-http http://localhost:3009 --output-http-timeout 30s
+sudo gor --input-file "20171031.log|6000%" --stats --output-http-stats --output-http "http://localhost:3009/|6000%" -verbose
 ```
 
-You can run the command with debug logging to get a better idea of progress using the below command:
+This runs the restore at 60x the speed it was saved so each hour of logs takes 1min to process.
 
-```
-sudo GODEBUG="netdns=go" /usr/local/bin/gor --input-file "/var/log/gor_dump/*.log|1000%" --output-http http://localhost:3009 --output-http-timeout 30s --verbose --debug
-```
-
-The above command replays the traffic at 10 times (1000%) the speed is was captured, this can be adjusted by changing the percentage value in the command.
+> This processed failed when running on the rummager server, but was successful when run locally with port forwarding.
+> This may be an issue with the `GOR` version on the server.


### PR DESCRIPTION
There is no search team next quarter, so assign everything to 2ndline.

There is now only one app (whitehall) indexing documents the old way, so there's less of a need for the GOR traffic replay, but it could still be used. Don't duplicate this in the backup guide though.

All the `es_dump` stuff should go away when we move to AWS as infra have set up S3 backups.