### PR TITLE
Improves docs for user access alert

### DIFF
--- a/source/manual/alerts/user-monitor.html.md
+++ b/source/manual/alerts/user-monitor.html.md
@@ -18,3 +18,6 @@ When the check fails, look at the console logs for the monitor task:
 
 [User monitor]: https://deploy.publishing.service.gov.uk/job/user-monitor
 [rev]: https://github.com/alphagov/govuk-user-reviewer
+
+When a new person joins, he or she is added on github, but they still have to open a number of PRs to give themselves access elsewhere (ex: in `govuk-puppet`). 
+If they're new, they might not have gotten to that yet so you should check with them before attempting to remove their access.  


### PR DESCRIPTION
New joiners will trigger an alert in Icinga for "Check that correct users have access" which might make people on 2ndline remove their access. This alert happens when people haven't had a chance to open a PR in govuk-puppet to give themselves access, but have already been added to the alphagov organisation and can see repos.