### PR TITLE
Reverse port forwarding for SSHing into a VM

### DIFF
--- a/source/manual/ssh-into-vm.html.md
+++ b/source/manual/ssh-into-vm.html.md
@@ -17,3 +17,10 @@ manually configure your SSH configuration:
 1. Run `vagrant ssh-config --host dev`
 2. Paste the output into your `~/.ssh/config`
 3. SSH into this using `ssh dev`
+
+### Reverse port forwarding
+If you need access to a specific port outside your VM, you can add a reverse port option when SSHing into the VM.
+
+For example, if you have a Docker image running on your host machine on port `5678`, use the following option to allow an app inside the VM to access it on port `1234`:
+
+`vagrant ssh -- -R 1234:localhost:5678`


### PR DESCRIPTION
The example below worked for me with a local Docker image running Elasticsearch (the rummager app could connect from inside the VM).