### PR TITLE
Tidy up page sections

### DIFF
--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -2,7 +2,7 @@
 title: Run an A/B or multivariate test
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: A/B testing
 owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2018-07-03
 review_in: 6 months

--- a/source/manual/access-jenkins.html.md
+++ b/source/manual/access-jenkins.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Get access to Jenkins
-section: Deployment
+section: Accounts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-06

--- a/source/manual/add-a-new-document-type.html.md
+++ b/source/manual/add-a-new-document-type.html.md
@@ -2,7 +2,7 @@
 title: Add a new document type
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: Publishing
 owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2018-08-17
 review_in: 3 months

--- a/source/manual/add-deployment-dashboard.html.md
+++ b/source/manual/add-deployment-dashboard.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Add a deployment dashboard for an application
-section: Deployment
+section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-04

--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Add a disk to a vCloud machine (Carrenza only)
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-04

--- a/source/manual/architecture.html.md
+++ b/source/manual/architecture.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "@tijmen.brommet"
 title: Architectural overview of GOV.UK applications
-section: Basics
+section: Architecture
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-07-03

--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Brakeman
-section: Tools
+section: Testing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-03

--- a/source/manual/concept-of-stacks.html.md
+++ b/source/manual/concept-of-stacks.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Stacks in AWS
-section: AWS
+section: Architecture
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-03

--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -2,7 +2,7 @@
 title: Configure a GitHub repo
 parent: /manual.html
 layout: manual_layout
-section: Tools
+section: GitHub
 owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2018-04-12
 review_in: 6 months

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: Create a GPG key
 parent: "/manual.html"
 layout: manual_layout
-section: Support
+section: Accounts
 last_reviewed_on: 2018-04-12
 review_in: 6 months
 ---

--- a/source/manual/deploying-terraform.html.md
+++ b/source/manual/deploying-terraform.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Deploy AWS infrastructure with Terraform
-section: AWS
+section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-10

--- a/source/manual/dictionary.html.erb
+++ b/source/manual/dictionary.html.erb
@@ -2,7 +2,7 @@
 title: Dictionary
 parent: /manual.html
 layout: false
-section: Manual
+section: Architecture
 source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dictionary.yml
 ---
 

--- a/source/manual/docs-style-guide.html.md
+++ b/source/manual/docs-style-guide.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "@tijmen.brommet"
 title: Documentation style guide
-section: Manual
+section: Documentation
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-05

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: GOV.UK's environments (integration, staging, production)
-section: Environments
+section: Architecture
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-07-11

--- a/source/manual/gds-hubot.html.md
+++ b/source/manual/gds-hubot.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Update Hubot (Slack bot)
-section: Tools
+section: Team tools
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-03

--- a/source/manual/generate-csr.html.md
+++ b/source/manual/generate-csr.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Generate a Certificate Signing Request (CSR) for GOV.UK
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-08

--- a/source/manual/github-enterprise.html.md
+++ b/source/manual/github-enterprise.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: GitHub Enterprise
-section: Tools
+section: GitHub
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-02

--- a/source/manual/github-trello-poster.html.md
+++ b/source/manual/github-trello-poster.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: 'GitHub Trello Poster'
-section: Tools
+section: Team tools
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-02

--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -2,7 +2,7 @@
 title: How we use GitHub
 parent: /manual.html
 layout: manual_layout
-section: Tools
+section: GitHub
 owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2018-04-12
 review_in: 6 months

--- a/source/manual/give-a-content-designer-access-to-github.html.md
+++ b/source/manual/give-a-content-designer-access-to-github.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: Give a content designer access to GitHub
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: Accounts
 last_reviewed_on: 2018-09-11
 review_in: 3 months
 ---

--- a/source/manual/govuk-in-aws.html.md
+++ b/source/manual/govuk-in-aws.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: GOV.UK in AWS
-section: AWS
+section: Architecture
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-03

--- a/source/manual/graphite-and-deployment-dashboards.html.md
+++ b/source/manual/graphite-and-deployment-dashboards.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Graphite and deployment dashboards
-section: Tools
+section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-12

--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Access apps on the shared Heroku account
-section: Tools
+section: Accounts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-12

--- a/source/manual/howto-backup-and-restore-in-aws-rds.html.md
+++ b/source/manual/howto-backup-and-restore-in-aws-rds.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Backup and restore databases in AWS RDS
-section: AWS
+section: Backups
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-07-25

--- a/source/manual/howto-remove-change-note-from-whitehall.html.md
+++ b/source/manual/howto-remove-change-note-from-whitehall.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Remove a change note in Whitehall
-section: Whitehall
+section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-17

--- a/source/manual/howto-ssh-to-machines-in-aws.html.md
+++ b/source/manual/howto-ssh-to-machines-in-aws.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: SSH into AWS machines
-section: AWS
+section: AWS accounts 
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-02

