### PR TITLE
Cache all HTTP requests for an hour

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,12 @@ end
 
 task default: [:spec]
 
+namespace :cache do
+  task :clear do
+    CACHE.clear
+  end
+end
+
 namespace :assets do
   task :precompile do
     sh 'git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build'

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -24,7 +24,9 @@ class GitHubRepoFetcher
 private
 
   def all_alphagov_repos
-    @@all_alphagov_repos ||= client.repos("alphagov")
+    @@all_alphagov_repos ||= CACHE.fetch("all-repos", expires_in: 1.hour) do
+      client.repos("alphagov")
+    end
   end
 
   def client

--- a/app/http.rb
+++ b/app/http.rb
@@ -7,6 +7,12 @@ module HTTP
   end
 
   def self.get(url)
+    CACHE.fetch url, expires_in: 1.hour do
+      get_without_cache(url)
+    end
+  end
+
+  def self.get_without_cache(url)
     uri = URI.parse(url)
 
     faraday = Faraday.new(url: uri) do |conn|

--- a/app/requires.rb
+++ b/app/requires.rb
@@ -4,5 +4,7 @@ require 'middleman-core'
 require 'yaml'
 require 'json'
 
+CACHE = ActiveSupport::Cache::FileStore.new(".cache")
+
 Dir[File.dirname(__FILE__) + '/../lib/*.rb'].each { |file| require file }
 Dir[File.dirname(__FILE__) + '/**/*.rb'].each { |file| require file }


### PR DESCRIPTION
Currently it's really slow to repeatedly rebuild the site during development. This commit adds caching to HTTP requests, so that we only do the requests once per hour. This doesn't affect the building on CI because the cache will always be empty.

## Cold cache

```
$ time be middleman build
real	1m29.137s
user	4m36.747s
sys	0m57.113s
```

## Warm cache

```
$ time be middleman build
real	0m56.648s
user	4m7.461s
sys	0m45.406s
```

