### PR TITLE
Add documentation for the Publishing API app healthcheck

### DIFF
--- a/source/manual/alerts/publishing-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/publishing-api-app-healthcheck-not-ok.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Publishing API app healthcheck not ok
+parent: "/manual.html"
+layout: manual_layout
+section: Icinga alerts
+last_reviewed_on: 2019-01-22
+review_in: 6 months
+---
+
+Along with some common checks, the Publishing API has the following
+specific checks.
+
+## `sidekiq_queue_latency`
+
+The latency on the `downstream_high` Sidekiq queue is checked, as this
+is critical for prompt publishing.
+
+If there is a backlog in the queue, one possible workaround is to try
+restarting Sidekiq. This has been used to workaround issues where the
+Sidekiq jobs have got stuck when encountering issues with RabbitMQ.
+


### PR DESCRIPTION
This should be visible when someone clicks on the relevant link in
Icinga.

This is following up on the addition of a check for the
`downstream_high` Sidekiq queue, which has got stuck a few times
recently.