### PR TITLE
Add platformhealth-powerusers AWS role

### DIFF
--- a/source/manual/aws-console-access.html.md
+++ b/source/manual/aws-console-access.html.md
@@ -37,6 +37,7 @@ Options for "Role":
 
 - `govuk-administrators`
 - `govuk-powerusers`
+- `govuk-platformhealth-powerusers`
 - `govuk-users`
 
 ![gds-users-switch-role-form](images/gds-users-switch-role-form.png)

--- a/source/manual/deploying-terraform.html.md
+++ b/source/manual/deploying-terraform.html.md
@@ -17,7 +17,7 @@ Which changes you can deploy depends on the level of access you have
 to our AWS environments.
 
 - `govuk-users` can't deploy anything
-- `govuk-powerusers` can deploy everything except IAM, ie users and policies.
+- `govuk-powerusers` and `govuk-platformhealth-powerusers` can deploy everything except IAM (users and policies).
 - `govuk-administrators` can deploy everything including IAM.
 
 You can find which class of user you are [in the infra-security

--- a/source/manual/set-up-aws-account.html.md
+++ b/source/manual/set-up-aws-account.html.md
@@ -41,6 +41,7 @@ Add yourself to a lists of users found in [the data for the infra-security proje
 
 - `govuk-administrators`: people in Reliability Engineering who are working on GOV.UK infrastructure, Architects and Lead Developers of GOV.UK and anyone else working on the AWS migration
 - `govuk-powerusers`: anyone else who can have production access on GOV.UK
+- `govuk-platformhealth-powerusers`: as above but for members of the GOV.UK Platform Health team
 - `govuk-users`: anyone else who needs integration access on GOV.UK
 
 The identifier you need to add is called the "User ARN". You can find this by going


### PR DESCRIPTION
This commit adds the `platformhealth-powerusers` role to the relevant AWS documentation to explain what it is.