### PR TITLE
Remove reference to datagovuk_infrastructure

### DIFF
--- a/source/manual/data-gov-uk-architecture.html.md
+++ b/source/manual/data-gov-uk-architecture.html.md
@@ -11,7 +11,6 @@ review_in: 6 months
 [find]: apps/datagovuk_find
 [ckan]: apps/ckanext-datagovuk
 [paas]: https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas
-[terraform]: https://github.com/alphagov/datagovuk_infrastructure
 [signon]: manual/manage-sign-on-accounts
 [deployment]: manual/data-gov-uk-deployment
 [monitoring]: manual/data-gov-uk-monitoring
@@ -53,7 +52,7 @@ The `data.gov.uk` platform is used to publish and view datasets. A dataset is a 
 
 ## [Publish] and [Find]
 
-[Publish] and [Find] are provisioned on [GOV.UK Paas][paas] using [Terraform]. The [deployment] and [monitoring] pages explain this in more detail, but you can use the following commands to get an overview.
+[Publish] and [Find] are provisioned on [GOV.UK Paas][paas]. The [deployment] and [monitoring] pages explain this in more detail, but you can use the following commands to get an overview.
 
 ```
 cf apps

--- a/source/manual/data-gov-uk-deployment.html.md
+++ b/source/manual/data-gov-uk-deployment.html.md
@@ -9,7 +9,6 @@ review_in: 6 months
 ---
 [publish]: apps/datagovuk_publish
 [find]: apps/datagovuk_find
-[terraform]: https://github.com/alphagov/datagovuk_infrastructure
 [publish-ci]: https://travis-ci.org/alphagov/datagovuk_publish/
 [find-ci]: https://travis-ci.org/alphagov/datagovuk_find
 [heroku]: https://docs.publishing.service.gov.uk/manual/review-apps.html#header
@@ -30,7 +29,7 @@ Each repo has a `Procfile` and an `app.json` file, which help to specify how the
 
 ## PaaS Staging/Prod Env
 
-[Publish] and [Find] are provisioning on [GOV.UK PaaS][paas] using [Terraform]. Each app repo contains a set of manifests that specify the container settings for when it's deployed. You can deploy an app manually as follows.
+[Publish] and [Find] are provisioned on [GOV.UK PaaS][paas]. Each app repo contains a set of manifests that specify the container settings for when it's deployed. You can deploy an app manually as follows.
 
 ```
 ## run once to install the plugin


### PR DESCRIPTION
It seems like there are issues using terraform to manage things in the
Paas. Remove the references to it so we don't overly confuse people.