### PR TITLE
Adds more information on common data.gov.uk publish data tasks

### DIFF
--- a/source/manual/data-gov-uk-common-tasks.html.md
+++ b/source/manual/data-gov-uk-common-tasks.html.md
@@ -229,8 +229,6 @@ Although the general policy is not to delete datasets, datasets that are harvest
 
 ```
 cf ssh publish-data-beta-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
-# Delete one dataset
 echo "UUID" | rake delete:datasets
-# Delete many datasets
 cat todelete.csv | rake delete:datasets
 ```


### PR DESCRIPTION
Adds information on how to run rake tasks to operate on the
database/search-index.  These commands are currently heavily used but
should eventually be less important.

Documents:

* How to delete a dataset
* How to delete a lot of datasets
* How to synchronise a single dataset
* How to synchronise an entire organisation's datasets

As a 'drive-by' change, also documents that you can increate the batch size when reindexing above the default setting of 50.