### PR TITLE
Add content audit tool to dev docs

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -114,7 +114,11 @@
 
 - github_repo_name: content-performance-manager
   type: Supporting apps
-  team: "#content-tools"
+  team: "#data-informed-content"
+
+- github_repo_name: content-audit-tool
+  type: Supporting apps
+  team: "#data-informed-content"
 
 - github_repo_name: search-admin
   type: Supporting apps


### PR DESCRIPTION
I think we need this to be able to set up sentry
https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html#configuring-sentry

I'll update that page in a separate PR if I get it working.

This also changes the slack channel associated with the apps.