### PR TITLE
Turn off hardbreaks option for importing markdown

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -8,6 +8,8 @@ class ExternalDoc
     )
 
     context = {
+      # Turn off hardbreaks as they behave different to github rendering
+      gfm: false,
       base_url: URI.join(
         'https://github.com',
         "#{repository}/blob/master/",


### PR DESCRIPTION
This is used to disable the hardbreaks option with commonmark that is
forced here: https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/markdown_filter.rb#L25

This option makes markdown such as:

hello
there

be rendered as <p>hello<br />there</p> rather than <p>hello there</p> as
markdown does by default, which therefore makes this inconsistent with
the other markdown rendering done in developer docs and Github's own
markdown rendering.