### PR TITLE
Add ValeLint to CI

### DIFF
--- a/.vale
+++ b/.vale
@@ -1,12 +1,10 @@
 StylesPath = styles/
-MinAlertLevel = warning
+MinAlertLevel = error
 
 # Global settings (applied to every syntax)
 [*]
 # List of styles to load
 BasedOnStyles = vale, PlainLanguage
-# Set level for styles
-vale.GenderBias = warning
 
 PlainLanguage.Slash = NO
 PlainLanguage.Words = warning

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,10 @@ node {
       govuk.rubyLinter("app lib helpers spec bin")
     }
 
+    stage("Lint documentation") {
+      sh "vale --glob='*.md' ."
+    }
+
     stage("Tests") {
       govuk.runTests()
     }

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -126,7 +126,6 @@ Once complete, you should run `git pull` to obtain the re-encrypted copy.
 You should now be able to use the `rake(1)` tasks below to access and
 modify encrypted Hiera data.
 
-<a name="zsh-note"></a>
 > **NOTE**
 >
 > If you use [ZSH](http://zsh.sourceforge.net/) as your local shell, you
@@ -435,7 +434,10 @@ If you encounter an error similar to
 zsh: no matches found: eyaml:edit[integration]
 ```
 
-you should read the [note](#zsh-note) and try:
+Try either enclosing the rake command in single quotes or
+set the
+[noglob](http://zsh.sourceforge.net/Doc/Release/Options.html#index-NOGLOB)
+option.
 
 ```
 noglob bundle exec rake eyaml:edit[integration]

--- a/source/manual/howto-remove-change-note-from-whitehall.html.md
+++ b/source/manual/howto-remove-change-note-from-whitehall.html.md
@@ -24,7 +24,7 @@ is referring to an `editorial_remark` in the Whitehall Admin, or to a public fac
 
 #### Editorial Remark
 1. Obtain the content item ID of the document on which the change note was created. 
-This can be done by visiting the `/api/content/` version of the the edition's url. 
+This can be done by visiting the `/api/content/` version of the edition's url. 
 This document will contain multiple editions. You will have to extract the 
 `editorial_remark` from these editions. 
 1. Create a data migration in Whitehall [docs here](https://github.com/alphagov/whitehall/blob/19cd7d72de32454d532c195f35b027fa1b3ba6ac/db/data_migration/README.md)

--- a/source/manual/howto-remove-change-note-from-whitehall.html.md
+++ b/source/manual/howto-remove-change-note-from-whitehall.html.md
@@ -8,47 +8,47 @@ last_reviewed_on: 2018-02-09
 review_in: 6 months
 ---
 
-Change notes are called `editorial_remarks` in Whitehall. An Edition can 
-have multiple editorial remarks and they are visible only in the Whitehall 
-Admin. On the hand, an Edition in the Publishing API can only have one 
-single `change_note`. The change note is public facing as it is displayed on 
-the frontend. The Publishing API creates a list of all the change notes 
-from all versions of the edition and presents them to the Content Store. 
+Change notes are called `editorial_remarks` in Whitehall. An Edition can
+have multiple editorial remarks and they are visible only in the Whitehall
+Admin. On the hand, an Edition in the Publishing API can only have one
+single `change_note`. The change note is public facing as it is displayed on
+the frontend. The Publishing API creates a list of all the change notes
+from all versions of the edition and presents them to the Content Store.
 You can read more about this in the Publishing API [docs](https://docs.publishing.service.gov.uk/apis/publishing-api/model.html#changenote).
 
 ### Remove a Change Note
 
 First of all determine whether the person requesting that you remove a change note
-is referring to an `editorial_remark` in the Whitehall Admin, or to a public facing 
-`change_note` which is collected from Publishing API. 
+is referring to an `editorial_remark` in the Whitehall Admin, or to a public facing
+`change_note` which is collected from Publishing API.
 
 #### Editorial Remark
-1. Obtain the content item ID of the document on which the change note was created. 
-This can be done by visiting the `/api/content/` version of the edition's url. 
-This document will contain multiple editions. You will have to extract the 
-`editorial_remark` from these editions. 
+1. Obtain the content item ID of the document on which the change note was created.
+This can be done by visiting the `/api/content/` version of the edition's url.
+This document will contain multiple editions. You will have to extract the
+`editorial_remark` from these editions.
 1. Create a data migration in Whitehall [docs here](https://github.com/alphagov/whitehall/blob/19cd7d72de32454d532c195f35b027fa1b3ba6ac/db/data_migration/README.md)
 1. In the data migration, search for the document by the content item ID and
-extract the `editorial_remark` that contains the text you are looking to delete. 
+extract the `editorial_remark` that contains the text you are looking to delete.
 1. If such an editorial remark is present, then destroy the `editorial_remark`
 and check in the UI that it is no longer displayed.
 
-#### Change Note 
+#### Change Note
 1. If not then it's probably a `change_note` in Publishing API so you should create
-a migration in publishing API instead. 
-1. Similarly, search for the document by content item ID in publishing API: 
+a migration in publishing API instead.
+1. Similarly, search for the document by content item ID in publishing API:
 `Document.where(content_id: "your-content-id")` and extract the `change_note`.
-If the document is associated with multiple editions you should search through all 
+If the document is associated with multiple editions you should search through all
 of them for the text of the change note: `document.editions.map(&:change_note)`.
 An example PR can be found here: https://github.com/alphagov/publishing-api/pull/1160
-1. Find the change note containing the text you are looking to delete and destroy it. 
-1. Check in the UI that the change note is no longer displayed. 
-1. If the change note was indicating a major change, then it will be propagated 
-to an Edition in publishing-api. You can search for that edition using the content 
+1. Find the change note containing the text you are looking to delete and destroy it.
+1. Check in the UI that the change note is no longer displayed.
+1. If the change note was indicating a major change, then it will be propagated
+to an Edition in publishing-api. You can search for that edition using the content
 item id (Edition IDs will not coincide between whitehall and
 publishing-api). You can also do a freetext search for the change note text in
-publishing-api. If it was a minor change, you will not find the change note in 
-publishing-api. 
-1. If you do find a change note, you will have to delete it and re-send 
-the edition to the content store to be updated. 
+publishing-api. If it was a minor change, you will not find the change note in
+publishing-api.
+1. If you do find a change note, you will have to delete it and re-send
+the edition to the content store to be updated.
 

--- a/source/manual/restore-from-offsite-backups.html.md
+++ b/source/manual/restore-from-offsite-backups.html.md
@@ -28,14 +28,10 @@ on a Vagrant VM.
 On a fresh VM, you may require the following packages for this exercise:
 
 > You can use either your dev VM or if you have the space you can create a new mysql server VM using the following command:
->
-> ```vagrant up mysql-master-1.backend```
->
+> `vagrant up mysql-master-1.backend`
 > This needs to be run from the root of the `govuk-puppet` repository
->
 > Access the new VM using:
->
-> ```vagrant ssh mysql-master-1.backend```
+> `vagrant ssh mysql-master-1.backend`
 
 #### Packages via `apt-get`
 


### PR DESCRIPTION
I added Vale as a pre-commit hook in b3dcb10783b238de3fbc0acc808da2647ee851f7.

The idea is that we can "lint" our documentation for grammar and readability. Documentation is often as important as the code we have to support, so we should ensure it is concise and accessible, particularly to people where English is not their first language.

This adds the tool to the CI chain. It can be further configured using `.vale`, and further styles may be added to `styles/`.