### PR TITLE
Speed up site build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export GITHUB_TOKEN=somethingsomething
 Build the site with:
 
 ```
-bundle exec middleman build
+NO_CONTRACTS=true bundle exec middleman build
 ```
 
 This will create a bunch of static files in `/build`.

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ end
 
 namespace :assets do
   task :precompile do
-    sh 'git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build'
+    sh 'git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build'
   end
 end
 

--- a/bin/deploy-to-s3
+++ b/bin/deploy-to-s3
@@ -7,5 +7,5 @@ git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-conte
 export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-bundle exec middleman build --verbose
+NO_CONTRACTS=true bundle exec middleman build --verbose
 s3cmd sync -v --acl-public --guess-mime-type --add-header='Cache-Control: max-age=3600, public' --delete-removed build/ s3://govuk-developer-documentation-production/

--- a/startup.sh
+++ b/startup.sh
@@ -1,1 +1,6 @@
-bundle exec middleman server 
+#!/bin/bash -x
+
+set -eu
+
+bundle check || bundle install
+NO_CONTRACTS=true bundle exec middleman server


### PR DESCRIPTION
Middleman uses a dope/weird system that implements types in Ruby using metaprogramming (I highly recommend watching the talk by middleman's creator about this - https://www.youtube.com/watch?v=W7qj_WFClls).

It's quite slow though. `NO_CONTRACTS=true` will turn off the system and speed up building. It's [recommended in the middleman docs](https://middlemanapp.com/basics/build-and-deploy).

## Before

```
$ time bundle exec middleman build
real	1m9.209s
user	4m55.782s
sys	0m51.051s
```

## After

```
$ time NO_CONTRACTS=true bundle exec middleman build
real	0m58.144s
user	4m3.325s
sys	0m46.966s
```