### PR TITLE
Link reindex and low disk space Elasticsearch docs

### DIFF
--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -106,7 +106,8 @@ If this continues to be a problem see if you need to [resize the disk](/manual/a
 
 ## Low available disk space on /mnt/elasticsearch
 
-Usually this is caused by old indices not being closed.
+This is often caused by old indices not being closed after reindexing
+[Elasticsearch](/manual/reindex-elasticsearch.html#cleanup).
 
 View the dashboard to see how many indices are active on the cluster:
 

--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -95,6 +95,9 @@ Avoid leaving old indices around for more than a few days. Rummager performance
 starts to degrade once there are more than three or four old indices in the
 cluster.
 
+There is also information on using the Elasticsearch web interface to close and
+delete old indices on the [Low available disk space](/manual/alerts/low-available-disk-space.html#low-available-disk-space-on-mntelasticsearch) docs.
+
 ### Troubleshooting
 
 #### To stop the reindexing job


### PR DESCRIPTION
Closing and deleting old Elasticsearch indices is mentioned in the
reindex page. We also have docs on our low disk space page. The docs on
the low disk space page detail how to use the Elasticsearch web
interface to perform the task.

Link these two pages together so developers have all the information at
their fingertips.