### PR TITLE
Remove the word 'internal'

### DIFF
--- a/source/partials/_intro.html.md
+++ b/source/partials/_intro.html.md
@@ -1,5 +1,6 @@
-This is the internal technical documentation for [GOV.UK][], built by the [Government Digital Service (GDS)][GDS]. For other projects built by GDS, see
-the [Service Toolkit][].
+This is the technical documentation for [GOV.UK][], built by the [Government
+Digital Service (GDS)][GDS]. For other projects built by GDS, see the [Service
+Toolkit][].
 
 [GDS]: https://gds.blog.gov.uk/about/
 [GOV.UK]: https://www.gov.uk/


### PR DESCRIPTION
This has caused panic more than once, with folks external to GOV.UK believing that private, interal information about GOV.UK has accidentally been made public.