### PR TITLE
Update VM disk space requirement

### DIFF
--- a/source/manual/development-disk-space.html.md
+++ b/source/manual/development-disk-space.html.md
@@ -9,7 +9,7 @@ review_in: 6 months
 ---
 
 You may run out of disk space when replicating data into your development
-environment. The default VM disk size is 100GB.
+environment. The default VM disk size is 150GB.
 
 First check if you are out of disk space on your host machine (`df -h`).
 If your host machine has plenty of available space, then the problem may be

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -18,7 +18,7 @@ Follow the steps on this page to get your GOV.UK development environment running
 
 It will take you roughly one day to do everything in this guide from start to finish. There are lots of things to download, and loads of installers need to do their thing.
 
-> You'll need up to 100GB of free space on your hard-drive to run the whole of GOV.UK.
+> You'll need up to 150GB of free space on your hard-drive to run the whole of GOV.UK.
 
 **Developing outside the VM**
 


### PR DESCRIPTION
The development VM can now require up to 150GB of disk space.

See https://github.com/alphagov/govuk-provisioning/pull/27