### PR TITLE
Fix following line being absorbed by blockquote

### DIFF
--- a/source/manual/docs-style-guide.html.md
+++ b/source/manual/docs-style-guide.html.md
@@ -37,6 +37,7 @@ Bad examples:
 > Data sync
 
 > Ruby (too vague: what about Ruby?)
+
 Don't use:
 
 - "how to" at the start


### PR DESCRIPTION
The "Don't use" on this page gets absorbed into the previous blockquote, because there's no blank line.  It looks like this:

> Bad examples:
>
>> How to reboot a machine
>>
>> Rebooting a machine
>>
>> Data sync
>>
>> Ruby (too vague: what about Ruby?) Don’t use:
>
> “how to” at the start
> ‘ing’ at the end of verbs (for example use ’“deploy an application”, not “deploying an application”)

See https://docs.publishing.service.gov.uk/manual/docs-style-guide.html