### PR TITLE
Update URL for alphagov-deployment repo

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -91,8 +91,8 @@
 
     - name: Deployment
       sites:
-        - name: gds/alphagov-deployment
-          url: https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment
+        - name: alphagov/alphagov-deployment
+          url: https://github.com/alphagov/alphagov-deployment
           description: (Deprecated) Capistrano scripts for deploying GOV.UK apps
         - name: alphagov/govuk-secrets
           url: https://github.com/alphagov/govuk-secrets


### PR DESCRIPTION
This repo has moved to public Github.