### PR TITLE
Add more Email Alert API documentation

### DIFF
--- a/source/apis/email-alert-api.html.md.erb
+++ b/source/apis/email-alert-api.html.md.erb
@@ -1,0 +1,11 @@
+---
+layout: api_layout
+title: Email Alert API
+parent: /apps.html
+source_url: https://github.com/alphagov/email-alert-api/blob/master/doc/api.md
+---
+
+This documents the endpoints for Email Alert API further documentation is
+available in the [github repo](https://github.com/alphagov/email-alert-api).
+
+<%= ExternalDoc.fetch(repository: 'alphagov/email-alert-api', path: 'doc/api.md') %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -1,6 +1,7 @@
 <% content_for :sidebar do %>
   <ul>
     <li><%= link_to 'Content Store', '/apis/content-store.html' %></li>
+    <li><%= link_to 'Email Alert API', '/apis/email-alert-api.html' %></li>
     <li><%= link_to 'Link Checker API', '/apis/link-checker-api.html' %></li>
     <li>
       <%= sidebar_link 'Publishing API', '/apis/publishing-api.html' %>

--- a/source/manual/email-alert-api-analytics.html.md.erb
+++ b/source/manual/email-alert-api-analytics.html.md.erb
@@ -1,0 +1,9 @@
+---
+title: "Email Alert API analytics"
+section: Emails
+layout: manual_layout
+parent: "/manual.html"
+source_url: https://github.com/alphagov/email-alert-api/blob/master/doc/analytics.md
+---
+
+<%= ExternalDoc.fetch(repository: 'alphagov/email-alert-api', path: 'doc/analytics.md') %>


### PR DESCRIPTION
This imports the API endpoint documentation for Email Alert API so it can be shown in the API's section.

It also imports a doc on accessing analytics which documents how to get insights into Email Alert API data through the database and through the S3 based archives.