### PR TITLE
Make clear where replicated data is imported to

### DIFF
--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -114,6 +114,8 @@ If you have integration access, you can download and import the latest data by r
 
 > You may be able to skip the -u and -F flags depending on your setup
 
+The data will download to a folder named with today's date in `./backups`, for example `./backups/2018-01-01`.
+
 then
 
     dev$ cd /var/govuk/govuk-puppet/development-vm/replication


### PR DESCRIPTION
The current instructions don't explain that downloads end up in `./backups` which makes the next instruction confusing.