### PR TITLE
Improve docs updating

### DIFF
--- a/app/page_freshness.rb
+++ b/app/page_freshness.rb
@@ -11,7 +11,7 @@ class PageFreshness
 
   def expired_pages
     sitemap.resources.select do |page|
-      PageReview.new(page).expired?
+      PageReview.new(page).expired? && page.data.section != Manual::ICINGA_ALERTS
     end
   end
 

--- a/app/page_freshness.rb
+++ b/app/page_freshness.rb
@@ -15,6 +15,10 @@ class PageFreshness
     end
   end
 
+  def all_pages
+    sitemap.resources.map { |page| PageReview.new(page) }.select(&:reviewable?)
+  end
+
   def expiring_soon
     soon = sitemap.resources.select do |page|
       PageReview.new(page).expiring_soon?

--- a/source/page-reviews.html.erb
+++ b/source/page-reviews.html.erb
@@ -1,0 +1,35 @@
+---
+layout: false
+title: Page reviews
+---
+
+<% content_for :sidebar do %>
+&nbsp;
+<% end %>
+
+<% wrap_layout :layout_with_sidebar do %>
+  <%= partial 'partials/header' %>
+  <table>
+    <tr>
+      <th>Page</th>
+      <th>Expired?</th>
+      <th>Owner</th>
+      <th>Section</th>
+      <th>Due date</th>
+      <th>Overdue</th>
+      <th>Review in</th>
+    </tr>
+
+    <% PageFreshness.new(sitemap).all_pages.each do |page| %>
+      <tr>
+        <td><%= link_to page.page.data.title, page.page.url %></td>
+        <td><%= page.expired? %></td>
+        <td><%= page.owner_slack %></td>
+        <td><%= page.page.data.section %></td>
+        <td><%= page.review_by %></td>
+        <td><%= time_ago_in_words page.review_by %></td>
+        <td><%= page.page.data.review_in %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>


### PR DESCRIPTION
We have a system that enforces regular documentation review. It works by settings a review date, the time in which it needs to be reviewed and who needs to review it. The overdue things are announced  in Slack.

We currently have a backlog of 43 pages that are overdue, out of a total of 239 pages (18%). While this is not super bad, it seems the number of overdue pages is rising. @thomasleese tried to fix this by limiting the number of messages in Slack in https://github.com/alphagov/govuk-docs-monitor/pull/5. This didn't have the desired effect yet.

## Why don't we review?

I've gone through the overdue ones and came up with a best guess why we aren't updating the page ([source sheet](https://docs.google.com/spreadsheets/d/12rWY86ecNGUf2Bk6zH1xi47ahKt0kVN1gqdMkUTOGiU/edit#gid=309294042)):

| Why | How many | 
-- | --
Icinga alert (hard to review) | 13
No reason | 11
Infrastructure page | 10
Wrong owner | 3
No knowledge in team | 2
Hard to review | 2
Wrong Slack | 1
Low review date | 1

## In this PR

- Creates a page with all the data that we can easily export to Google docs so we can analyse the data ([done here](https://docs.google.com/spreadsheets/d/12rWY86ecNGUf2Bk6zH1xi47ahKt0kVN1gqdMkUTOGiU/edit#gid=0)).
- We **stop alerting** for Icinga alerts. We do this by not returning `/alert` pages from the API.
- Fix non-existing Slack usernames/channels
- Assign a bunch of 2nd line pages to @hongoose, who as lord protector of 2nd line is responsible for the pages about 2nd line & incident management

## Future work

- RE should become responsible for some of the infrastructure pages
- We should consider upping review_in to a year or more for some information
- We should pay down the current backlog asap to start cleanly 