### PR TITLE
Spell "license" incorrectly

### DIFF
--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -69,7 +69,7 @@ Keep this section limited to core endpoints - if the app is complex link out to 
 
 ## Licence
 
-[MIT License](LICENCE)
+[MIT License](LICENSE.txt)
 
 ## Versioning policy (for Gems only)
 


### PR DESCRIPTION
Every time I create a README file I mess up this link to the license.
I thought I just couldn't spell, which is true, but it turns out this manual is
sabotaging me as well.

It's spelled with an S in the text but a C in the link.

The correct spelling in British english is licence when you use it
as a noun and license when you use it as a verb.
Source: https://www.grammarly.com/blog/licence-license/

Can we just use american english? Thanks.

I also put a .txt on the end because lots of our repos use this
extension.