### PR TITLE
Add an MFA serial to the gds AWS profile

### DIFF
--- a/source/manual/user-management-in-aws.html.md
+++ b/source/manual/user-management-in-aws.html.md
@@ -75,6 +75,10 @@ role_arn = <Role ARN>
 mfa_serial = <MFA ARN>
 source_profile = gds
 region = eu-west-1
+
+[profile gds]
+mfa_serial = <MFA ARN>
+region = eu-west-1
 ```
 
 Create `~/.aws/credentials`:


### PR DESCRIPTION
This is needed by govukcli for `aws sts get-session-token` in https://github.com/alphagov/govuk-aws/pull/507