### PR TITLE
Guess the mime type when deploying

### DIFF
--- a/bin/deploy-to-s3
+++ b/bin/deploy-to-s3
@@ -8,6 +8,4 @@ export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec middleman build --verbose
-s3cmd sync -v --acl-public --add-header='Cache-Control: max-age=3600, public' --delete-removed build/ s3://govuk-developer-documentation-production/
-s3cmd put -m "text/css" --add-header='Cache-Control: max-age=3600, public' --acl-public build/stylesheets/screen.css s3://govuk-developer-documentation-production/stylesheets/screen.css
-s3cmd put -m "text/css" --add-header='Cache-Control: max-age=3600, public' --acl-public build/stylesheets/print.css s3://govuk-developer-documentation-production/stylesheets/print.css
+s3cmd sync -v --acl-public --guess-mime-type --add-header='Cache-Control: max-age=3600, public' --delete-removed build/ s3://govuk-developer-documentation-production/


### PR DESCRIPTION
We're currently seeing the search feature fail because it doesn't recognise `/search.json` as JSON, since it has the default content type of `text/css`.

The `--guess-mime-type` flag should set this automatically, which means we don't have to set it for the the CSS as well.