### PR TITLE
Fix compatibility with latest tech docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ DEPENDENCIES
   webmock (~> 3.4)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.15.1
+   1.16.2

--- a/config.rb
+++ b/config.rb
@@ -5,7 +5,9 @@ GovukTechDocs.configure(self)
 
 set :markdown,
     renderer: DeveloperDocsRenderer.new(
-      with_toc_data: true
+      with_toc_data: true,
+      api: true,
+      context: self,
     ),
     fenced_code_blocks: true,
     tables: true,


### PR DESCRIPTION
The middleman build is currently failing (since https://github.com/alphagov/govuk-developer-docs/pull/1230) because our customisations aren't compatible with the latest version of the `govuk_tech_docs` gem.

https://deploy.publishing.service.gov.uk/job/govuk-developer-docs/5362/console