### PR TITLE
Allow merging of Gems in the test block with only 1 review

### DIFF
--- a/source/manual/manage-ruby-dependencies.html.md
+++ b/source/manual/manage-ruby-dependencies.html.md
@@ -15,8 +15,9 @@ To help with this, we use a service called [Dependabot][] to perform automated d
 
 ## Who can merge Dependabot PRs
 
-- Dependabot PRs for external gems (Rails for example) are [considered to be from a external contributor][ext] and need 2 reviews
-- Dependabot PRs for GOV.UK-owned gems (govuk_app_config, govspeak for example) need 1 reviewer
+- GOV.UK-owned gems (govuk_app_config, govspeak for example) need 1 reviewer
+- Gems found in the `test` block in the `Gemfile` (Capybara for example) need 1 reviewer
+- All other gems (Rails for example) are [considered to be from a external contributor][ext] and need 2 reviews
 
 You can ignore pull requests from the bot by replying `@dependabot ignore this major version`, but you have to add the PR to the [tech debt Trello board][tech-debt]
 


### PR DESCRIPTION
These Gems aren't installed in production, so we can be confident that they won't have any affect if they're broken. Instead, it's much more likely that these will break the tests which will be visible on the PR anyway.

This came out of a retro the Platform Health team had about the number of open Dependabot PRs.

[Trello Card](https://trello.com/c/CnEq5wbu/352-consider-allowing-single-approve-and-merge-for-test-updates)