### PR TITLE
Bump the last reviewed date of the PostgreSQL update page

### DIFF
--- a/source/manual/upgrade-development-vm-to-postgresql-9.6.html.md
+++ b/source/manual/upgrade-development-vm-to-postgresql-9.6.html.md
@@ -4,7 +4,7 @@ title: Upgrade PostgreSQL to 9.6 in the Development VM
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-11-14
+last_reviewed_on: 2019-02-22
 review_in: 3 months
 ---
 


### PR DESCRIPTION
I don't know of any issues with this guidance, it can probably be
removed the next time it's up for review.