### PR TITLE
Remove the wombles from data.gov.uk docs

### DIFF
--- a/source/manual/data-gov-uk-continuous-integration-and-deployment.html.md
+++ b/source/manual/data-gov-uk-continuous-integration-and-deployment.html.md
@@ -50,4 +50,4 @@ The account is free and unverified. This means there’s a limit of 5 review app
 
 Zendesk support tickets and Sentry are disabled for Heroku apps.
 
-Heroku is pointing at our Elasticsearch instance on AWS called `wombles`. It’s worth periodically re-importing and reindexing `wombles` to ensure that the review apps are reflecting the current state of the apps.
+Heroku is pointing at a Heroku addon for Elasticsearch.


### PR DESCRIPTION
The 'temporary' elastic server on AWS is no longer necessary and has
been shutdown, so we are removing mention of it from the docs.