### PR TITLE
add documentation about the ping alert in icinga for the Carrenza-AWS VPN

### DIFF
--- a/source/manual/alerts/cannot-ping-across-AWS-Carrenza-VPN.html.md
+++ b/source/manual/alerts/cannot-ping-across-AWS-Carrenza-VPN.html.md
@@ -1,0 +1,23 @@
+---
+owner_slack: "#govuk-2ndline"
+title: cannot ping across AWS-Carrenza VPN
+parent: "/manual.html"
+layout: manual_layout
+section: Icinga alerts
+last_reviewed_on: 2018-12-13
+review_in: 6 months
+---
+
+There is a VPN tunnel between AWS and Carrenza for both the Staging and
+Production environment.
+
+To check the status and obtain troubleshooting information about the VPN,
+please consult the document [here](yet_to_defined)
+
+If the VPN is up/active and the ping probes are failing, check the following:
+1. the security groups of the AWS EC2 instances allow ping packets, i.e. ICMP
+   packets
+2. the firewall in the vCloud in Carrenza allows ping packets
+3. the VPN routes have been propagated to the subnet of the AWS EC2 instances
+4. the subnet of the VPN in the Carrenza vCloud Graphical User Interface (GUI) is
+   includes the Carrenza endpoint that is being pinged.


### PR DESCRIPTION
# Content

During the AWS migration, there is a VPN tunnel between the Carrenza and AWS VPC to enable private applications in both VPCs to communicate with each other.

Since the status of the VPN along with the configuration of security groups and firewalls are paramount to the effective communication between the two VPCs, it was decided to add Icinga ping probes between specific virtual machines. 

# Decisions

1. add documentation here about the Icinga ping probes that are being introduced to check connectivity between the 2 VPCs 