### PR TITLE
Add how to disable mirror failover

### DIFF
--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -76,6 +76,12 @@ is unavailable, all you need to do is [stop Nginx on the cache machines with Fab
 fab $environment class:cache incident.fail_to_mirror
 ```
 
+to disable to fallback:
+
+```
+fab $environment class:cache incident.recover_origin
+```
+
 [fab-fail]: https://github.com/alphagov/fabric-scripts/blob/master/incident.py
 
 ## Emergency publishing using the static mirror


### PR DESCRIPTION
The docs tell us how to switch on the failover to our mirrors, but not how to revert back. Seeing as these are emergency docs, it's nicer to not make our on-call people have to dig that out.