### PR TITLE
Move email team docs to 2ndline

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -64,12 +64,12 @@
 
 - github_repo_name: email-alert-api
   type: APIs
-  team: "#email"
+  team: "#platform_support"
   metrics_dashboard_url: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 
 - github_repo_name: email-alert-service
   type: APIs
-  team: "#email"
+  team: "#platform_support"
 
 - github_repo_name: imminence
   type: APIs
@@ -162,7 +162,7 @@
 
 - github_repo_name: email-alert-frontend
   type: Frontend apps
-  team: "#email"
+  team: "#platform_support"
 
 - github_repo_name: feedback
   type: Frontend apps

--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: email-alert-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout

--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: Email alerts not sent
 section: Icinga alerts
 layout: manual_layout

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: "Email notifications: how they work"
 section: Emails
 layout: manual_layout

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: Receiving emails from Email Alert API in integration and staging
 section: Emails
 layout: manual_layout

--- a/source/manual/send-test-email.html.md
+++ b/source/manual/send-test-email.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: Send a test email via Notify
 section: Development VM
 layout: manual_layout

--- a/source/manual/stop-all-email-subscription-sending.html.md
+++ b/source/manual/stop-all-email-subscription-sending.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: "Stop all email subscription sending"
 section: Emails
 layout: manual_layout

--- a/source/manual/test-email-sending.html.md
+++ b/source/manual/test-email-sending.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#email"
+owner_slack: "#2ndline"
 title: Test email sending
 section: Emails
 layout: manual_layout


### PR DESCRIPTION
This PR changes the owner of the email apps to Platform Support and changes the owners of email-related documentation to 2nd line.