### PR TITLE
Add failing test hint for unnecessary H1

### DIFF
--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -32,7 +32,8 @@ Dir.glob("source/manual/**/*.md").each do |filename|
       source/manual/howto-merge-a-pull-request-from-an-external-contributor.html.md
     ])
       it "doesn't use H1 tags (the page title is already an H1)" do
-        expect(raw).not_to match(/\n#\s/)
+        expect(raw).not_to match(/\n#\s/), "This page contains an unnecessary H1." \
+          " This may have been triggered because of a # comment in a code block"
       end
     end
   end


### PR DESCRIPTION
Although the tests check for the presence of a H1 (#) on the page, the
presence of a comment in a code block also triggers a failure.  This
isn't easily fixable without a markdown AST.

This PR adds a hint as to a possible cause, to avoid confusion when this
edge case occurs and fixes #933