### PR TITLE
Use consistent titles in the manual

### DIFF
--- a/source/manual/bowl-error.html.md
+++ b/source/manual/bowl-error.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Using `bowl` fails with bundler error
+title: Fix bundler errors when running `bowl`
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/business-readiness-publish-changes.html.md
+++ b/source/manual/business-readiness-publish-changes.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-platform-health"
-title: Publishing changes to the business readiness finder
+title: Publish changes to the business readiness finder
 section: Business readiness finder
 layout: manual_layout
 parent: "/manual.html"
@@ -9,7 +9,7 @@ last_reviewed_on: 2019-01-18
 review_in: 3 months
 ---
 
-*If you are trying to update the content returned by the business readiness finder, see: [Updating content for the business readiness finder](/manual/business-readiness-update-content.html)*
+*If you are trying to update the content returned by the business readiness finder, see: [Update content for the business readiness finder](/manual/business-readiness-update-content.html)*
 
 The full journey for the  [business readiness finder][business-readiness-finder] is made up of the following content items:
 

--- a/source/manual/business-readiness-update-content.html.md
+++ b/source/manual/business-readiness-update-content.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-platform-health"
-title: Updating content for the business readiness finder
+title: Update content for the business readiness finder
 section: Business readiness finder
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/data-gov-uk-migrating-ckan.html.md
+++ b/source/manual/data-gov-uk-migrating-ckan.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-platform-health"
-title: Migrating data between CKAN instances
+title: Migrate data between CKAN instances
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/data-gov-uk-monitoring.html.md
+++ b/source/manual/data-gov-uk-monitoring.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-platform-health"
-title: Monitoring for data.gov.uk
+title: Monitor data.gov.uk
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-platform-health"
-title: Supporting CKAN
+title: Support tasks for CKAN
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/data-gov-uk-troubleshooting.html.md
+++ b/source/manual/data-gov-uk-troubleshooting.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-platform-health"
-title: Troubleshooting data.gov.uk
+title: Troubleshoot data.gov.uk
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Query CDN Logs
+title: Query CDN logs
 section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
@@ -180,4 +180,3 @@ to your local machine and then parse each JSON blob in each of the files with a
 JSON tool (such as `JSON.parse` in Ruby) until you find the problem. Once
 identified you may need to need to contact Fastly about the
 problem or update the log formatting in Fastly to resolve the issue.
-

--- a/source/manual/raising-issues-with-reliability-engineering.html.md
+++ b/source/manual/raising-issues-with-reliability-engineering.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Raising issues with Reliability Engineering
+title: Raise issues with Reliability Engineering
 parent: "/manual.html"
 layout: manual_layout
 section: 2nd line

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Receiving emails from Email Alert API in integration and staging
+title: Receive emails from Email Alert API in integration and staging
 section: Emails
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/republishing-content.html.md
+++ b/source/manual/republishing-content.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Republishing Content
+title: Republish content
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/rummager-traffic-replay.html.md
+++ b/source/manual/rummager-traffic-replay.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Replaying traffic to correct an out-of-sync search index
+title: Replay traffic to correct an out-of-sync search index
 parent: "/manual.html"
 layout: manual_layout
 section: Backups

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Monitoring screens
+title: Screens that we have in the office
 parent: "/manual.html"
 layout: manual_layout
 section: Monitoring

--- a/source/manual/ssh-config.html.md
+++ b/source/manual/ssh-config.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: SSH Configuration
+title: Set up your SSH configuration
 parent: "/manual.html"
 layout: manual_layout
 section: Accounts

--- a/source/manual/troubleshooting-jenkins-performance.html.md
+++ b/source/manual/troubleshooting-jenkins-performance.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Troubleshooting CI Jenkins Performance
+title: Troubleshoot CI Jenkins Performance
 parent: "/manual.html"
 layout: manual_layout
 section: Testing

--- a/source/manual/working-on-2nd-line.html.md
+++ b/source/manual/working-on-2nd-line.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "@hong.nguyen"
-title: Working on 2nd line
+title: What we do on 2nd line
 parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
@@ -21,15 +21,15 @@ Other things to know:
 
 ## Ongoing issues to be aware of
 
-Record critical alerts that aren't easily solved to the [GOV.UK 2nd line Trello board](https://trello.com/b/M7UzqXpk/govuk-2nd-line) to help inform the Platform Health and the GOV.UK AWS migration team. 
+Record critical alerts that aren't easily solved to the [GOV.UK 2nd line Trello board](https://trello.com/b/M7UzqXpk/govuk-2nd-line) to help inform the Platform Health and the GOV.UK AWS migration team.
 
-2nd line should investigate these alerts when there is downtime. 
+2nd line should investigate these alerts when there is downtime.
 
 You do not have to fix the issue necessarily.
 
-We record these alerts here because so other developers are aware that they are likely to happen. 
+We record these alerts here because so other developers are aware that they are likely to happen.
 
 These alerts shouldn't cause big issues but that's not to say it won't - which is why we should log it here.
 
-## Declaring and responding to an incident 
+## Declaring and responding to an incident
 Find out [what to do if there’s an incident](https://docs.publishing.service.gov.uk/manual/incident-management-guidance.html).

--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -22,6 +22,13 @@ Dir.glob("source/manual/**/*.md").each do |filename|
       expect(frontmatter['title']).to be_present, "Page doesn't have `title` set"
     end
 
+    unless frontmatter["section"] == "Icinga alerts"
+      it "follows the styleguide" do
+        expect(frontmatter['title'].split(" ").first).not_to end_with("ing"),
+          "Page title `#{frontmatter['title']}`: don't use 'ing' at the end of verbs - https://docs.publishing.service.gov.uk/manual/docs-style-guide.html#title"
+      end
+    end
+
     it "has the correct suffix" do
       expect(filename).to match(/\.html\.md$/)
     end


### PR DESCRIPTION
The docs styleguide says to use active titles:

https://docs.publishing.service.gov.uk/manual/docs-style-guide.html#title

This PR updates the titles to be consistent and adds a test to make sure we never end titles `ing`.