### PR TITLE
Add a page about republishing content

### DIFF
--- a/source/manual/republishing-content.html.md
+++ b/source/manual/republishing-content.html.md
@@ -1,0 +1,18 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Republishing Content
+section: Publishing
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2019-01-24
+review_in: 6 months
+---
+
+Sometimes it may be necessary to republish content to make it show up on the
+website. This process varies per app.
+
+## Whitehall
+
+If the document is in Whitehall, there is a Rake task you can run.
+
+[`publishing_api:republish_document[slug]`](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug])


### PR DESCRIPTION
Currently only includes a new Rake task in Whitehall.

[Trello Card](https://trello.com/c/6EIwWTyj/735-create-rake-task-for-representing-content-from-whitehall-to-publishing-api)