### PR TITLE
How to change a base_path for a specialist document

### DIFF
--- a/source/manual/change-base-path-in-specialist-publisher.html.md
+++ b/source/manual/change-base-path-in-specialist-publisher.html.md
@@ -1,0 +1,24 @@
+---
+title: Change a specialist document base path
+parent: "/manual.html"
+layout: manual_layout
+section: Publishing
+owner_slack: "#govuk-2ndline"
+last_reviewed_on: 2018-10-17
+review_in: 3 months
+---
+
+In [Specialist Publisher](https://specialist-publisher.publishing.service.gov.uk/), the base path is automatically generated based on the title when the specialist document is first created. We sometimes receive Zendesk tickets to change a base path when the title has been updated, as the publisher does not have the ability to do this.
+
+You can use the Jenkins rake task runner to run the task:
+
+```
+base_path:edit[content_id,new_base_path]
+```
+
+[⚙ Run rake task on production][change]
+
+[change]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=specialist-publisher&MACHINE_CLASS=backend&RAKE_TASK=base_path:edit[content_id,/new_base_path]
+
+> **Note**
+>You can find the `content_id` of the document using the [govuk-toolkit](https://github.com/alphagov/govuk-browser-extension) browser extension.


### PR DESCRIPTION
We now have a rake task that updates a document's `base_path` in `specialist-publisher`. This often comes through to 2ndline as a Zendesk request so is worth adding information on how to do this.

Dependent on these PR's being merged and deployed:
https://github.com/alphagov/specialist-publisher/pull/1317
https://github.com/alphagov/specialist-publisher/pull/1318

Trello card: https://trello.com/c/kTKWF48j/530-document-how-to-change-a-url-in-specialist-publisher