### PR TITLE
Add docs about Notify whitelist

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -4,8 +4,8 @@ title: email-alert-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-03-06
-review_in: 1 month
+last_reviewed_on: 2018-04-12
+review_in: 6 months
 ---
 
 If there is a health check error showing for Email Alert API, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
@@ -24,3 +24,13 @@ This means that we haven’t received status updates from Notify on some emails 
 
 ## Technical failures (technical_failure)
 This means that we’ve received a technical failure status code back from Notify or a request to send an email via Notify failed within the last hour. This means that there may be a problem with our system or that Notify is unable to send emails.
+
+In non-production environments, this failure may also mean that we’re attempting to send emails to people who are not members of the Notify team for the relevant environment.
+
+In this case, ensure the contents of the  `govuk::apps::email_alert_api::email_address_override_whitelist` key in [hieradata](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml) and [hieradata_aws](https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml) matches the members of the staging/integration Notify teams.
+
+You can login to the Notify account by going to
+[https://www.notifications.service.gov.uk](). The login credentials are
+in the [2nd line password store][password-store] under `govuk-notify/govuk-email-courtesy-copies`.
+
+[password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify


### PR DESCRIPTION
This commit adds docs about technical failures that happen when the hieradata and Notify whitelists for staging/integration are not in sync.