### PR TITLE
Move support and support-api to AWS

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -118,7 +118,7 @@
 - github_repo_name: support-api
   type: APIs
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 
 - github_repo_name: hmrc-manuals-api
   type: APIs
@@ -173,7 +173,7 @@
 - github_repo_name: support
   type: Supporting apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 
 - github_repo_name: authenticating-proxy
   type: Supporting apps


### PR DESCRIPTION
These apps have now been migrated.