### PR TITLE
Make warnings consistent by using same style

### DIFF
--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -57,6 +57,7 @@ Please view this [page](https://github.com/alphagov/govuk-legacy-opsmanual/blob/
 > here](http://www.vmware.com/pdf/Perf_Best_Practices_vSphere5.0.pdf).
 
 > **WARNING**
+>
 > When adding new disks, be careful to select an appropriate disk
 > controller.
 >

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -12,7 +12,13 @@ Data and assets/attachments are synced from production to staging and integratio
 
 Check the output of the production Jenkins job to see which part of the sync failed. It may be safe to re-run part of the sync.
 
-Warning: the mysql backup will cause signon in staging to point to production until the `Data Sync Complete` job runs and renames the hostnames copied from production to back to their staging equivalents.  This means that any deploys to staging that rely on GDS API Adapters are likely to fail due to authentication failures, as well as Smokey tests that attempt to use Signon.
+> **WARNING**
+>
+> The mysql backup will cause signon in staging to point to production until the
+> `Data Sync Complete` job runs and renames the hostnames copied from production
+> to back to their staging equivalents.  This means that any deploys to staging
+> that rely on GDS API Adapters are likely to fail due to authentication
+> failures, as well as Smokey tests that attempt to use Signon.
 
 The Jenkins jobs included in the sync are:
 

--- a/source/manual/clone-mysql-slave.html.md
+++ b/source/manual/clone-mysql-slave.html.md
@@ -78,7 +78,10 @@ On your second terminal run the following command:
 
 You should set `<username>` to your short name as set in puppet (e.g. 'bobwalker').
 
-**warning** forwarding your ssh-agent (`-A`) means that anyone with sufficient access on the remote server can authenticate as you. Do not use it on un-trusted servers.
+> **WARNING**
+>
+> Forwarding your ssh-agent (`-A`) means that anyone with sufficient access on
+> the remote server can authenticate as you. Do not use it on un-trusted servers.
 
 > **Note**
 >

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -321,7 +321,9 @@ psql ckan -c "UPDATE harvest_job SET finished = NOW(), status = 'Finished' WHERE
 It may be necessary, if there is a schedule clash and the system is too busy,
 to purge the queues used in the various stages of harvesting
 
-> Warning: This command will empty the Redis queues
+> **WARNING**
+>
+> This command will empty the Redis queues
 
 ```
 paster --plugin=ckanext-harvest harvester purge_queues -c $CKAN_INI

--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -182,8 +182,8 @@ When doing any of the `publish` actions below you will be prompted for
 the password. This can be found in the same place. You will need to use
 `sudo -i` for such actions, in order to reference root's GPG files.
 
-> **warning**
-
+> **WARNING**
+>
 > Please make sure that you use `sudo` and NOT a root shell, so that we
 > have a record of the actions performed.
 

--- a/source/manual/deploy-puppet.html.md
+++ b/source/manual/deploy-puppet.html.md
@@ -73,7 +73,8 @@ It may occassionally be neccessary to trick Puppet into not restarting a
 service, if it is a single point of failure and doing so would cause a
 brief outage, e.g. MySQL.
 
-> **Warning**
+> **WARNING**
+>
 > This is not a "normal" procedure. You should only do this if you need
 > to and you MUST have some plan for restarting the service in the near
 > future so that it's not inconsistent with its configuration.

--- a/source/manual/move-apps-between-servers.html.md
+++ b/source/manual/move-apps-between-servers.html.md
@@ -72,8 +72,14 @@ Once all the load balancers have been updated, requests to the app(s) will be us
 1. Change the relevant [app deployment scripts][deploy-scripts] to deploy to only the new servers.
 1. Re-run everything in production once you've checked everything works.
 
-> **Warning**
-> Bundling up the removal of the old servers from the load balancers and the removal of the app(s) from the old servers may result in a period where the old servers are still part of the load balancer group but don't have the app(s) running. This can be mitigated by either splitting up these changes, or running puppet manually on the load balancers after deployment to ensure no further traffic is routed to the old servers.
+> **WARNING**
+>
+> Bundling up the removal of the old servers from the load balancers and the
+> removal of the app(s) from the old servers may result in a period where the
+> old servers are still part of the load balancer group but don't have the
+> app(s) running. This can be mitigated by either splitting up these changes,
+> or running puppet manually on the load balancers after deployment to ensure
+> no further traffic is routed to the old servers.
 
 [hieradata]: https://github.com/alphagov/govuk-puppet/pull/7310
 [deploy-scripts]: https://github.com/alphagov/govuk-app-deployment/pull/250

--- a/source/manual/resync-mongo-db.html.md
+++ b/source/manual/resync-mongo-db.html.md
@@ -8,11 +8,13 @@ last_reviewed_on: 2018-07-31
 review_in: 6 months
 ---
 
-Warning: This process deletes all data from a MongoDB node and forces a full
-copy from the current primary member of the replica set. This causes additional
-load on the primary member of the replica set and reduces the number of
-available copies of the database, so is best performed at a quiet time. Try not
-to resync more than one secondary at a time.
+> **WARNING**
+>
+> This process deletes all data from a MongoDB node and forces a full
+> copy from the current primary member of the replica set. This causes
+> additional load on the primary member of the replica set and reduces the
+> number of available copies of the database, so is best performed at a quiet
+> time. Try not to resync more than one secondary at a time.
 
 To
 [resync](https://docs.mongodb.org/v2.4/tutorial/resync-replica-set-member/)

--- a/source/manual/stop-all-email-subscription-sending.html.md
+++ b/source/manual/stop-all-email-subscription-sending.html.md
@@ -10,7 +10,8 @@ review_in: 6 month
 
 In an emergency, the following steps will immediately stop all emails being sent by the GOV.UK email subscription system.
 
-> **Warning**
+> **WARNING**
+>
 > This is an emergency stopgap solution that should be reverted as soon as possible. All emails (including urgent ones such as travel alerts) will not be sent while this is active.
 
 > **Note**

--- a/source/manual/use-aws-xray-to-trace-app-requests.html.md
+++ b/source/manual/use-aws-xray-to-trace-app-requests.html.md
@@ -41,6 +41,7 @@ The [`govuk_app_config`](https://github.com/alphagov/govuk_app_config) gem autom
 The default configuration traces 1% of all requests. The can be changed on a per-app basis by specifying the `XRAY_SAMPLE_RATE` environment variable with a number between 0 (no tracing) and 1 (100% request tracing).
 
 > **WARNING**
+>
 > A high sampling rate can result in app slowness since each trace takes some non-zero time to complete. It will also result in cost increases since charges are based on the amount of data sent to the X-Ray service.
 
 ## X-Ray daemon


### PR DESCRIPTION
This commit is just to use the same style in all the warnings. We had warnings in many different styles, so I picked the one that seemed used most often and applied it everywhere. As I haven't reviewed the content of the docs, I left last_reviewed_on unchanged.