### PR TITLE
Remove duplication in the reindexing of Whitehall instructions

### DIFF
--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -136,14 +136,8 @@ where `full_index_name` is the full name of the new index, including the date
 and UUID, e.g. `govuk-2018-01-29t17:08:21z-31f39bdb-c62b-4607-8081-19ea87fb1498`.
 
 Switching back to an old index means that you'll **lose any content updates**
-that were published while the new index was live. To fix this:
-
-0. [Replay traffic from whitehall][traffic-replay]
-0. Republish other content using the publishing-api rake task:
-
-    ```
-    rake 'represent_downstream:published_between[2018-01-04T09:30:00, 2018-01-04T10:00:00]'
-    ```
+that were published while the new index was live. To fix this, [replay the
+traffic][traffic-replay] from both publishing-api and Whitehall.
 
 [update-fields-or-doc-types]: /apis/search/add-new-fields-or-document-types.html
 [index-alias]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html


### PR DESCRIPTION
The rake task for representing publishing-api updates is already described in the replaying document.  Therefore it doesn't need to be duplicated here, since it just confuses things.