### PR TITLE
Update content designer access docs

### DIFF
--- a/source/manual/give-a-content-designer-access-to-github.html.md
+++ b/source/manual/give-a-content-designer-access-to-github.html.md
@@ -4,7 +4,7 @@ title: Give a content designer access to GitHub
 parent: "/manual.html"
 layout: manual_layout
 section: Tools
-last_reviewed_on: 2018-06-01
+last_reviewed_on: 2018-09-11
 review_in: 3 months
 ---
 
@@ -25,7 +25,7 @@ When a content designer joins they will need to be added to our monitoring
 software and then can be added to the GitHub team. These are the steps to
 follow:
 
-1. Edit the [users.yml][] file in [govuk-user-reviewer][] with the following
+1. Edit the [govuk_non_tech.yml][] file in [govuk-user-reviewer][] with the following
    details for each designer: their name, GitHub username and role in
    GOV.UK - [example][user-example]
 1. Raise this as a pull request
@@ -42,9 +42,8 @@ follow:
 When a content designer leaves GOV.UK they need to be removed from the GitHub
 team to revoke their access.
 
-First, check the [users.yml][] file in [govuk-user-reviewer][] to see if the
-users are listed as having access. If they are not listed you do need to take
-any further steps.
+First, check the [govuk_non_tech.yml][] file in [govuk-user-reviewer][] to see if the
+users are listed as having access. If they are not listed you are done.
 
 If they are listed follow these steps:
 
@@ -52,13 +51,13 @@ If they are listed follow these steps:
    with the GitHub usernames asking for the users to be removed from
    https://github.com/orgs/alphagov/teams/gov-uk-content-designers
    which is the "GOV.UK Content Designers" GitHub team
-1. Edit the [users.yml][] file in [govuk-user-reviewer][] to remove the users
+1. Edit the [govuk_non_tech.yml][] file in [govuk-user-reviewer][] to remove the users
 1. Raise this as a pull request
 1. Once merged 2nd Line will be alerted if the users continues to have
    access despite having left
 
 [smart-answers-github]: https://github.com/alphagov/smart-answers
 [github-team]: https://github.com/orgs/alphagov/teams/gov-uk-content-designers
-[users.yml]: https://github.com/alphagov/govuk-user-reviewer/blob/master/config/users.yml
+[govuk_non_tech.yml]: https://github.com/alphagov/govuk-user-reviewer/blob/master/config/govuk_non_tech.yml
 [govuk-user-reviewer]: https://github.com/alphagov/govuk-user-reviewer
-[user-example]: https://github.com/alphagov/govuk-user-reviewer/pull/114/commits/2bfff951faf1eb57b70022f90e926e51605e63a0
+[user-example]: https://github.com/alphagov/govuk-user-reviewer/commit/24fc52955ce1247966b6d2069028ff4189915fe1


### PR DESCRIPTION
Some minor changes:

* Link to correct govuk_non_tech.yml file for non-technical users
* Update link to an example PR for adding user so the PR shows an
example in the new govuk_non_tech.yml file
* Update some wording to make it clearer