### PR TITLE
Fix last reviewed date for AWS RDS memory utilisation

### DIFF
--- a/source/manual/alerts/aws-rds-memory.html.md
+++ b/source/manual/alerts/aws-rds-memory.html.md
@@ -4,7 +4,7 @@ title: AWS RDS Instance Memory Utilization
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2018-11-06
+last_reviewed_on: 2018-06-11
 review_in: 6 months
 ---
 


### PR DESCRIPTION
The month and day were the wrong way around.