### PR TITLE
Document mission searches google analytics

### DIFF
--- a/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
@@ -44,5 +44,19 @@ To fix this problem run the [following rake task][2]:
 rake etl:repopulateviews[2018-01-01 2018-01-02]
 ```
 
+## ETL :: no searches for yesterday
+
+This means that the [the ETL master process][1] that runs daily to collect metrics from Google Analytics has failed. In particular, the ETL processor that collects number of searches.
+
+
+To fix this problem run the [following rake task][3]:
+
+```bash
+rake etl:repopulate_searches[2018-01-01 2018-01-02]
+```
+
+
+
 [1]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_etl_master_process/
 [2]: https://github.com/alphagov/content-performance-manager/blob/87116d3ab6f75c0d3dd8be9d4aff80865702f1b9/lib/tasks/etl.rake#L8
+[3]: https://github.com/alphagov/content-performance-manager/blob/8dd689e6917d7bbbf23a99387b85bfe1ce04d7b1/lib/tasks/etl.rake#L18

--- a/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
@@ -29,7 +29,7 @@ At least the `page-views` metric for each content item has not been received
 To fix this problem run the [following rake task][2]:
 
 ```bash
-rake etl:repopulate_views[2018-01-01 2018-01-02]
+rake etl:repopulate_views[2018-01-01 2018-01-01]
 ```
 
 ## ETL :: no upviews for yesterday
@@ -41,7 +41,7 @@ At least the `unique-page-views` metric for each content item has not been recei
 To fix this problem run the [following rake task][2]:
 
 ```bash
-rake etl:repopulate_views[2018-01-01 2018-01-02]
+rake etl:repopulate_views[2018-01-01 2018-01-01]
 ```
 
 ## ETL :: no searches for yesterday
@@ -52,7 +52,7 @@ This means that the [the ETL master process][1] that runs daily to collect metri
 To fix this problem run the [following rake task][3]:
 
 ```bash
-rake etl:repopulate_searches[2018-01-01 2018-01-02]
+rake etl:repopulate_searches[2018-01-01 2018-01-01]
 ```
 
 

--- a/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
@@ -8,17 +8,41 @@ last_reviewed_on: 2019-02-04
 review_in: 6 months
 ---
 
+## Notify Data Informed Content team
+
+Please notify Data Informed Content via Slack `#govuk-data-informed` about the alarm. The product is currently in private beta, so the development team will help solve any issues.
+
 If there is a health check error showing for Content Performance Manager, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
 
 ## ETL :: no daily metrics for yesterday
 
 This means that [the ETL master process][1] that runs daily to retrieve metrics for content items has failed.  
 
-#### Notify Data Informed Content team
+To fix this problem [Re-run the master process again][1] 
 
-Please notify Data Informed Content via Slack `#govuk-data-informed` about the alarm. The product is currently in private beta, so the development team will help solve any issues.
+## ETL :: no pviews for yesterday
 
-[Re-run the master process again][1] 
+This means that the [the ETL master process][1] that runs daily to collect metrics from Google Analytics has failed. In particular, the ETL processor that collects the core metrics.
 
+At least the `page-views` metric for each content item has not been received
+
+To fix this problem run the [following rake task][2]:
+
+```bash
+rake etl:repopulateviews[2018-01-01 2018-01-02]
+```
+
+## ETL :: no upviews for yesterday
+
+This means that the [the ETL master process][1] that runs daily to collect metrics from Google Analytics has failed. In particular, the ETL processor that collects the core metrics.
+
+At least the `unique-page-views` metric for each content item has not been received
+
+To fix this problem run the [following rake task][2]:
+
+```bash
+rake etl:repopulateviews[2018-01-01 2018-01-02]
+```
 
 [1]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_etl_master_process/
+[2]: https://github.com/alphagov/content-performance-manager/blob/87116d3ab6f75c0d3dd8be9d4aff80865702f1b9/lib/tasks/etl.rake#L8

--- a/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-performance-manager-app-healthcheck-not-ok.html.md
@@ -29,7 +29,7 @@ At least the `page-views` metric for each content item has not been received
 To fix this problem run the [following rake task][2]:
 
 ```bash
-rake etl:repopulateviews[2018-01-01 2018-01-02]
+rake etl:repopulate_views[2018-01-01 2018-01-02]
 ```
 
 ## ETL :: no upviews for yesterday
@@ -41,7 +41,7 @@ At least the `unique-page-views` metric for each content item has not been recei
 To fix this problem run the [following rake task][2]:
 
 ```bash
-rake etl:repopulateviews[2018-01-01 2018-01-02]
+rake etl:repopulate_views[2018-01-01 2018-01-02]
 ```
 
 ## ETL :: no searches for yesterday


### PR DESCRIPTION
https://trello.com/c/56rS8RRM/1147-2-raise-2ndline-alarms-when-user-feedback-metrics-are-not-created

When the ETL process to collect Google Analytics metrics fails, an alarm
is triggered, and 2ndline need to run a rake task to repopulate the
data.