### PR TITLE
Rename cdn-configs to govuk-cdn-config-secrets

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -63,8 +63,8 @@
           url: https://github.com/alphagov/router-data
           description: Send routes directly to the router-api (deprecated)
       sites:
-        - name: cdn-configs
-          url: https://github.com/alphagov/cdn-configs
+        - name: govuk-cdn-config-secrets
+          url: https://github.com/alphagov/govuk-cdn-config-secrets
           description: Configuration secrets for Fastly
 
     - name: Configuration

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -26,7 +26,7 @@ The CDN is responsible for retrying requests against the
 Most of the CDN config is versioned and scripted:
 
 - [CDN configuration](https://github.com/alphagov/govuk-cdn-config/)
-- [CDN config secrets](https://github.com/alphagov/cdn-configs)
+- [CDN config secrets](https://github.com/alphagov/govuk-cdn-config-secrets)
 
 These are deployed to [integration][integration_cdn], [staging][staging_cdn]
 and [production][production_cdn].
@@ -73,7 +73,7 @@ always a chance that we may block a legitimate user when we ban IP addresses.
 You can change the list of banned IP addresses by modifying the
 [YAML config file][ip_ban_config] and [deploying the configuration][ip_ban_deploy].
 
-[ip_ban_config]: https://github.com/alphagov/cdn-configs/blob/master/fastly/dictionaries/config/ip_address_blacklist.yaml
+[ip_ban_config]: https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/dictionaries/config/ip_address_blacklist.yaml
 [ip_ban_deploy]: https://deploy.publishing.service.gov.uk/job/Update_CDN_Dictionaries/build
 
 ## Bouncer's Fastly service

--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -56,7 +56,7 @@ need more data.
 [analytics-dimensions]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Analytics+on+GOV.UK
 [govuk-secrets]: https://github.com/alphagov/govuk-secrets
 [dictionaries-readme]: https://github.com/alphagov/govuk-cdn-config#fastly-dictionaries
-[dictionary-config-example]: https://github.com/alphagov/cdn-configs/commit/ba3ec923c0bb5bdf17bdaf02419ff4e049516fda
+[dictionary-config-example]: https://github.com/alphagov/govuk-cdn-config-secrets/commit/ba3ec923c0bb5bdf17bdaf02419ff4e049516fda
 [govuk_ab_testing]: https://github.com/alphagov/govuk_ab_testing
 [cdn-config-example]: https://github.com/alphagov/fastly-configure/pull/29/files
 


### PR DESCRIPTION
The CDN secrets repo was renamed:

https://github.com/alphagov/govuk-cdn-config-secrets