### PR TITLE
Make the last 2 steps of gpg generation clearer

### DIFF
--- a/source/manual/rotate-offsite-backup-gpg-keys.html.md
+++ b/source/manual/rotate-offsite-backup-gpg-keys.html.md
@@ -18,8 +18,10 @@ good security practice we rotate these keys each year.
 3. `gpg2 --batch --gen-key gpg_templates/offsite_backup_gpg_template.txt`
 4. Ensure you make a copy of the password you use.
 5. Get the key ID you just generated with `gpg2 --list-keys --fingerprint`, and make a copy of the full fingerprint ID.
-6. Copy the output of `gpg2 --export-secret-key --armor <key id>`
-7. Export the public key to a key server by submitting the output of `gpg2 --export --armor <key id>` to a public key server, for instance https://pgp.mit.edu/
+6. Export _secret_ key: Copy the output of `gpg2 --export-secret-key --armor <key id>`
+7. Export _public_ key: Copy the output of `gpg2 --export --armor <key id>` to a public key server, for instance https://pgp.mit.edu/
+
+NB: Steps 6 & 7 use different commands for exporting. 
 
 ## What do I need to update?
 


### PR DESCRIPTION
Following an incident with GPG key generation caused by the last two steps of the relevant docs not being clear enough about requiring two _different_ commands to export the private versus the public key, I've added a bit more text to make people more aware that they need to read the last two steps more thoroughly.

Current version can be seen here: https://docs.publishing.service.gov.uk/manual/rotate-offsite-backup-gpg-keys.html#header