### PR TITLE
Add basic page about Licensify app

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -20,7 +20,7 @@ class AppDocs
   end
 
   def self.topics_on_github
-    pages.reject(&:retired?).flat_map(&:topics).sort.uniq
+    pages.reject(&:retired?).reject(&:private_repo?).flat_map(&:topics).sort.uniq
   end
 
   def self.aws_machines
@@ -76,6 +76,10 @@ class AppDocs
 
     def retired?
       app_data["retired"]
+    end
+
+    def private_repo?
+      app_data["private_repo"]
     end
 
     def page_title
@@ -187,6 +191,7 @@ class AppDocs
     end
 
     def github_repo_data
+      return {} if private_repo?
       @github_repo_data ||= GitHubRepoFetcher.client.repo(github_repo_name)
     end
   end

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -3,6 +3,8 @@ class AppDocs
     klass = case app_data["type"]
             when "data.gov.uk apps"
               DataGovUkApp
+            when "Licensing apps"
+              LicensingApp
             else
               App
             end
@@ -180,6 +182,10 @@ class AppDocs
       true
     end
 
+    def in_ukcloud?
+      false
+    end
+
   private
 
     def puppet_name
@@ -228,6 +234,40 @@ class AppDocs
     end
 
     def in_paas?
+      true
+    end
+
+    def in_aws?
+      false
+    end
+  end
+
+  class LicensingApp < App
+    def carrenza_machine
+      # noop
+    end
+
+    def sentry_url
+      # noop
+    end
+
+    def puppet_url
+      # noop
+    end
+
+    def deploy_url
+      # noop
+    end
+
+    def dashboard_url
+      # noop
+    end
+
+    def has_rake_tasks?
+      false
+    end
+
+    def in_ukcloud?
       true
     end
 

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -237,6 +237,14 @@
   type: data.gov.uk apps
   team: "#govuk-datagovuk-tech"
 
+# Licensing
+
+- github_repo_name: licensify
+  private_repo: true
+  type: Licensing apps
+  team: "#govuk-licensing"
+  description: |
+    GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 # Retired applications
 

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -6,6 +6,7 @@
     - name: Supporting apps
     - name: Frontend apps
     - name: data.gov.uk apps
+    - name: Licensing apps
 
 - name: Developing
   sections:

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -69,11 +69,13 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   <% end %>
 </ul>
 
-<h3>SSH access</h3>
+<h3>Hosting & SSH Access</h3>
 <% if application.pending_hosting? %>
   This application's hosting arrangements are not yet complete.
 <% elsif application.in_paas? %>
   This applications lives on [GOV.UK PaaS](https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas).
+<% elsif application.in_ukcloud? %>
+  This applications lives in UK Cloud.
 <% elsif application.carrenza_machine %>
   This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
 

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -16,7 +16,9 @@ This application is retired.
 
 <% else %>
 
+<% unless application.topics.nil? %>
 GitHub topics: <%= application.topics.map { |topic| link_to(topic, "https://github.com/search?q=topic:#{topic}+org:alphagov") }.to_sentence %>
+<% end %>
 
 ### Ownership
 


### PR DESCRIPTION
Because Licensify is a private repo, we need to access the repo list in a different way, and that requires an auth key with permission to access those private repos in the alphagov org (which the current deployment process doesn't have.)

**Update:** Approach changed to just use data from the applications.yml file instead of needing access to private repos.