### PR TITLE
Add docs for fixing failed offsite backups

### DIFF
--- a/source/manual/alerts/offsite-backups.html.md
+++ b/source/manual/alerts/offsite-backups.html.md
@@ -4,7 +4,7 @@ title: Offsite backups
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2018-03-26
+last_reviewed_on: 2018-04-12
 review_in: 6 months
 ---
 
@@ -15,7 +15,7 @@ If a backup fails then start by looking at any output captured by
 cron and sent to the "machine email" list. This is linked from the
 Nagios alert under "extra actions".
 
-If the backup hasn't failed but is flagged with a freshness warning it may still be in progress. The asset stores are large and backups can take a long time, check whether the duplicity process is still running (e.g. using `htop` or `ps aux | grep duplicity`).
+If the backup hasn't failed but is flagged with a freshness warning, it may still be in progress. The asset stores are large and backups can take a long time, check whether the duplicity process is still running (e.g. using `htop` or `ps aux | grep duplicity`).
 
 To proceed further you will need to know a few things which you can
 determine either from the job configuration in Puppet or by listing
@@ -41,8 +41,17 @@ so it's recommended to use `tmux` or `screen`:
 
     sudo -iu <user> /var/spool/duplicity/<script>
 
-You can look for output of the backup jobs in the "machine email plat1"
-google group. If the log contains the line
+You can look for output of the backup jobs in the
+"machine email carrenza" google group. If the log contains the line
 `"Warning, found the following orphaned backup files` then try running
 the command
 `sudo -iugovuk-backup duplicity cleanup <destination>  --no-encryption --force`
+
+If a backup fails part way through (eg. if the disk runs out of space),
+then subsequent backups will also fail since duplicity will attempt
+to ask for a GPG passphrase interactively and fail. The output of jobs
+that have failed for this reason will end with an `EOFError` message.
+In these cases, you will need to run the backup again manually, and
+provide the passphrase when asked. The passphrase is contained in the
+`backup::assets::backup_private_gpg_key_passphrase` key in
+[govuk-secrets](https://github.com/alphagov/govuk-secrets/blob/master/puppet/hieradata/production_credentials.yaml).


### PR DESCRIPTION
This commit adds information about how to recover from offsite backup errors caused duplicity asking for a GPG passphrase to fix earlier failed backups.