### PR TITLE
Add your ssh keys to govuk_mirror-puppet as part of being on-call

### DIFF
--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -30,19 +30,22 @@ You should do these things before going on call so you're prepared.
 
 1. Have the numbers of other people on your shift saved in your phone. This
    includes whoever is on Escalations. Get these numbers from PagerDuty.
-2. Ensure you have an up to date local copy of the [Developer Docs][docs] repository
+1. Ensure you have an up to date local copy of the [Developer Docs][docs] repository
    and that you can build it.
-3. Make sure your [`fabric-scripts`][fabric] are up to date.
-4. Make sure you can VPN to the office or disaster recovery location.
-5. Ensure your PagerDuty alert settings will wake you if you're called. You might want
+1. Make sure your [`fabric-scripts`][fabric] are up to date.
+1. Make sure you can VPN to the office or disaster recovery location.
+1. Ensure your PagerDuty alert settings will wake you if you're called. You might want
    to install the [PagerDuty App](https://www.pagerduty.com/features/mobile-incident-management/)
    on your phone.
-6. Ensure you can [decrypt secrets][govuk-secrets] with your GPG setup.
-7. Ensure you can access [vCloud Director][vcloud] in production.
-8. Read these documents:
+1. Ensure you can [decrypt secrets][govuk-secrets] with your GPG setup.
+1. Ensure you can access [vCloud Director][vcloud] in production.
+1. Ensure you can access [govuk_mirror-puppet][] by [adding your SSH key to hierdata](https://github.com/alphagov/govuk_mirror-puppet/blob/master/hieradata/common.yaml#L126).
+1. Read these documents:
     - [So, you're having an incident](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301531/So+you+re+having+an+incident)
     - [Falling back to the static mirror](/manual/fall-back-to-mirror.html)
     - [Emergency publishing](/manual/emergency-publishing.html)
+
+[govuk_mirror-puppet]: https://github.com/alphagov/govuk_mirror-puppet
 
 ## Things that may result in you being contacted
 


### PR DESCRIPTION
We had an incident where we realised that not all on-call developers have access to the mirrorer boxes.