### PR TITLE
Add info following Elasticsearch backup/restore drill

### DIFF
--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -27,10 +27,17 @@ The first argument is the Elasticsearch instance and the second is the
 directory in which to store the output. The user running the dump needs
 permission to write to this directory.
 
+The [env-sync-and-backup job](https://github.com/alphagov/env-sync-and-backup/blob/master/jobs/elasticsearch-rummager.sh)
+creates daily copies of the Elasticsearch snapshots and stores them in S3 for 5 days.
+
 ## Restoring a backup
 
 Before restoring a backup, make sure you are
 [monitoring the cluster](/manual/alerts/elasticsearch-cluster-health.html).
+
+To view the current status of the indices from inside the Elasticsearch instance:
+
+    curl http://localhost:9200/_cat/indices
 
 Restoring to an index which exists is additive - it doesn't replace the
 existing data or delete any documents which don't exist in the dump.
@@ -72,3 +79,8 @@ updated since the backup was taken.
 After restoring a backup, follow
 [Replaying traffic to correct an out of sync search index](/manual/rummager-traffic-replay.html)
 to bring the search index back in sync with the publishing apps.
+
+### Elasticsearch 5.x support
+
+[es_dump_restore](https://github.com/patientslikeme/es_dump_restore) does not support
+Elasticseach 5.x. This applies to both creating a backup and restoring from a backup.

--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -61,6 +61,10 @@ ssh $(ssh integration "govuk_node_list --single-node -c rummager_elasticsearch")
 Then visit <http://localhost:9200/_plugin/head/> to check how many documents have
 been copied to the new index.
 
+Alternatively, to view a summary of the indices from inside the Elasticsearch instance:
+
+    curl http://localhost:9200/_cat/indices
+
 ### Replay traffic
 
 This step is only necessary if you ran reindexing job during working hours,

--- a/source/manual/rummager-traffic-replay.html.md
+++ b/source/manual/rummager-traffic-replay.html.md
@@ -15,9 +15,14 @@ and `unpublish` messages that have not been processed need to be resent.
 ## `govuk` index
 
 Content in the `govuk` index is populated from the [Publishing API message queue][queue].
-Missing documents can be recovered by resending the content to the message queue,
-for example by running `represent_downstream:document_type[:document_type]` rake
-task in Publishing API.
+Missing documents can be recovered by resending the content to the message queue. In the
+Publishing API, run the following rake task (including the quotes) to replay traffic between
+two datestamps:
+
+    bundle exec rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
+
+[Other replay options are available](https://github.com/alphagov/publishing-api/blob/master/lib/tasks/represent_downstream.rake), for example replaying all traffic for a single publishing app or doctype.
+Be aware that these options will replay the entire Publisher API history for that app or doctype, and may take some time.
 
 ## `government`/`detailed` indexes
 


### PR DESCRIPTION
- `curl` command for a quick indices status check
- info on S3 backup process
- change replay command to use 'between' option (likely to be more
practical)
- note about the lack of ES5 support on `es_dump_restore`