### PR TITLE
CDN logs are now stored on monitoring-1, not logs-cdn-1

### DIFF
--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -16,8 +16,8 @@ period of time.
 The alert appears on `monitoring-1.management`. A good starting point for
 investigation is to examine the Fastly CDN logs.
 
-- `ssh logs-cdn-1.management.production`
-- `cd /mnt/logs_cdn` to access log files
+- `ssh monitoring-1.management.production`
+- `cd /var/log/cdn` to access log files
 
 Alternatively you can look in [Kibana](/manual/tools.html#kibana) with the query
 `application:"govuk-cdn-logs-monitor"`

--- a/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
+++ b/source/manual/alerts/logs-are-not-being-received-from-the-cdn.html.md
@@ -9,16 +9,15 @@ review_in: 6 months
 ---
 
 Sometimes, we stop receiving either GOV.UK or Bouncer logs from Fastly
-to `logs-cdn-1.management`. We run Rsyslog on this machine, and Fastly
+to `monitoring-1.management`. We run Rsyslog on this machine, and Fastly
 send us logs using Syslog on their side to a port we have previously
 specified.
 
-Firstly, look at how old and how large `/mnt/logs_cdn/cdn-govuk.log` or
-`/mnt/logs_cdn/cdn-bouncer.log` is. In GOV.UK's case, the file should be
-created early in the morning each day, and the file size should be
-positive and greater than 0 bytes. At the end of each day, a file is
-created for the following day, the previous day's file is gzipped up.
-Bouncer's logs rotate once per hour.
+Firstly, look at how old and how large `/var/log/cdn/cdn-govuk.log` or
+`/var/log/cdn/cdn-bouncer.log` is. In GOV.UK's case, the file should
+be created each hour, and the file size should be positive and greater
+than 0 bytes. These log files rotate once per hour, with the previous
+hour gzipped up.
 
 To fix, try (in order):
 
@@ -37,8 +36,8 @@ To fix, try (in order):
     Fastly are currently unable to log to our endpoint.
 
 -   restarting Rsyslog on the box: `sudo service rsyslog restart`, then
-    `sudo tail -f /mnt/logs_cdn/cdn-govuk.log`, or
-    `/mnt/logs_cdn/cdn-bouncer.log`, to check that logs are being
+    `sudo tail -f /var/log/cdn-govuk.log`, or
+    `/var/log/cdn-bouncer.log`, to check that logs are being
     streamed in to us. You'll be able to see when they are, as the
     file size increases and human-readable log lines are entered in to
     that file. It can take as long as 45 minutes for logs to start

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -32,7 +32,7 @@ These are deployed to [integration][integration_cdn], [staging][staging_cdn]
 and [production][production_cdn].
 
 Some configuration isn't scripted, such as logging. The www, bouncer and assets
-services sends logs to S3 and stream them to `logs-cdn-1`. These logging
+services sends logs to S3 and stream them to `monitoring-1`. These logging
 endpoints are configured directly in the Fastly UI. There is
 [documentation](/manual/query-cdn-logs.html) on how to query the CDN logs.
 

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -68,7 +68,7 @@ There's some documentation on [useful Kibana queries for 2nd line][kibana-docs].
 Fastly sends logs to multiple locations for the www, assets and bouncer
 services:
 
-- via syslog to the logs-cdn-1 boxes in all environments (`/mnt/logs_cdn`),
+- via syslog to the monitoring-1 boxes in all environments (`/var/log/cdn`),
   available immediately
 - to an S3 bucket per environment, available every 10 minutes
 

--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -13,8 +13,8 @@ and are stored for 90 days. The data in these log files can be queried via
 [Amazon Athena][] to gain a variety of insights into GOV.UK traffic.
 
 If you need to access the logs within 15 minutes of the request you can
-access the log files on the `logs-cdn-1` server. These are sent via syslog and
-are available in the `/mnt/logs_cdn/` directory.
+access the log files on the `monitoring-1` server. These are sent via syslog and
+are available in the `/var/log/cdn/` directory.
 
 [Amazon Athena]: https://aws.amazon.com/athena/
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/D8dyNE9y/524-transition-athena-logs-stretch-goal-remove-logs-cdn-1)