### PR TITLE
Update docs for SSHing to environment

### DIFF
--- a/source/manual/howto-ssh-to-machines-in-aws.html.md
+++ b/source/manual/howto-ssh-to-machines-in-aws.html.md
@@ -4,8 +4,8 @@ title: SSH into AWS machines
 section: AWS
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-01-11
-review_in: 3 months
+last_reviewed_on: 2018-02-14
+review_in: 2 months
 ---
 
 This document explains how to SSH into machines in AWS, as it's markedly
@@ -16,53 +16,63 @@ In AWS, there are no static hostnames, so we can't have
 dynamically assigned IPs, which means hostnames like
 `ip-10-1-5-53.eu-west-1.compute.internal`. Each Puppeted instance has a "node
 class" (backend, frontend, ...), and the list of instances belonging to these
-classes is accessible via `govuk_node_list`.
+classes is accessible via `govuk_node_list` when logged onto the environment.
 
-Ensure that your [SSH configuration](ssh-config.html) is up to date.
+To help connecting to the environments, there is a wrapper tool called [`govukcli`](https://github.com/alphagov/govuk-aws/blob/master/tools/govukcli).
 
-### Use SSH proxy configuration
+## Install
 
-Using the SSH configuration supplied above, you should be able to go directly
-to instances using:
-
-`ssh ip-1-2-3-4.eu-west-1.compute.internal.integration`
-
-This is useful when responding to machines within Icinga.
-
-If you do not know the hostname of the type of node to connect to, list them by
-running:
-
-`ssh integration "govuk_node_list -c <node type>"`
-
-Example:
+Ensure you have cloned the `govuk-aws` repository:
 
 ```
-$ ssh integration "govuk_node_list -c backend"
-ip-10-1-5-57.eu-west-1.compute.internal
-ip-10-1-6-88.eu-west-1.compute.internal
+cd ~/govuk
+git clone https://github.com/alphagov/govuk-aws
 ```
 
-### Agent forwarding
+Add a symlink to ensure you use the current version:
 
-SSH with agent forwarding to the jumpbox:
+```
+ln -s ~/govuk/govuk-aws/tools/govukcli /usr/local/bin/govukcli
+```
 
-        ssh -A $USERNAME@integration
+## Connecting to instances
 
-2. Use `govuk_node_list` to narrow down the IP addresses you require:
+The tool uses the idea of "contexts", where a "context" is a specific environment.
 
-        govuk_node_list -c backend
+To view the contexts run:
 
-3. In most cases, you'll get multiple hostnames as the output of that command,
-   for example:
+`govukcli list-contexts`
 
-        ip-10-1-5-57.eu-west-1.compute.internal
-        ip-10-1-6-88.eu-west-1.compute.internal
+Set a context to interact with that environment:
 
-   Choose one, and copy/paste into a normal SSH command:
+`govukcli set-context integration`
 
-        ssh ip-10-1-5-57.eu-west-1.compute.internal.integration
+### AWS
 
-5. To get to a single node, you can use the `--single-node` switch on
-   `govuk_node_list`, straight into your SSH command:
+In AWS you must specify a node class only. You must use `_` rather than `-` when specifying
+the class.
 
-        ssh `govuk_node_list -c backend --single-node`
+`govukcli ssh calculators_frontend`
+
+This will take you to a random instance of that class.
+
+If you wish to go to a specific node, you can log into the jumpbox:
+
+`govukcli ssh jumpbox`
+
+Return a list of available instances:
+
+`govuk_node_list -c calculators_frontend`
+
+Use the SSH command to connect to a specific hostname.
+
+### Carrenza
+
+If the environment you're using is in Carrenza, you can connect to instances in
+the traditional way:
+
+`govukcli ssh backend-1`
+
+You may also use the node class to select a random node:
+
+`govukcli ssh calculators_frontend`


### PR DESCRIPTION
It's always a good idea to abstract the technical detail into a wrapper coded in bash, so add documentation about how to use this particular wrapper.

This documents how to use the `govukcli` tool which will hopefully make SSHing into different environments easier. This also allows the use of one method to use in different environments while we migrate.