### PR TITLE
Remove spurious "my" in a troubleshooting headings

### DIFF
--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -362,7 +362,7 @@ before your one. If this is the case, the credentials will need to be
 re-encrypted again, making sure that your GPG key fingerprint is in the
 relevant recipient files.
 
-### Puppet fails because my it can't find a usable GPG key
+### Puppet fails because it can't find a usable GPG key
 
 When Puppet runs, you may see the following error:
 


### PR DESCRIPTION
"Puppet fails because my it can’t find a usable GPG key" should read
"Puppet fails because it can’t find a usable GPG key"