### PR TITLE
Fix markdown for GOV.UK Technology Blog link

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -108,7 +108,7 @@ Run the VM bootstrap script:
     mac$ vagrant up
     mac$ vagrant dns --install
 
-This will take a little while, but it will throw up a question or two in your console so check back on it occasionally. Now might be a good time to scan through the [GOV.UK technology blog](govuk-tech-blog) while Puppet runs.
+This will take a little while, but it will throw up a question or two in your console so check back on it occasionally. Now might be a good time to scan through the [GOV.UK technology blog][govuk-tech-blog] while Puppet runs.
 
 Once your VM is running, you can SSH into it with:
 


### PR DESCRIPTION
Erroneous markdown was pointing to https://docs.publishing.service.gov.uk/manual/govuk-tech-blog (404).