### PR TITLE
Updated with latest version of incident report template

### DIFF
--- a/source/manual/incident-reports.html.md
+++ b/source/manual/incident-reports.html.md
@@ -8,70 +8,83 @@ last_reviewed_on: 2018-04-11
 review_in: 2 months
 ---
 
-This page contains guidance about how to fill in an incident report.
+This is a template of the incident report as guidance.
 
-You can find the [incident report template][tpl] on Google Drive.
+Use the [incident report template][tpl] on Google Drive when drafting the report.
 
 [tpl]: https://docs.google.com/document/d/1cMJP2p_PlDalJEcpS6TbXjZgUwdm9gd1rFrhUXa6uh4/edit
 
-## Info
+## Incident report checklist:
 
-Report title: YYYY-MM-DD: Name of incident
+* Ensure you make a copy of this document and edit the copy.
+* Read the [guidance for what to do if you are comms lead](https://docs.google.com/document/d/1ty12B5eBWB9YSfnD9xY1mr5rtTQxdNxRdmEGgibilN0/edit).
+* Share this report with the GOV.UK Incident list as soon as possible.
+* Make it clear that it’s a draft version.
+* Include as much information as possible and a draft root cause ahead of the review.  
+* Ensure this document is viewable to anyone with a GDS email account.
 
-Date:  YYYY-MM-DD
+## Incident report
 
-Time: Include when the incident started and when it ended. Always use local time, e.g. 10:20 - 15:00
+Start Date|YYYY-MM-DD
+----------|----------
+End Date|YYYY-MM-DD
+Start Time|HH:MM (local time)
+End Time|HH:MM (local time)
+Application / process|
+Priority|Was it a P1, P2, or P3 incident? 
+Incident lead| 2nd line primary engineer or a senior developer 
+Comms lead|2nd line secondary engineer 
 
-Service/application: Detail the service or application that was affected
+Overview
 
-Severity: [Was it a P1, P2, or P3 incident?](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/64487471/Incident+severity+levels)
+_[Provide a summary here]_
 
-Incident lead: Please don't leave this blank. The incident lead has a few post-incident responsibilities so we require a named person.
+User impact
 
-Comms lead: Please don't leave this blank.
+_[Detail of the specific front-end user impact]_
 
-## Overview
+Departmental impact
 
-This section contains a brief, executive summary of the issue, so that people can see what the incident was at a glance. It should not contain detailed analysis, just the high level summary of the incident.
+_[Detail of the specific departmental/publisher impact]_
 
-### Good example
+Timeline
+All times in local time, unless otherwise stated.
 
-> A widespread disc failure cased an outage of most of GOV.UK machines and connectivity. This was picked up by monitoring and the GOV.UK on-call engineers failed over to the mirrors while the disc issue was resolved.
+Time|Description
+----|-----------  
+HH:MM|
+Total duration of incident|
+Time to fix|
 
-### Bad example
+## Incident Review
 
-> At 15:36, Jonathan received an envelope from an unnamed source. When Jonathan was in the server room, he opened the envelope and found that it contained several kilograms of glitter, which was sucked into the machines via their intake fans. This caused a widespread disc failure which resulted in a full GOV.UK outage. Marie was paged and called Susan to inform her of the issue. Susan called Ian while Marie failed over to the mirrors.
+### Date:	
+### Time:	
+### Attendance: 
 
-## User impact
+### Root cause
 
-Clearly state what the user impact of this issue was using stats from systems like Google analytics, Kibana or Fastly. There can be discrepancies in stats, so mention where the numbers came from and why there’s a discrepancy (if you know). Describe what users would have seen during the incident. If publishers were impacted, describe what systems were affected and for how long.
+Use this section to summarise the root cause of the incident. A draft root cause should be included, and discussed and agreed upon during the incident review. This root cause should be written for a non-technical audience. 
+ 
+Please also include the root cause category:
+* Unexpected effect of code change
+* Infrastructure failure (disk space, logging etc)
+* Provider failure (hardware, network failure etc
+* Security
 
-This is so that anyone reading the report understands the scale of the impact to users.
+...
+### Actions
 
-### Good example
+Use this section to assign actions to individuals (not teams). These are actions to be taken to fix the root cause of the issue or for preventative measures.
 
-> Google Analytics reports that we served 248,000 404 errors and 56,000 5xx errors from 10:40 - 10:50, which represents 19% of our traffic for that period. From 10:50, when the site failed over to the mirrors, the 404 and 5xx errors drop off completely meaning that users weren’t seeing any more errors, but editors didn’t have access to publishing tools. Full service was restored at 15:37.
+* ...
+### Standing actions
 
-### Bad example
+* Does it need a blogpost? (P1 or P2; P3 if interesting). 
+* Present a summary of the incident at TSAD to share learning. 
+Recommendations
 
-> During the incident, users saw 404 pages. Once the site failed over to the mirrors, full service was restored.
+* ...
+### Recommendations
 
-## Timeline
-
-All times should be in local time, unless otherwise stated.
-
-This section establishes a timeline of events. It’s fine to use it as a WIP section and make notes for tidying up later. The final version should contain only the facts of the incident, the decisions made and the actions taken.
-
-Do:
-
-- Summarise actions/decisions
-- Convert times to local time
-- Include relevant links
-- Include when alerts were sent and received
-- When additional people were called in to help
-- Include red herrings and wrong turns
-
-Don’t:
-
-- Paste IM conversations
-- Include anything not relevant to the incident
+* ...

--- a/source/manual/incident-reports.html.md
+++ b/source/manual/incident-reports.html.md
@@ -67,6 +67,7 @@ Time to fix|
 Use this section to summarise the root cause of the incident. A draft root cause should be included, and discussed and agreed upon during the incident review. This root cause should be written for a non-technical audience. 
  
 Please also include the root cause category:
+
 * Unexpected effect of code change
 * Infrastructure failure (disk space, logging etc)
 * Provider failure (hardware, network failure etc


### PR DESCRIPTION
We've transferred this page over from the Incident management guidance wiki page with the latest version of the report template (thanks Tim Blair). This is so it's more accessible to developers on 2nd line who have to respond to an incident.