### PR TITLE
Update emergency banner links following move to AWS

### DIFF
--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 important: true
-last_reviewed_on: 2019-01-28
+last_reviewed_on: 2019-03-12
 review_in: 3 months
 ---
 
@@ -38,8 +38,8 @@ The data for the emergency banner is stored in Redis. Jenkins is used to set the
 1. Go to the Jenkins task:
 
   - [Deploy the emergency banner on Integration](https://deploy.integration.publishing.service.gov.uk/job/deploy-emergency-banner/)
-  - [Deploy the emergency banner on Staging](https://deploy.staging.publishing.service.gov.uk/job/deploy-emergency-banner/)
-  - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.publishing.service.gov.uk/job/deploy-emergency-banner/)
+  - [Deploy the emergency banner on Staging](https://deploy.staging.govuk.digital/job/deploy-emergency-banner/)
+  - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.production.govuk.digital/job/deploy-emergency-banner/)
 
 2. Fill in the appropriate variables using the form presented by Jenkins
 
@@ -92,8 +92,8 @@ Once all caches have had time to clear, check that the emergency banner is visib
 1. Navigate to the appropriate deploy Jenkins environment (integration, staging or production):
 
   - [Remove the emergency banner from Integration](https://deploy.integration.publishing.service.gov.uk/job/remove-emergency-banner/)
-  - [Remove the emergency banner from Staging](https://deploy.staging.publishing.service.gov.uk/job/remove-emergency-banner/)
-  - [Remove the emergency banner from Production](https://deploy.publishing.service.gov.uk/job/remove-emergency-banner/)
+  - [Remove the emergency banner from Staging](https://deploy.staging.govuk.digital/job/remove-emergency-banner/)
+  - [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.production.govuk.digital/job/remove-emergency-banner/)
 
 2. Click `Build now` in the left hand menu.
 
@@ -130,26 +130,26 @@ You can manually check whether the data has been stored in Redis by the Jenkins 
 
 1. From your development machine, SSH into a frontend machine appropriate to the environment you want to check.
 
-```
-ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+```bash
+$ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
 ```
 
 2. Load a Rails console for static:
 
-```
-govuk_app_console static
+```bash
+$ govuk_app_console static
 ```
 
 3. Check the Redis key exists:
 
-```
+```rb
 irb(main):001:0> Redis.new.hgetall("emergency_banner")
 #> {}
 ```
 
 In the above example, the key has not been set. A successfully set key would return a result similar to the following:
 
-```
+```rb
 irb(main):001:0> Redis.new.hgetall("emergency_banner")
 => {"campaign_class"=>"notable-death", "heading"=>"The heading", "short_description"=>"The short description", "link"=>"https://www.gov.uk", "link_text"=>"More information about the emergency"}
 ```
@@ -161,22 +161,21 @@ If you need to manually run the rake tasks to set the Redis keys, you can do so 
 1. SSH into a `frontend` machine appropriate to the environment you are
 deploying the banner on. For example:
 
-```
-ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+```bash
+$ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
 ```
 
 2. Change into the directory for `static`:
 
-```
-cd /var/apps/static
+```bash
+$ cd /var/apps/static
 ```
 
 3. Run the rake task to create the emergency banner hash in Redis, substituting
 the quoted data for the parameters:
 
-```
-sudo -u deploy govuk_setenv static bundle exec rake
-emergency_banner:deploy[campaign_class,heading,short_description,link,link_text]
+```bash
+$ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:deploy[campaign_class,heading,short_description,link,link_text]
 ```
 
 The `campaign_class` is directly injected into the HTML as a `class` and must be one of
@@ -196,45 +195,42 @@ following information:
 
 You would enter the following command:
 
-```
-sudo -u deploy govuk_setenv static bundle exec rake
-emergency_banner:deploy["notable-death","Alas poor Yorick","I knew him
-Horatio","https://www.gov.uk","Click for more information"]
+```bash
+$ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:deploy["notable-death","Alas poor Yorick","I knew him Horatio","https://www.gov.uk","Click for more information"]
 ```
 
 Note there are no spaces after the commas between parameters to the rake task.
 
 Quit your SSH session:
 
-```
-exit
+```bash
+$ exit
 ```
 
 ### Manually running the rake task to remove an emergency banner
 
 1. SSH into a frontend machine:
 
-```
-ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+```bash
+$ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
 ```
 
 2. Change into the directory for `static`:
 
-```
-cd /var/apps/static
+```bash
+$ cd /var/apps/static
 ```
 
 3. Run the rake task to remove the emergency banner hash from Redis:
 
-```
-sudo -u deploy govuk_setenv static bundle exec rake
-emergency_banner:remove
+```bash
+$ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:remove
 ```
 
 4. Quit your SSH session
 
-```
-exit
+```bash
+$ exit
 ```
 
 ---


### PR DESCRIPTION
The job now exists in AWS so we need to update the links to point to the right place.

Depends on https://github.com/alphagov/govuk-puppet/pull/8832 being deployed.