### PR TITLE
Updates docs for change note removal

### DIFF
--- a/source/manual/howto-remove-change-note-from-whitehall.html.md
+++ b/source/manual/howto-remove-change-note-from-whitehall.html.md
@@ -9,25 +9,39 @@ review_in: 6 months
 ---
 
 Change notes are called `editorial_remarks` in Whitehall. An Edition can 
-have multiple editorial remarks, but in the Publishing API an Edition can 
-only have one single change note. Not all editorial remarks are propagated 
-to the Publishing API, only ones marking major changes. The Publishing API 
-then creates a list of all the change notes from all versions of the edition
-and presents them to the Content Store. You can read more about this in the 
-Publishing API [docs](https://docs.publishing.service.gov.uk/apis/publishing-api/model.html#changenote).
+have multiple editorial remarks and they are visible only in the Whitehall 
+Admin. On the hand, an Edition in the Publishing API can only have one 
+single `change_note`. The change note is public facing as it is displayed on 
+the frontend. The Publishing API creates a list of all the change notes 
+from all versions of the edition and presents them to the Content Store. 
+You can read more about this in the Publishing API [docs](https://docs.publishing.service.gov.uk/apis/publishing-api/model.html#changenote).
 
 ### Remove a Change Note
 
-Steps to undertake when someone has requested that you remove a change note 
-from Whitehall: 
+First of all determine whether the person requesting that you remove a change note
+is referring to an `editorial_remark` in the Whitehall Admin, or to a public facing 
+`change_note` which is collected from Publishing API. 
 
-1. Obtain the ID of the edition on which the change note was created. 
-1. Create a migration in Whitehall where you search for the edition by ID 
-and extract the `editorial_remarks` from it. Find the editorial remark 
-containing the text of the change note and destroy it. An example PR can 
-be found [here](https://github.com/alphagov/whitehall/pull/3762/files#diff-4beba2c08746b9f02186f396b3cc1df0R17). 
-This will also remove it from the editorial_remark_trail stored on the Edition 
-in Whitehall.
+#### Editorial Remark
+1. Obtain the content item ID of the document on which the change note was created. 
+This can be done by visiting the `/api/content/` version of the the edition's url. 
+This document will contain multiple editions. You will have to extract the 
+`editorial_remark` from these editions. 
+1. Create a data migration in Whitehall [docs here](https://github.com/alphagov/whitehall/blob/19cd7d72de32454d532c195f35b027fa1b3ba6ac/db/data_migration/README.md)
+1. In the data migration, search for the document by the content item ID and
+extract the `editorial_remark` that contains the text you are looking to delete. 
+1. If such an editorial remark is present, then destroy the `editorial_remark`
+and check in the UI that it is no longer displayed.
+
+#### Change Note 
+1. If not then it's probably a `change_note` in Publishing API so you should create
+a migration in publishing API instead. 
+1. Similarly, search for the document by content item ID in publishing API: 
+`Document.where(content_id: "your-content-id")` and extract the `change_note`.
+If the document is associated with multiple editions you should search through all 
+of them for the text of the change note: `document.editions.map(&:change_note)`.
+An example PR can be found here: https://github.com/alphagov/publishing-api/pull/1160
+1. Find the change note containing the text you are looking to delete and destroy it. 
 1. Check in the UI that the change note is no longer displayed. 
 1. If the change note was indicating a major change, then it will be propagated 
 to an Edition in publishing-api. You can search for that edition using the content 
@@ -37,3 +51,4 @@ publishing-api. If it was a minor change, you will not find the change note in
 publishing-api. 
 1. If you do find a change note, you will have to delete it and re-send 
 the edition to the content store to be updated. 
+


### PR DESCRIPTION
After further investigation into how to remove change notes, we've updated the documentation to reflect that.

For: https://trello.com/c/sOPRBrrT/63-2-remove-change-note-and-redirect-html-attachment-url