### PR TITLE
Remove references to the GOV.UK Infrastructure team

### DIFF
--- a/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
+++ b/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
@@ -47,8 +47,9 @@ To fix, try (in order):
     Jenkins
     job](https://deploy.publishing.service.gov.uk/job/Deploy_CDN/).
     Authenticate with the 2nd Line user, details of which can be found
-    in the `infra_team` cred store. If you don't have access, ask someone
-    on the Infrastructure team to deploy it for you.
+    in the `infra` password store. If you don't have access, ask one of
+    GOV.UK's senior technologists, or Reliability Engineering, to deploy
+    it for you.
 -   tailing Syslog - `sudo tail -f /var/log/syslog` for the current file,
     and `sudo zless syslog.x.gz` for any gzipped files replacing x with
     the number from the file itself. It's pretty verbose, and might not

--- a/source/manual/alerts/reboot-required-by-apt.html.md
+++ b/source/manual/alerts/reboot-required-by-apt.html.md
@@ -39,11 +39,11 @@ the procedures particular to each machine.
 
 In production environment, you are normally dealing with variety of hosts.
 Some machines, like MongoDB and Elasticsearch, can be rebooted with caution.
-Others, like MySQL and PostgreSQL, require out-of-hours reboots by infrastructure.
+Others, like MySQL and PostgreSQL, require out-of-hours reboots by Platform Support.
 
 Work through the guide on [rebooting machines][reboot-machines] to
-safely reboot the machines that can be, and kindly ask the
-infrastructure team to schedule out-of-hour reboots for the other machines.
+safely reboot the machines that can be, and kindly ask Platform Support to
+schedule out-of-hours reboots for the other machines.
 
 ## Checking locking status
 

--- a/source/manual/alerts/root-filesystem-is-readonly.html.md
+++ b/source/manual/alerts/root-filesystem-is-readonly.html.md
@@ -14,9 +14,8 @@ problems with their Storage Area Network (SAN).
 
 The machine will need to have a filesystem check forced on reboot. To do
 this you will need access to the vCloud Director instance for the
-environment, this access is typically only available to members
-of the GOV.UK Infrastructure team. However, if you do on-call, you should have access
-to the vCloud Production environment.
+environment. If you do on-call, you should have access to the vCloud Production
+environment.
 
 In the vCloud Director instance:
 

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -8,7 +8,7 @@ last_reviewed_on: 2017-11-22
 review_in: 6 months
 ---
 
-The GOV.UK Infrastructure team is responsible for managing several DNS zones.
+The Reliability Engineering team is responsible for managing several DNS zones.
 
 By default, zones are managed using DynDNS.
 
@@ -90,7 +90,8 @@ make a change and don't have access.
 
 ## Delegating `service.gov.uk` domains
 
-At the moment we're also responsible for delegating DNS to other government services.
+At the moment Reliability Engineering are also responsible for delegating DNS
+to other government services.
 
 The request will arrive by email or Zendesk from a member of the GOV.UK Proposition
 team.

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -45,7 +45,7 @@ If two members of GOV.UK staff worked on the same branch and individually contri
 
 ### Other considerations
 
-1. When raising a PR, if you feel you don't have full confidence in your change and want a particular review from someone, it's ok to ask for that review in the PR description. For example, a puppet change might warrant a particular review from a member of the Infrastructure team.
+1. When raising a PR, if you feel you don't have full confidence in your change and want a particular review from someone, it's ok to ask for that review in the PR description. For example, a puppet change might warrant a particular review from a member of the Reliability Engineering team.
 2. It's ok for someone other than the author to merge a PR, particularly if the author is off work. The merger should be confident that the change doesn't have dependencies on other changes, and that it won't break master.
 3. If a PR is particularly good, remember to praise the author for it. Emoji are a great way of showing appreciation for a PR that fixes a problem you've been having, or implements something you've wanted to do for a while.
 4. It's sometimes ok for merges to happen when test suites are failing. This ability is limited to repo administrators and account owners, so ask them if you need them to force a merge. This is particularly useful in a catch-22 situation of two repos with failing test suites that depend on each other.

--- a/source/manual/migrate-zone-from-dyn.html.md
+++ b/source/manual/migrate-zone-from-dyn.html.md
@@ -10,7 +10,7 @@ review_in: 6 months
 
 ## Migrate a zone from DynDNS
 
-GOV.UK Infrastructure are currently responsible for managing several DNS zones
+Reliability Engineering is currently responsible for managing several DNS zones
 in [DynDNS](www.dyn.com/dns). This is a step-by-step guide to migrate these zones
 to using [Google Cloud DNS](https://cloud.google.com/dns/docs/) and/or [Amazon Route 53](https://aws.amazon.com/route53/).
 

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -125,7 +125,7 @@ rebooted during working hours in production. Other services rely directly on
 particular Redis hosts and may error if they are unvailable.
 
 Reboots of these machines, in the production environment, should be organised
-with the Infrastructure Team.
+with Platform Support.
 
 They may be rebooted in working hours in the staging environment, however you
 should notify colleagues before doing so as this may remove in flight jobs
@@ -249,7 +249,7 @@ When the app has been redeployed then the machine which is **not** being
 read from can be rebooted.
 
 Reboots of these machines, in the production environment, should be organised
-with the Infrastructure Team.
+with Platform Support.
 
 They may be rebooted in working hours in the staging environment, however you
 should notify colleagues before doing so.
@@ -263,7 +263,7 @@ standby machines (with the exception of the slave within the DR
 environment).
 
 Reboots of these machines, in the production environment, should be organised
-with the Infrastructure Team.
+with Platform Support.
 
 They may be rebooted in working hours in the staging environment, however you
 should notify colleagues before doing so.
@@ -277,7 +277,7 @@ for attachments to be uploaded.
 The slave machines can be rebooted as they hold a copy of data and are resynced
 regularly.
 
-Reboots of the master machine should be organised with the Infrastructure team,
+Reboots of the master machine should be organised with Platform Support,
 for the production environment.
 
 You may reboot the master machine in the staging environment during working

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -94,7 +94,7 @@ Request any public DNS entries be removed. If the app had an admin UI, it will
 have had public DNS entries in the `publishing.service.gov.uk` domain.
 
 Follow the [instructions for DNS changes][dns-changes] in order to remove these,
-and ask the infrastructure team to approve any necessary Pull Requests.
+and ask the Reliability Engineering team to approve any necessary Pull Requests.
 
 [dns-changes]:
 https://docs.publishing.service.gov.uk/manual/dns.html#making-changes-to-publishingservicegovuk

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -84,8 +84,10 @@ Be sure to use the same port number which you assigned in the
 ## Setting up DNS entries
 
 If the app requires the creation of new external (publicly accessible)
-subdomains, speak to the infrastructure team. They can create these for
-you and point them to the correct boxes.
+subdomains, you can do this via [the govuk-dns-config
+repo](https://github.com/alphagov/govuk-dns-config). If you need assistance
+with pointing the records at the correct boxes, talk to Reliability
+Engineering.
 
 ## Adding deployment scripts
 
@@ -176,7 +178,7 @@ To configure your app so users (or API clients) can authenticate:
     repo](https://github.com/alphagov/signonotron2/blob/master/doc/usage.md)
     No need to run this in Staging as Production credentials will be
     copied over.
-    
+
 2.  Save the OAuth ID and OAuth secret this command gives you into the
     GDS-SSO configuration in the `initializers_by_organisation`
     directory for your environment, as described above. Example:
@@ -189,10 +191,10 @@ To configure your app so it can talk to an existing API application:
     Users](https://signon.integration.publishing.service.gov.uk/api_users)
     section in Signon (you'll need to be a signon superadmin to
     access this).
-    
+
 2.  Add an application token for this user to access the
     necessary application.
-    
+
 3.  Save the access token this generates into the [API
     adapters](https://github.com/alphagov/gds-api-adapters) client
     configuration in the `initializers_by_organisation` directory for


### PR DESCRIPTION
- These have been replaced with either "GOV.UK senior technologists",
  "Platform Support", or "Reliability Engineering", as appropriate.