### PR TITLE
Add metrics dashboard link for Email Alert Api

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -126,6 +126,10 @@ class AppDocs
       app_data["component_guide_url"]
     end
 
+    def metrics_dashboard_url
+      app_data["metrics_dashboard_url"]
+    end
+
     def type
       app_data.fetch("type")
     end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -65,6 +65,7 @@
 - github_repo_name: email-alert-api
   type: APIs
   team: "#email"
+  metrics_dashboard_url: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 
 - github_repo_name: email-alert-service
   type: APIs

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -45,6 +45,10 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
     <li><%= link_to "Component guide", application.component_guide_url %></li>
   <% end %>
 
+  <% if application.metrics_dashboard_url %>
+    <li><%= link_to "Metrics dashboard", application.metrics_dashboard_url %></li>
+  <% end %>
+
   <% if application.production_url %>
     <li><%= link_to application.production_url.gsub('https://', ''), application.production_url %></li>
   <% end %>


### PR DESCRIPTION
When viewing docs for Email Alert Api, we want to display a link to the Email Alert Api metrics dashboard. To do that:

* Add a new variable `metrics_dashboard_url`
* Conditionally render the url in the application template if the metrics dashboard url exists for the application
* Add the `metrics_dashboard_url` data to Email Alert Api yaml definition