### PR TITLE
Add troubleshooting tip on reprovisioning VM if Elasticsearch not installed

### DIFF
--- a/source/manual/replicate-app-data-locally.html.md
+++ b/source/manual/replicate-app-data-locally.html.md
@@ -57,6 +57,10 @@ Check the service is running:
 
     dev$ sudo service elasticsearch-development.development start
 
+If you get an error saying Elasticsearch is not installed, you may need to reprovision the VM from your host machine:
+
+    mac$ vagrant provision
+
 ## Can't take a write lock while out of disk space (in MongoDB)
 
 You may see such an error message which will prevent you from creating or even dropping collections. So you won't be able to replicate the latest data.


### PR DESCRIPTION
After previously running `vagrant destroy` on my local VM, `vagrant up` didn't actually run the provisioning step. Thankfully there's a separate command for that.