### PR TITLE
Add docs for new email notifications system

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -1,0 +1,26 @@
+---
+owner_slack: "#email"
+title: email-alert-api app healthcheck not ok
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-06
+review_in: 1 month
+---
+
+If there is a health check error showing for Email Alert API, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
+
+## High queue size (queue_size)
+This means that there are a high number of items in the queue. This may indicate a problem down the line which is preventing workers from being processed. It may also imply the threshold is too low if a large number of emails have being sent out due to a content change.
+
+## High queue latency (queue_latency)
+This means the time it takes for a job to be processed is unusually high. This may indicate a problem down the line which is preventing workers from being processed. It may also imply the threshold is too low if a large number of emails have being sent out due to a content change.
+
+## High retry queue size (retry_size)
+This means there are a high number of items in the retry queue. The Email Alert API relies on the retry queue for rate limiting, so it’s not unusual to see items in the queue, but if it is very high it suggests that there may be a problem down the line which is preventing jobs from being processed. It may also imply the threshold is too low if a large number of emails have been sent out due to a content change.
+
+## Status updates (status_update)
+This means that we haven’t received status updates from Notify on some emails and it’s been 72 hours since the emails were sent out. This could mean there is a problem with our system, or there could be a problem with Notify.
+
+## Technical failures (technical_failure)
+This means that we’ve received a technical failure status code back from Notify or a request to send an email via Notify failed within the last hour. This means that there may be a problem with our system or that Notify is unable to send emails.

--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -1,32 +1,31 @@
 ---
 owner_slack: "#email"
 title: Email alerts not sent
-parent: "/manual.html"
-layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2018-02-05
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-06
 review_in: 1 month
 ---
 
