### PR TITLE
Fix the repo URL for RabbitMQ guidance

### DIFF
--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -63,7 +63,7 @@ and exchanges.
     The username is root. The password you can obtain from the govuk-secrets
     repo if you have access. Look for govuk\_rabbitmq::root\_password in the file for the
     relevant environment in
-    <https://github.com/alphagov/govuk-secrets/tree/master/puppet/hieradata> or <https://github.com/alphagov/govuk-secrets/tree/master/puppet/hieradata_aws>
+    <https://github.com/alphagov/govuk-secrets/tree/master/puppet/hieradata> or <https://github.com/alphagov/govuk-secrets/tree/master/puppet_aws/hieradata>
 
 3.  Do your business
 4.  Tidy up


### PR DESCRIPTION
The link to a path in `govuk-secrets` was broken