### PR TITLE
Add instructions for accessing *.dev.gov.uk after using GDS VPN

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -221,7 +221,7 @@ Most GOV.UK web applications and services are available via the public internet,
 
 The basic authentication username and password is widely known, so just ask somebody on your team if you don't know it.
 
-If you can't resolve `dev.gov.uk` domains, see [fix issues with vagrant-dns](vagrant-dns.html).
+If you can't resolve `dev.gov.uk` domains, see [fix issues with vagrant-dns](/manual/vagrant-dns.html) or [VM access after using VPN](/manual/vm-vpn-issues.html).
 
 ## 9. Keep your VM up to date
 

--- a/source/manual/vm-vpn-issues.html.md
+++ b/source/manual/vm-vpn-issues.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Acccess the VM after using the VPN
+section: Development VM
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2019-03-08
+review_in: 6 months
+---
+
+## Using the GDS VPN
+
+Using Cisco AnyConnect will prevent traffic to *.dev.gov.uk from the host (i.e.
+your machine) reaching the guest (i.e. the VM).
+
+After disconnecting from the VPN, the routing can be restored using the following:
+
+```
+mac$ sudo ipconfig vboxnet0 delete 10.1.1.1
+mac$ sudo ipconfig set vboxnet0 manual 10.1.1.1
+```
+


### PR DESCRIPTION
The GDS VPN modifies your Mac's routing table to direct traffic to *.dev.gov.uk through the VPN.  These instructions allow you to revert that without restarting the machine.

Networking team will soon add this as a script on VPN disconnect, but this solves the problem in the meantime.