### PR TITLE
Add a page about the platform health dashboard

### DIFF
--- a/source/manual/platform-health-dashboard.html.md
+++ b/source/manual/platform-health-dashboard.html.md
@@ -1,0 +1,15 @@
+---
+owner_slack: "#govuk-platform-health"
+title: Platform Health Dashboard
+parent: "/manual.html"
+layout: manual_layout
+section: Monitoring
+last_reviewed_on: 2019-01-30
+review_in: 12 months
+---
+
+Platform Health maintains a dashboard which offers an overview of the health of
+GOV.UK including information about traffic levels, incidents, Icinga alerts and
+support tickets.
+
+You can [access the dashboard by clicking here](https://datastudio.google.com/reporting/1bXgS9j2mgMJtifuQrVHaZ5rYwxKCns0k/page/gKOG).


### PR DESCRIPTION
During the 2nd line tech support retro it was requested that this information was more easily available to look at.

[Trello Card](https://trello.com/c/nF5gJoCK/425-share-data-on-2nd-line-performance)