### PR TITLE
Existing IAM users can log in, then switch roles

### DIFF
--- a/source/manual/set-up-aws-account.html.md
+++ b/source/manual/set-up-aws-account.html.md
@@ -13,6 +13,8 @@ old_paths:
 To work with [govuk-aws](https://github.com/alphagov/govuk-aws) and [govuk-aws-data](https://github.com/alphagov/govuk-aws-data),
 you will require an account in AWS.
 
+If you already have an AWS user associated with a different team's account, you can continue using it to log in to the AWS console, and then [switch roles](aws-console-access.html) where necessary.
+
 ## 1. Request a GDS AWS account
 
 GDS maintains a central account for AWS access. You will need to request an account from the Technology and Operations team.


### PR DESCRIPTION
If a developer has moved teams, and already has an user with MFA set up, they don't need to request a new account from Reliability Engineering. This should save people having to go through the MFA set up all over again.

I've checked that using the same user ARN in `~/.aws/config` works as well 🎉  