### PR TITLE
Add documentation on the publishing e2e tests suite

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -112,6 +112,12 @@ class AppDocs
       "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_#{puppet_name}.json"
     end
 
+    def publishing_e2e_tests_url
+      if ["Frontend apps", "Publishing apps"].include?(type)
+        "https://github.com/alphagov/publishing-e2e-tests/search?q=%22#{app_name.underscore}%3A+true%22+path%3A%2Fspec%2F"
+      end
+    end
+
     def api_docs_url
       app_data["api_docs_url"]
     end

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -48,6 +48,7 @@
         - govuk_security_audit
         - govuk-rfcs
         - govuk-lint
+        - publishing-e2e-tests
         - styleguides
 
 - name: Infrastructure

--- a/source/manual/publishing-e2e-tests.html.md
+++ b/source/manual/publishing-e2e-tests.html.md
@@ -1,0 +1,36 @@
+---
+title: End to end testing publishing apps
+section: Testing
+layout: manual_layout
+parent: "/manual.html"
+owner_slack: "#govuk-developers"
+last_reviewed_on: 2018-02-01
+review_in: 6 months
+---
+
+We have [end to end tests][repo] running against proposed changes to applications to verify
+that the change doesn't break flows interacting with multiple applications.
+
+## Flaky tests
+
+These tests execute through the UI, and can be fragile and flaky as a result.  Rerunning a build may fix the immediate
+problem but [you are implored to tackle the root cause][flaky-tests-guide].
+
+## Test against branch
+
+The test-against branch is used by [Jenkins when executing the test suite][jenkins-test-against] against proposed
+changes.  This branch should get pushed to automatically whenever a change is made to master branch.  On occasion the
+master branch has failed due to the flaky nature of the test suite causing test-against to
+[become behind master][compare-test-against-master].  [Rerunning the master branch build][rebuild-master-branch] should fix it.
+
+## How to add new tests
+
+If you are writing a new publishing application or wanting to cover new end to end flows you are advised to
+[read the guidance on Github][add-new-tests-guidance].
+
+[repo]: https://github.com/alphagov/publishing-e2e-tests
+[flaky-tests-guide]: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md#dealing-with-flaky-tests
+[compare-test-against-master]: https://github.com/alphagov/publishing-e2e-tests/compare/test-against...master
+[jenkins-test-against]: https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/
+[add-new-tests-guidance]: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md#adding-new-tests
+[rebuild-master-branch]: https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/master/build?delay=0sec

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -33,6 +33,9 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   <li><%= link_to "Puppet configuration", application.puppet_url %></li>
   <li><%= link_to "Deploy scripts", application.deploy_url %></li>
   <li><%= link_to "Deployment dashboard", application.dashboard_url %> (warning: not all apps have a dashboard)</li>
+  <% if application.publishing_e2e_tests_url %>
+    <li><%= link_to "Publishing E2E scenarios", application.publishing_e2e_tests_url %> (warning: not all apps have E2E tests)</li>
+  <% end %>
 
   <% if application.api_docs_url %>
     <li><%= link_to "API docs", application.api_docs_url %></li>


### PR DESCRIPTION
Follow through to the repository README for now.  Will look at automatically generating E2E test information on each app at in a later story.