### PR TITLE
Mention the `govuk aws` tool when deploying DNS

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -51,20 +51,12 @@ selected provider.
 When the changes have been reviewed and merged, you can deploy them using [the
 "Deploy DNS" Jenkins job](https://deploy.publishing.service.gov.uk/job/Deploy_DNS/).
 
-You will need to copy and paste the below variables into Jenkins for each operation.
-These can be obtained using the [AWS CLI](user-management-in-aws.html#exporting-credentials-to-environment):
+You will need to assume the appropriate role and copy and paste the
+credentials in to the Jenkins job.
 
 ```sh
-aws sts assume-role \
-  --role-session-name "$(whoami)-$(date +%d-%m-%y_%H-%M)" \
-  --role-arn <Role ARN> \
-  --serial-number <MFA ARN> \
-  --duration-seconds 28800 \
-  --profile gds \
-  --token-code <MFA token>
+govuk aws --profile <Profile>
 ```
-
-If you've [set up AWS CLI correctly](/manual/aws-cli-access.html) you can get the Role ARN and MFA ARN with `cat ~/.aws/config`.
 
 Changes should be deployed for each provider (AWS & Google) separately, first
 run a "plan" action, and when you're happy with the changes, run "apply".


### PR DESCRIPTION
This is a more convinient alternative to the `aws sts assume-role`
command.