### PR TITLE
Replicate app data locally fixes

### DIFF
--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -50,7 +50,7 @@ want to do developer replication you will need to:
 
 1. Install the AWS CLI application locally
 
-    On MacOS this can be done using `brew install awscli`. This is being installed locally with the assumption you will be doing a two step backup process, i.e. download the files on your local machine and then update you VM. This is the recommended process as the download is quicker to you local machine for most users.
+    On macOS this can be done using `brew install awscli`. This is being installed locally with the assumption you will be doing a two step backup process, i.e. download the files on your local machine and then update you VM. This is the recommended process as the download is quicker to you local machine for most users.
 
 1. Setup your AWS access config and credentials files
 

--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -31,7 +31,7 @@ To get production data on to your local VM, you'll need to have either:
 
 ## AWS access
 
-The [aws setup guide](/manual/user-management-in-aws.html) covers using the interface in full, however if you only
+The [AWS setup guide](/manual/user-management-in-aws.html) covers using the interface in full, however if you only
 want to do developer replication you will need to:
 
 1. Log into AWS
@@ -54,7 +54,7 @@ want to do developer replication you will need to:
 
 1. Setup your AWS access config and credentials files
 
-    I am repeating the instructions described in the [aws setup guide](/manual/user-management-in-aws.html) with one difference. In the credentials file the setting must be under default as otherwise they are not found by the replication script.
+    I am repeating the instructions described in the [AWS setup guide](/manual/user-management-in-aws.html) with one difference. In the credentials file the setting must be under default as otherwise they are not found by the replication script.
 
     Create a `~/.aws/config` file:
 

--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -40,13 +40,13 @@ want to do developer replication you will need to:
 
 1. Setup MFA/2FA on your device
 
-    Naviagte to `IAM -> Users -> <Your username>`
+    Navigate to `IAM -> Users -> <Your username>`
 
     If you don't see an ARN ID next to `Assigned MFA device` click the edit button and set one up.
 
 1. Create an access token
 
-    Under `Access keys`click `Create access key` - you will secret is only displayed once, however if you fail to note it down just remove it and create another.
+    Under `Access keys` click `Create access key` – you will secret is only displayed once, however if you fail to note it down just remove it and create another.
 
 1. Install the AWS CLI application locally
 
@@ -66,7 +66,7 @@ want to do developer replication you will need to:
     region = eu-west-1
     ```
 
-    Role ARN: should be one of the following depending on the level of access you have been configured with [here](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/integration/common.tfvars):
+    **Role ARN**: should be one of the following depending on the level of access you have been configured with [here](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/integration/common.tfvars):
 
         * govuk-admins: arn:aws:iam::210287912431:role/govuk-administrators
         * govuk-poweruser: arn:aws:iam::210287912431:role/govuk-poweruser
@@ -82,19 +82,18 @@ want to do developer replication you will need to:
     aws_secret_access_key = <secret access key>
     ```
 
-    **access key id**: This is the ID that we created earlier
-    
-    **secret access key**: This is the secret associated with the key we created earlier. If you didn't note these down you can simply create a new one.
+    **AWS access key id**: This is the ID that we created earlier
+
+    **AWS secret access key**: This is the secret associated with the key we created earlier. If you didn't note these down you can simply create a new one.
 
 ## If you have integration access
 
-If you have integration access, you can download and import the latest data by
-running:
+If you have integration access, you can download and import the latest data by running:
 
     mac$ cd ~/govuk/govuk-puppet/development-vm/replication
     mac$ ./replicate-data-local.sh -u $USERNAME -F ../ssh_config -n
 
-> You may be able to skip the -u anf -F flags depending on your setup
+> You may be able to skip the -u and -F flags depending on your setup
 
 then
 

--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -36,54 +36,55 @@ want to do developer replication you will need to:
 
 1. Log into AWS
 
-You should have received a email requesting you do this. If you have multiple AWS accounts ensure you are logged into `gds-users`
+    You should have received a email requesting you do this. If you have multiple AWS accounts ensure you are logged into `gds-users`
 
 1. Setup MFA/2FA on your device
 
