### PR TITLE
Rename govuk-prototype-kit

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -141,7 +141,7 @@
   sections:
     - name: Shared GOV.UK Frontend across Government
       repos:
-        - govuk_prototype_kit
+        - govuk-prototype-kit
         - govuk_template
         - govuk_elements
         - govuk_elements_rails


### PR DESCRIPTION
The repository has been renamed from govuk_prototype_kit and this is preventing builds from succeeding.

https://github.com/alphagov/govuk-prototype-kit/pull/532