### PR TITLE
Add a note that the PagerDuty drill runs in AWS

### DIFF
--- a/source/manual/alerts/pagerduty-drill.html.md
+++ b/source/manual/alerts/pagerduty-drill.html.md
@@ -4,7 +4,7 @@ title: PagerDuty drill
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2018-08-31
+last_reviewed_on: 2019-01-09
 review_in: 6 months
 ---
 
@@ -16,6 +16,10 @@ file exists with an Icinga contact group set so that PagerDuty is
 notified. After a short amount of time, cron will remove the file to
 resolve the alert. The [code that does this is in
 Puppet](https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/pagerduty_drill.pp).
+
+> **Note**: The drill runs within the AWS environment while we migrate
+> our apps to AWS. If you need to trigger the drill manually, make sure
+> you're logged in to the AWS monitoring instance.
 
 You don't need to take any action for this alert. The primary in-office
 2nd line should escalate the call to the secondary who should escalate


### PR DESCRIPTION
I didn't realise and spent a while trying to work out why it wasn't triggering in Carrenza before trying AWS.