### PR TITLE
Update high priority documentation for Elasticsearch upgrade

### DIFF
--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -4,7 +4,7 @@ title: Elasticsearch cluster health
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-03-20
+last_reviewed_on: 2019-03-25
 review_in: 6 months
 ---
 
@@ -28,39 +28,25 @@ can be found in the Elasticsearch documentation.
 Make sure you understand the consequences of the problem before jumping to a
 solution.
 
-Icinga uses the `check_elasticsearch` check from
+Icinga uses the `check_elasticsearch_aws` check from
 [nagios-plugins](https://github.com/alphagov/nagios-plugins/) to monitor the
-health of the Elasticsearch cluster. This plugin uses various endpoints of the
-Elasticsearch API, but also extrapolates additional information to help you
-diagnose any problems.
+health of the AWS managed Elasticsearch cluster. This plugin uses various
+endpoints of the Elasticsearch API, but also extrapolates additional
+information to help you diagnose any problems.
 
 ### Investigating problems
 
-#### Find hosts in an Elasticsearch cluster
-
-The `rummager-elasticsearch` cluster powers the GOV.UK search API and sector
-name lookup in `licence-finder`.
-
-You can find hostnames by running:
-
-```bash
-$ fab production puppet_class:govuk_elasticsearch hosts
-```
-
 #### View a live dashboard
 
-The [elasticsearch-head](http://mobz.github.io/elasticsearch-head/) plugin is a
-nice UI for looking at current state of Elasticsearch.
+The [AWS Console](https://eu-west-1.console.aws.amazon.com/es/home?region=eu-west-1#)
+provides a dashboard with graphical UI showing the state of the cluster and
+individual instances.  After logging into the console, you must [assume a
+role](/manual/aws-console-access.html#1-click-quotswitch-rolequot-in-the-top-right-corner)
+for the relevant environment to see the cluster (referred to as a 'domain' by AWS).
 
-To use this, forward port 9200 from the Elasticsearch box to your localhost:
-
-```bash
-$ ssh -L9200:localhost:9200 rummager-elasticsearch-1.api.staging
-```
-
-Access the UI at <http://localhost:9200/_plugin/head/>
-
-The tabs on top right corner for Cluster Status & Cluster Health come in handy.
+There are tabs for 'Cluster health' and 'Instance health'.  The graphs in the
+console link to AWS Cloudwatch, where historic metrics can be viewed over custom
+time periods.
 
 #### Use the Elasticsearch API
 
@@ -87,106 +73,33 @@ Response JSON from the `/_cluster/health` endpoint looks like:
 }
 ```
 
-#### Other options
-
-- Configuration files for Elasticsearch are in `/etc/elasticsearch/<name>/elasticsearch.yml`
-
-- Elasticsearch logs live at `/var/log/elasticsearch/<name>/`
-
-### How to fix unassigned shards in indices?
-
-#### Before you do anything
-
-Make sure a thorough analysis is done before fixing the problem,
-as any down time of the Elasticsearch cluster can result in loss of data. In
-general, avoid shutting down a node when there isn't any other node available
-with replicas of its shards.
-
-#### Unassigned replica shards
-
-When the health is yellow, i.e. replica shards are not allocated, Elasticsearch
-should automatically allocate another node to create replicas on, given enough
-time.
-
-You can manually interfere with this process using the
-[Cluster Reroute API][cluster-reroute-api].
-
-[cluster-reroute-api]: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html#cluster-reroute
-
-#### Unassigned primary shards
-
-We can have a red status on Elasticsearch cluster health when you have
-unassigned shards for some indices. (We have seen a similar scenario
-occur on the integration environment, when logs-es-1/3 ran out of space
-and logs-es-2 reached it load limit \[number of file open error\]).
-
-This can be solved by:
-
-Restarting Elasticsearch node in order giving elastic node enough time
-to start up and reallocate the shards allocated to it before starting
-the other Elasticsearch (this can be checked using elasticsearch-head or
-using cluster health api). This should be enough to fix the issue.
-
-An exception to the above case can happen after the restart of the
-cluster, when some shards in indices can have both primary and replica
-version unassigned. Then any further restarting would not fix the issue.
-Closing and opening the index with such an issue should fix the problem:
+A tunnel to Elasticsearch in a specific environment (e.g staging) can be created
+using the following:
 
 ```
-curl -XPOST 'localhost:9200/<index_name>/_close?pretty=true'
-curl -XPOST 'localhost:9200/<index_name>/_open?pretty=true'
+ssh -At jumpbox.staging.govuk.digital -L 9200:localhost:9200 "ssh -q \`govuk_node_list --single-node -c search\` -L 9200:elasticsearch5.blue.staging.govuk-internal.digital:80"
 ```
 
-### Split brain
+Elasticsearch will then be available at http://localhost:9200.
 
-Split brain occurs when two parts of the cluster lose connectivity with each
-other and both independently elect new master nodes, and each part of the
-cluster starts operating independently, allowing the data indexed to diverge.
+#### Logging
 
-We guard against split brain problem by following the
-[recommended practice][blog]
-of setting minimum number of master-eligible nodes to `([the size of the cluster] / 2) + 1` N/2+1.
+Access to logs is detailed in the [logging documentation](/manual/logging.html#elasticsearch).
 
-This means that when adding or removing nodes you need to ensure that all
-nodes get the updated configuration with the new value for this calculation.
+### Fixing issues with the cluster
 
-If split brain does occur, you can use the following steps to fix it. But it is
-**strongly** suggested to thoroughly investigate the problem first before
-doing so.
+GOV.UK have a Enterprise level support plan with AWS for staging and production.
+Since we are using a managed service, AWS should be the first point of contact
+for fixing issues with the Elasticsearch cluster.  They can be contacted by
+telephone, live chat or support request.
 
-- By stopping the node which considers itself to belong to two cluster
-  and belongs to two different masters. example:
+Response times are:
 
-    cluster of three boxes: e1, e2, e3
-    Clusters present after split brain:
-      e1 <-> e2
-      e2 <-> e3
+- General guidance: 24 hours
+- System impaired: 12 hours
+- Production system impaired: 4 hours
+- Production system down: 1 hour
+- Business-critical system down: 15 minutes
 
-    As per first cluster, e1 is the master, and the latter cluster e3 is the master
-
-- Waiting for the cluster health to change to yellow before restarting
-  the stopped Elasticsearch box.
-
-[blog]: http://asquera.de/opensource/2012/11/25/elasticsearch-pre-flight-checklist/#avoiding-split-brain
-
-### 'One or more indexes are missing replica shards.' despite cluster being green
-
-For some reason the Elasticsearch plugin [does not consider a replica in the
-`REALLOCATING` state to be
-healthy](https://github.com/alphagov/nagios-plugins/blob/6534386f658ce573a8b65e0f9147f61b1b0fe964/plugins/command/check_elasticsearch.py#L453).
-
-You can identify reallocating replica shards using Elasticsearch Head - they
-will be displayed in purple (reallocating) and without a thick border (replica).
-
-Alternatively, you can run check_elasticsearch directly on the Elasticsearch
-box:
-
-```
-check_elasticsearch -vv
-```
-
-As long as the cluster health is green, Elasticsearch should be reasonably happy
-and you can leave it to reallocate the replicas, which may take some time.
-
-You can monitor the progress of shard (re)allocation using the [cat recovery
-endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-recovery.html).
+All requests are created through the [AWS Console](https://console.aws.amazon.com/support/home).
+Be sure to assume the correct role first, for the environment in question.

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -4,88 +4,16 @@ title: Backup and restore Elasticsearch indices
 parent: "/manual.html"
 layout: manual_layout
 section: Backups
-last_reviewed_on: 2019-02-25
+last_reviewed_on: 2019-03-25
 review_in: 4 weeks
 ---
-There are currently two types of Elasticsearch cluster running on
-GOV.UK:
 
-* Non-managed Elasticsearch on Carrenza: Elasticsearch 2.x, being
-used by `rummager` in staging and production
-* AWS Managed Elasticsearch: Elasticsearch 5.x, used by `search-api`
-in integration only (staging and production will use this in the near
-future).
+GOV.UK uses AWS Managed Elasticsearch which takes daily snapshots
+of the cluster.
 
-There are different routes to restoring backups for each of the types
-of deployment.  Regardless of the type of cluster, traffic will need
-to be [replayed](/manual/rummager-traffic-replay.html) following the
-restore, since the index will be out-of-sync with the publishing apps.
-
-## Non-managed Elasticsearch on Carrenza
-
-The Elasticsearch indexes used for search are backed up to disk using
-[es_dump_restore](https://github.com/patientslikeme/es_dump_restore).
-
-> **Note**
->
-> This will change to S3 snapshots when production is moved to AWS
-
-### Creating a backup
-
-Sometimes you may need to take a backup before a critical operation. To do
-this, SSH to a `rummager-elasticsearch` box and run:
-
-```bash
-$ es_dump http://localhost:9200 /var/es_dump
-```
-
-The first argument is the Elasticsearch instance and the second is the
-directory in which to store the output. The user running the dump needs
-permission to write to this directory.
-
-The [env-sync-and-backup job](https://github.com/alphagov/env-sync-and-backup/blob/master/jobs/elasticsearch-rummager.sh)
-creates daily copies of the Elasticsearch snapshots and stores them in S3 for 5 days.
-
-### Restoring a backup
-
-Before restoring a backup, make sure you are
-[monitoring the cluster](/manual/alerts/elasticsearch-cluster-health.html).
-
-To view the current status of the indices from inside the Elasticsearch instance:
-
-    curl http://localhost:9200/_cat/indices
-
-Restoring to an index which exists is additive - it doesn't replace the
-existing data or delete any documents which don't exist in the dump.
-This means that if the import fails (as it sometimes does), you can simply
-re-run the command.
-
-Given a directory of dumps named after their respective indices, you can
-restore them using the same steps as the environment data sync script,
-[elasticsearch-restore.sh](https://github.com/alphagov/env-sync-and-backup/blob/master/scripts/elasticsearch-restore.sh).
-
-```
-backupfile="government.zip"
-alias_name=$(basename $backupfile .zip)
-iso_date="$(date --iso-8601=seconds|cut --byte=-19|tr [:upper:] [:lower:])z"
-real_name="$alias_name-$(date --iso-8601=seconds|cut --byte=-19|tr [:upper:] [:lower:])z-00000000-0000-0000-0000-000000000000"
-
-es_dump_restore restore_alias "http://localhost:9200/" "$alias_name" "$real_name" "$backupfile" '{}' $BATCH_SIZE
-```
-
-This will restore each backup into a new index, and then move the alias to point to it.
-
-If you need to change the alias back for any reason, you can run the rummager
-rake task `rummager:switch_to_named_index[foo-2017-01-01...]`, where
-`foo-2017-01-01...` is the name of the index you want to point the alias to.
-The task will automatically determine the correct alias name from the index
-name.
-
-Once backups have been restored it is necessary to manually delete the old
-indices as otherwise Elasticsearch will eventually run out of disk space and
-memory. It's OK to keep an old index around for a few days in case you need to
-roll back. You can delete all the unaliased indices by running the rummager
-task: `rummager:clean`.
+After a restore has taken place, traffic will need to be [replayed](/manual/rummager-traffic-replay.html)
+following the restore, since the index will be out-of-sync with the
+publishing apps.
 
 ## AWS Managed Elasticsearch 5.x
 

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -5,7 +5,7 @@ section: Logging
 layout: manual_layout
 type: learn
 parent: "/manual.html"
-last_reviewed_on: 2019-03-14
+last_reviewed_on: 2019-03-25
 review_in: 6 months
 ---
 
@@ -24,17 +24,11 @@ For information on how to log in and view stacks, please see the
 
 ### Elasticsearch
 
-#### Non-managed Elasticsearch
-
-You can access the credentials for the Elasticsearch instances in Logit using
-the `logit` key in the [govuk-secrets] 2nd Line password store.
-
-#### AWS Managed Elasticsearch
-
 Elasticsearch in AWS uses a managed service.  Logs are exported to
 [AWS Cloudwatch][aws-cloudwatch-es5] and retained for 3 days.
 
-Logs are also written to a [S3 bucket][s3-es5] for longer-term storage.
+Logs are also written to a [S3 bucket][s3-es5] which is used to import the logs
+into Logit.
 
 [aws-cloudwatch-es5]: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logs:prefix=/aws/aes/domains/blue-elasticsearch5-domain
 [s3-es5]: https://s3.console.aws.amazon.com/s3/buckets/govuk-integration-aws-logging/elasticsearch5/?region=eu-west-1&tab=overview


### PR DESCRIPTION
These documents allow 2nd line to continue supporting Elasticsearch after the upgrade.

Not to be merged until applications in production are switch to ES5/`search-api`.

Trello card: https://trello.com/c/yQ0uSINr/91-update-high-priority-documentation