### PR TITLE
Move authenticating-proxy and cache-clearing-service to AWS

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -142,7 +142,7 @@
 - github_repo_name: cache-clearing-service
   type: Services
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 
 - github_repo_name: email-alert-service
   type: Services
@@ -184,7 +184,7 @@
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 
 - github_repo_name: release
   type: Supporting apps


### PR DESCRIPTION
These apps have also been migrated to AWS as part of the frontend migration.