### PR TITLE
Update links to govuk-browser-extension

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -134,7 +134,7 @@
         - binaryberry/seal
         - emmabeynon/github-trello-poster
         - dsingleton/deploy-lag-radiator
-        - govuk-toolkit-chrome
+        - govuk-browser-extension
         - govuk-dependencies
         - govuk-deploy-lag-badger
         - govuk-display-screen

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -44,7 +44,7 @@ The apps are secured by behind a [single signon system][signon]. They use an
 of the apps are shared using [a gem called govuk\_admin\_template][govuk_admin_template].
 
 [rails]: http://rubyonrails.org/
-[extension]: https://github.com/alphagov/govuk-toolkit-chrome
+[extension]: https://github.com/alphagov/govuk-browser-extension
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet
 [govuk-app-deployment]: https://github.com/alphagov/govuk-app-deployment
 [slimmer]: https://github.com/alphagov/slimmer

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -29,7 +29,7 @@ for details of how we improved this for non-whitehall formats.
 
 A page with URL [/council-tax](https://www.gov.uk/council-tax) can be queried using [/api/search.json?filter_link=/council-tax](https://www.gov.uk/api/search.json?filter_link=/council-tax). You can quickly
 switch between the two using the [GOV.UK chrome
-plugin](https://github.com/alphagov/govuk-toolkit-chrome).
+plugin](https://github.com/alphagov/govuk-browser-extension).
 
 You can compare the data returned with the publishing app to check if it's up
 to date. An empty response means search has never received the content.


### PR DESCRIPTION
The repo was renamed because it's now also available for Firefox.