### PR TITLE
Add content schema keywords

### DIFF
--- a/source/content-schemas.html.md.erb
+++ b/source/content-schemas.html.md.erb
@@ -5,4 +5,14 @@ title: Content schemas
 
 The content schemas are defined in the [govuk-content-schemas repo][repo].
 
+| Keyword       | Explanation                                                                            |
+| ------------- | ------------------------------------------------------------------------------------- |
+| `type`        | The data type of a schema |
+| `required`    | Specify object-level properties that must exist - by default all object properties are optional |
+| `enum`                        | To specify values a request parameter or model property can accept     |
+| `oneOf`, `anyOf`, `allOf`     | These allow you to validate the use of other subschemas in your schema |
+| `additionalProperties`        | Controls whether properties that are not already specified can be accepted. By default any additional properties are allowed     |
+
+
+
 [repo]: https://github.com/alphagov/govuk-content-schemas


### PR DESCRIPTION
The Modelling Services team have been working on the content schema for step by step navigtion (previously called `task lists`).

We had to do a bit of research to find out how to represent certain properties of our task list, and thought it would be good to add to the Developer docs.

Please feel free to add to this.

![screen shot 2018-01-25 at 16 39 13](https://user-images.githubusercontent.com/19667619/35400439-b459dbe6-01ee-11e8-81d4-38aa21f06522.png)