### PR TITLE
Update the page about purging cache

### DIFF
--- a/source/manual/cache-flush.html.md
+++ b/source/manual/cache-flush.html.md
@@ -5,112 +5,79 @@ section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2018-09-03
+last_reviewed_on: 2018-09-11
 review_in: 6 months
 ---
 
-
 The `www.gov.uk` domain is served through Fastly, which honours the
-cache control headers sent by Varnish.
+cache control headers sent by Varnish. When new content is published, the
+[Cache Clearing Service][cache-clearing-service] should take care of purging
+the page from Varnish and Fastly.
 
--   Publishing a page at a page previously unseen by Fastly will be
-    available immediately.
--   Content published and seen by Fastly may be cached for an hour
-    (depending on the Varnish cache headers).
--   Purges are for named URLs only, wildcard purges aren't supported by
-    default (though [Fastly do support it if set up in
-    advance](https://docs.fastly.com/guides/purging/wildcard-purges))
+[cache-clearing-service]: https://github.com/alphagov/cache-clearing-service
 
-## Purging a page from Fastly (with Fabric)
+If, for whatever reason, this hasn't worked properly content already seen by
+Fastly may be cached for up to an hour (depending on the Varnish cache
+headers). In this case, you may need to manually purge a page from the two
+caches.
 
-The easiest way to purge an item from the cache (cachebust) is to use
-[Fabric](https://github.com/alphagov/fabric-scripts/blob/master/cdn.py)
-which assumes that our Production infrastructure is working. If it
-isn't, then see instructions below regarding purging from a mirror
-machine.
+## Purging a page from the cache
 
-This can be used as::
+Cache Clearing Service provides three Rake tasks which can be used to clear
+the various caches manually:
 
-    fab $environment class:cache cdn.purge_all:'/one,/two,/three'
+- **Varnish**: [`rake cache:clear_varnish[/your-path-here]`][jenkins-varnish-task]
+- **Fastly**: [`rake cache:clear_fastly[/your-path-here]`][jenkins-fastly-task]
+- **Both**: [`rake cache:clear[/your-path-here]`][jenkins-both-task]
 
-This will purge the page from the CDN
-cache.
-
-Each page that's purged will output 2 kinds of things.
-
-First is a purge from Fastly for `www.gov.uk`:
-
-    [cache-1.router] run: curl -s -X PURGE -H 'Host: www.gov.uk' http://www-gov-uk.map.fastly.net/bank-holidays | grep 'ok'
-    [cache-1.router] out: {"status": "ok", "id": "175-1426788291-3713988"}
-
-Second is a purge from Fastly for `assets.publishing.service.gov.uk`:
-
-    [cache-1.router] run: curl -s -X PURGE -H 'Host: assets.publishing.service.gov.uk' http://www-gov-uk.map.fastly.net/bank-holidays | grep 'ok'
-    [cache-1.router] out: {"status": "ok", "id": "292-1426787371-4043665"}
-
-We purge from both hostnames as some parts of GOV.UK are available from
-both hostnames, and we want to be certain that pages are no longer
-cached.
-
-If the `grep` fails on an individual response then the task will exit
-early.
-
-You can purge multiple URLs with a single command; in this case all the
-Varnish purges will happen before any of the Fastly purges:
-
-    $ fab $environment class:cache cdn.purge_all:'/bank-holidays,/another/url'
+[jenkins-varnish-task]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear_varnish[/your-path-here]
+[jenkins-fastly-task]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear_fastly[/your-path-here]
+[jenkins-both-task]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear[/your-path-here]
 
 ## Purging a page from Fastly manually (e.g. if GOV.UK Production is dead)
 
-> **warning**
+> **Note**
 >
-> The following command *must* be run from one of the mirror boxes
-> because we restrict which IP addresses PURGE requests are accepted from.
+> The following command *must* be run from one of the mirror boxes because we
+> restrict which IP addresses PURGE requests are accepted from.
 
-To purge content on the Fastly cache nodes, use the PURGE method against
-the URL you wish to purge. For instance:
+To purge content on the Fastly cache nodes, use the PURGE method against the
+URL you wish to purge. For instance:
 
-    curl -XPURGE https://www.gov.uk/bank-holidays
+```sh
+$ curl -XPURGE https://www.gov.uk/bank-holidays
+```
 
-You should receive "ok" returned as a response. If not, you may wish to
-request more verbose output using the -i switch:
+You should receive `ok` returned as a response. If not, you may wish to request
+more verbose output using the `-i` switch:
 
-    curl -i -XPURGE https://www.gov.uk/bank-holidays
+```sh
+$ curl -i -XPURGE https://www.gov.uk/bank-holidays
+```
 
 You can manually flush the cache from the following machines:
 
-> -   mirror0.mirror.provider1.$environment.govuk.service.gov.uk
-> -   mirror1.mirror.provider1.$environment.govuk.service.gov.uk
-
-## Purging a page from our origin server varnish cache
-
-Use the [Jenkins job](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear[/your-path-here])
-
-## Automatic purging on publication
-
-The intention is for the backend to automatically purge Fastly on
-publication.
-
-We probably can't do this without requiring authentication for cache
-purging.
+> - mirror0.mirror.provider1.$environment.govuk.service.gov.uk
+> - mirror1.mirror.provider1.$environment.govuk.service.gov.uk
 
 ## Full Edge Flush on Fastly
 
-There are two steps involved in flushing *everything*; our origin (the
-cache servers) followed by Fastly.
+There are two steps involved in flushing *everything*; our origin (the cache
+servers) followed by Fastly.
 
-To flush our origin run the following Fabric command::
+To flush our origin run the following Fabric command:
 
-    fab $environment class:cache class:draft_cache cache.ban_all
+```sh
+$ fab $environment class:cache class:draft_cache cache.ban_all
+```
 
-Once this is done move on to Fastly. This can only be done through the
-Fastly UI - the credentials are in the 2nd line store. If possible,
-speak to a member of the senior tech team before doing this, to
-evaluate the risk.
+Once this is done move on to Fastly. This can only be done through the Fastly
+UI - the credentials are in the 2nd line store. If possible, speak to a member
+of the senior tech team before doing this, to evaluate the risk.
 
 Within the UI you reach the purge all functionality.
 
--   click "configure"
--   chose the correct service in the service drop down
--   click on the "Purge" drop down
--   click on "Purge All"
+- Click "Configure"
+- Choose the correct service in the service drop down
+- Click on the "Purge" drop down
+- Click on "Purge All"


### PR DESCRIPTION
The process of clearing cache is simpler now using the Cache Clearing Service.

[Trello Card](https://trello.com/c/9k1peA1F/434-make-the-new-cache-clearing-app-invalidate-cache-in-fastly)