### PR TITLE
Create howto-recreate-a-mongo-instance-in-aws

### DIFF
--- a/source/manual/howto-recreate-a-mongo-instance-in-aws.html.md
+++ b/source/manual/howto-recreate-a-mongo-instance-in-aws.html.md
@@ -1,0 +1,61 @@
+---
+owner_slack: "#2ndline"
+title: Re-create an AWS mongo instance
+section: Development VM
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-02-23
+review_in: 2 months
+---
+
+## Re-create an AWS mongo instance
+
+## Symptom
+Mongo log file error similar to the below text.
+```
+can't get local.system.replset config from self or any seed (EMPTYCONFIG)
+```
+When you access the mongo shell and execute `rs.status()`, you can only see your instance and no other members of the cluster.
+
+## Prognosis
+There is a fault with the clustering and it might take a considerable amount of time to identify the root cause. It might be easier to re-create the instance.
+
+## Solution
+In this example we are looking at the `integration` environment.
+
+1. You will need the following repositories.
+  - https://github.com/alphagov/govuk-aws
+  - https://github.com/alphagov/govuk-aws-data
+  - https://github.com/alphagov/govuk-secrets
+
+2. It is very useful to have acces to the AWS console, to observer the changes as they happen.
+
+3. You can now execute a `terraform plan` to view the actual module names.
+  - $ cd govuk-aws
+  - tools/build-terraform-project.sh -c plan  -p app-mongo -s blue -d data -e integration **Please check the script to identify the keys**
+  
+4. The out-put, will show you the components and how they are named by `terraform`.
+  ```
+  Initializing modules...
+- module.mongo-1
+  Getting source "../../modules/aws/node_group"
+  ....
+  ```
+5. The instance of intrest to us at this point is **mongo-1**.
+
+6. We can now execute a targetted plan to see details related to that specific component and make sure that we are working on the correct instance.
+  - tools/build-terraform-project.sh -c plan  -p app-mongo -s blue -d data -e integration -- -target=module.mongo-1
+  ```
+  data.terraform_remote_state.infra_monitoring: Refreshing state...
+data.terraform_remote_state.infra_security_groups: Refreshing state...
+data.terraform_remote_state.infra_networking: Refreshing state...
+null_resource.user_data[0]: Refreshing state... (ID: 8732671785102119409)
+null_resource.user_data[2]: Refreshing state... (ID: 2147797089831867692)
+...
+```
+
+7. Once you are really sure that you have the correct instance, you can destroy the instance as below.
+  - tools/build-terraform-project.sh -c **destroy**  -p app-mongo -s blue -d data -e integration -- -target=module.mongo-1
+  
+8. Once the command completes execution, we can execute a `terraform apply`. This will recreate the deleted instance.
+  - tools/build-terraform-project.sh -c apply  -p app-mongo -s blue -d data -e integration **you can do a targetted apply but it is not necessary**


### PR DESCRIPTION
This document gives a summary of how to re-create an AWS Mongo instance that doesn't respond correctly or have entered a problem state.