### PR TITLE
Add govuk-dependencies to the list of team tools

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -134,6 +134,7 @@
         - emmabeynon/github-trello-poster
         - dsingleton/deploy-lag-radiator
         - govuk-toolkit-chrome
+        - govuk-dependencies
         - govuk-deploy-lag-badger
         - govuk-display-screen
 


### PR DESCRIPTION
https://trello.com/c/DEeV9Bcp/76-add-app-to-docspublishingservicegovuk