### PR TITLE
Document issues I encountered following the getting started docs

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -198,7 +198,7 @@ Once the data has been downloaded (if you don't have integration access, ask som
 
     dev$ ./replicate-data-local.sh -d path/to/dir -s
 
-For more information, see the guide in the developer docs on [replicating application data locally for development][data-replication].
+For more information, and for troubleshooting advice, see the guide in the developer docs on [replicating application data locally for development][data-replication].
 
 [data-replication]: replicate-app-data-locally.html
 [data-replication-aws-access]: replicate-app-data-locally.html#aws-access

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -237,3 +237,5 @@ Most GOV.UK web applications and services are available via the public internet,
 * [https://alert.publishing.service.gov.uk](https://alert.publishing.service.gov.uk) (production, restricted to GDS office IP addresses)
 
 The basic authentication username and password is widely known, so just ask somebody on your team if you don't know it.
+
+If you can't resolve `dev.gov.uk` domains, see [fix issues with vagrant-dns](vagrant-dns.html).

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -55,6 +55,19 @@ First, install:
 [VirtualBox]: https://www.virtualbox.org/
 [Vagrant]: https://www.vagrantup.com/downloads.html
 
+Starting with High Sierra 10.13, kernel extensions must be approved by
+the user (see [this Apple technical note][kext].  This causes the
+VirtualBox installer to fail with a permissions error.
+
+[kext]: https://developer.apple.com/library/content/technotes/tn2459/_index.html
+
+To install VirtualBox on High Sierra 10.13 or later:
+
+1. Run the VirtualBox installer
+2. Open "Security & Privacy" in the system preferences
+3. Allow the blocked VirtualBox kernel extension
+4. Run the VirtualBox installer again
+
 ## 2. Create your GitHub accounts
 
 1. Set up a [GitHub][] account.

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -153,6 +153,14 @@ There are also some Python apps, which use [PIP][]. You’ll probably need to in
 
     dev$ ./update-pip.sh
 
+If installing the Python dependencies for fabric-scripts fails, your version of setuptools may be too old:
+
+   dev$ cd /var/govuk/fabric-scripts
+   dev$ virtualenv .venv
+   dev$ source .venv/bin/activate
+   dev$ pip install --upgrade setuptools
+   dev$ pip install -r requirements.txt
+
 > `~/govuk/` on your host machine is mounted as `/var/govuk` inside the VM. Any app repositories you clone should go here.
 
 [Bundler]: http://bundler.io/rationale.html

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -36,7 +36,7 @@ Run `dev$` commands in the shell on the development VM:
 
 **If you run into problems**
 
-If you're having trouble with Vagrant or the development VM, [troubleshooting tips](troubleshooting-vagrant.html) are available. You can also ask your colleagues or the #govuk-developers channel in Slack.
+If you're having trouble with Vagrant or the development VM, you can ask your colleagues or the #govuk-developers channel in Slack.
 
 [GDS]: https://gds.blog.gov.uk/about/
 [VirtualBox]: https://www.virtualbox.org/

--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -128,6 +128,12 @@ Then follow the instructions above for importing using the `-s` flag.
 
 See [running out of disk space in development](/manual/development-disk-space.html).
 
+## If you get a curl error when restoring Elasticsearch data
+
+Check the service is running:
+
+    dev$ sudo service elasticsearch-development.development start
+
 ## Can't take a write lock while out of disk space (in MongoDB)
 
 You may see such an error message which will prevent you from creating or even dropping collections. So you won't be able to replicate the latest data.

--- a/source/manual/vagrant-dns.html.md
+++ b/source/manual/vagrant-dns.html.md
@@ -46,6 +46,15 @@ ps aux | grep vagrant-dns
 vagrant dns --start -o
 ```
 
+If this gives an error about an "undefined method `socket_type`", then
+you have hit a bug in async-dns, a dependency of vagrant-dns.  The
+solution is to install an older version of vagrant-dns:
+
+```shell
+vagrant plugin uninstall vagrant-dns
+vagrant plugin install vagrant-dns --plugin-version 1.1.0
+```
+
 If you're still having issues you can try to update the vagrant-dns plugin:
 
 ```shell


### PR DESCRIPTION
~Also resurrects the `troubleshooting-vagrant` page, which was referred to on the `get-started` page, but didn't exist.~

~Alternatively, that page could remain as-is and I could put the extra information directly in the `get-started` page.  This might be better, as I'm not sure an issue with VirtualBox installation really belongs on a troubleshooting page.~

The new troubleshooting stuff is scattered around the existing pages, and I've added a couple of extra links to the getting started page to aid discoverability.