### PR TITLE
Update team channel names

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -2,16 +2,16 @@
 
 - github_repo_name: collections-publisher
   type: Publishing apps
-  team: "#taxonomy-and-nav"
+  team: "#govuk-taxonomy"
 
 - github_repo_name: contacts-admin
   type: Publishing apps
   puppet_name: contacts
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: content-tagger
   type: Publishing apps
-  team: "#taxonomy-and-nav"
+  team: "#govuk-taxonomy"
 
 - github_repo_name: content-publisher
   type: Publishing apps
@@ -19,213 +19,213 @@
 
 - github_repo_name: local-links-manager
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: manuals-publisher
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: maslow
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: organisations-publisher
   type: Publishing apps
-  team: "#govuk-porg-pages"
+  team: "#govuk-platform-health"
 
 - github_repo_name: policy-publisher
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: publisher
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: service-manual-publisher
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: short-url-manager
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: specialist-publisher
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   api_docs_url: /apis/whitehall.html
 
 # api
 
 - github_repo_name: content-store
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   api_docs_url: /apis/content-store.html
 
 - github_repo_name: email-alert-api
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   metrics_dashboard_url: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 
 - github_repo_name: email-alert-service
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: imminence
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: link-checker-api
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   api_docs_url: /apis/link-checker-api.html
 
 - github_repo_name: publishing-api
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   api_docs_url: /apis/publishing-api.html
 
 - github_repo_name: rummager
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   api_docs_url: /apis/search-api.html
 
 - github_repo_name: asset-manager
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: router-api
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: support-api
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: hmrc-manuals-api
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: mapit
   type: APIs
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   api_docs_url: https://mapit.mysociety.org/docs/
 
 # Support
 
 - github_repo_name: content-performance-manager
   type: Supporting apps
-  team: "#data-informed-content"
+  team: "#govuk-data-informed"
 
 - github_repo_name: content-audit-tool
   type: Supporting apps
-  team: "#data-informed-content"
+  team: "#govuk-data-informed"
 
 - github_repo_name: search-admin
   type: Supporting apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: signon
   type: Supporting apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: support
   type: Supporting apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: authenticating-proxy
   type: Supporting apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: release
   type: Supporting apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: router
   type: Supporting apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 # frontend
 
 - github_repo_name: calculators
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: calendars
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: collections
   type: Frontend apps
-  team: "#taxonomy-and-nav"
+  team: "#govuk-taxonomy"
   component_guide_url: https://govuk-collections.herokuapp.com/component-guide
 
 - github_repo_name: email-alert-frontend
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: feedback
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: finder-frontend
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
 
 - github_repo_name: frontend
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: government-frontend
   type: Frontend apps
-  team: "#taxonomy-and-nav"
+  team: "#govuk-taxonomy"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
 
 - github_repo_name: info-frontend
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: licence-finder
   type: Frontend apps
   puppet_name: licencefinder
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: manuals-frontend
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: smart-answers
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   puppet_name: smartanswers
 
 - github_repo_name: service-manual-frontend
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   type: Frontend apps
 
 - github_repo_name: static
   type: Frontend apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
   component_guide_url: https://govuk-static.herokuapp.com/component-guide
 
 # Transition
 
 - github_repo_name: bouncer
   type: Transition apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 - github_repo_name: transition
   type: Transition apps
-  team: "#platform-health"
+  team: "#govuk-platform-health"
 
 # data.gov.uk
 


### PR DESCRIPTION
* Add `govuk-` prefix to channel names
* Update channel names for taxonomy and data informed content
* Move organisations-publisher to platform health team