### PR TITLE
Update docs following incident review (failure of search indexing)

### DIFF
--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -64,6 +64,10 @@ is an example of a machine that cannot be safely rebooted. The
 is `safe_to_reboot::can_reboot: 'yes'`, so if it does not say it is
 unsafe, or does not have a class in hieradata at all, then it is safe.
 
+> If there is an incident which requires the rebooting of a machine
+> otherwise marked as 'no', then it may be done provided any downstream
+> effects of this reboot have been considered.
+
 There is a Fabric task to schedule a machine for downtime in Nagios for
 20 minutes and then reboot it:
 

--- a/source/manual/rebooting-machines.html.md
+++ b/source/manual/rebooting-machines.html.md
@@ -127,7 +127,7 @@ rebooted during working hours in production. Other services rely directly on
 particular Redis hosts and may error if they are unvailable.
 
 Reboots of these machines, in the production environment, should be organised
-with Platform Health.
+with Platform Health and rummager workers must be restarted after the reboot.
 
 They may be rebooted in working hours in other environments, however you
 should notify colleagues before doing so as this may remove in-flight jobs


### PR DESCRIPTION
* Make it clear that single point-of-failure machines can be rebooted during an incident
* Add a note to ensure rummager workers are rebooted after a redis machine reboot

Incident review: https://docs.google.com/document/d/1I_BC3SyvoTD9N_JcaYq5gifsLYqoVls9yvOZHq5VBzI/edit