### PR TITLE
Update references to production publish application

### DIFF
--- a/source/manual/data-gov-uk-architecture.html.md
+++ b/source/manual/data-gov-uk-architecture.html.md
@@ -40,7 +40,7 @@ This is a rails worker used to fetch data from legacy. It uses Redis to queue im
 
 The way data is normally imported from legacy is:
 
-* Every hour, pingdom GETs https://publish-data-beta.cloudapps.digital/api/sync-beta
+* Every hour, pingdom GETs https://publish-data-beta-production.cloudapps.digital/api/sync-beta
 * This runs the `sync:beta` Rails task that queries the Legacy API for new and updated datasets
 * Changes are reflected in the Publish database and pushed to elasticsearch
 

--- a/source/manual/data-gov-uk-common-tasks.html.md
+++ b/source/manual/data-gov-uk-common-tasks.html.md
@@ -210,7 +210,7 @@ server {
 Occassionally a single dataset fails to synchronise from CKAN to Publish Data.  If you know the legacy slug, or the UUID of the dataset you can use the following commands to import it into publish.
 
 ```
-cf ssh publish-data-beta-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
+cf ssh publish-data-beta-production-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
 rake import:single_legacy_dataset[UUID]
 ```
 
@@ -223,7 +223,7 @@ if they fall outside the 24 hour window that is used to check for changes.  You 
 organisations datasets if you know the short-name (slug) for the organisation
 
 ```
-cf ssh publish-data-beta-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
+cf ssh publish-data-beta-production-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
 rake import:organisation_datasets[organisation-slug,true]
 ```
 
@@ -234,7 +234,7 @@ The boolean option to the command denotes whether you with to delete the existin
 Although the general policy is not to delete datasets, datasets that are harvested can be withdrawn in the legacy system.  If they are withdrawn, then they also need to be deleted from Publish as it does not currently sync deletions. You will either need a CSV containing a list of UUIDs (or legacy slugs), or a single UUID (or legacy slug).
 
 ```
-cf ssh publish-data-beta-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
+cf ssh publish-data-beta-production-worker -t -c "/tmp/lifecycle/launcher /home/vcap/app bash ''"
 echo "UUID" | rake delete:datasets
 cat todelete.csv | rake delete:datasets
 ```

--- a/source/manual/data-gov-uk-incidents.html.md
+++ b/source/manual/data-gov-uk-incidents.html.md
@@ -90,7 +90,7 @@ If you see that Find doesn’t update with either manual or harvested changes ma
 Check if the Redis server is working. SSH into it and run `redis-cli`. Look at the Graphite dashboard and restart the server if need be. If you suspect changes were lost:
 
 * For change over 24 hours old, [reimport all datasets](/manual/data-gov-uk-common-tasks.html#import-data-from-legacy) from a daily dump.
-* For changes less than 24 hours old, hit the legacy-sync API by going to [](https://publish-data-beta.cloudapps.digital/api/sync-beta).
+* For changes less than 24 hours old, hit the legacy-sync API by going to [](https://publish-data-beta-production.cloudapps.digital/api/sync-beta).
 
 ## Elasticsearch goes down
 


### PR DESCRIPTION
The application name has changed so that it conforms to conventions needed for production to staging sign-on sync.

See https://trello.com/c/mBViuo1y