### PR TITLE
Add IAM link to AWS command line setup

### DIFF
--- a/source/manual/aws-cli-access.html.md
+++ b/source/manual/aws-cli-access.html.md
@@ -4,7 +4,7 @@ title: Use AWS on the command line
 section: AWS accounts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-10-10
+last_reviewed_on: 2018-11-02
 review_in: 3 months
 ---
 

--- a/source/manual/aws-cli-access.html.md
+++ b/source/manual/aws-cli-access.html.md
@@ -8,14 +8,16 @@ last_reviewed_on: 2018-10-10
 review_in: 3 months
 ---
 
-💡 Before you can access something in AWS, you [need to set up your AWS account](/manual/set-up-aws-account.html).
+💡 Before you can access something in AWS, you [need to set up your AWS
+account][set-up-account].
 
 ---
 
 ## 1. Create `~/.aws/config`
 
-1. You can find the `role_arn` in the ["Role ARN" table in the docs][secret-docs]
-1. You can find your `mfa_serial` under "Assigned MFA device" in your user profile [in the AWS Console](/manual/aws-console-access.html):
+1. You can find the `role_arn` in the ["Role ARN" table][secret-docs]
+1. You can find your `mfa_serial` under "Assigned MFA device" in your user
+   profile [in the AWS Console][aws-console]:
 
   ![](images/aws-how-to-get-mfa.png)
 
@@ -53,7 +55,10 @@ To test your configuration run:
 aws --profile govuk-integration s3 ls
 ```
 
-You should be prompted for an MFA token. If successful, you should receive some output.
+You should be prompted for an MFA token. If successful, you should receive some
+output.
 
+[set-up-account]: /manual/set-up-aws-account.html
+[aws-console]: /manual/aws-console-access.html
 [secret-docs]: https://github.com/alphagov/govuk-aws-data/blob/master/docs/govuk-aws-accounts.md
 [access-keys]: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys

--- a/source/manual/aws-cli-access.html.md
+++ b/source/manual/aws-cli-access.html.md
@@ -17,7 +17,8 @@ account][set-up-account].
 
 1. You can find the `role_arn` in the ["Role ARN" table][secret-docs]
 1. You can find your `mfa_serial` under "Assigned MFA device" in your user
-   profile [in the AWS Console][aws-console]:
+   profile [in the AWS Console][aws-console], under the [IAM
+   service][iam-service]:
 
   ![](images/aws-how-to-get-mfa.png)
 
@@ -60,5 +61,6 @@ output.
 
 [set-up-account]: /manual/set-up-aws-account.html
 [aws-console]: /manual/aws-console-access.html
+[iam-service]: https://console.aws.amazon.com/iam/home?#/users
 [secret-docs]: https://github.com/alphagov/govuk-aws-data/blob/master/docs/govuk-aws-accounts.md
 [access-keys]: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys


### PR DESCRIPTION
Make life easier for folks who are less au fait with the AWS console.