### PR TITLE
Add RFCs about pull request merging, naming, errors

### DIFF
--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -1,0 +1,109 @@
+---
+owner_slack: "#2ndline"
+title: How to deal with errors
+section: Monitoring
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-08
+review_in: 6 months
+---
+
+Sometimes applications will encounter exceptions. This policy describes what we should do for different types of errors. It was first proposed in [RFC 87](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-087-dealing-with-errors.md).
+
+## Principles
+
+### 1. When something goes wrong, we should be notified
+
+Applications should report exceptions to Sentry. Applications must not swallow errors.
+
+### 2. Notifications should be actionable
+
+Sentry notifications should be something that requires a developer of the app to do something about it. Not just a piece of information.
+
+### 3. Applications should not error
+
+The goal of GOV.UK is that applications should not error. When something goes wrong it should be fixed.
+
+## Classifying errors
+
+### Bug
+
+A code change makes the application crash.
+
+Desired behaviour: error is sent to Sentry, developers are notified and fix the error. Developers mark the error in Sentry as `Resolved`. This means a recurrence of the error will alert developers again.
+
+### Intermittent errors without user impact
+
+Frontend applications often see timeouts when talking to the content-store.
+
+There's no or little user impact because the request will be answered by the caching layer.
+
+Example: <https://sentry.io/govuk/app-finder-frontend/issues/352985400>
+
+Desired behaviour: error is not sent to Sentry. Instead, we rely on Smokey and Icinga checks to make sure we the site functions.
+
+### Intermittent errors with user impact
+
+Publishing applications sometimes see timeouts when talking to publishing-api. This results in the publisher seeing an error page and possibly losing data.
+
+Example: <https://sentry.io/govuk/app-content-tagger/issues/367277928>
+
+Desired behaviour: apps handle these errors better, for example by offloading the work to a Sidekiq worker. Since these errors aren't actionable, they should not be reported to Sentry. They should be tracked in Graphite.
+
+### Intermittent retryable errors
+
+Sidekiq worker sends something to the publishing-api, which times out. Sidekiq retries, the next time it works.
+
+Desired behaviour: errors are not reported to Sentry until retries are exhausted. See [this PR for an example](https://github.com/alphagov/content-performance-manager/pull/353).
+
+Relevant: https://github.com/getsentry/raven-ruby/pull/784
+
+### Expected environment-based errors
+
+MySQL errors on staging while data sync happens.
+
+Example: <https://sentry.io/govuk/app-whitehall/issues/343619055>
+
+Desired behaviour: our environment is set up such that these errors do not occur.
+
+### Bad request errors
+
+User makes a request the application can't handle ([example][bad-request]).
+
+Often happens in [security checks](https://sentry.io/govuk/app-frontend/issues/400074979).
+
+Example: <https://sentry.io/govuk/app-frontend/issues/400074979>
+
+Desired behaviour: user gets feedback, error is not reported to Sentry
+
+[bad-request]: https://sentry.io/govuk/app-service-manual-frontend/issues/400074003
+
+### Incorrect bubbling up of errors
+
+Rummager crashes on date parsing, returns `422`, which raises an error in finder-frontend.
+
+Example: <https://sentry.io/govuk/app-finder-frontend/issues/400074507>
+
+Desired behaviour: a 4XX reponse is returned to the browser, including an error message. Nothing is ever sent to Sentry.
+
+### Manually logged errors
+
+Something goes wrong and we need to let developers know.
+
+Example: [Slimmer's old behaviour](https://github.com/alphagov/slimmer/pull/203/files#diff-e5615a250f587cf4e2147f6163616a1a)
+
+Desired behaviour: developers do not use Sentry for logging. The app either raises the actual error (which causes the user to see the error) or logs the error to Kibana.
+
+### IP spoof errors
+
+Rails reports `ActionDispatch::RemoteIp::IpSpoofAttackError`.
+
+Example: <https://sentry.io/govuk/app-service-manual-frontend/issues/365951370>
+
+Desired behaviour: HTTP 400 is returned, error is not reported to Sentry.
+
+### Database entry not found
+
+Often a controller will do something like `Thing.find(params[:id])` and rely on Rails to show a 404 page for the `ActiveRecord::RecordNotFound` it raises ([context](https://stackoverflow.com/questions/27925282/activerecordrecordnotfound-raises-404-instead-of-500)).
+
+Desired behaviour: errors are not reported to Sentry

--- a/source/manual/howto-merge-a-pull-request-from-an-external-contributor.html.md
+++ b/source/manual/howto-merge-a-pull-request-from-an-external-contributor.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#2ndline"
 title: Merge a Pull Request from an external contributor
-section: Testing
+section: Development & Reviews
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2017-12-19

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -1,0 +1,51 @@
+---
+owner_slack: "#2ndline"
+title: Merge a Pull Request
+section: Development & Reviews
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-08
+review_in: 6 months
+---
+
+There are just four rules of reviewing and merging PRs:
+
+1. `master` must be able to be released at any time.
+2. The change must have two reviews from people from GDS (preferably GOV.UK). This can (and normally will) include the author.
+3. Use the Github Review UI to mark a PR as approved or requiring changes.
+4. Use the Github UI to merge the PR. This ensures the PR number is added to the merge commit.
+
+These rules apply to all applications, including Whitehall. As long as these rules are followed, PRs can be reviewed and merged in a way best suited to the situation.
+
+### Example scenarios
+
+#### A simple change
+
+A small PR against a well-understood application, written by someone with good knowledge of the problem domain and with a well defined scope. When a PR is raised, someone with similar understanding of the application and change can just approve and merge the PR. Both people are very confident that master will be deployable once this PR is merged.
+
+#### A simple change for a repository that has a long running test suite
+
+Similar to the above. If a PR is against a repository that has a long running test suite and you've approved the change and are confident that the suite will pass, the reviewer can approve the Pull Request. The author of the PR now has approval to merge the PR themselves once the test suite has passed.
+
+#### A change where a reviewer doesn't have the full context or knowledge required
+
+Some changes require different levels of context and knowledge. For example, a PR which involves a lot of CSS changes may not be easily reviewable by a backend developer. They may have the product context required to be able to review the before and after screenshots and say "this looks good to me", but not understand the implications of the code changes. In this instance you can leave a review comment with something like "Looks good to me, but I'd appreciate an additional review from someone with more frontend knowledge". If you can, you should also&nbsp;@mention someone who you think may be better placed to review it. This is essentially registering your review as a half review. Someone else with the other half of the knowledge (or full knowledge) can then merge the PR once they've reviewed it.
+
+#### A change that has timing or dependency implications
+
+If a change is ready to be reviewed but must wait to be merged for some other event, the title should be prefixed with&nbsp;`[Do not merge]`. A description of what the PR is waiting for should be included in the main description of the PR. When a change like this is reviewed, you can simply approve the Pull Request. It's then up to the author to merge that PR when the correct conditions are met.
+
+#### A change from an external contributor
+
+We occasionally receive PRs from external contributors who use our code. These will come from forks of the main repo. In the majority of cases, our test suite will not run automatically against these PRs. First, review the code carefully for anything that might be malicious and damaging if run inside our infrastructure. Once you're satisfied, follow Github's instructions to pull the forked branch locally, then push it to origin. This will cause the test suite to run with the original commits, which will cause Github to (hopefully, eventually) green light the original PR. Two people from GDS should review this PR. The first reviewer should approve the PR, and the second reviewer should merge. You should also thank the contributor with an amount of emoji proportional to the time they're saving GDS developers.
+
+#### A change where two people worked on the same branch
+
+If two members of GOV.UK staff worked on the same branch and individually contributed commits, they can approve each other's work. If they worked as a pair, that pair counts as a single contributor, so someone else should review the work.
+
+### Other considerations
+
+1. When raising a PR, if you feel you don't have full confidence in your change and want a particular review from someone, it's ok to ask for that review in the PR description. For example, a puppet change might warrant a particular review from a member of the Infrastructure team.
+2. It's ok for someone other than the author to merge a PR, particularly if the author is off work. The merger should be confident that the change doesn't have dependencies on other changes, and that it won't break master.
+3. If a PR is particularly good, remember to praise the author for it. Emoji are a great way of showing appreciation for a PR that fixes a problem you've been having, or implements something you've wanted to do for a while.
+4. It's sometimes ok for merges to happen when test suites are failing. This ability is limited to repo administrators and account owners, so ask them if you need them to force a merge. This is particularly useful in a catch-22 situation of two repos with failing test suites that depend on each other.

--- a/source/manual/naming.html.md
+++ b/source/manual/naming.html.md
@@ -1,0 +1,99 @@
+---
+owner_slack: "#2ndline"
+title: Name a new application or gem
+section: Packaging
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-03-08
+review_in: 6 months
+---
+
+This describes how you should name an application or gem on GOV.UK. It was first proposed in [RFC 63](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-063-naming-new-apps-gems-on-gov-uk.md).
+
+## Naming applications
+
+Firstly, the [service manual has good guidance on naming things](https://www.gov.uk/service-manual/design/naming-your-service).
+
+The most important rules:
+
+- The name should be self-descriptive. No branding or puns.
+- Use dashes for the URL and GitHub repo
+- The name of the app should be the same on GitHub, Puppet and hostname
+
+### Publishing applications
+
+Applications that publish things are named **x-publisher**.
+
+Good:
+
+- specialist-publisher
+- manuals-publisher
+
+Not so good:
+
+- publisher (too generic)
+- contacts-admin (could be contacts-publisher)
+
+### Frontend applications
+
+Applications that render content to end users on GOV.UK are named
+**x-frontend**
+
+Good:
+
+- government-frontend
+- email-alert-frontend
+
+Not so good:
+
+- collections (could be collections-frontend)
+- frontend (too generic)
+
+### APIs
+
+Applications that just expose an API are named **x-api**.
+
+Good:
+
+- publishing-api
+- email-alert-api
+- router-api
+
+Not so good:
+
+- rummager (should be search-api)
+
+### Admin applications
+
+Applications that "manage" things can be called **x-manager** or **x-admin** or
+**thing-doer**.
+
+Good:
+
+- search-admin
+- local-links-manager
+- content-tagger
+
+No so good:
+
+- signonotron2000
+- maslow (needs-manager)
+
+## Naming gems
+
+- Use the official [Rubygems naming convention](http://guides.rubygems.org/name-your-gem/)
+- Use underscores for multiple words
+- Use `govuk_` prefix if the gem is only interesting to projects within GOV.UK
+
+Good:
+
+- `govuk_sidekiq`
+- `govuk_content_models`
+- `govuk_admin_template`
+- `vcloud-edge_gateway`
+
+Not so good:
+
+- `slimmer`
+- `plek`
+- `gds-sso` (should be `gds_sso`, or `govuk_sso`)


### PR DESCRIPTION
This adds the content from following RFCs as pages:

- https://github.com/alphagov/govuk-rfcs/pull/52: Merge a Pull Request
- https://github.com/alphagov/govuk-rfcs/pull/63: Name a new application or gem
- https://github.com/alphagov/govuk-rfcs/pull/87: How to deal with errors

Those RFCs describe policies on GOV.UK that we should often refer to. Having them in the docs makes them more easily findable and linkable. Some of the RFCs have already been added (https://github.com/alphagov/govuk-developer-docs/pull/76).

I've considered importing all the RFCs (using the method we use for API docs), but a lot of them are reflect a change or plan rather than something that is permanently relevant.
