### PR TITLE
Updates review date for bowl error documentation

### DIFF
--- a/source/manual/bowl-error.html.md
+++ b/source/manual/bowl-error.html.md
@@ -4,7 +4,7 @@ title: Using `bowl` fails with bundler error
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-03-28
+last_reviewed_on: 2018-10-12
 review_in: 6 months
 ---
 


### PR DESCRIPTION
Looked at the documentation, it is still valid and works. (Used it myself only a few days ago).