### PR TITLE
Add staging links to sit with the live links

### DIFF
--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -98,10 +98,10 @@ fab $environment class:frontend app.restart:memcached
 
 You can automate this by using the [emergency publishing scraper](https://github.com/alphagov/emergency-publishing-scraper)
 
-- [https://www.gov.uk/?ae00e491](https://www.gov.uk/?ae00e491)
-- [https://www.gov.uk/financial-help-disabled?7f7992eb](https://www.gov.uk/financial-help-disabled?7f7992eb)
-- [https://www.gov.uk/government/organisations/hm-revenue-customs?49854527](https://www.gov.uk/government/organisations/hm-revenue-customs?49854527)
-- [https://www.gov.uk/search?q=69b197b8](https://www.gov.uk/search?q=69b197b8)
+- [https://www.gov.uk/?ae00e491](https://www.gov.uk/?ae00e491) ([Staging](https://www-origin.staging.publishing.service.gov.uk/?ae00e491))
+- [https://www.gov.uk/financial-help-disabled?7f7992eb](https://www.gov.uk/financial-help-disabled?7f7992eb) ([Staging](https://www-origin.staging.publishing.service.gov.uk/financial-help-disabled?7f7992eb))
+- [https://www.gov.uk/government/organisations/hm-revenue-customs?49854527](https://www.gov.uk/government/organisations/hm-revenue-customs?49854527) ([Staging](https://www-origin.staging.publishing.service.gov.uk/government/organisations/hm-revenue-customs?49854527))
+- [https://www.gov.uk/search?q=69b197b8](https://www.gov.uk/search?q=69b197b8) ([Staging](https://www-origin.staging.publishing.service.gov.uk/search?q=69b197b8))
 
 Check the banner displays as expected and double check the information for the
 header, short description and link are as they should be. Test the link if it is
@@ -136,11 +136,10 @@ purging the cache.
 
 3) Check that the emergency banner is visible when accessing the same pages as before but without a cache-bust string.
 
-- [https://www.gov.uk/](https://www.gov.uk/)
-- [https://www.gov.uk/financial-help-disabled](https://www.gov.uk/financial-help-disabled)
-- [https://www.gov.uk/government/organisations/hm-revenue-customs](https://www.gov.uk/government/organisations/hm-revenue-customs)
-- [https://www.gov.uk/search](https://www.gov.uk/search)
-
+- [https://www.gov.uk/](https://www.gov.uk/) ([Staging](https://www-origin.staging.publishing.service.gov.uk/))
+- [https://www.gov.uk/financial-help-disabled](https://www.gov.uk/financial-help-disabled) ([Staging](https://www-origin.staging.publishing.service.gov.uk/financial-help-disabled))
+- [https://www.gov.uk/government/organisations/hm-revenue-customs](https://www.gov.uk/government/organisations/hm-revenue-customs) ([Staging](https://www-origin.staging.publishing.service.gov.uk/government/organisations/hm-revenue-customs))
+- [https://www.gov.uk/search](https://www.gov.uk/search) ([Staging](https://www-origin.staging.publishing.service.gov.uk/search))
 
 <a name="unset-env-var"></a>
 ### 7. Unset your environment variable and deactivate your virtual environment


### PR DESCRIPTION
Trello: https://trello.com/c/ktLcZLIN/102-emergency-publishing-drill

This makes it a bit quicker to access the pages when you are running the
drill instead of constantly changing the live ones to staging.