### PR TITLE
Add absolute path check to example publishing app pages

### DIFF
--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -120,8 +120,13 @@ ssh -A -t jumpbox.production.govuk.digital 'ssh `govuk_node_list -c <%= applicat
 <h3>Example pages published by <%= application.app_name %></h3>
 
 <ul>
+<% absolute_path = Regexp.new('^([a-z]+://|//)') %>
 <% application.example_published_pages.each do |example| %>
-  <li><%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
+  <% if absolute_path.match(example['link']) %>
+    <li><%= link_to example['title'], "#{example['link']}" %></li>
+  <% else %>
+    <li><%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
+  <% end %>
 <% end %>
 </ul>
 <% end %>


### PR DESCRIPTION
Not all example published pages are on the `www.gov.uk` domain. This means that we sometimes create a malformed link such as `https://www.gov.ukhttp//www.gravesham.gov.uk`.

This adds a check to ensure that, if a protocol is present, example pages will link to their full
external path.
If no protocol is present, we continue to prefix a `www.gov.uk` domain.

https://docs.publishing.service.gov.uk/apps/search-admin.html
![Screen Shot 2019-03-18 at 15 40 35](https://user-images.githubusercontent.com/13475227/54542698-371ac700-4994-11e9-8d61-8932a0ccdc10.png)

before: `https://www.gov.ukhttp//www.gravesham.gov.uk`
after: `http://www.gravesham.gov.uk/`