### PR TITLE
Fix Logit links to RE site

### DIFF
--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -4,7 +4,7 @@ title: How to use Logit for GOV.UK
 section: Logging
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-07-11
+last_reviewed_on: 2019-01-03
 review_in: 6 months
 ---
 
@@ -19,11 +19,11 @@ on [logging](https://gds-way.cloudapps.digital/standards/logging.html).
 ## If Logit is down
 
 If there is a problem with Logit you should report it by following the
-instructions in the Reliability Engineering manual for [reporting an incident](https://reliability-engineering.cloudapps.digital/manuals/logit-incident-management.html).
+instructions in the Reliability Engineering manual for [reporting an incident](https://reliability-engineering.cloudapps.digital/logging.html#logit-incident-management).
 
 ## Accessing Logit
 
-You can [access Logit](https://reliability-engineering.cloudapps.digital/manuals/logit-io-joiners.html) by following the instructions in the Reliability Engineering manual.
+You can [access Logit](https://reliability-engineering.cloudapps.digital/logging.html#get-started-with-logit) by following the instructions in the Reliability Engineering manual.
 
 Logit stores the last environment you visited in a session. If you open any
 direct links externally they will take you to this stack.


### PR DESCRIPTION
These have changed. Fixes https://github.com/alphagov/govuk-developer-docs/issues/1380.