### PR TITLE
Add jumpbox definition to CI ssh-config

### DIFF
--- a/source/manual/ssh-config.html.md
+++ b/source/manual/ssh-config.html.md
@@ -13,8 +13,11 @@ Add the following to `~/.ssh/config`:
 ```
 ## CI
 ## -------
+Host ci-jumpbox
+  Hostname ci-jumpbox.integration.publishing.service.gov.uk
+
 Host *.ci
-  ProxyCommand ssh -e none %r@ci-jumpbox.integration.publishing.service.gov.uk -W %h:%p
+  ProxyCommand ssh -e none %r@ci-jumpbox -W $(echo %h | sed 's/\.ci$//'):%p
 
 ## Integration
 ## -------


### PR DESCRIPTION
The CI stanza needs to be more like the integration one otherwise it doesn't work 
correctly.  We define the ci-jumpbox separately, and we strip `.ci` from the end of
the host name we're trying to ssh into through the jumpbox.