### PR TITLE
Use "contribution banner" feature from gem

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,3 +16,6 @@ header_links:
   Document types: /document-types.html
 
 ga_tracking_id: UA-91585274-1
+
+show_contribution_banner: true
+github_repo: alphagov/govuk-developer-docs

--- a/helpers/url_helpers.rb
+++ b/helpers/url_helpers.rb
@@ -2,12 +2,4 @@ module UrlHelpers
   def document_type_url(document_type_name)
     "/document-types/#{document_type_name}.html"
   end
-
-  def view_source_url
-    SourceUrl.new(locals, current_page).source_url
-  end
-
-  def report_issue_url
-    "https://github.com/alphagov/govuk-developer-docs/issues/new?labels=bug&title=Problem with '#{current_page.data.title}'&body=Problem with '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})"
-  end
 end

--- a/source/layouts/layout_with_sidebar.erb
+++ b/source/layouts/layout_with_sidebar.erb
@@ -19,7 +19,12 @@
     <div class="app-pane__content toc-open-disabled">
       <main id="content" class="technical-documentation" data-module="anchored-headings">
         <%= yield %>
-        <%= partial 'partials/source' %>
+        <%# Copy-pasted from the gem because we're overriding this layout %>
+        <ul class="contribution-banner">
+          <li><%= link_to "View source", source_urls.view_source_url %></li>
+          <li><%= link_to "Report problem", source_urls.report_issue_url %></li>
+          <li><%= link_to "GitHub Repo", source_urls.repo_url %></li>
+        </ul>
       </main>
     </div>
   </div>

--- a/source/partials/_source.html.erb
+++ b/source/partials/_source.html.erb
@@ -1,6 +1,0 @@
-
-<div class="meta-links">
-  <%= link_to "View source", view_source_url %>
-  <%= link_to "Report problem", report_issue_url %>
-  <%= link_to "GitHub Repo", "https://github.com/alphagov/govuk-developer-docs" %>
-</div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,18 +1,6 @@
 @import "govuk_tech_docs";
 @import "modules/search";
 
-.meta-links {
-  margin-top: $gutter * 2;
-  margin-bottom: $gutter;
-  margin-left: -$gutter-half;
-  margin-right: -$gutter-half;
-
-  a {
-    margin-left: $gutter-half;
-    margin-right: $gutter-half;
-  }
-}
-
 .warning {
   padding: 10px;
   margin-top: 40px;


### PR DESCRIPTION
The contribution banner was moved up to the gem:

https://github.com/alphagov/tech-docs-gem/blob/master/CHANGELOG.md#new-feature-contribution-banner

We have to copy-paste a little bit into `layout_with_sidebar`, because we're overriding that template so the HTML won't be added by default. We'll try to use the layout from the gem soon, which means we won't have to customise it anymore.