### PR TITLE
Update Elasticsearch docs

### DIFF
--- a/source/apis/search/add-new-fields-or-document-types.html.md.erb
+++ b/source/apis/search/add-new-fields-or-document-types.html.md.erb
@@ -1,0 +1,8 @@
+---
+layout: api_layout
+title: Add new fields or document types to search
+parent: /apis/search/
+source_url: https://github.com/alphagov/rummager/blob/master/doc/adding-new-fields.md
+---
+
+<%= ExternalDoc.fetch(repository: 'alphagov/rummager', path: 'doc/adding-new-fields.md') %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -12,9 +12,10 @@
     </li>
     <li><%= sidebar_link 'Search API', '/apis/search/search-api.html' %></li>
     <ul>
+      <li><%= sidebar_link "Add new fields or document types", "/apis/search/add-new-fields-or-document-types.html" %></li>
+      <li><%= sidebar_link "Content indexed in search", "/apis/search/content.html" %></li>
       <li><%= sidebar_link "Faceted search", "/apis/search/faceted-search.html" %></li>
       <li><%= sidebar_link "Field reference", "/apis/search/fields.html" %></li>
-      <li><%= sidebar_link "Content indexed in search", "/apis/search/content.html" %></li>
     </ul>
     <li><%= sidebar_link 'Whitehall API', '/apis/whitehall.html' %></li>
   </ul>

--- a/source/manual/add-a-new-document-type.html.md
+++ b/source/manual/add-a-new-document-type.html.md
@@ -3,8 +3,8 @@ title: Add a new document type
 parent: "/manual.html"
 layout: manual_layout
 section: Tools
-owner_slack: "@davidslv and @matmoore"
-last_reviewed_on: 2017-08-08
+owner_slack: "#2ndline"
+last_reviewed_on: 2018-01-26
 review_in: 3 months
 ---
 
