### PR TITLE
Remove datagovuk_infrastructure from apps

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -247,10 +247,6 @@
   type: data.gov.uk apps
   team: "#govuk-platform-health"
 
-- github_repo_name: datagovuk_infrastructure
-  type: data.gov.uk apps
-  team: "#govuk-platform-health"
-
 - github_repo_name: datagovuk_cf_scripts
   type: data.gov.uk apps
   team: "#govuk-platform-health"


### PR DESCRIPTION
We can't include private repos in this list because the deployment script can't see them.