### PR TITLE
There is only one Elasticsearch cluster for GOV.UK

### DIFF
--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -36,8 +36,8 @@ to help you diagnose any problems.
 
 #### Find hosts in an Elasticsearch cluster
 
-We use different Elasticsearch clusters for different applications. For example
-the `rummager-elasticsearch` cluster powers the GOV.UK search API.
+The `rummager-elasticsearch` cluster powers the GOV.UK search API and sector
+name lookup in `licence-finder`.
 
 You can find hostnames by running:
 


### PR DESCRIPTION
Remove text implying there are multiple Elasticsearch clusters, when we only have the one.