### PR TITLE
The app govuk-cdn-logs-monitor has been deprecated

### DIFF
--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -19,9 +19,6 @@ investigation is to examine the Fastly CDN logs.
 - `ssh monitoring-1.management.production`
 - `cd /var/log/cdn` to access log files
 
-Alternatively you can look in [Kibana](/manual/tools.html#kibana) with the query
-`application:"govuk-cdn-logs-monitor"`
-
 ## `Unknown` alert
 
 The alert appears on `monitoring-1.management`. Collectd uses the Fastly API to get statistics which it pushes to Graphite. If the alert is unknown, collectd likely cannot talk to Fastly so restart collectd.

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -13,8 +13,7 @@ network (CDN) whenever origin (the application server) times out or serves an er
 response.
 
 This process is handled by our CDN config and is entirely transparent to us and
-our users. It happens multiple times a day, for lots of different reasons. The
-`govuk-cdn-logs-monitor` app outputs [stats showing if the mirrors are active][graphite_cdn_backend].
+our users. It happens multiple times a day, for lots of different reasons.
 
 This is why we refer to switching off Nginx on the origin cache machines as
 "falling back to the mirrors".
@@ -106,7 +105,6 @@ If you're notified that the edit you've made can be reverted, do that the same w
 Once origin becomes available again, somebody (maybe you) will have to ensure that
 origin has been updated to serve the change that you made.
 
-[graphite_cdn_backend]: https://graphite.publishing.service.gov.uk/render?from=-1months&until=now&width=800&height=600&target=stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror1&target=stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror0
 [govuk_crawler_worker]: https://github.com/alphagov/govuk_crawler_worker
 [govuk_seed_crawler]: https://github.com/alphagov/govuk_seed_crawler
 [govuk_mirror-puppet]: https://github.com/alphagov/govuk_mirror-puppet

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -65,12 +65,6 @@ tags:"nginx" AND application:frontend*
 
 Note: the `@timestamp` field records the request END time. To calculate request start time subtract `@fields.request_time`.
 
-### CDN logs
-
-```rb
-application:"govuk-cdn-logs-monitor"
-```
-
 ### Application upstart logs
 
 ```rb


### PR DESCRIPTION
In [RFC-93](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-093-retire-govuk-cdn-logs-monitor.md), `govuk-cdn-logs-monitor` was deprecated and not replaced.  Removing all references to this app, as the Kibana queries do not return any results and the Graphite dashboard shows no data.