### PR TITLE
Remove Policy Publisher from applications.yml

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -33,10 +33,6 @@
   type: Publishing apps
   team: "#govuk-platform-health"
 
-- github_repo_name: policy-publisher
-  type: Publishing apps
-  team: "#govuk-platform-health"
-
 - github_repo_name: publisher
   type: Publishing apps
   team: "#govuk-platform-health"


### PR DESCRIPTION
This application has been retired now, so remove it from here, mostly
to stop the deploy lag badger from moaning on Slack.