--- a/source/manual/howto-switch-off-app.html.md
+++ b/source/manual/howto-switch-off-app.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Switch an app off
+title: Switch an app off temporarily
 layout: manual_layout
 section: Deployment
 parent: "/manual.html"

--- a/source/manual/howto-update-pingdom-ip-ranges.html.md
+++ b/source/manual/howto-update-pingdom-ip-ranges.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Update Pingdom IP ranges
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-04

--- a/source/manual/incident-management-guidance.html.md
+++ b/source/manual/incident-management-guidance.html.md
@@ -3,7 +3,7 @@ owner_slack: "@hong.nguyen"
 title: Incident management guidance
 parent: "/manual.html"
 layout: manual_layout
-section: 2nd line
+section: Incidents
 last_reviewed_on: 2018-07-19
 review_in: 2 months
 ---

--- a/source/manual/incident-reports.html.md
+++ b/source/manual/incident-reports.html.md
@@ -3,7 +3,7 @@ owner_slack: "@hong.nguyen"
 title: Write an incident report
 parent: "/manual.html"
 layout: manual_layout
-section: 2nd line
+section: Incidents
 last_reviewed_on: 2018-07-19
 review_in: 2 months
 ---

--- a/source/manual/incident-what-to-do.html.md
+++ b/source/manual/incident-what-to-do.html.md
@@ -3,7 +3,7 @@ owner_slack: "@hong.nguyen"
 title: So, you're having an incident
 parent: "/manual.html"
 layout: manual_layout
-section: 2nd line
+section: Incidents
 last_reviewed_on: 2018-07-19
 review_in: 2 months
 ---

--- a/source/manual/manage-sign-on-accounts.html.md
+++ b/source/manual/manage-sign-on-accounts.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Manage Signon accounts
-section: Support
+section: Accounts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-07-26

--- a/source/manual/managing-product-support-tickets-zendesk.html.md
+++ b/source/manual/managing-product-support-tickets-zendesk.html.md
@@ -2,7 +2,7 @@
 title: Manage product support tickets (Zendesk)
 parent: "/manual.html"
 layout: manual_layout
-section: Support
+section: 2nd line
 owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2018-10-02
 review_in: 6 months

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Merge a Pull Request
-section: Development & Reviews
+section: GitHub
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-04

--- a/source/manual/monitor-docs-traffic.html.md
+++ b/source/manual/monitor-docs-traffic.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "@tijmen.brommet"
 title: Monitor docs traffic
-section: Manual
+section: Documentation
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-05

--- a/source/manual/move-apps-between-servers.html.md
+++ b/source/manual/move-apps-between-servers.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Move apps between servers
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-03

--- a/source/manual/naming.html.md
+++ b/source/manual/naming.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Name a new application or gem
-section: Packaging
+section: Applications
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-20

--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Out of hours support (on-call)
-section: Support
+section: 2nd line
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-02

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Pact Broker
-section: Tools
+section: Testing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-05-15

--- a/source/manual/patching-jenkins.html.md
+++ b/source/manual/patching-jenkins.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: Patch Jenkins
 parent: "/manual.html"
 layout: manual_layout
-section: Testing
+section: Infrastructure tasks
 last_reviewed_on: 2018-07-26
 review_in: 6 months
 ---

--- a/source/manual/post-a-statuspage-message.html.md
+++ b/source/manual/post-a-statuspage-message.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Post a message on the status page
-section: 2nd line
+section: Incidents
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-01
@@ -47,7 +47,7 @@ Example messages:
 > We’re looking into an issue with Whitehall Publisher which is causing attachment uploads to fail. We’ll update this page as soon as we know what's causing it.
 
 <!-- -->
-> We're looking into a delay that's occuring when trying to publish new content. Your content may appear on the site later than usual. 
+> We're looking into a delay that's occuring when trying to publish new content. Your content may appear on the site later than usual.
 
 <!-- -->
 > We're looking into a problem that means email alerts aren't being sent out as quickly as they should. We'll update this page as soon as we know what's causing it.

--- a/source/manual/publishing-a-ruby-gem.html.md
+++ b/source/manual/publishing-a-ruby-gem.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Publish a Ruby gem
-section: Patterns & Style Guides
+section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-05

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: RabbitMQ
-section: Tools
+title: Manage RabbitMQ
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-05-17

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Reboot a machine
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 important: true

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: Remove a machine
 parent: "/manual.html"
 layout: manual_layout
-section: Environments
+section: Infrastructure tasks
 last_reviewed_on: 2018-09-04
 review_in: 6 months
 ---

