### PR TITLE
Update gds-attic URLs

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -295,7 +295,7 @@
 - github_repo_name: panopticon
   retired: true
   type: Publishing apps
-  repo_url: https://github.com/gds-attic/panopticon
+  repo_url: https://github.com/alphagov/panopticon
   description: |
     Application that was at one time used for management of "artefacts", route
     registration, tagging and search indexing. The functionality was slowly moved
@@ -355,7 +355,7 @@
 - github_repo_name: business-support-finder
   retired: true
   type: Frontend apps
-  repo_url: https://github.com/gds-attic/business-support-finder
+  repo_url: https://github.com/alphagov/business-support-finder
   description: |
     Application that was used to display the "business support finder", an early
     finder-style page with search functionality for finding details of business


### PR DESCRIPTION
The repos in the attic were moved back to alphagov when GitHub added
support for archiving repositories.