### PR TITLE
Update RE and Logit docs

### DIFF
--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -4,7 +4,7 @@ title: How to use Logit for GOV.UK
 section: Logging
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2017-12-21
+last_reviewed_on: 2018-07-11
 review_in: 6 months
 ---
 
@@ -16,18 +16,14 @@ GOV.UK use [Logit](https://logit.io) to provide our
 This is in line with [The GDS Way](https://gds-way.cloudapps.digital/) guidance
 on [logging](https://gds-way.cloudapps.digital/standards/logging.html).
 
+## If Logit is down
+
+If there is a problem with Logit you should report it by following the
+instructions in the Reliability Engineering manual for [reporting an incident](https://reliability-engineering.cloudapps.digital/manuals/logit-incident-management.html).
+
 ## Accessing Logit
 
-You can access Logit by visiting
-[kibana.publishing.service.gov.uk](https://kibana.publishing.service.gov.uk).
-You will be prompted to log in with your GDS Google account if you're not
-already logged in.
-
-You can access logs for integration and staging too:
-
-[kibana.integration.publishing.service.gov.uk](https://kibana.integration.publishing.service.gov.uk)
-
-[kibana.staging.publishing.service.gov.uk](https://kibana.staging.publishing.service.gov.uk)
+You can [access Logit](https://reliability-engineering.cloudapps.digital/manuals/logit-io-joiners.html) by following the instructions in the Reliability Engineering manual.
 
 Logit stores the last environment you visited in a session. If you open any
 direct links externally they will take you to this stack.

--- a/source/manual/raising-issues-with-reliability-engineering.html.md
+++ b/source/manual/raising-issues-with-reliability-engineering.html.md
@@ -4,7 +4,7 @@ title: Raising issues with Reliability Engineering
 parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
-last_reviewed_on: 2018-05-24
+last_reviewed_on: 2018-07-11
 review_in: 3 months
 ---
 
@@ -15,6 +15,8 @@ various GDS programmes such as logging and monitoring tools.
 
 When on 2nd line you may experience an issue with GOV.UK that requires asking
 Reliability Engineering for assistance.
+
+[There are Reliability Engineering tech docs](https://reliability-engineering.cloudapps.digital/) for users of their systems.
 
 ## If you require urgent assistance
 


### PR DESCRIPTION
Update Logit docs:

- Provide link to the RE logit incident docs.
- Remove links to Kibana URLs, these are often unhelpful if you're not signed in.
 reliability-engineering

Update RE docs:

- Provide a link to the RE manual