### PR TITLE
Don't index the error page

### DIFF
--- a/source/error.html.erb
+++ b/source/error.html.erb
@@ -2,6 +2,7 @@
 layout: core
 title: Page not found
 hide_from_sitemap: true
+index: false
 ---
 
 <%= partial "partials/header" %>


### PR DESCRIPTION
The error page is currently indexed in search. If I understand middleman-search correctly `index: false` will prevent this from happening.