-GOV.UK sends out emails when certain publications are published. There is [a check](https://github.com/alphagov/email-alert-monitoring) to verify that emails are sent for [drug and medical device alerts](https://www.gov.uk/drug-device-alerts)
+GOV.UK sends out emails when certain publications are published. There
+is [a check](https://github.com/alphagov/email-alert-monitoring) to
+verify that emails are sent for [drug and medical device alerts](https://www.gov.uk/drug-device-alerts)
 and [travel advice updates](https://www.gov.uk/foreign-travel-advice).
 
 If the check fails:
 
-- Inspect the console logs for the [travel advice email alert](https://deploy.publishing.service.gov.uk/job/travel-advice-email-alert-check/) and the [email alert monitoring](https://deploy.publishing.service.gov.uk/job/email-alert-check/) jobs. These will tell you which emails are missing.
-- Check the monitoring inbox to rule out false alerts. Emails are sent to a
-monitoring inbox at `googleapi@digital.cabinet-office.gov.uk`. Credentials for
-the account can be found in the [2nd line password store](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/google-accounts). **In order to login you will need to use one of the backup codes.** (Remove the one you used after), The test is
-diacritic-sensitive so you may see false alerts where `São Tomé and Principe`
-fails to match `Sao Tome and Principe`.
-- Search for `@tags:"govdelivery"` in [Kibana](https://kibana.publishing.service.gov.uk).
+* Inspect the console logs for the [travel advice email alert](https://deploy.publishing.service.gov.uk/job/travel-advice-email-alert-check/) and the [drug and medical device email alert](https://deploy.publishing.service.gov.uk/job/email-alert-check/) jobs. These will tell you which emails are missing.
+* Check the monitoring inbox to rule out false alerts. Emails are sent to a monitoring inbox at `googleapi@digital.cabinet-office.gov.uk`. Credentials for the account can be found in the [2nd line password store](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/google-accounts). **In order to login you will need to use one of the backup codes.** (Remove the one you used after), The test is diacritic-sensitive so you may see false alerts where `São Tomé and Principe` fails to match `Sao Tome and Principe`.
+* Email Alert API stores information on what emails have been sent and where they originated from. In lieu of dedicated tasks for diagnosing the following steps can be done in the Email Alert API console:
+  * `ContentChange.where(content_id: "<items-content-id>")` to look up the content changes Email Alert API has received for a particular content-id
+  * Given a particular content change you can monitor whether this should have been sent to people by querying `SubscriptionContent.where(content_change: <your_content_change>)` to look up the email data directly.
 
 ## Resending travel advice emails
 
 If you need to force the sending of a travel advice email alert, there
-is a rake task in the travel advice publisher, which you can run using
-[this Jenkins
-job](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE=backend-1.backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D),
+is a rake task in Travel Advice Publisher, which you can run using
+[this Jenkins job](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE=backend-1.backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D),
 where the edition ID of the travel advice content item can be found in
-the URL of the country's edit page in the travel advice publisher and
+the URL of the country's edit page in Travel Advice Publisher and
 looks like `fedc13e231ccd7d63e1abf65`.

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -1,0 +1,73 @@
+---
+owner_slack: "#email"
+title: "Email notifications: how they work"
+section: Emails
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-06
+review_in: 1 month
+---
+
+## High-level overview
+
+The purpose of the email notifications system is to inform users when
+content they are interested in is added to or changed on GOV.UK. Users
+indicate their interest by subscribing to receive updates for an area of
+interest (such as topic or government department).
+
+The applications that comprise the email notifications system are:
+
+### Email Alert API
+
+* Stores the persistent data involved in email alerts, such as processed content changes, subscribers and their subscriptions.
+* Provides an HTTP JSON API to alter stored data, such as: create alerts, set up lists and set up subscription preferences.
+* Coordinates sending of notifications with the underlying email sending service, which is currently GOV.UK Notify.
+
+### Email Alert Frontend
+
+* Provides a user interface to sign up to a mailing list.
+* Provides a user interface for a user to manage their subscriptions.
+* Communicates with Email Alert API to make changes.
+
+### Email Alert Service
+
+* Listens to the Publishing API message queue.
+* Communicates with Email Alert API when an appropriate Publishing API event occurs to trigger an alert. This is usually a ‘major’ edit to some content.
+
+### GOV.UK Notify
+
+* Used as a means to send emails.
+* Does not know about subscribers or lists.
+
+Other than these applications, a number of frontend and publishing apps
+communicate with the service. Frontend applications use Email Alert API
+to create new mailing lists and as a redirect destination for signing
+up. Travel Advice Publisher and Specialist Publisher communicate
+directly with Email Alert API to send alerts to have a greater degree of
+control.
+
+To have a near real-time overview of the status of data passing through the Email Alert API, view the [metrics dashboard][dashboard].
+
+## Integration with GOV.UK Notify
+
+The email notifications system uses GOV.UK Notify as a means to send
+emails to users. Email Alert API will request Notify to send an email
+and at a later time Notify will inform the Email Alert API whether that
+was successful.
+
+Communication from Email Alert API to Notify is done via a HTTP API
+which is authenticated by an API key. Communication from Notify to Email
+Alert API is done via a verified HTTP callback with a bearer token.
+Email Alert API is an internal application, so to enable callbacks one
+endpoint is exposed publicly through
+https://email-alert-api-public.publishing.service.gov.uk.
+
+You can login to the Notify account by going to
+[https://www.notifications.service.gov.uk](). The login credentials are
+in the [2nd line password store][password-store] under `govuk-notify/govuk-email-courtesy-copies`.
+
+A courtesy copy of every email sent is available in [a Google Group][google-group].
+
+[dashboard]: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+[password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify
+[google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies

--- a/source/manual/test-email-sending.html.md
+++ b/source/manual/test-email-sending.html.md
@@ -1,0 +1,42 @@
+---
+owner_slack: "#email"
+title: Test email sending
+section: Emails
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-06
+review_in: 1 month
+---
+
+A courtesy copy of all email sent from the integration, staging and
+production environments is sent to [a Google Group][google-group].
+Integration and staging emails have a subject prefixed by the
+environment name.
+
+If you need to test the process of subscribing to an email alert, you
+can subscribe with govuk-email-courtesy-copies@digital.cabinet-office.gov.uk.
+You should then see two copies of the email at that address when you
+perform an action that triggers an email alert (the courtesy copy and
+the subscriber one).
+
+The process for triggering an alert varies by publishing application,
+but it usually involves creating a new edition of some content, then
+publishing it with a 'major' update type. The change note you enter
+will appear in the email that gets sent.
+
+A useful debug step if you're not sure if an email has been sent is to
+check Email Alert API to see if it has created records in its database.
+
+```
+$ govuk_app_console email-alert-api
+> ContentChange.last
+> Email.last
+> DeliveryAttempt.last
+```
+
+Emails won't be sent if no one is subscribed, so you'll need to do that
+first. The integration and staging environments only allow email to be
+sent to a small number of email addresses so you cannot test using your
+own email address in these environments.
+
+[google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies


### PR DESCRIPTION
This commit adds documentation for the new email notifications system.

Trello: https://trello.com/c/J01s1e6c/661-make-documentation-live