### PR TITLE
Sensible message when the app isn't in puppet

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -62,6 +62,7 @@ class AppDocs
           return puppet_class
         end
       end
+      'Unknown - have you configured and merged your app in govuk-puppet/hieradata_aws/common.yaml'
     end
 
     def carrenza_machine
@@ -70,6 +71,7 @@ class AppDocs
           return puppet_class
         end
       end
+      'Unknown - have you configured and merged your app in govuk-puppet/hieradata/common.yaml'
     end
 
     def html_url


### PR DESCRIPTION
When viewing the docs for an application, if the
app has not been merged in govuk-puppet, you see
a load of json instead of which type of machine
it runs on.

This commit adds a message to this effect when
it does not exist in puppet.

Before:
![before](https://user-images.githubusercontent.com/511319/43899580-539afa16-9bda-11e8-850a-ea732e2f50cf.png)

After:
![after](https://user-images.githubusercontent.com/511319/43899592-5ca27fc6-9bda-11e8-9ed0-bed0eb73e131.png)
