### PR TITLE
Remove some old information about Plek in AWS

### DIFF
--- a/source/manual/govuk-in-aws.html.md
+++ b/source/manual/govuk-in-aws.html.md
@@ -64,7 +64,7 @@ calculators-frontend.blue.integration.govuk-internal.digital has address 10.1.6.
 
 The service name will first resolve the top level environment domain name (`integration.govuk-internal.digital`), which will be a [CNAME record](https://en.wikipedia.org/wiki/CNAME_record) to a stack specific DNS record. Please see the documentation about [the concept of stacks in the infrastructure](concept-of-stacks.html).
 
-GOV.UK applications use [Plek](https://github.com/alphagov/plek) for service discovery. Plek will return the fully-qualified domain name (FQDN) of the service it is discovering. To ensure that all internal traffic is routed internally, we must set [specific overrides for Plek to ensure internal names are resolved](https://github.com/alphagov/govuk-puppet/blob/6d19af8a266eaa1680a6a3b54f9b4fc7af943c20/modules/govuk/manifests/deploy/config.pp#L103-L117):
+GOV.UK applications use [Plek](https://github.com/alphagov/plek) for service discovery. Plek will return the fully-qualified domain name (FQDN) of the service it is discovering.
 
 ```
 irb(main):001:0> Plek.find("publishing-api")


### PR DESCRIPTION
The GOVUK_APP_DOMAIN is now set to the internal domain, so the
overrides have changed.