### PR TITLE
Update CKAN docs to include pairing mandate

### DIFF
--- a/source/manual/data-gov-uk-operations.html.md
+++ b/source/manual/data-gov-uk-operations.html.md
@@ -39,6 +39,8 @@ You will need to arrange with 2nd line for your public SSH key to be added to th
 ssh co@co-prod3.dh.bytemark.co.uk
 ```
 
+**When working on co-prod3, you must pair because we don't have a robust development environment for the current CKAN configuration.**
+
 ## Reindexing [Find]
 
 This is done using the `search:reindex` rake task in [Publish] and will not cause any app downtime.

--- a/source/manual/data-gov-uk-operations.html.md
+++ b/source/manual/data-gov-uk-operations.html.md
@@ -4,7 +4,7 @@ title: Operation of data.gov.uk
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-08-15
+last_reviewed_on: 2018-09-13
 review_in: 6 months
 ---
 [find]: apps/datagovuk_find
@@ -33,10 +33,9 @@ There are [detailed instructions](https://docs.cloud.service.gov.uk/get_started.
 
 ### Bytemark
 
-You will need to arrange with 2nd line for your public SSH key to be added to the Bytemark staging and production servers.  Once this is done, you can connect by SSH with the username `co`.
+You will need to arrange with 2nd line for your public SSH key to be added to the Bytemark production server.  Once this is done, you can connect by SSH with the username `co`.
 
 ```
-ssh co@co-prod2.dh.bytemark.co.uk
 ssh co@co-prod3.dh.bytemark.co.uk
 ```
 

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -21,6 +21,7 @@ There are currently two environments for [CKAN]:
 
 You can ssh on to these machines with `ssh co@<machine-name>`.
 
+**When working on co-prod3, you must pair because we don't have a robust development environment for the current CKAN configuration.**
 
 If you cannot `ssh` as above, arrange with 2nd line to add your public SSH key to the servers.
 

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -4,7 +4,7 @@ title: Supporting CKAN
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-09-10
+last_reviewed_on: 2018-09-13
 review_in: 3 months
 ---
 [ckan]: https://ckan.org
@@ -14,14 +14,12 @@ review_in: 3 months
 
 ## Environments
 
-There are currently three environments for [CKAN]:
+There are currently two environments for [CKAN]:
 
 - [Live](https://data.gov.uk) — co-prod3.dh.bytemark.co.uk
-- [Test](https://test.data.gov.uk) — co-prod2.dh.bytemark.co.uk
 - Development — co-dev1.dh.bytemark.co.uk
 
-You can ssh on to these machines with `ssh co@<machine-name>`. For example, to
-access the Test machine, you would `ssh co@co-prod2.dh.bytemark.co.uk`.
+You can ssh on to these machines with `ssh co@<machine-name>`.
 
 If you cannot `ssh` as above, it's worth asking
 someone in the #platform-health slack channel to make sure you are in the

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -21,9 +21,8 @@ There are currently two environments for [CKAN]:
 
 You can ssh on to these machines with `ssh co@<machine-name>`.
 
-If you cannot `ssh` as above, it's worth asking
-someone in the #platform-health slack channel to make sure you are in the
-`authorized_keys`.
+
+If you cannot `ssh` as above, arrange with 2nd line to add your public SSH key to the servers.
 
 We are in the process of migrating [CKAN] to standard GOV.UK infrastructure.
 


### PR DESCRIPTION
Remove `co-prod2` form the docs because we have turned it off.
Add note mandating pairing on `co-prod3`.
Make 2nd line the first port of call for any SSH access issues.