### PR TITLE
Document Heroku apps

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -4,6 +4,7 @@ class AppDocs
     "paas" => "GOV.UK PaaS",
     "carrenza" => "Carrenza",
     "ukcloud" => "UK Cloud",
+    "heroku" => "Heroku",
   }.freeze
 
   def self.pages
@@ -114,6 +115,10 @@ class AppDocs
       app_data.fetch("github_repo_name")
     end
 
+    def management_url
+      app_data["management_url"]
+    end
+
     def repo_url
       app_data["repo_url"] || "https://github.com/alphagov/#{github_repo_name}"
     end
@@ -135,7 +140,7 @@ class AppDocs
     end
 
     def deploy_url
-      return if app_data["deploy_url"] == false || production_hosted_on.in?(%w[paas])
+      return if app_data["deploy_url"] == false || production_hosted_on.in?(%w[paas heroku])
 
       "https://github.com/alphagov/govuk-app-deployment/blob/master/#{github_repo_name}/config/deploy.rb"
     end

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -302,6 +302,13 @@
   sentry_url: false
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
 
+- github_repo_name: datagovuk_reference
+  management_url: https://dashboard.heroku.com/apps/interval-server
+  production_hosted_on: heroku
+  type: data.gov.uk apps
+  sentry_url: false
+  dashboard_url: false
+
 # Licensing
 
 - github_repo_name: licensify
@@ -314,6 +321,66 @@
   dashboard_url: false
   description: |
     GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
+
+# Utility Heroku apps (don't add apps that are only for review here)
+
+- github_repo_name: seal
+  management_url: https://dashboard.heroku.com/apps/moody-seal
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: govuk-alert-tracker
+  management_url: https://dashboard.heroku.com/apps/govuk-alert-tracker
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: govuk-content-schemas
+  app_name: govuk-content-store-examples
+  management_url: https://dashboard.heroku.com/apps/govuk-content-store-examples
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: govuk-display-screen
+  management_url: https://dashboard.heroku.com/apps/govuk-display-screen
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: govuk-dependencies
+  management_url: https://dashboard.heroku.com/apps/govuk-dependencies
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: blinkenjs
+  app_name: govuk-secondline-blinken
+  management_url: https://dashboard.heroku.com/apps/govuk-secondline-blinken
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: side-by-side-browser
+  management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- github_repo_name: tech-docs-monitor
+  management_url: https://dashboard.heroku.com/apps/govuk-tech-docs-monitor
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 # Retired applications
 

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -20,12 +20,11 @@ This application is retired.
 GitHub topics: <%= application.topics.map { |topic| link_to(topic, "https://github.com/search?q=topic:#{topic}+org:alphagov") }.to_sentence %>
 <% end %>
 
+<% if application.team %>
+
 ### Ownership
 
-<% if application.team %>
 Owned by team **<%= application.team %>**.
-<% else %>
-Do you support this application? Help out by [adding your team name][app-yaml] to the documentation.
 <% end %>
 
 ### Hosting
@@ -39,6 +38,10 @@ The production version of this application is hosted on **<%= application.hostin
 
   <% if application.sentry_url %>
     <li><%= link_to "Sentry (error tracking)", application.sentry_url %></li>
+  <% end %>
+
+  <% if application.management_url %>
+    <li><%= link_to "Manage application", application.management_url %></li>
   <% end %>
 
   <% if application.puppet_url %>


### PR DESCRIPTION
This documents the applications running on Heroku that perform some kind of useful function (but aren't part of the official GOV.UK estate). I've omitted all the review apps for the frontend. A better name than "Utilities" would be welcome but unlikely.

<img width="1552" alt="screen shot 2019-01-03 at 16 04 33" src="https://user-images.githubusercontent.com/233676/50647753-4c757d00-0f71-11e9-9a5c-3ae8bdb49082.png">
