### PR TITLE
Add to and review postgresql replication docs

### DIFF
--- a/source/manual/alerts/postgresql-replication-too-far-behind.html.md
+++ b/source/manual/alerts/postgresql-replication-too-far-behind.html.md
@@ -4,7 +4,7 @@ title: 'PostgreSQL: replication too far behind'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2017-08-31
+last_reviewed_on: 2018-03-06
 review_in: 6 months
 ---
 
@@ -22,14 +22,21 @@ If both nodes are down then Graphite will return no data and an UNKNOWN
 alert will be raised. This should correlate with other checks for server
 and database health.
 
+You can get a quick view of postgresql's wal by doing the following:
+
+on a `postgresql-primary`: `ps -ef | grep sender`
+
+on a `postgresql-standby`: `ps -ef | grep receiver`
+
 If the slave has fallen too far behind or is in an otherwise
 unrecoverable state then you may need to [resync
 it](/manual/setup-postgresql-replication.html#syncing-a-standby).
 
-If this is a new machine, the issue may be that PostgreSQL replication
-is set up and running correctly, but `collectd` needs to be restarted on
-either the primary or standby to ensure that Graphite is receiving the
-metrics it needs.
+If this is a new machine, or if you have recently resynced it, the issue may be that PostgreSQL replication is set up and running correctly, but `collectd` needs to be restarted on either the primary or standby to ensure that Graphite is receiving the metrics it needs.
+
+```
+sudo service collectd restart
+```
 
 The replication lag is measured by examining the difference in the [XLOG
 location in

--- a/source/manual/resync-postgres-standby.html.md
+++ b/source/manual/resync-postgres-standby.html.md
@@ -4,7 +4,7 @@ title: Resync a PostgreSQL standby
 section: Databases
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-12-19
+last_reviewed_on: 2018-03-06
 review_in: 6 months
 ---
 
@@ -23,4 +23,22 @@ Password:
 pg_basebackup: base backup completed
  * Stopping PostgreSQL 9.3 database server                                 [ OK ]
  * Starting PostgreSQL 9.3 database server                                 [ OK ]
+```
+
+You can get the password from encrypted hieradata.
+
+You can get a quick view of postgresql's wal by doing the following:
+
+on a `postgresql-primary`: `ps -ef | grep sender`
+
+on a `postgresql-standby`: `ps -ef | grep receiver`
+
+## Restarting collectd
+
+If you are resyncing because the standby has fallen too far behind primary,
+you might need to restart `collectd` on the standby machine to resolve the
+incinga alerts:
+
+```
+sudo service collectd restart
 ```


### PR DESCRIPTION
Review postgresql replication documentation, update the last reviewed
dates.

Add some extra commands detailing a way to get a quick view of
postgresql sender and receiver's current log location.

Note how to restart `collectd` and point out that you might have to do so
to clear icinga alerts.

Note where to get passwords so we have a less stressful time figuring
stuff out when trying to solve an alert.