### PR TITLE
Add organisations-publisher

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -25,6 +25,10 @@
   type: Publishing apps
   team: "#platform-health"
 
+- github_repo_name: organisations-publisher
+  type: Publishing apps
+  team: "#govuk-porg-pages"
+
 - github_repo_name: policy-publisher
   type: Publishing apps
   team: "#platform-health"


### PR DESCRIPTION
This commit adds organisations-publisher to the list of apps fo the developer documentation.