### PR TITLE
Add suggestion to restart the computer

### DIFF
--- a/source/manual/nfs-errors-vm.html.md
+++ b/source/manual/nfs-errors-vm.html.md
@@ -21,6 +21,8 @@ Or, consider using [OpenConnect] for your VPN. You can access the
 $ sudo openconnect -v --pfs --no-dtls -u $USER vpn.digital.cabinet-office.gov.uk/ah
 ```
 
+If this doesn't work, restart your computer and try the command above again, without launching Cisco AnyConnect first.
+
 [gds-vpn]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/how-to/how-to/connect-to-the-aviation-house-vpn
 [openconnect]: http://formulae.brew.sh/formula/openconnect
 


### PR DESCRIPTION
Here we suggest to use OpenConnect, if we have troubles with Cisco AnyConnect,
but when I followed this guide, the command suggested didn't initially solve the
problem. The issue was fixed by restarting the computer and trying the same
command again, without launching Cisco AnyConnect first, so I'm adding this step
to the guide.