### PR TITLE
Clamav tip to remove blacklisted mirrors

### DIFF
--- a/source/manual/alerts/clamav-definitions-out-of-date.html.md
+++ b/source/manual/alerts/clamav-definitions-out-of-date.html.md
@@ -4,7 +4,7 @@ title: ClamAV definitions out of date
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2018-04-12
+last_reviewed_on: 2018-04-24
 review_in: 6 months
 ---
 
@@ -17,3 +17,10 @@ If it reports the virus databases are up to date then you may need to
 check the [ClamAV virusdb
 archive](http://lists.clamav.net/pipermail/clamav-virusdb/) to
 investigate.
+
+If it can't seem to download the updated definition files, with errors
+such as `Ignoring mirror 130.59.113.36 (due to previous errors)`, it
+could be that all the mirrors available have been blacklisted. You 
+can reset the blacklisted mirrors by deleting the file that stores
+them: `sudo rm /var/lib/clamav/mirrors.dat`. After doing this running
+`sudo freshclam -v` may well work again.


### PR DESCRIPTION
Using this has fixed a bunch of the clamav alerts for me on this 2nd line shift and is hopefully useful for others to come.