### PR TITLE
Review GOV.UK's environments

### DIFF
--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -4,7 +4,7 @@ title: GOV.UK's environments (integration, staging, production)
 section: Environments
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-11-22
+last_reviewed_on: 2018-03-07
 review_in: 3 months
 ---
 
@@ -22,12 +22,9 @@ Right now this environment is also used by content editors at GDS and in other d
 to preview their content changes. This functionality should be replaced by draft preview
 functionality as part of the publishing platform.
 
-Integration is [shut down each weekday night][jenkins-integration-shutdown] and [started each weekday morning][jenkins-integration-startup].
+Integration is hosted on [AWS][govuk-in-aws].
 
-Integration is hosted by Carrenza in their Slough datacentre.
-
-[jenkins-integration-shutdown]: https://github.com/alphagov/govuk-puppet/blob/850ac77f75f41be0bd34ff0a04bd59bff9e50c30/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
-[jenkins-integration-startup]: https://github.com/alphagov/govuk-puppet/blob/850ac77f75f41be0bd34ff0a04bd59bff9e50c30/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
+[govuk-in-aws]: /manual/govuk-in-aws.html
 
 ## Staging
 


### PR DESCRIPTION
We now host integration on AWS, not Carrenza and we don't turn integration off out of hours.