@@ -12,12 +12,12 @@ The [document type](https://docs.publishing.service.gov.uk/document-types.html) 
 
 ## Add the document type in the govuk-content-schema repo
 
-You need to add the document type into the [allowed document types](https://github.com/alphagov/govuk-content-schemas/blob/master/lib/govuk_content_schemas/allowed_document_types.yml) in [content-schemas](https://github.com/alphagov/govuk-content-schemas/blob/master/lib/govuk_content_schemas).
+You need to add the document type into the [allowed document types](https://github.com/alphagov/govuk-content-schemas/blob/master/lib/govuk_content_schemas/allowed_document_types.yml) in [content-schemas](https://github.com/alphagov/govuk-content-schemas).
 
 Once you have added the document type you should:
 
 - commit the change
-- run the default [rake task](https://docs.publishing.service.gov.uk/manual/running-rake-tasks.html) to generate the schemas again
+- run `bundle exec rake` to generate the schemas again
 - commit this update separately
 
 Examples of implementation:
@@ -75,5 +75,3 @@ Republish all the documents and they should appear in search. You can test this 
 
 - [https://www.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide](https://www.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide)
 - [https://www-origin.integration.publishing.service.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide](https://www-origin.integration.publishing.service.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide)
-
-

--- a/source/manual/alerts/redis.html.md
+++ b/source/manual/alerts/redis.html.md
@@ -4,7 +4,7 @@ title: Redis alerts
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-10-09
+last_reviewed_on: 2018-01-26
 review_in: 6 months
 ---
 
@@ -12,7 +12,6 @@ We have a few monitoring checks for Redis:
 
 -  memory usage
 -  number of connected clients
--  list length (for the `logs-redis` machines only)
 
 Redis is configured to use 75% of the system memory. If Redis memory usage
 reaches this limit it will stop accepting data input. Redis is also unable to
@@ -26,45 +25,3 @@ descriptors that can be opened at a time.
 
 If Redis is using large amounts of memory you could use ``redis-cli --bigkeys``
 to find out what those things might be.
-
-## Redis for logs
-
-### Investigation of the problem
-
-For logs-redis, memory may be exhausted if the Elasticsearch river is not
-consuming data from Redis for some reason. In this case, redis will accumulate
-data up to its memory limit and then stop accepting log data. In this
-condition log data will be lost from the logging pipeline because logship
-discards data.
-
--  You should use graphite for looking at CPU load and used memory.
-   (Pending: More graphite inputs)
--  Also check how this impacts Elasticsearch.
--  `redis-cli INFO` and `redis-cli CLIENT LIST` commands help to
-   see present info. [Other commands may come handy](http://redis.io/commands).
-
-### Redis rivers for Elasticsearch
-
-We use [elasticsearch-redis-river](https://github.com/leeadkins/elasticsearch-redis-river)
-(a Redis river for Elasticsearch). This is a special process which reads data continuously from a redis queue (called `logs`) into Elasticsearch.
-
-There is a Nagios alert (listed above) for when the `logs` Redis list gets
-too long. This might be because Elasticsearch is unavailable or may be for
-some other reason.
-
-Generally this can be fixed by deleting and recreating the rivers. This is safe to do because the river pulls data from Redis (rather than redis pushing data into Elasticsearch).
-
-Delete and recreate the rivers with this Fabric command:
-
-```
-fab $environment -H logs-elasticsearch-1.management elasticsearch.delete:_river puppet
-```
-
-The `elasticsearch.delete:_river` command deletes all rivers, and `puppet`
-runs Puppet which will recreate them.
-
-To manually check the length of the list, use:
-
-```
-fab $environment -H logs-redis-1.management do:'redis-cli LLEN logs'
-```

--- a/source/manual/alerts/search-reindex-failed.html.md
+++ b/source/manual/alerts/search-reindex-failed.html.md
@@ -8,9 +8,11 @@ last_reviewed_on: 2017-11-23
 review_in: 12 months
 ---
 
-The reindex task is run weekly on a Monday at 12pm on integration.  This is to ensure the process works as
-expected when we need to run it in production.  This task is manually run in production by the
-development team after they have made and changes to the elasticsearch schema.
+The reindex task is run weekly on a Monday at 12pm on integration. It
+[reindexes][reindexing]  every Elasticsearch index used by [rummager][]. This is
+to ensure the process works as expected when we need to run it in production.
+This task is manually run in production by the development team after they have
+made and changes to the elasticsearch schema.
 
 If this process fails then please escalate to the Search team as they are responsible for ensuring this process
 works.
@@ -20,3 +22,6 @@ This task can be manually run with the following command:
 ```
 bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=true RUMMAGER_INDEX=<index_alias_name>
 ```
+
+[reindexing]: /manual/reindex-elasticsearch.html
+[rummager]: /apps/rummager.html

--- a/source/manual/fix-blank-finder-filter-options.html.md
+++ b/source/manual/fix-blank-finder-filter-options.html.md
@@ -1,0 +1,30 @@
+---
+title: Fix blank options in finder filters
+parent: "/manual.html"
+layout: manual_layout
+section: Publishing
+owner_slack: "#2ndline"
+last_reviewed_on: 2018-01-26
+review_in: 3 months
+related_applications: [rummager, finder-frontend]
+---
+
+On finder pages, facets on the left hand side can be populated from "link"
+fields in the search documents, like people, organisations, topics.
+
+If the pages for those things don't themselves exist in search, finder frontend
+won't be able to fill in the titles:
+
+![People facet with blank options](/images/blank-facets.png)
+
+This can be detected by the [Finder Frontend feature in
+Smokey][finder-frontend-smokey]. An example error would be `And I should see a
+closed facet titled "People" with non-blank values`.
+
+To fix the issue:
+
+- Inspect the blank options using your browser developer tools to work out which
+  pages are affected
+- Republish those pages in whitehall
+
+[finder-frontend-smokey]: https://github.com/alphagov/smokey/blob/master/features/finder_frontend.feature

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -62,19 +62,4 @@ to remove unwanted duplicates.
 
 #### There are blank options on finder pages
 
-On finder pages, facets on the left hand side can be populated from "link"
-fields in the search documents, like people, organisations, topics.
-
-This can be detected by the Finder Frontend feature in Smokey (an
-example error would be `And I should see a closed facet titled
-"People" with non-blank values`).
-
-If the pages for those things don't themselves exist in search, finder frontend
-won't be able to fill in the titles.
-
-To fix the issue:
-- Inspect the blank options using browser developer tools to work out which
-  people are affected
-- Republish those people in whitehall
-
-![People facet with blank options](/images/blank-facets.png)
+See the instructions for [fixing blank finder filter options](fix-blank-finder-filter-options.html).

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -4,7 +4,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 owner_slack: "#2ndline"
-last_reviewed_on: 2018-01-09
+last_reviewed_on: 2018-01-26
 review_in: 3 months
 related_applications: [rummager]
 ---
@@ -15,15 +15,15 @@ navigation pages and related links.
 
 ### Root cause
 
-For most document formats (those that have not been [migrated to the new
-index](https://github.com/alphagov/rummager/blob/master/config/govuk_index/migrated_formats.yaml)),
-Rummager depends on requests from publishing apps to stay
-up to date. This is usually a "fire and forget" task that doesn't block
-the user's publishing action, and if anything goes wrong, the search data
-will stay unchanged until the next time an update is made to the document.
+For whitehall document formats (i.e. those that have not been [migrated to the
+new index](https://github.com/alphagov/rummager/blob/master/config/govuk_index/migrated_formats.yaml)),
+Rummager depends on requests from whitehall admin to stay up to date. This is a
+"fire and forget" task that doesn't block the user's publishing action, and if
+anything goes wrong, the search data will stay unchanged until the next time an
+update is made to the document.
 
-The search team are [working on improving
-this](https://github.com/alphagov/rummager/blob/master/doc/arch/adr-004-transition-mainstream-to-publishing-api-index.md).
+See [rummager ADR 004](https://github.com/alphagov/rummager/blob/master/doc/arch/adr-004-transition-mainstream-to-publishing-api-index.md)
+for details of how we improved this for non-whitehall formats.
 
 ### Check if search is the problem
 
@@ -36,6 +36,45 @@ to date. An empty response means search has never received the content.
 
 You can also request [different fields](/apis/search/fields.html), for example
 [/api/search.json?filter_link=/council-tax&fields=format,content_id](https://www.gov.uk/api/search.json?filter_link=/council-tax&fields=format,content_id).
+
+If the document is missing from the search API, check the search index itself to
+see if it is present and has the expected fields:
+
+0. ssh to an elasticsearch box with port-forwarding:
+
+    ```
+    ssh -L9200:localhost:9200 rummager-elasticsearch-1.api.staging
+    ```
+
+0. Go to the Any Request tab and use the panel on the left to send a `POST`
+request to hostname `http://localhost:9200/` and path `govuk/_search`:
+
+    ```
+    {
+      "filter": {
+        "term": {
+          "link": "/the/path/to/the/page"
+        }
+      }
+    }
+    ```
+
+    Or search by content ID:
+
+    ```
+    {
+      "filter": {
+        "term": {
+          "content_id": "638db33a-fe73-45fd-96e2-7dcf8281ff16"
+        }
+      }
+    }
+    ```
+
+If the document is present and looks correct, it suggests that the problem is
+that the document does not match the search query. You can debug the query by
+adding the parameter `debug=show_query` to the search API URL, e.g.
+<https://www.gov.uk/api/search.json?q=badgers&debug=show_query>.
 
 ### Correct the search data
 

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -18,7 +18,7 @@ For information on how to log in and view stacks, please see the [GOV.UK Logit d
 ## Filebeat
 
 Each machine runs [Elastic Filebeat](https://www.elastic.co/products/beats/filebeat), and
-indepedently ships logs to the Logit provided logstash endpoint.
+independently ships logs to the Logit provided logstash endpoint.
 
 Filebeat tails logs and can output to a variety of sources. It is fully incorporated into the
 Elastic ecosystem.

--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -1,0 +1,67 @@
+---
+owner_slack: "#2ndline"
+title: Reindex an Elasticsearch index
+section: Publishing
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-01-27
+review_in: 3 months
+related_applications: [rummager]
+---
+
+After updating an Elasticsearch index's schema by [changing the fields or
+document types][update-fields-or-doc-types], you need to reindex the affected
+index before the new fields and types can be used.
+
+The reindexing process:
+
+0. Locks the Elasticsearch index to prevent writes to the index while data is
+being copied
+0. Creates a new index using the schema defined in the deployed version of
+rummager
+0. Copies all the data from the old to the new index
+0. Compares the old and new data to check for inconsistencies
+0. If everything looks the same, switches the [alias][index-alias] to the new
+index
+
+## How to reindex an Elasticsearch index
+
+**Do not reindex on production during working hours except in an emergency.**
+Reindexing locks the index for writes, so content is not updated in the search
+index. See the [Replay traffic](#replay-traffic) section below if you need to
+run a reindexing during working hours.
+
+To reindex, run the `rummager:migrate_schema` rake task:
+
+```
+bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=name_of_index_to_migrate
+```
+
+If you set the last parameter to `RUMMAGER_INDEX=all`, rummager will reindex all
+the indices sequentially.
+
+You can run this task from Jenkins, but it will block other rake tasks from
+being run for 15 minutes to an hour. You can avoid this by running the command
+directly on a `search` machine, but you need to prefix the command with
+`govuk_setenv rummager` to make sure the Elasticsearch hostname is set
+correctly.
+
+To monitor progress, SSH to an elasticsearch box with port-forwarding:
+
+```
+ssh -L9200:localhost:9200 rummager-elasticsearch-1.api.staging
+```
+
+Then visit <http://localhost:9200/_plugin/head/> to check how many documents have
+been copied to the new index.
+
+### Replay traffic
+
+This step is only necessary if you ran reindexing job during working hours,
+which means that content published in whitehall will be missing from search.
+
+See [Replaying traffic to correct an out of sync search index][rummager-traffic-replay.html]
+for details.
+
+[update-fields-or-doc-types]: /apis/search/add-new-fields-or-document-types.html
+[index-alias]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -95,6 +95,7 @@ Our [deployment dashboards](deployment-dashboards.html) use Graphite extensively
 ### Applying Functions
 
 Graphite has a whole bunch of functions you can apply to your data to make it more useful: they’re listed out [in the Graphite docs](http://graphite.readthedocs.org/en/0.9.12/functions.html). One particularly useful one is `keepLastValue`: if your graphs come out nearly black with a few spots of colour in them, you probably want this one. Both views have an Apply Function button.
+
 ## Kibana
 
 You can access GOV.UK Kibana through [Logit](logit.html).
@@ -104,6 +105,8 @@ Kibana is a log viewer and search engine. In Kibana, you can filter down log mes
 You can tweak the time range manually with the drop down at the top or by dragging on the timeline.
 
 Check out some of the [useful Kibana queries](kibana.html) to get an idea of what's possible.
+
+Logs are sent to Kibana using [Filebeat](logging.html#filebeat).
 
 ## Fabric Scripts
 


### PR DESCRIPTION
This should hopefully make it a bit easier for 2ndline to debug search issues. In particular:

- Explain how to run the reindexing job
- Add some example ES queries
- Remove references to the old logs-elasticsearch cluster