--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -1,9 +1,9 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Removing a user from Puppet
+title: Remove a user from Puppet
 parent: "/manual.html"
 layout: manual_layout
-section: 2nd line
+section: Accounts
 last_reviewed_on: 2018-05-18
 review_in: 12 months
 ---

--- a/source/manual/renew-a-tls-certificate.html.md
+++ b/source/manual/renew-a-tls-certificate.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Renew a TLS certificate for GOV.UK
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-10-08

--- a/source/manual/reprovision.html.md
+++ b/source/manual/reprovision.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Reprovision a machine
-section: Environments
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-03-22

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Retire an application
-section: Deployment
+section: Applications
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-06

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "@tijmen.brommet"
 title: Review a page in this manual
-section: Manual
+section: Documentation
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-08-31

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Add a new Ruby version
-section: Tools
+section: Infrastructure tasks
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-07-19

--- a/source/manual/schemas.html.md
+++ b/source/manual/schemas.html.md
@@ -1,14 +1,14 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Schemas
+title: Schema.org structured data
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: Publishing
 last_reviewed_on: 2018-09-10
 review_in: 12 months
 ---
 
-Here are a list of schemas being used on GOV.UK
+Here are a list of [schema.org](https://schema.org) markup being used on GOV.UK
 
 ## [HowTo][how-to]
 Used in step-by-step, for example, [learn to drive a car][learn-to-drive-a-car]
@@ -17,7 +17,7 @@ Used in step-by-step, for example, [learn to drive a car][learn-to-drive-a-car]
 [learn-to-drive-a-car]: https://www.gov.uk/learn-to-drive-a-car
 
 ## [NewsArticle][news-article]
-Used in News Story, for example, [asian hornet identified in cornwall][hornet-news-story] 
+Used in News Story, for example, [asian hornet identified in cornwall][hornet-news-story]
 
 [news-article]: https://schema.org/NewsArticle
 [hornet-news-story]: https://www.gov.uk/government/news/asian-hornet-identified-in-cornwall
@@ -28,7 +28,7 @@ Used for Topics, for example, [student finance][student-finance]
 [article]: https://schema.org/Article
 [student-finance]: https://www.gov.uk/student-finance
 
-## [BreadcrumbList][breadcumb-list] 
+## [BreadcrumbList][breadcumb-list]
 Used when there is chain of linked Web pages, for example, [attorney generals office][attorney-generals-office]
 
 [breadcumb-list]: https://schema.org/BreadcrumbList
@@ -38,4 +38,3 @@ Used when there is chain of linked Web pages, for example, [attorney generals of
 Used for a governmental organization or agency, for example, [attorney generals office][attorney-generals-office]
 
 [government-org]: https://schema.org/GovernmentOrganization
-

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: Monitoring screens
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: Monitoring
 last_reviewed_on: 2018-09-06
 review_in: 12 months
 ---

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Set up a new Rails app
-section: Deployment
+title: Set up a new Rails application
+section: Applications
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-04

--- a/source/manual/sidekiq-retries.html.md
+++ b/source/manual/sidekiq-retries.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: Sidekiq
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: Monitoring
 last_reviewed_on: 2018-06-14
 review_in: 6 months
 ---

--- a/source/manual/ssh-config.html.md
+++ b/source/manual/ssh-config.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline"
 title: SSH Configuration
 parent: "/manual.html"
 layout: manual_layout
-section: Tools
+section: Accounts
 last_reviewed_on: 2018-10-09
 review_in: 6 months
 ---

--- a/source/manual/testing.html.md
+++ b/source/manual/testing.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Test Ruby projects
-section: Patterns & Style Guides
+section: Testing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-05

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: 'Tools: Icinga, Grafana and Graphite, Kibana and Fabric'
-section: Tools
+section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-03-26

--- a/source/manual/use-terraboard-to-monitor-terraform-state.html.md
+++ b/source/manual/use-terraboard-to-monitor-terraform-state.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-platform-health"
 title: Use Terraboard to monitor Terraform state
-section: AWS
+section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-09-27

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "@tijmen.brommet"
 title: Where to find what documentation
-section: Manual
+section: Documentation
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2018-04-05

--- a/source/manual/who-do-i-ask-for-support.html.md
+++ b/source/manual/who-do-i-ask-for-support.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-platform-health"
 title: Who do I ask for support?
 parent: "/manual.html"
 layout: manual_layout
-section: Support
+section: Basics
 last_reviewed_on: 2018-08-17
 review_in: 3 months
 ---


### PR DESCRIPTION
This tidies up the page sections for the pages in the manual.

Highlights:

- Split up "AWS" into separate sections
- Add an "Accounts" section for access-related things
- Move a lot out of "Tools" into more appropriate sections

## Preview

https://govuk-developer-docs-pr-1273.herokuapp.com/manual.html