### PR TITLE
Update encrypted hiera data docs

### DIFF
--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -4,7 +4,7 @@ title: Handle encrypted hieradata
 parent: "/manual.html"
 layout: manual_layout
 section: Deployment
-last_reviewed_on: 2018-07-20
+last_reviewed_on: 2018-10-16
 review_in: 6 months
 ---
 
@@ -18,11 +18,11 @@ Hiera eYAML GPG acts as a
 [backend](https://docs.puppetlabs.com/hiera/1/custom_backends.html) to
 Hiera; like a plugin. It enables us to encrypt Hiera data using GPG
 keys. In our case, we encrypt the data using the GPG keys of all
-security-cleared members of 2nd line.
+security-cleared developers on GOV.UK.
 
 Hiera eYAML GPG only encrypts the Hiera values, rather than the whole file.
 It also encrypts each Hiera value individually, so you can see which ones
-changed in a Git commit.
+changed in a git commit.
 
 ## What Hiera data do we encrypt?
 
@@ -45,27 +45,23 @@ this is intentional for reasons of simplicity.
 ## Why do we encrypt Hiera data?
 
 We store secrets and sensitive data in a separate repository,
-[alphagov/govuk-secrets](https://github.com/alphagov/govuk-secrets). This lets
-us open the [alphagov/govuk-puppet](https://github.com/alphagov/govuk-puppet)
+[govuk-secrets](https://github.com/alphagov/govuk-secrets). This lets
+us open the [govuk-puppet](https://github.com/alphagov/govuk-puppet)
 repository to all developers, while restricting access to the
-`alphagov/govuk-secrets` repository to a small number of staff.
+govuk-secrets repository to a small number of staff.
 
-Deploying puppet copies `alphagov/govuk-secrets` over the
-files in the [alphagov/govuk-puppet](https://github.com/alphagov/govuk-puppet)
-repository.
+Deploying puppet copies govuk-secrets over the files in the
+[govuk-puppet](https://github.com/alphagov/govuk-puppet) repository.
 
-This patten enables us to restrict access to sensitive credentials while
-still allowing developers to access the main Puppet repository.
-
-Even though we restrict who can see `govuk-secrets` there are still downsides
-to storing secrets in plaintext:
+Even though we restrict who can see govuk-secrets, there are still downsides
+to storing secrets in plain text:
 
 -   It's dangerous to leave sensitive data unencrypted on disk. Even if
-    everyone who has access to the `alphagov/govuk-secrets` repository uses
+    everyone who has access to the govuk-secrets repository uses
     full disk encryption, secrets would be readable if a laptop is infected by
     malware, or if someone accidentally commits to a public repository or
     copies to an unencrypted disk.
--   GitHub notifications send secrets over plaintext email if users comment
+-   GitHub notifications send secrets over plain text email if users comment
     on specific lines of a pull request that include changes to sensitive data.
 -   A vulnerability in GitHub or an administrative error when setting
     access permissions could expose secrets.
@@ -74,9 +70,8 @@ By encrypting Hiera data using GPG, we can define who has access to these
 secrets (using GPG keys) and we have the extra protection of GPG encryption,
 which gives us time to change credentials when secrets are exposed.
 
-There are no plans to merge the `alphagov/govuk-puppet` and
-`alphagov/govuk-secrets` repositories. Having them separate still provides
-extra protection against accidental exposure.
+There are no plans to merge the govuk-puppet and govuk-secrets repositories.
+Having them separate still provides extra protection against accidental exposure.
 
 ## Common tasks for handling encrypted Hiera data
 
@@ -86,7 +81,7 @@ encrypted data.
 There is a
 [Rakefile](https://github.com/alphagov/govuk-secrets/blob/master/puppet/Rakefile)
 in the puppet/ directory of the
-[alphagov/govuk-secrets](https://github.com/alphagov/govuk-secrets) repository
+[govuk-secrets](https://github.com/alphagov/govuk-secrets) repository
 which wraps the Hiera eYAML tool and helps to ensure that sensitive data is
 only accessible to the intended recipients.
 
@@ -95,48 +90,18 @@ You must use the rake tasks to change encrypted Hiera data.
 ### Prerequisites
 
 1.  Pull the latest changes from the
-    [alphagov/govuk-secrets](https://github.com/alphagov/govuk-secrets) repo
+    [govuk-secrets](https://github.com/alphagov/govuk-secrets) repository.
 
-2.  Next, run `bundler(1)` to install dependencies:
+2.  Run `bundler` to install dependencies:
 
         cd puppet/
         bundle install
-
-3.  You'll need to [create a GPG key](create-a-gpg-key.html)
-    before you can access or modify encrypted Hiera data.
-
-4.  You will need to ask someone who already has access to the
-    credential file to add your GPG fingerprint to the relevant
-    recipient file and re-encrypt the credential file so that you can
-    access it.
-
-    You can find your GPG fingerprint by running:
-
-        gpg --fingerprint
-
-    To re-encrypt the credentials, ask the person with access to run:
-
-        bundle exec rake eyaml:recrypt[integration]
-
-    ...where integration is the name of the environment whose
-    credentials you wish to access.
-
-Once complete, you should run `git pull` to obtain the re-encrypted copy.
-
-You should now be able to use the `rake(1)` tasks below to access and
-modify encrypted Hiera data.
-
-> **NOTE**
->
-> If you use [ZSH](http://zsh.sourceforge.net/) as your local shell, you
-> will need to either enclose the rake(1) command in single quotes or
-> set the
-> [noglob](http://zsh.sourceforge.net/Doc/Release/Options.html#index-NOGLOB)
-> option.
+        cd puppet_aws/
+        bundle install
 
 ### Encrypting a Hiera key
 
-1.  Where integration is the name of the environment whose credentials
+1.  Where `integration` is the name of the environment whose credentials
     you wish to edit, run:
 
         bundle exec rake eyaml:edit[integration]
@@ -174,16 +139,19 @@ modify encrypted Hiera data.
     > example: DEC::GPG(1). You should not make any changes to the number, as
     > Hiera eYAML GPG uses this to identify existing encrypted data.
 
-3. Check that the value is really encrypted! If you make a typo in your markup, Hiera Eyaml doesn't always treat it as an error.
+3.  Check that the value is really encrypted! If you make a typo in your markup,
+    Hiera eYAML doesn't always treat it as an error.
 
         GIT_PAGER='less -S' git diff
 
 ## Managing access to encrypted Hiera data
 
-The list of people that have access to encrypted Hiera data in stored in
-'recipient' file specific to each environment (`.rcp` extension).
+The list of people that have access to encrypted Hiera data in stored in a
+recipient file specific to each environment (`.rcp` extension).
 
-The production and integration files are stored in the [govuk-secrets repo](https://github.com/alphagov/govuk-secrets/tree/master/puppet/gpg_recipients).
+The production and integration files are stored in the govuk-secrets repo for
+[Carrenza](https://github.com/alphagov/govuk-secrets/tree/master/puppet/gpg_recipients)
+and [AWS](https://github.com/alphagov/govuk-secrets/tree/master/puppet_aws/gpg_recipients).
 There is no separate staging file; the production file is used for both
 staging and production.
 
@@ -194,6 +162,29 @@ usually is identified by a comment after the hash (\#) symbol denoting
 its owner. Each GPG key (and owner of that key) listed in the recipient
 file is able to decrypt data belonging to the environment that the
 recipient file pertains to.
+
+### What to do when someone joins
+
+1.  Ask the joiner to [create a GPG key](create-a-gpg-key.html) and upload it
+    to a public key server (such as <https://pgp.mit.edu/>).
+2.  Get the fingerprint of the new GPG key by running `gpg --fingerprint`.
+3.  Add the joiners's GPG fingerprint to each of the recipient files
+    for Carrenza
+    [integration](https://github.com/alphagov/govuk-secrets/blob/master/puppet/gpg_recipients/integration_hiera_gpg.rcp)
+    and [production](https://github.com/alphagov/govuk-secrets/blob/master/puppet/gpg_recipients/production_hiera_gpg.rcp),
+    AWS [integration](https://github.com/alphagov/govuk-secrets/blob/master/puppet_aws/gpg_recipients/integration_hiera_gpg.rcp)
+    and [production](https://github.com/alphagov/govuk-secrets/blob/master/puppet_aws/gpg_recipients/production_hiera_gpg.rcp),
+    and
+    [Vagrant](https://github.com/alphagov/govuk-puppet/blob/master/gpg_recipients/vagrant_hiera_gpg.rcp).
+    There are no staging recipient files since these are the same as the
+    production recipient files.
+4.  Recrypt the hieradata by running `re-encrypt-all.sh <message>` where `<message>`
+    is something like "Adding new key for Jane Smith".
+5.  Commit your changes and raise a pull request for review.
+6.  Take care when rebasing changes to master that have been merged since you
+    started your PR. The encrypted hieradata files are effectively binary data
+    that git's text diff may not correctly merge. You will likely have to
+    reset your recrypted versions and start again from the versions on master.
 
 ### What to do when someone leaves
 
@@ -208,19 +199,14 @@ credentials.
     and [production](https://github.com/alphagov/govuk-secrets/blob/master/puppet_aws/gpg_recipients/production_hiera_gpg.rcp),
     and
     [Vagrant](https://github.com/alphagov/govuk-puppet/blob/master/gpg_recipients/vagrant_hiera_gpg.rcp).
-    There are separate recipients file for staging on Carrenza and AWS as these
-    environments share the production key list.
-2.  Recrypt the hieradata that they had access to with the recrypt rake task.
-    For example `bundle exec rake 'eyaml:recrypt[integration]` to recrypt the
-    integration hieradata.  For AWS remember to recrypt all the hieradata files
-    - the common ones and any for individual stacks. For example `bundle exec
-    rake 'eyaml:recrypt[integration] && bundle exec rake
-    'eyaml:recrypt[integration,blue]` to recrypt the common integration
-    hieradata and the integration hieradata for the "blue" stack.
+    There are no staging recipient files since these are the same as the
+    production recipient files.
+2.  Recrypt the hieradata by running `re-encrypt-all.sh <message>` where `<message>`
+    is something like "Removing key for Jane Smith".
 3.  Commit your changes and raise a pull request for review.
 4.  Take care when rebasing changes to master that have been merged since you
-    started your PR.  The encrypted hieradata files are effectively binary data
-    that git's text diff may not correctly merge.  You will likely have to
+    started your PR. The encrypted hieradata files are effectively binary data
+    that git's text diff may not correctly merge. You will likely have to
     reset your recrypted versions and start again from the versions on master.
 
 > **WARNING**
@@ -238,7 +224,7 @@ credentials.
 > credentials file can still be read by anyone with a GPG key previously
 > listed in the recipient list.
 
-### How to (re)generate GPG keys for an environment
+## How to (re)generate GPG keys for an environment
 
 If a new environment is added or the Puppet GPG key for an existing environment
 expires or is compromised, a new GPG key must be generated. This key allows
@@ -256,8 +242,8 @@ To generate a new key:
     passphrase when prompted.
 3.  Depending on the version of `gpg` you are using, you may end up with either
     `.gpg` or `.kbx` files saved to the [2ndline password store](https://github.com/alphagov/govuk-secrets/tree/master/pass) in the
-    [alphagov/govuk-secrets](https://github.com/alphagov/govuk-secrets)
-    repository, or in the `gpg` directory of the [alphagov/govuk-puppet](https://github.com/alphagov/govuk-puppet)
+    [govuk-secrets](https://github.com/alphagov/govuk-secrets)
+    repository, or in the `gpg` directory of the [govuk-puppet](https://github.com/alphagov/govuk-puppet)
     repository if you are generating a key for the 'vagrant' environment.
 4.  If you have `.kbx` files as a result of step 3, you'll need to export the
     public and secret keys into `.gpg` files by running
@@ -291,11 +277,11 @@ To generate a new key:
 
 The GPG key, stored in the [2ndline password
 store](https://github.com/alphagov/govuk-secrets/tree/master/pass) in the
-[alphagov/govuk-secrets](https://github.com/alphagov/govuk-secrets) repository,
+[govuk-secrets](https://github.com/alphagov/govuk-secrets) repository,
 must be installed on the Puppet Master so that encrypted Hiera data is available
 to Puppet:
 
-1.  Remove the passphrase from the secret key, where 6DB296C0 is the ID or
+1.  Remove the passphrase from the secret key, where `6DB296C0` is the ID or
     fingerprint of the new key (the Puppet Master requires a secret key without
     a passphrase):
 
@@ -309,13 +295,13 @@ to Puppet:
           $ gpg --export-secret-key 6DB296C0 > secring.gpg
 
 2.  SSH to the Puppet Master (for example,
-    `puppetmaster-1.management.integration`).
+    `puppetmaster-1.management.staging`).
 3.  Change to the root user (`sudo su -`).
 4.  Go to `/etc/puppet/gpg`.
 5.  Create a new folder (for example, `old`) and move all files currently in the
     `gpg` folder into there as a backup.
 6.  Copy the new files to the Puppet Master using rsync from your local machine:
-    `rsync --rsync-path="sudo rsync" ~/govuk/govuk-secrets/pass/2ndline/hiera-eyaml-gpg/integration/* puppetmaster-1.management.integration:/etc/puppet/gpg/`
+    `rsync --rsync-path="sudo rsync" ~/govuk/govuk-secrets/pass/2ndline/hiera-eyaml-gpg/integration/* puppetmaster-1.management.staging:/etc/puppet/gpg/`
 7.  Make sure the new files have the correct permissions:
     `sudo chown -R puppet: /etc/puppet/gpg` and
     `sudo chmod -R 0700 /etc/puppet/gpg`.
@@ -325,7 +311,7 @@ to Puppet:
 
 > **WARNING**
 >
-> Make sure not to copy the Production GPG key to the Integration environment.
+> Make sure **not** to copy the production GPG key to the integration environment.
 
 > **NOTE**
 >
@@ -386,7 +372,7 @@ This error can occur for the following reasons:
 -   Puppet cannot find a GPG keyring in `/etc/puppet/gpg`. This
     should only occur in development or test VMs **or** on the
     Puppet Master. If this is a non-Vagrant environment (e.g.
-    Production), check that you have copied the GPG keys from the
+    production), check that you have copied the GPG keys from the
     2ndline pass store to `/etc/puppet/gpg` - see [configuring the Puppet Master](#configuring-the-puppet-master).
     Servers running `puppet-agent` do not require a GPG key as they
     rely on the Puppet Master to provide and, when necessary, decrypt
@@ -404,7 +390,7 @@ This error can occur for the following reasons:
 -   The shared folder configured in the
     [Vagrantfile](https://github.com/alphagov/govuk-puppet/blob/master/Vagrantfile)
     for Vagrant boxes is not being mounted correctly at `/etc/puppet/gpg`.
-    Check the output of mount(1) and try reloading the machine using:
+    Check the output of `mount` and try reloading the machine using:
 
         vagrant reload
 
@@ -426,7 +412,7 @@ for the development VM:
 Alternatively, you can add the `$LOAD_PATH` to `/usr/bin/puppet` as shown
 in [this commit](https://github.com/alphagov/govuk-puppet/commit/b7743452875b1dd83fda982e28ae8e776bc3a8b8).
 
-### Zsh: no matches found
+### zsh: no matches found
 
 If you encounter an error similar to
 


### PR DESCRIPTION
This commit makes a number of tweaks and changes to the encrypted hiera data documentation, mostly to clarity the new joiners process and also remove duplicated content.