### PR TITLE
Add some docs on renewing SSL certificates

### DIFF
--- a/source/manual/generate-csr.html.md
+++ b/source/manual/generate-csr.html.md
@@ -8,10 +8,10 @@ last_reviewed_on: 2018-04-12
 review_in: 6 months
 ---
 
-When buying an SSL certificate for a GOV.UK domain, a certificate
+When buying or renewing an SSL certificate for a GOV.UK domain, a certificate
 signing request is required.
 
-## Generating the CSR
+## Buying a new certificate
 
 Execute the following on a POSIX-compliant machine, for example your
 Mac:
@@ -22,7 +22,30 @@ Be sure to replace the value 'example.service.gov.uk' set in the
 `DOMAIN_NAME` environment variable to the domain name the SSL
 certificate is intended for.
 
-The contents of the .key file must be kept secret. It should be stored encrypted in the [govuk-secrets](https://github.com/alphagov/govuk-secrets) repository.
+The contents of the .key file must be kept secret. It should be stored encrypted
+in the [govuk-secrets](https://github.com/alphagov/govuk-secrets) repository.
 
 The contents of the CSR should be shared with the SSL certificate
 provider. This allows them to generate the SSL certificate.
+
+## Renewing a certificate
+
+This is different from generating a new certificate in that we don't want to
+have a whole new key, we want to generate a CSR against an existing key.
+
+To find the existing key, decrypt Puppet hieradata for the required environment
+and find the `wildcard_publishing` key. Save this to a file, for the next step.
+
+Execute the following on a POSIX-compliant machine, for example your
+Mac:
+
+    DOMAIN_NAME=*.publishing.service.gov.uk sh -c 'openssl req -nodes -new -key /path/to/wildcard_publishing.key -out ${DOMAIN_NAME//[^a-zA-Z0-9]/_}.csr -subj "/C=GB/ST=England/L=London/O=UK government/OU=Government Digital Service/CN=${DOMAIN_NAME}/"'
+
+Be sure to replace the value 'example.service.gov.uk' set in the
+`DOMAIN_NAME` environment variable to the domain name the SSL
+certificate is intended for.
+
+The contents of the CSR should be shared with the SSL certificate
+provider. This allows them to generate the SSL certificate.
+
+Now delete the key file you saved.

--- a/source/manual/renew_ssl_certificates.html.md
+++ b/source/manual/renew_ssl_certificates.html.md
@@ -1,0 +1,36 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Renewing an SSL certificate for GOV.UK
+section: Environments
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-07-04
+review_in: 6 months
+---
+
+We use SSL on GOV.UK. This documentation covers how to renew wildcard SSL
+certificates for `publishing.service.gov.uk` and the `integration` and `staging`
+subdomains. It is a task performed by Reliability Engineering.
+
+## Where these are bought from
+
+GOV.UK's SSL certificates are bought from Gandi. There are credentials for the
+`govuk` account in the infra password store.
+
+## How to renew
+
+1. Log into Gandi [using the credentials in the infra password
+   store](https://github.com/alphagov/govuk-secrets/blob/master/pass/infra/gandi/govuk.gpg).
+2. Go to the account dashboard and find the list of SSL certificates on the
+   account.
+3. Find the certificate you wish to renew and click Renew. You'll want to
+   request a wildcard certificate (`*.publishing.service.gov.uk`, for example).
+4. Go through the steps on the renewal form until you reach a page requesting a
+   Certificate Signing Request.
+5. [Generate a Certificate Signing Request
+   (CSR)](source/manual/generate-csr.html.md) for a *renewal*.
+6. Upload the CSR to Gandi by pasting the contents of the .csr file into the
+   text box.
+7. Next, choose DNS validation to validate it.
+8. Pay for it - we don't have a stored payment method, so find the person with
+   the GOV.UK credit card.


### PR DESCRIPTION
Rendered versions of these docs are [here](https://govuk-developer-docs-pr-1038.herokuapp.com/manual/renew_ssl_certificates.html) and [here](https://govuk-developer-docs-pr-1038.herokuapp.com/manual/generate-csr.html#renewing-a-certificate).