### PR TITLE
Add whitehall url to getting started guide

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -229,6 +229,12 @@ If you don't need an optional dependency, you can pass the `-w` option:
 
 If these `bowl` commands fail, try the troubleshooting guide on [how to fix a broken bowl][bowl-error].
 
+Now visit this url once the app is running:
+
+`http://whitehall-admin.dev.gov.uk/`
+
+You should be able to see whitehall.
+
 [bowler]: https://github.com/JordanHatch/bowler
 [bowl-error]: bowl-error.html
 


### PR DESCRIPTION
- Include url in step 8 of guide