### PR TITLE
Don't show "related" headings when there's nothing

### DIFF
--- a/app/related_things.rb
+++ b/app/related_things.rb
@@ -1,0 +1,30 @@
+class RelatedThings
+  attr_reader :manual, :current_page
+
+  def initialize(manual, current_page)
+    @manual = manual
+    @current_page = current_page
+  end
+
+  def related_applications
+    @related_applications ||= current_page.data.related_applications.to_a.map do |app_name|
+      [app_name, "/apps/#{app_name}.html"]
+    end
+  end
+
+  def any_related_pages?
+    (related_learning_pages + related_task_pages).any?
+  end
+
+  def related_learning_pages
+    manual.other_pages_from_section(current_page).select do |page|
+      page.data.type == "learn"
+    end
+  end
+
+  def related_task_pages
+    manual.other_pages_from_section(current_page).select do |page|
+      page.data.type.nil?
+    end
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -47,6 +47,10 @@ helpers do
   def page_review
     @page_review ||= PageReview.new(current_page)
   end
+
+  def related_things
+    @related_things ||= RelatedThings.new(manual, current_page)
+  end
 end
 
 ignore 'templates/*'

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -25,45 +25,7 @@
 
   <%= html %>
 
-  <div class='related-content grid-row'>
-    <% if related_things.related_applications.any? %>
-      <h4>Related applications</h4>
-
-      <ul>
-      <% related_things.related_applications.each do |name, url| %>
-        <li><%= link_to name, url %></li>
-      <% end %>
-      </ul>
-    <% end %>
-
-    <% if related_things.any_related_pages? %>
-      <h3>More in the <%= current_page.data.section %> section</h3>
-
-      <% if related_things.related_learning_pages.any? %>
-        <div class='column-half'>
-          <h4>Learn</h4>
-
-          <ul>
-          <% related_things.related_learning_pages.each do |page| %>
-            <li><%= link_to page.data.title, page.url %></li>
-          <% end %>
-          </ul>
-        </div>
-      <% end %>
-
-      <% if related_things.related_task_pages.any? %>
-        <div class='column-half'>
-          <h4>How to...</h4>
-
-          <ul>
-          <% related_things.related_task_pages.each do |page| %>
-            <li><%= link_to page.data.title, page.url %></li>
-          <% end %>
-          </ul>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
+  <%= partial 'partials/related_content' %>
 
   <% if page_review.reviewable? %>
     <% if page_review.expired? %>

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -26,37 +26,43 @@
   <%= html %>
 
   <div class='related-content grid-row'>
-    <% if current_page.data.related_applications %>
+    <% if related_things.related_applications.any? %>
       <h4>Related applications</h4>
 
       <ul>
-      <% current_page.data.related_applications.to_a.each do |app_name| %>
-        <li><%= link_to app_name, "/apps/#{app_name}.html" %></li>
+      <% related_things.related_applications.each do |name, url| %>
+        <li><%= link_to name, url %></li>
       <% end %>
       </ul>
     <% end %>
 
-    <h3>More in the <%= current_page.data.section %> section</h3>
+    <% if related_things.any_related_pages? %>
+      <h3>More in the <%= current_page.data.section %> section</h3>
 
-    <div class='column-half'>
-      <h4>Learn</h4>
+      <% if related_things.related_learning_pages.any? %>
+        <div class='column-half'>
+          <h4>Learn</h4>
 
-      <ul>
-      <% manual.other_pages_from_section(current_page).select { |page| page.data.type == "learn" }.each do |page| %>
-        <li><%= link_to page.data.title, page.url %></li>
+          <ul>
+          <% related_things.related_learning_pages.each do |page| %>
+            <li><%= link_to page.data.title, page.url %></li>
+          <% end %>
+          </ul>
+        </div>
       <% end %>
-      </ul>
-    </div>
 
-    <div class='column-half'>
-      <h4>How to...</h4>
+      <% if related_things.related_task_pages.any? %>
+        <div class='column-half'>
+          <h4>How to...</h4>
 
-      <ul>
-      <% manual.other_pages_from_section(current_page).select { |page| page.data.type.nil? }.each do |page| %>
-        <li><%= link_to page.data.title, page.url %></li>
+          <ul>
+          <% related_things.related_task_pages.each do |page| %>
+            <li><%= link_to page.data.title, page.url %></li>
+          <% end %>
+          </ul>
+        </div>
       <% end %>
-      </ul>
-    </div>
+    <% end %>
   </div>
 
   <% if page_review.reviewable? %>

--- a/source/partials/_related_content.html.erb
+++ b/source/partials/_related_content.html.erb
@@ -1,0 +1,39 @@
+<div class='related-content grid-row'>
+  <% if related_things.related_applications.any? %>
+    <h4>Related applications</h4>
+
+    <ul>
+    <% related_things.related_applications.each do |name, url| %>
+      <li><%= link_to name, url %></li>
+    <% end %>
+    </ul>
+  <% end %>
+
+  <% if related_things.any_related_pages? %>
+    <h3>More in the <%= current_page.data.section %> section</h3>
+
+    <% if related_things.related_learning_pages.any? %>
+      <div class='column-half'>
+        <h4>Learn</h4>
+
+        <ul>
+        <% related_things.related_learning_pages.each do |page| %>
+          <li><%= link_to page.data.title, page.url %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <% if related_things.related_task_pages.any? %>
+      <div class='column-half'>
+        <h4>How to...</h4>
+
+        <ul>
+        <% related_things.related_task_pages.each do |page| %>
+          <li><%= link_to page.data.title, page.url %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
Currently, when a page is the only one in the section, we show "Learn" and "How to.." headings at the footer, but nothing below it. This removes that.

## Before

<img width="1476" alt="screenshot 2019-02-07 at 12 17 26" src="https://user-images.githubusercontent.com/233676/52411091-6a834f80-2ad2-11e9-8c58-9e03d15a22b3.png">

## After

<img width="1476" alt="screenshot 2019-02-07 at 12 17 02" src="https://user-images.githubusercontent.com/233676/52411092-6ce5a980-2ad2-11e9-9644-54f121eadc27.png">
