### PR TITLE
Document problems with publishing high priority content

### DIFF
--- a/source/manual/documents-are-published-but-links-arent-updated.html.md
+++ b/source/manual/documents-are-published-but-links-arent-updated.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#govuk-developers"
+title: Documents are published, but the links aren't up to date
+section: Publishing
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-09-19
+review_in: 6 months
+---
+
+This can happen when the Publishing API is still working through all of the
+pages that may have changed due to dependency resolution. You can find out if
+this is a problem [by monitoring Publishing API sidekiq queue][sidekiq-queue]
+and seeing if the downstream_low queue is high.
+
+To get things processed faster you can run the following Rake task on the
+Publishing API in Jenkins,
+[`represent_downstream:high_priority:content_id['some-content-id some-other-content-id']`][jenkins-task],
+which will re-represent them downstream via the high priority queue.
+
+[sidekiq-queue]: https://docs.publishing.service.gov.uk/manual/monitor-sidekiq-workers.html#header
+[jenkins-task]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[%27some-content-id%20some-other-content-id%27]

--- a/source/manual/help-with-publishing-high-priority-content.html.md
+++ b/source/manual/help-with-publishing-high-priority-content.html.md
@@ -1,0 +1,35 @@
+---
+owner_slack: "#govuk-developers"
+title: Help with publishing high priority content
+section: Publishing
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-09-19
+review_in: 6 months
+---
+
+When a department is publishing content that is high priority, it may be
+necessary to intervene to ensure it goes out as smoothly as possible.
+
+### [If documents are published and links aren't updated][links]
+
+You might see this happening if the format is still showing as "Coming Soon"
+on some pages.
+
+[links]: documents-are-published-but-links-arent-updated.html
+
+### [If the cache (our Varnish or Fastly CDN) needs clearing][cache]
+
+You may need to do this if the content is not showing on the live site quick
+enough.
+
+[cache]: cache-flush.html
+
+### [If guidance pages are expected to show on taxon pages but aren't][search]
+
+The guidance pages visible on topic pages like
+[/government/brexit](https://www.gov.uk/government/brexit) are populated based
+on search ranking, which is only updated over night, so it may be necessary to
+set it manually.
+
+[search]: manually-setting-search-popularity-of-content.html

--- a/source/manual/manually-setting-search-popularity-of-content.html.md
+++ b/source/manual/manually-setting-search-popularity-of-content.html.md
@@ -1,0 +1,28 @@
+---
+owner_slack: "#govuk-developers"
+title: Manually setting the search popularity of content
+section: Publishing
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2018-09-19
+review_in: 6 months
+---
+
+To look up the popularity of an item you can query rummager by `ssh`ing into
+`rummager-elasticsearch-1.production`.
+
+To looking up popularity of a particular item you will need its `base_path` URL
+encoded and then look it up with a `curl` command:
+
+```shell
+$ curl localhost:9200/government/edition/%2Fgovernment%2Fpublications%2Fdraft-capital-requirements-amendment-eu-exit-regulations-2018?fields=popularity
+```
+
+Once popularity is determined we can then update with the new popularity using
+the following command:
+
+```shell
+$ curl -XPOST
+localhost:9200/government/edition/%2Fgovernment%2Fpublications%2Fdraft-capital-requirements-amendment-eu-exit-regulations-2018/_update
+-d '{"doc": {"popularity": 10}}'
+```


### PR DESCRIPTION
Add some basic documentation that should be helpful when high priority content is being published and 2nd line need to manually intervene.

It's based heavily on a card that was written up when this happened recently.

[Trello Card](https://trello.com/c/9cqVuUDy/491-document-problems-dealing-with-high-priority-content)