### PR TITLE
Add docs on restarting Logstash when data suddendly stops

### DIFF
--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -21,6 +21,22 @@ on [logging](https://gds-way.cloudapps.digital/standards/logging.html).
 If there is a problem with Logit you should report it by following the
 instructions in the Reliability Engineering manual for [reporting an incident](https://reliability-engineering.cloudapps.digital/logging.html#logit-incident-management).
 
+## If Logit's data falls off a cliff
+
+If there seems to be no recent data in Logit when there really should be, you can try "restarting" the logstash instance.
+
+You can get an visual indication of logs sent by navigating to the "Settings" for an environment and then looking at the "Statistics". If no logs are coming in, then this might indicate a restart is required.
+
+Navigate to the Logit dashboard and select the "Settings" button next to the environment that is experiencing issues. Next select "Logstash Filters" in the left hand menu. The "Restart Logstash" button is in the "Danger Zone".
+
+When we experienced this on 04/03/2019, the Logstash logs for our Staging environment reported the following error repeatedly:
+
+```
+Exception: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memory
+```
+
+> If you don't have Settings option, speak to your tech lead/lead developer who will hopefully be able to help.
+
 ## Accessing Logit
 
 You can [access Logit](https://reliability-engineering.cloudapps.digital/logging.html#get-started-with-logit) by following the instructions in the Reliability Engineering manual.


### PR DESCRIPTION
We noticed that Logit stopped collecting data recently for Staging.
It looked like the logs just dropped off a cliff (when viewing the
"Statistics") and Logstash logs reported the following error repeatedly:

```
INFO org.logstash.beats.BeatsHandler Exception: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memory (used: 8463678787, max: 8476557312)
```

Restarting Logstash seemed to solve the problem.