### PR TITLE
Enforce use of classes for fabric tasks

### DIFF
--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md
@@ -21,7 +21,7 @@ apps](applications/sidekiq-monitoring.html).
 
 You can verify that there are overdue published documents using:
 
-    $ fab $environment whitehall.overdue_scheduled_publications
+    $ fab $environment class:whitehall_backend whitehall.overdue_scheduled_publications
 
 You'll see output like this:
 
@@ -30,7 +30,7 @@ You'll see output like this:
 If there are overdue publications you can publish by running the
 following:
 
-    $ fab $environment whitehall.schedule_publications
+    $ fab $environment class:whitehall_backend whitehall.schedule_publications
 
 #### After a database restore
 

--- a/source/manual/cache-flush.html.md
+++ b/source/manual/cache-flush.html.md
@@ -31,7 +31,7 @@ machine.
 
 This can be used as::
 
-    fab $environment cdn.purge_all:'/one,/two,/three'
+    fab $environment class:cache cdn.purge_all:'/one,/two,/three'
 
 This will purge the page from all our origin cache nodes and the CDN
 cache.
@@ -39,7 +39,7 @@ cache.
 Each page that's purged will output 3 kinds of things. First are
 responses from each of our origin Varnish nodes confirming the purge:
 
-    $ fab $environment cdn.purge_all:'/bank-holidays'
+    $ fab $environment class:cache cdn.purge_all:'/bank-holidays'
     [cache-1.router] run: curl -s -I -X PURGE http://localhost:7999/bank-holidays | grep '200 Purged'
     [cache-1.router] out: HTTP/1.1 200 Purged
 
@@ -69,7 +69,7 @@ early.
 You can purge multiple URLs with a single command; in this case all the
 Varnish purges will happen before any of the Fastly purges:
 
-    $ fab $environment cdn.purge_all:'/bank-holidays,/another/url'
+    $ fab $environment class:cache cdn.purge_all:'/bank-holidays,/another/url'
 
 ## Purging a page from Fastly manually (e.g. if GOV.UK Production is dead)
 
@@ -101,7 +101,7 @@ Use the Fabric command from
 [fabric-scripts](https://github.com/alphagov/fabric-scripts). Note that
 you can if necessary specify multiple URLs in one go:
 
-    fab $environment cache.purge:'/bank-holidays,/some-other-url'
+    fab $environment class:cache class:draft_cache cache.purge:'/bank-holidays,/some-other-url'
 
 ## Automatic purging on publication
 
@@ -118,7 +118,7 @@ cache servers) followed by Fastly.
 
 To flush our origin run the following Fabric command::
 
-    fab $environment cache.ban_all
+    fab $environment class:cache class:draft_cache cache.ban_all
 
 Once this is done move on to Fastly. This can only be done through the
 Fastly UI - the credentials are in the 2nd line store. If possible,

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -73,7 +73,7 @@ Because the CDN will retry every request against the mirrors automatically if or
 is unavailable, all you need to do is [stop Nginx on the cache machines with Fabric][fab-fail]:
 
 ```
-fab $environment incident.fail_to_mirror
+fab $environment class:cache incident.fail_to_mirror
 ```
 
 [fab-fail]: https://github.com/alphagov/fabric-scripts/blob/master/incident.py

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -110,6 +110,6 @@ the previous version of the software.
 10.  Purge the cache, which will otherwise take up to 12 hours to
     expire:
 
-        fab $environment cdn.purge_all:/government/uploads/uploaded/hmrc/realtimepayetools-update-vXX.xml
+        fab $environment class:cache cdn.purge_all:/government/uploads/uploaded/hmrc/realtimepayetools-update-vXX.xml
 
 10.  Update and resolve the Zendesk ticket

--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -19,7 +19,7 @@ follow these steps:
 6. `asset = Asset.find("asset-id-from-url")` (e.g. `57a9c52b40f0b608a700000a`) or for a Whitehall asset `asset = WhitehallAsset.find_by(legacy_url_path: '/government/uploads/system/uploads/attachment_data/file/id/path.extension')`
 7. Check the asset is what you think it is and delete: `asset.destroy`
 8. Navigate to your local fabric-scripts directory
-9. `fab production cdn.purge_all:'/media/.../some-asset.pdf`
+9. `fab production class:cache cdn.purge_all:'/media/.../some-asset.pdf`
 10. Check that the asset responds with a 404
 11. Request removal of the asset using the [Google Search Console](https://www.google.com/webmasters/tools/removals)
 

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -178,7 +178,7 @@ take manual action to resolve the problem.
 
 -   Reboot the nodes in the cluster:
 
-        fab <environment> rabbitmq.safe_reboot
+        fab <environment> class:rabbitmq rabbitmq.safe_reboot
 
 -   after rabbitmq-1 has recovered, restart govuk-crawler:
 


### PR DESCRIPTION
https://trello.com/c/lDiAvOhV/145-speedup-fabric-scripts-so-theyre-quicker-than-doing-stuff-manually

Previously some fabric tasks would automatically set the group of
hosts on which they should run, such as 'cache' or 'whitehall_backend'.
The code to support this magic was causing all fabric tasks to take a
long time to run. As only a few tasks had this behaviour, it's more
consistent to enforce the group of hosts be specified when running all
fabric tasks, while also making it easy to remove the task bottleneck.