### PR TITLE
Update rummager replay docs

### DIFF
--- a/source/manual/rummager-traffic-replay.html.md
+++ b/source/manual/rummager-traffic-replay.html.md
@@ -34,7 +34,10 @@ These indexes are populated by whitehall calling an HTTP API in Rummager.
 We have also setup [Gor][gor] logging for `POST` and `GET` requests so that we
 can replay the traffic.
 
-The logs are stored on the rummager servers (1 file per server) location at:
+The logs are stored on the rummager servers. You will need to run the replay on
+each server.
+
+The location of the logs is:
 
 ```
 /var/log/gor_dump

--- a/source/manual/rummager-traffic-replay.html.md
+++ b/source/manual/rummager-traffic-replay.html.md
@@ -43,9 +43,10 @@ The location of the logs is:
 /var/log/gor_dump
 ```
 
-A copy of the file should be taken for the restore, as the restore requests
-will be logged to the file. The following command can be used to run the
-restore:
+You must copy the file for the restore, as the restore requests
+will be logged to the file.
+
+The following command can be used to run the restore:
 
 ```bash
 $ sudo goreplay -input-file "20171031.log|6000%" -stats -output-http-stats -output-http "http://localhost:3009/|6000%" -verbose

--- a/source/manual/rummager-traffic-replay.html.md
+++ b/source/manual/rummager-traffic-replay.html.md
@@ -49,11 +49,11 @@ will be logged to the file.
 The following command can be used to run the restore:
 
 ```bash
-$ sudo goreplay -input-file "20171031.log|6000%" -stats -output-http-stats -output-http "http://localhost:3009/|6000%" -verbose
+$ sudo goreplay -input-file "20171031.log|1000%" -stats -output-http-stats -output-http "http://localhost:3009/|6000%" -verbose
 ```
 
-This runs the restore at 60x the speed it was saved so each hour of logs takes
-1 minute to process.
+This runs the restore at 10x the speed it was saved so each hour of logs takes
+6 minutes to process.
 
 [restore-backups]: https://docs.publishing.service.gov.uk/manual/elasticsearch-dumps.html
 [queue]: https://github.com/alphagov/rummager/blob/master/doc/new-indexing-process.md


### PR DESCRIPTION
Update the rummager replay docs.

Running things at 60x speed seems to cause lots of lost connections. Drop this down to 10x which seems more reliable.

Make sure we are explicit about running the replay on all 3 servers.

Also tighten up some language to point out that you `must` make a copy of the logs.
