### PR TITLE
Better encapsulate customisations for special snowflake apps

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -1,3 +1,5 @@
+require "active_support/inflector"
+
 class AppDocs
   def self.pages
     @pages ||= YAML.load_file('data/applications.yml').map do |app_data|
@@ -224,17 +226,7 @@ class AppDocs
   private
 
   def self.new_by_type(app_data)
-    # Turns an app type into a potential class name in the same way that
-    # `x.classify` from the ActiveSupport inflector would.
-    #
-    # E.g. "data.gov.uk apps" --> "AppDocs::DataGovUkApp"
-    klass_name = name + "::" + app_data["type"].
-      downcase.
-      gsub(/[^a-z]+/, " ").
-      sub(/ apps$/, " app").
-      split(" ").
-      map { |x| x.capitalize }.
-      join
+    klass_name = self.name + "::" + app_data["type"].downcase.gsub(/[^a-z]+/, "_").classify
     klass = Module.const_defined?(klass_name) ? Module.const_get(klass_name) : App
     klass.new(app_data)
   end

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -1,6 +1,12 @@
 require "active_support/inflector"
 
 class AppDocs
+  def self.new_by_type(app_data)
+    klass_name = self.name + "::" + app_data["type"].downcase.gsub(/[^a-z]+/, "_").classify
+    klass = Module.const_defined?(klass_name) ? Module.const_get(klass_name) : App
+    klass.new(app_data)
+  end
+
   def self.pages
     @pages ||= YAML.load_file('data/applications.yml').map do |app_data|
       new_by_type(app_data)
@@ -221,13 +227,5 @@ class AppDocs
     def in_aws?
       false
     end
-  end
-
-  private
-
-  def self.new_by_type(app_data)
-    klass_name = self.name + "::" + app_data["type"].downcase.gsub(/[^a-z]+/, "_").classify
-    klass = Module.const_defined?(klass_name) ? Module.const_get(klass_name) : App
-    klass.new(app_data)
   end
 end

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -1,9 +1,11 @@
-require "active_support/inflector"
-
 class AppDocs
   def self.new_by_type(app_data)
-    klass_name = self.name + "::" + app_data["type"].downcase.gsub(/[^a-z]+/, "_").classify
-    klass = Module.const_defined?(klass_name) ? Module.const_get(klass_name) : App
+    klass = case app_data["type"]
+            when "data.gov.uk apps"
+              DataGovUkApp
+            else
+              App
+            end
     klass.new(app_data)
   end
 

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -29,7 +29,11 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
 
 <ul>
   <li><%= link_to "GitHub repo", application.repo_url %></li>
-  <li><%= link_to "Sentry (error tracking)", application.sentry_url %></li>
+
+  <% if application.sentry_url %>
+    <li><%= link_to "Sentry (error tracking)", application.sentry_url %></li>
+  <% end %>
+
   <% if application.puppet_url %>
     <li><%= link_to "Puppet configuration", application.puppet_url %></li>
   <% end %>
@@ -68,7 +72,7 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   This application's hosting arrangements are not yet complete
 <% elsif application.in_paas? %>
   This applications lives on [GOV.UK PaaS](https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas).
-<% else %>
+<% elsif application.carrenza_machine %>
   This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
 
   To SSH to one of these machines:

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -69,7 +69,7 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
 
 <h3>SSH access</h3>
 <% if application.pending_hosting? %>
-  This application's hosting arrangements are not yet complete
+  This application's hosting arrangements are not yet complete.
 <% elsif application.in_paas? %>
   This applications lives on [GOV.UK PaaS](https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas).
 <% elsif application.carrenza_machine %>

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -66,7 +66,7 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
 <h3>SSH access</h3>
 <% if application.pending_hosting? %>
   This application's hosting arrangements are not yet complete
-<% elsif application.datagovuk_app? %>
+<% elsif application.in_paas? %>
   This applications lives on [GOV.UK PaaS](https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas).
 <% else %>
   This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
@@ -79,7 +79,7 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   ```
 <% end %>
 
-<% unless application.datagovuk_app? %>
+<% if application.in_aws? %>
   <h3>AWS SSH access</h3>
 
   This application lives on `<%= application.aws_puppet_class %>` machines on the integration environment in AWS.
@@ -89,7 +89,9 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   ```
   ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
   ```
+<% end %>
 
+<% if application.has_rake_tasks? %>
   <h3>Run a rake task</h3>
 
   - <%= link_to "Run on Integration Jenkins", "https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.carrenza_machine}" %>


### PR DESCRIPTION
DGU-isms were spread around the `App` class, which was fine when DGU was the only special snowflake, but we need to add some documentation for Licensing, so it makes sense to extract the specifics for those cases to separate objects.