### PR TITLE
Add information about AWS managed Elasticsearch logging

### DIFF
--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -24,9 +24,17 @@ For information on how to log in and view stacks, please see the
 
 ### Elasticsearch
 
+#### Non-managed Elasticsearch
+
 You can access the credentials for the Elasticsearch instances in Logit using
 the `logit` key in the [govuk-secrets] 2nd Line password store.
 
+#### AWS Managed Elasticsearch
+
+Elasticsearch in AWS uses a managed service.  Logs are exported to
+[AWS Cloudwatch[aws-cloudwatch-es5] and retained for 90 days.
+
+[aws-cloudwatch-es5]: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logs:prefix=/aws/aes/domains/blue-elasticsearch5-domain
 [gds-way-logging]: https://gds-way.cloudapps.digital/standards/logging.html#content
 [logit]: https://logit.io
 [logit-docs]: /manual/logit.html

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -32,9 +32,12 @@ the `logit` key in the [govuk-secrets] 2nd Line password store.
 #### AWS Managed Elasticsearch
 
 Elasticsearch in AWS uses a managed service.  Logs are exported to
-[AWS Cloudwatch[aws-cloudwatch-es5] and retained for 90 days.
+[AWS Cloudwatch][aws-cloudwatch-es5] and retained for 3 days.
+
+Logs are also written to a [S3 bucket][s3-es5] for longer-term storage.
 
 [aws-cloudwatch-es5]: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logs:prefix=/aws/aes/domains/blue-elasticsearch5-domain
+[s3-es5]: https://s3.console.aws.amazon.com/s3/buckets/govuk-integration-aws-logging/elasticsearch5/?region=eu-west-1&tab=overview
 [gds-way-logging]: https://gds-way.cloudapps.digital/standards/logging.html#content
 [logit]: https://logit.io
 [logit-docs]: /manual/logit.html


### PR DESCRIPTION
Add information about accessing logs from the managed AWS Elasticsearch service.

Trello cards: https://trello.com/c/jc1LM6nM/58-set-up-export-of-error-logs-from-elasticsearch-to-cloudwatch and https://trello.com/c/44CAPD5j/57-set-up-export-of-logs-from-cloudwatch-to-s3