### PR TITLE
Document the use of `aws sts assume-role` and eight hour token expiry

### DIFF
--- a/source/manual/user-management-in-aws.html.md
+++ b/source/manual/user-management-in-aws.html.md
@@ -109,6 +109,7 @@ aws sts assume-role \
   --role-session-name "$(whoami)-$(date +%d-%m-%y_%H-%M)" \
   --role-arn <Role ARN> \
   --serial-number <MFA ARN> \
+  --duration-seconds 28800 \
   --token-code <MFA token>
 ```
 

--- a/source/manual/user-management-in-aws.html.md
+++ b/source/manual/user-management-in-aws.html.md
@@ -61,9 +61,9 @@ Both methods require the following:
  - Role ARN: this is the ARN of the role that you are using for the GOV.UK specific account, eg govuk-administrators, govuk-powerusers, govuk-users
  - MFA ARN: this is the ARN assigned to the MFA device in your own account
 
-Both methods will allow a valid session up to an hour. Once the hour has
-elapsed, you will need to rerun the `assume-role` command, but shouldn't be
-prompted for MFA.
+Both methods will allow a valid session up to eight hours. Once the hour has
+elapsed, you will need to rerun the `assume-role` command. If you want to switch
+between environments, you will need to re-authenticate with MFA.
 
 ##### Storing credentials on disk
 
@@ -105,23 +105,16 @@ Ensure [`awscli`](https://aws.amazon.com/cli/) is installed. Ensure you have you
 MFA token ready, and run:
 
 ```
-aws --profile=gds sts get-session-token \
+aws sts assume-role \
+  --role-session-name "$(whoami)-$(date +%d-%m-%y_%H-%M)" \
+  --role-arn <Role ARN> \
   --serial-number <MFA ARN> \
   --token-code <MFA token>
 ```
 
-This will authenticate your account via MFA for 12 hours. Then, you can assume
-the required role with the following:
-
-```
-aws sts assume-role \
-  --role-session-name "$(whoami)-$(date +%d-%m-%y_%H-%M)" \
-  --role-arn <Role ARN>
-```
-
 If successful, this will output some credentials. Store them in your environment using
-the following environment variables. Refresh them when they expire after an
-hour with another `sts assume-role` command.
+the following environment variables. Refresh them when they expire after eight
+hours with another `aws sts assume-role` command.
 
 ```
 AWS_ACCESS_KEY_ID


### PR DESCRIPTION
- Now that tokens have an eight hour expiry
  (https://github.com/alphagov/govuk-aws/pull/533), we don't need to do
  the intermediary workaround of calling `aws sts get-session-token` for
  a longer session without MFA.
- This has the side effect that you'll need to re-authenticate with MFA
  if you wish to switch environments, but I don't think that's
  necessarily a bad thing at the moment.