### PR TITLE
Update instructions for migrating between CKAN instances

### DIFF
--- a/source/manual/data-gov-uk-migrating-ckan.html.md
+++ b/source/manual/data-gov-uk-migrating-ckan.html.md
@@ -4,102 +4,65 @@ title: Migrating data between CKAN instances
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-10-11
+last_reviewed_on: 2018-11-15
 review_in: 6 weeks
 ---
 [ckanext-datagovuk-github]: https://github.com/alphagov/ckanext-datagovuk
 
 ### Accessing CKAN
 
-In order to transfer data between CKAN instances, it is required to dump the content of the old instance into JSONL format, do a conversion to the new schema, then reload into a new instance.  This can be done using the CKAN API, by installing [ckanapi](https://github.com/ckan/ckanapi) on your local machine.
-
-For a local CKAN, you must append the path to the `ckan.ini` file:
-
-```
-ckanapi -c CKAN_INI ...
-```
-
-To administer a remote instance, you will require a sysadmin account, your username and an API key (obtained through the web interface).  Append the remote URL and API key to each ckanapi request, in place of the `-c` flag:
-
-```
-ckanapi -r URL -a API_KEY ...
-```
+In order to transfer data between CKAN instances, it is required to dump the
+CKAN database, reload into a new instance then perform the data migration.
 
 #### Dumping data
 
-Active data (i.e. everything that is publicly available) can be retrieved through the API.  To dump data that is not available publicly, you must use an API key belonging to a sysadmin user.
-
-Dumping users:
+Log into the Bytemark production machine and dump the database:
 
 ```
-ckanapi dump users --all -O USER_FILE.jsonl.gz -z -p 4
+ssh co@co-prod3.dh.bytemark.co.uk pg_dump ckan > ckan_dump.sql
 ```
 
-Dumping publishers:
+Log into the new machine in the correct environment and copy the file using SCP:
 
 ```
-ckanapi dump organizations --all -O ORGANIZATION_FILE.jsonl.gz -z -p 4
+scp co@co-prod3.dh.bytemark.co.uk:ckan_dump.sql /some/local/directory
 ```
 
-Dumping datasets:
+Load the database dump into the new environment:
 
 ```
-ckanapi dump datasets --all -O DATASET_FILE.jsonl.gz -z -p 4
-```
-
-Retrieve the user data from Drupal (this is a nightly dumped file):
-
-```
-rsync -L --progress co@co-prod3.dh.bytemark.co.uk:/var/lib/ckan/ckan/dumps_with_private_data/drupal_users_table.csv.gz DRUPAL_USER_DUMP.csv.gz
+sudo -u postgres psql -c 'CREATE DATABASE ckan;'
+sudo -u postgres psql ckan -f /some/local/directory/ckan_dump.sql
 ```
 
 #### Data schema migration
 
-The data schema for the two CKAN instances may not match.  Therefore a conversion is required to allow the dump to be imported to the new CKAN installation.  Scripts are available in [ckanext-datagovuk][ckanext-datagovuk-github] to enable this.
+The data schema and models for the two CKAN instances do not match.  Therefore a
+conversion is required to allow the dump to be used with the new CKAN
+installation.  Scripts are available in
+[ckanext-datagovuk][ckanext-datagovuk-github] to enable this.
 
-Migrating users and publishers (this is a single step as user-publisher assignment is updated at the same time):
+##### Data models
 
-```
-python import/migrate_users.py USER_FILE.json.gz DRUPAL_USER_DUMP.csv.gz USER_MIGRATED_FILE.jsonl.gz ORGANIZATION_FILE.jsonl.gz ORGANIZATION_MIGRATED_FILE.jsonl.gz
-```
-
-Migrating datasets:
-
-```
-python import/migrated_datasets.py -s DATASET_FILE.jsonl.gz -o DATASET_MIGRATED_FILE.jsonl.gz
-```
-
-It is also possible to trim the datasets file to include only datasets that have been modified/created since a specific time (as a ISO8601 timestamp, e.g. 2018-04-12T17:07:36.284461).  This allows for faster incremental imports:
+The changes to the models are included in a single SQL migration script.  This
+modifies the data to make it compatible with changes made in the new DGU
+instance of CKAN.  It also removes non-publishing users and some deprecated
+features, such as tags.
 
 ```
-python import/incremental_update.py -s DATASET_FILE.jsonl.gz -o DATASET_MIGRATED_FILE.jsonl.gz -t TIMESTAMP
+sudo -u postgres psql ckan -f /path/to/ckanext-datagovuk/migrations/001_bytemark_to_govuk.sql
 ```
 
-#### Importing data
+> All sysadmin users will be demoted when running this migration.  They must be
+> promoted again after the migration is complete.  This is to ensure only
+> relevant people are given sysadmin access on the new system.
 
-CKAN supports the bulk import of data (users, publishers and datasets) from a JSONL file representing the data to be imported.  If a record already exists (based on the UUID on the object), CKAN will perform a comparison and update the record with changes from the import file.  Data from the import file will always overwrite data in the database in the event of a conflict.
+##### Database schema
 
-Importing users:
-
-```
-ckanapi load users -I USER_MIGRATED_FILE -p 4
-```
-
-Importing publishers:
+CKAN provides a paster script to upgrade the database schema.  This should be
+run after the data models have been updated.
 
 ```
-ckanapi load organizations -I PUBLISHERS_MIGRATED_FILE -p 4
-```
-
-Importing datasets:
-
-```
-ckanapi load datasets -I DATASET_MIGRATED_FILE -p 4
-```
-
-Importing harvesters (this must be run on the server on which the new CKAN is installed):
-
-```
-python import/migrated_harvest_sources.py --production
+paster db upgrade -c $CKAN_INI
 ```
 


### PR DESCRIPTION
We were previously using the API to migrate data from one CKAN to another.  The new method takes a database dump and updates this to reflect the changes to the schema and models.

Trello card: https://trello.com/c/e3qWIvmc/48-implement-new-method-for-importing-data-from-old-ckan-to-new-ckan