### PR TITLE
Fix Faraday warning

### DIFF
--- a/app/http.rb
+++ b/app/http.rb
@@ -13,8 +13,8 @@ module HTTP
       conn.response :logger
       conn.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
       conn.use Octokit::Response::RaiseError
-      conn.adapter Faraday.default_adapter
       conn.response :json, content_type: /\bjson$/
+      conn.adapter Faraday.default_adapter
     end
 
     response = faraday.get(uri.path)


### PR DESCRIPTION
Faraday now complains if middleware is set after adapter which causes
Heroku to error when trying to build assets annoyingly. It doesn't seem
particularly logical that this will fix it but it seems to.