### PR TITLE
Add information on new attachment sync jobs

### DIFF
--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -4,21 +4,22 @@ title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-03-13
+last_reviewed_on: 2018-04-17
 review_in: 6 months
 ---
 
-Data is synced from production to staging and integration every night.
+Data and assets/attachments are synced from production to staging and integration every night.
 
-Check the output of the production Jenkins job to see which part of
-the data sync failed. It may be safe to re-run part of the sync.
+Check the output of the production Jenkins job to see which part of the sync failed. It may be safe to re-run part of the sync.
 
-Warning: the mysql backup will cause signon in staging to point to production until the `Data Sync Complete` job runs and renames the hostnames copied from production to back to their staging equivalents.  This means that any deploys to staging that rely on GDS API Adapters are likely to fail due to authentication failures.
+Warning: the mysql backup will cause signon in staging to point to production until the `Data Sync Complete` job runs and renames the hostnames copied from production to back to their staging equivalents.  This means that any deploys to staging that rely on GDS API Adapters are likely to fail due to authentication failures, as well as Smokey tests that attempt to use Signon.
 
 The Jenkins jobs included in the sync are:
 
 * Copy Data to Staging
-* Copy Data to integration
-* Copy Licensify Data to staging
+* Copy Attachments to Staging
+* Copy Data to Integration
+* Copy Attachments to Integration
+* Copy Licensify Data to Staging
 
 See the [source code](https://github.com/alphagov/env-sync-and-backup/tree/master/jobs) of the jobs for more information about how they work.


### PR DESCRIPTION
This commit adds the new attachment sync jobs to the docs as well as a note on failing Smokey tests before the `Data Sync Complete` job has run.