### PR TITLE
Update vcs docs with aws cc info

### DIFF
--- a/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
+++ b/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
@@ -11,7 +11,7 @@ review_in: 3 months
 When responding to a security incident, we should review the changes in private
 before deploying them, so that we don't accidentally disclose the vulnerability.
 
-To do this, push branches to the [GitLab backup](github-unavailable.html)
+To do this, push branches to the [AWS CodeCommit backup](github-unavailable.html)
 of the repository, rather than the normal repository on github.com.
 
 This repository should be up to date as of the previous release, but will be
@@ -23,13 +23,13 @@ This is fine as you don't want to deploy these.
 1. Ensure nobody else deploys the app until you've confirmed the vulnerability
    is fixed.
 
-1. Review the pull request on GitLab
+1. Review the pull request on AWS CodeCommit
 
 1. Create a release tag manually in git. This should follow the standard format
    `release_X`. Tag the branch directly instead of merging it.
 
 1. Don't use the release app. Go directly to the `deploy_app` Jenkins job, and
-   check "DEPLOY_FROM_GITLAB".
+   check "DEPLOY_FROM_AWS_CODECOMMIT".
 
 ## After deploying
 

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -17,17 +17,17 @@ If GitHub is unavailable, we lose:
 * Access to our primary code repository
 * The ability to authenticate with Jenkins, as it makes use of GitHub groups
 
-We mirror all our repositories to GitLab.com every two hours using the
+We mirror all our repositories to AWS CodeComit every two hours using the
 [`govuk-repo-mirror`](https://github.com/alphagov/govuk-repo-mirror) scripts. This is run from the [`Mirror_Repositories`](https://ci.integration.publishing.service.gov.uk/job/Mirror_Repositories/) CI job
-In the event of Github being down, we can deploy the code from the [govuk team](https://gitlab.com/govuk/) on GitLab.com.
+In the event of Github being down, we can deploy the code from AWS CodeCommit repos. This requires help from a GOV.UK AWS admin.
 
-### Deploying from GitLab.com
+### Deploying from AWS CodeCommit
 
-Use the normal deployment job but check the box to deploy from GitLab.com.
+Use the normal deployment job but check the box to deploy from AWS CodeCommit.
 
-### Making changes to code in GitLab before deployment
+### Making changes to code in AWS CodeCommit before deployment
 
-GOV.UK Tech Leads are owners on the `govuk` team on GitLab.com. They can give access to developers who need to make changes to the code before deployment. This may be necessary if we need to work in private, for example to fix a security vulnerability without disclosing it to the public. To do this, push to a new branch on GitLab.com and then deploy that code.
+GOV.UK AWS admin users can give access to developers who need to make changes to the code before deployment. This may be necessary if we need to work in private, for example to fix a security vulnerability without disclosing it to the public. To do this, push to a new branch on AWS CodeCommit and then deploy that code.
 
 ### Authenticating with Jenkins
 


### PR DESCRIPTION
https://trello.com/c/TX8kPxzK/319-start-backing-up-our-code-in-aws-codecommit-not-gitlab

We mirror GOVUK Github repos to AWS CodeCommit instead of Gitlab now so update docs to reflect this.
