### PR TITLE
Document where applications are hosted

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -1,4 +1,11 @@
 class AppDocs
+  HOSTERS = {
+    "aws" => "AWS",
+    "paas" => "GOV.UK PaaS",
+    "carrenza" => "Carrenza",
+    "ukcloud" => "UK Cloud",
+  }.freeze
+
   def self.new_by_type(app_data)
     klass = case app_data["type"]
             when "data.gov.uk apps"
@@ -47,6 +54,7 @@ class AppDocs
         app_name: app_name,
         team: team,
         puppet_name: puppet_name,
+        production_hosted_on: production_hosted_on,
         links: {
           self: "https://docs.publishing.service.gov.uk/apps/#{app_name}.json",
           html_url: html_url,
@@ -72,6 +80,14 @@ class AppDocs
         end
       end
       'Unknown - have you configured and merged your app in govuk-puppet/hieradata/common.yaml'
+    end
+
+    def production_hosted_on
+      app_data["production_hosted_on"]
+    end
+
+    def hosting_name
+      AppDocs::HOSTERS.fetch(production_hosted_on)
     end
 
     def html_url
@@ -168,24 +184,8 @@ class AppDocs
       github_repo_data["topics"]
     end
 
-    def pending_hosting?
-      false
-    end
-
     def has_rake_tasks?
       true
-    end
-
-    def in_paas?
-      false
-    end
-
-    def in_aws?
-      true
-    end
-
-    def in_ukcloud?
-      false
     end
 
   private
@@ -227,19 +227,7 @@ class AppDocs
       "https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1"
     end
 
-    def pending_hosting?
-      github_repo_name == "ckanext-datagovuk"
-    end
-
     def has_rake_tasks?
-      false
-    end
-
-    def in_paas?
-      true
-    end
-
-    def in_aws?
       false
     end
   end
@@ -266,14 +254,6 @@ class AppDocs
     end
 
     def has_rake_tasks?
-      false
-    end
-
-    def in_ukcloud?
-      true
-    end
-
-    def in_aws?
       false
     end
   end

--- a/app/apps_csv.rb
+++ b/app/apps_csv.rb
@@ -9,7 +9,7 @@ class AppsCSV
 
   def to_csv
     CSV.generate do |csv|
-      csv << ["Name", "Team", "Docs URL", "Repo URL"]
+      csv << ["Name", "Team", "Docs URL", "Repo URL", "Hosted On"]
 
       @apps.each do |app|
         csv << [
@@ -17,6 +17,7 @@ class AppsCSV
           app.team,
           app.html_url,
           app.repo_url,
+          app.production_hosted_on,
         ]
       end
     end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -3,57 +3,70 @@
 - github_repo_name: collections-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: contacts-admin
   type: Publishing apps
   puppet_name: contacts
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: content-tagger
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: content-publisher
   type: Publishing apps
   team: "#govuk-pub-workflow"
+  production_hosted_on: carrenza
 
 - github_repo_name: local-links-manager
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: aws
 
 - github_repo_name: manuals-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: maslow
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: service-manual-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: short-url-manager
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: specialist-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
   team: "#govuk-platform-health"
   api_docs_url: /apis/whitehall.html
+  production_hosted_on: carrenza
 
 # api
 
@@ -61,192 +74,234 @@
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: /apis/content-store.html
+  production_hosted_on: aws
 
 - github_repo_name: email-alert-api
   type: APIs
   team: "#govuk-platform-health"
   metrics_dashboard_url: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+  production_hosted_on: carrenza
 
 - github_repo_name: imminence
   type: APIs
   team: "#govuk-platform-health"
+  production_hosted_on: aws
 
 - github_repo_name: link-checker-api
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: /apis/link-checker-api.html
+  production_hosted_on: aws
 
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: /apis/publishing-api.html
+  production_hosted_on: carrenza
 
 - github_repo_name: rummager
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: /apis/search-api.html
+  production_hosted_on: carrenza
 
 - github_repo_name: asset-manager
   type: APIs
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: router-api
   type: APIs
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: support-api
   type: APIs
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: mapit
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: https://mapit.mysociety.org/docs/
+  production_hosted_on: aws
 
 # Services
 
 - github_repo_name: cache-clearing-service
   type: Services
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: email-alert-service
   type: Services
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 # Support
 
 - github_repo_name: content-performance-manager
   type: Supporting apps
   team: "#govuk-data-informed"
+  production_hosted_on: carrenza
 
 - github_repo_name: content-audit-tool
   type: Supporting apps
   team: "#govuk-data-informed"
+  production_hosted_on: carrenza
 
 - github_repo_name: content-data-admin
   type: Supporting apps
   team: "#govuk-data-informed"
+  production_hosted_on: carrenza
 
 - github_repo_name: search-admin
   type: Supporting apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: signon
   type: Supporting apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: support
   type: Supporting apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: release
   type: Supporting apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: router
   type: Supporting apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 # frontend
 
 - github_repo_name: calculators
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: calendars
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: collections
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://govuk-collections.herokuapp.com/component-guide
+  production_hosted_on: carrenza
 
 - github_repo_name: email-alert-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: feedback
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: finder-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
+  production_hosted_on: carrenza
 
 - github_repo_name: frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: government-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
+  production_hosted_on: carrenza
 
 - github_repo_name: info-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: licence-finder
   type: Frontend apps
   puppet_name: licencefinder
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: manuals-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 - github_repo_name: smart-answers
   type: Frontend apps
   team: "#govuk-platform-health"
   puppet_name: smartanswers
+  production_hosted_on: carrenza
 
 - github_repo_name: service-manual-frontend
   team: "#govuk-platform-health"
   type: Frontend apps
+  production_hosted_on: carrenza
 
 - github_repo_name: static
   type: Frontend apps
   team: "#govuk-platform-health"
+  production_hosted_on: carrenza
 
 # Transition
 
 - github_repo_name: bouncer
   type: Transition apps
   team: "#govuk-platform-health"
+  production_hosted_on: aws
 
 - github_repo_name: transition
   type: Transition apps
   team: "#govuk-platform-health"
+  production_hosted_on: aws
 
 # data.gov.uk
 
 - github_repo_name: datagovuk_find
   type: data.gov.uk apps
   team: "#govuk-platform-health"
+  production_hosted_on: paas
 
 - github_repo_name: datagovuk_publish
   type: data.gov.uk apps
   team: "#govuk-platform-health"
+  production_hosted_on: paas
 
 - github_repo_name: ckanext-datagovuk
   type: data.gov.uk apps
   team: "#govuk-platform-health"
+  production_hosted_on: paas
 
 # Licensing
 
 - github_repo_name: licensify
   private_repo: true
   type: Licensing apps
+  production_hosted_on: ukcloud
   team: "#govuk-licensing"
   description: |
     GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -294,7 +294,7 @@
 - github_repo_name: ckanext-datagovuk
   type: data.gov.uk apps
   team: "#govuk-platform-health"
-  production_hosted_on: paas
+  production_hosted_on: aws
 
 # Licensing
 

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -6,8 +6,18 @@ title: Applications on GOV.UK
 The publishing platform of GOV.UK consists of at least <%= active_app_pages.size %>
 separate applications. Most of them are built using [Ruby on Rails][rails].
 
+## Hosting
+
+| Hosting | Number of applications |
+| --- | --- |
+<% AppDocs::HOSTERS.each do |id, name| %>
+| <%= name %> | <%= AppDocs.pages.count { |app| app.production_hosted_on == id } %> |
+<% end %>
+
+## Reuse this data
+
 You can [download this data as JSON](/apps.json), or [download this data as CSV](/apps.csv).
-In Google Spreadsheets, use the following formula:
+In Google Spreadsheets, use the following formula to import all of the data:
 
 ```
 =importData("https://docs.publishing.service.gov.uk/apps.csv")
@@ -27,7 +37,7 @@ For example, a [HMRC manual page][hmrc-manual] is rendered by an application cal
 You can use the [chrome extension][extension] to find out which application
 is rendering any given page.
 
-You can [read more about the frontend architecture on GOV.UK](/manual/frontend-architecture.html). 
+You can [read more about the frontend architecture on GOV.UK](/manual/frontend-architecture.html).
 
 ## Publishing apps
 

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -27,7 +27,12 @@ Owned by team **<%= application.team %>**.
 <% else %>
 Do you support this application? Help out by [adding your team name][app-yaml] to the documentation.
 <% end %>
-<br>
+
+### Hosting
+
+The production version of this application is hosted on **<%= application.hosting_name %>**.
+
+### Links
 
 <ul>
   <li><%= link_to "GitHub repo", application.repo_url %></li>
@@ -69,34 +74,35 @@ Do you support this application? Help out by [adding your team name][app-yaml] t
   <% end %>
 </ul>
 
-<h3>Hosting & SSH Access</h3>
-<% if application.pending_hosting? %>
-  This application's hosting arrangements are not yet complete.
-<% elsif application.in_paas? %>
-  This applications lives on [GOV.UK PaaS](https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas).
-<% elsif application.in_ukcloud? %>
-  This applications lives in UK Cloud.
-<% elsif application.carrenza_machine %>
-  This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
+<% case application.production_hosted_on %>
+<% when  "carrenza" %>
 
-  To SSH to one of these machines:
+### SSH Access (Carrenza & AWS)
 
-  ```
-  ssh -A -t jumpbox.staging.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
-  ssh -A -t jumpbox.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
-  ```
-<% end %>
+This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
 
-<% if application.in_aws? %>
-  <h3>AWS SSH access</h3>
+To SSH to one of these machines:
 
-  This application lives on `<%= application.aws_puppet_class %>` machines on the integration environment in AWS.
+```
+ssh -A -t jumpbox.staging.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
+ssh -A -t jumpbox.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
+```
 
-  To SSH to one of these machines [via the jumpbox](https://docs.publishing.service.gov.uk/manual/howto-ssh-to-machines-in-aws.html), use this command:
+This application lives on `<%= application.aws_puppet_class %>` machines on the integration environment in AWS.
 
-  ```
-  ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
-  ```
+To SSH to one of these machines [via the jumpbox](/manual/howto-ssh-to-machines-in-aws.html), use this command:
+
+```
+ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
+```
+<% when  "aws" %>
+### SSH Access (AWS)
+
+```
+ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
+ssh -A -t jumpbox.staging.govuk.digital 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
+ssh -A -t jumpbox.production.govuk.digital 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
+```
 <% end %>
 
 <% if application.has_rake_tasks? %>


### PR DESCRIPTION
At the moment it's not easy to find in the document whether an app is hosted on Carrenza or AWS, because we're currently migrating apps over.

This PR adds where the application is hosted to the application page, application index pages and CSV export. It should make it easier to find the location of the apps, as well as automating some parts of the docs. Source of the apps is [this Trello ticket on 2nd line](https://trello.com/c/49OGPxEk/314-%F0%9F%94%AD-where-are-our-apps-apps-are-moving-from-carrenza-to-aws).

- Add hosting to app page
- Add list of providers and number of apps to application home
- Add hosting to CSV and JSON export for reuse
- Fix SSH instructions

## Screenies

<img width="1532" alt="screen shot 2019-01-03 at 12 51 19" src="https://user-images.githubusercontent.com/233676/50638628-68b7f080-0f56-11e9-8dd0-47c7504b1abc.png">
<img width="1532" alt="screen shot 2019-01-03 at 12 50 59" src="https://user-images.githubusercontent.com/233676/50638629-68b7f080-0f56-11e9-813c-9a12e9df17dc.png">
<img width="1532" alt="screen shot 2019-01-03 at 12 50 55" src="https://user-images.githubusercontent.com/233676/50638630-68b7f080-0f56-11e9-9e9e-63e133da2faa.png">