-Naviagte to `IAM -> Users -> <Your username>`
+    Naviagte to `IAM -> Users -> <Your username>`
 
-If you don't see an ARN ID next to `Assigned MFA device` click the edit button and set one up.
+    If you don't see an ARN ID next to `Assigned MFA device` click the edit button and set one up.
 
 1. Create an access token
 
-Under `Access keys`click `Create access key` - you will secret is only displayed once, however if you fail to note it down just remove it and create another.
+    Under `Access keys`click `Create access key` - you will secret is only displayed once, however if you fail to note it down just remove it and create another.
 
 1. Install the AWS CLI application locally
 
-On MacOS this can be done using `brew install awscli`. This is being installed locally with the assumption you will be doing a two step backup process, i.e. download the files on your local machine and then update you VM. This is the recommended process as the download is quicker to you local machine for most users.
+    On MacOS this can be done using `brew install awscli`. This is being installed locally with the assumption you will be doing a two step backup process, i.e. download the files on your local machine and then update you VM. This is the recommended process as the download is quicker to you local machine for most users.
 
 1. Setup your AWS access config and credentials files
 
-I am repeating the instructions described in the [aws setup guide](/manual/user-management-in-aws.html) with one difference. In the credentials file the setting must be under default as otherwise they are not found by the replication script.
+    I am repeating the instructions described in the [aws setup guide](/manual/user-management-in-aws.html) with one difference. In the credentials file the setting must be under default as otherwise they are not found by the replication script.
 
-Create a `~/.aws/config` file:
+    Create a `~/.aws/config` file:
 
-```
-[profile govuk-integration]
-role_arn = <Role ARN>
-mfa_serial = <MFA ARN>
-source_profile = gds
-region = eu-west-1
-```
+    ```
+    [profile govuk-integration]
+    role_arn = <Role ARN>
+    mfa_serial = <MFA ARN>
+    source_profile = gds
+    region = eu-west-1
+    ```
 
-Role ARN: should be one of the following depending on the level of access you have been configured with [here](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/integration/common.tfvars):
+    Role ARN: should be one of the following depending on the level of access you have been configured with [here](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/integration/common.tfvars):
 
-* govuk-admins: arn:aws:iam::210287912431:role/govuk-administrators
-* govuk-poweruser: arn:aws:iam::210287912431:role/govuk-poweruser
-* govuk-users: arn:aws:iam::210287912431:role/govuk-users
+        * govuk-admins: arn:aws:iam::210287912431:role/govuk-administrators
+        * govuk-poweruser: arn:aws:iam::210287912431:role/govuk-poweruser
+        * govuk-users: arn:aws:iam::210287912431:role/govuk-users
 
-**MFA ARN**: This is the long string next to `Assigned MFA device` in the AWS console
+    **MFA ARN**: This is the long string next to `Assigned MFA device` in the AWS console
 
-Create a `~/.aws/credentials` file
+    Create a `~/.aws/credentials` file
 
-```
-[gds]
-aws_access_key_id = <access key id>
-aws_secret_access_key = <secret access key>
-```
+    ```
+    [gds]
+    aws_access_key_id = <access key id>
+    aws_secret_access_key = <secret access key>
+    ```
 
-**access key id**: This is the ID that we created earlier
-**secret access key**: This is the secret associated with the key we created earlier. If you didn't note these down you can simply create a new one.
+    **access key id**: This is the ID that we created earlier
+    
+    **secret access key**: This is the secret associated with the key we created earlier. If you didn't note these down you can simply create a new one.
 
 ## If you have integration access
 


### PR DESCRIPTION
Fixes the 'AWS access' section so that it displays correctly as an ordered list. We need to indent the content within each list item or the markdown renderer interprets each list item as a new list.

Also contains a number of spelling, grammar and punctuation fixes.

#### Before:

![screen shot 2018-03-15 at 12 19 58](https://user-images.githubusercontent.com/2715/37462850-38cc7276-284b-11e8-868e-2409af248051.png)

#### After:

![screen shot 2018-03-15 at 12 19 31](https://user-images.githubusercontent.com/2715/37462855-3cc60522-284b-11e8-9383-fafc0c7eb4a3.png)