### PR TITLE
Include ssh instructions for DGU Bytemark machines

### DIFF
--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -20,6 +20,13 @@ There are currently three environments for [CKAN]:
 - [Test](https://test.data.gov.uk) — co-prod2.dh.bytemark.co.uk
 - Development — co-dev1.dh.bytemark.co.uk
 
+You can ssh on to these machines with `ssh co@<machine-name>`. For example, to
+access the Test machine, you would `ssh co@co-prod2.dh.bytemark.co.uk`.
+
+If you cannot `ssh` as above, it's worth asking
+someone in the #platform-health slack channel to make sure you are in the
+`authorized_keys`.
+
 We are in the process of migrating [CKAN] to standard GOV.UK infrastructure.
 
 ## Applications


### PR DESCRIPTION
These servers are a little different to our normal GOV.UK set up so it's
worth having explicit instructions on how to ssh in to them.