### PR TITLE
Delete codecommit http creds from keychain

### DIFF
--- a/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
+++ b/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
@@ -77,3 +77,33 @@ This is fine as you don't want to deploy these.
 1. Merge the branch into master.
 
 1. Record the missing deployment in the Release app.
+
+## Troubleshooting
+
+If running any `git` commands against CodeCommit returns you a 403, you probably
+have expired credentials stored in your MacOS keychain from a previous attempt.
+Apparently MacOS stores these the first time you use it and subsequently tries
+to use them again despite you setting new AWS credentials.
+
+To fix this:
+
+1. Open Keychain Access (use cmd-space to search for it).
+
+1. Select "Passwords" from the "Category" on the left.
+
+1. Search for `git-codecommit`.
+
+1. Right click on the item and select "Get Info".
+
+1. Click "Access Control" on the modal that pops up.
+
+1. Select "git-credential-osxkeychain" from the list.
+
+1. Hit the minus key.
+
+1. Try your terminal commands again.
+
+1. If you are prompted to add the item to keychain, deny.
+
+There is more information in Step 3 in the [AWS
+guide](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html)

--- a/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
+++ b/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
@@ -22,20 +22,24 @@ This is fine as you don't want to deploy these.
 
 1. In the root of the local repo, run the following commands to install the AWS
    credential helper and add CodeCommit as a remote:
-   
-   `git config credential.helper '!aws codecommit credential-helper $@'`
-   `git config credential.UseHttpPath true`
-   `git remote add aws https://git-codecommit.eu-west-2.amazonaws.com/v1/repos/<app>`
+
+   ```
+   git config credential.helper '!aws codecommit credential-helper $@'
+   git config credential.UseHttpPath true
+   git remote add aws https://git-codecommit.eu-west-2.amazonaws.com/v1/repos/<app>
+   ```
 
 1. [Get some AWS credentials](/manual/deploying-terraform.html#2-get-your-credentials)
    for the `govuk-tools` AWS account
 
 1. Export the access key ID, secret access key and session token from the last step,
    for example:
-   
-   `export AWS_ACCESS_KEY_ID=...`
-   `export AWS_SECRET_ACCESS_KEY=...`
-   `export AWS_SESSION_TOKEN=...`
+
+   ```
+   export AWS_ACCESS_KEY_ID=...
+   export AWS_SECRET_ACCESS_KEY=...
+   export AWS_SESSION_TOKEN=...
+   ```
 
 1. Fetch the AWS upstream by running `git fetch aws`
 


### PR DESCRIPTION
AWS credentials can stick in the KeyChain which will cause 403 errors
when trying to use CodeCommit. Add instructions to remove the
credentials so developers can actually push commits.