### PR TITLE
Help avoid AWS ARN pitfalls for Roles/MFAs

### DIFF
--- a/source/manual/user-management-in-aws.html.md
+++ b/source/manual/user-management-in-aws.html.md
@@ -62,8 +62,8 @@ There are two methods to assume roles using the CLI.
 
 Both methods require the following:
 
- - Role ARN: this is the ARN of the role that you are using for the GOV.UK specific account, eg `govuk-administrators`, `govuk-powerusers`, `govuk-users`
- - MFA ARN: this is the ARN assigned to the MFA device in your own account
+ - Role ARN: `arn:aws:iam::<Account ID>:role/<Role Name>` ([Account IDs are here](https://github.com/alphagov/govuk-aws-data/blob/master/docs/govuk-aws-accounts.md) and [Role Names are here](https://github.com/alphagov/govuk-aws/blob/master/terraform/projects/infra-security/main.tf))
+ - MFA ARN: the ARN assigned to the MFA device in your account (**be careful not to use your User ARN!**)
 
 Both methods will allow a valid session up to eight hours. Once the hour has
 elapsed, you will need to rerun the `assume-role` command. If you want to switch


### PR DESCRIPTION
The note for the MFA ARN now makes a point to stop people accidentally
using their User ARN instead, as this looks very similar and is shown on
the same page in the AWS Console UI.

The note for the Role ARN now gives an example of how this should look,
with a link to the Account IDs and a link to where the role names are
defined, in case they change.