### PR TITLE
Updates to Business Readiness docs

### DIFF
--- a/source/manual/business-readiness-publish-changes.html.md
+++ b/source/manual/business-readiness-publish-changes.html.md
@@ -5,7 +5,7 @@ section: Business readiness finder
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2019-03-26
+last_reviewed_on: 2019-04-10
 review_in: 3 months
 ---
 
@@ -31,15 +31,15 @@ The content item for the finder is updated from a [YAML file][govuk-app-deployme
 
 ## Updating the business readiness finder
 
-The content item for the business readiness finder and its email signup page are published by search-api. However the actual config is read in from [govuk-app-deployment-secrets][govuk-app-deployment-secrets].
+The content item for the business readiness finder and its email signup page are published by `search-api`. However the actual config is read in from [govuk-app-deployment-secrets][govuk-app-deployment-secrets].
 
 1. Update [govuk-app-deployment-secrets][govuk-app-deployment-secrets]
 2. Merge the changes to [govuk-app-deployment-secrets][govuk-app-deployment-secrets]
-3. Re-deploy search-api so it can pick up the changes in [govuk-app-deployment-secrets][govuk-app-deployment-secrets]
+3. Re-deploy `search-api` so it can pick up the changes in [govuk-app-deployment-secrets][govuk-app-deployment-secrets]
 
-  N.B. If you have made changes to the facets, you may also need to re-deploy email-alert-api and finder-frontend
+  >> If you have made changes to the facets, you may also need to re-deploy email-alert-api and finder-frontend
 
-4. Run the `publishing_api:publish_eu_exit_business_finder` [rake task][staging-rake-task] in search-api to publish the changes:
+4. Run the [`publishing_api:publish_eu_exit_business_finder` rake task][staging-rake-task] in `search-api` to publish the changes:
 
     ![download](images/publish-business-readiness.png)
 

--- a/source/manual/business-readiness-update-content.html.md
+++ b/source/manual/business-readiness-update-content.html.md
@@ -5,7 +5,7 @@ section: Business readiness finder
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2019-03-26
+last_reviewed_on: 2019-04-10
 review_in: 3 months
 ---
 
@@ -13,7 +13,7 @@ The [business readiness finder][business-readiness-finder] relies on metadata ta
 
 ## Updating content
 
-Content is curated and added to a [spreadsheet][] by the content team. Developer help is needed to upload the content. We do this by converting the spreadsheet into a CSV, including it in [govuk-app-deplopment-secrets][govuk-app-deployment-secrets] and then releasing search-api.
+Content is curated and added to a [spreadsheet][] by the content team. Developer help is needed to upload the content. We do this by converting the spreadsheet into a CSV, including it in [govuk-app-deployment-secrets][govuk-app-deployment-secrets] and then releasing `search-api`.
 
 The process of converting the spreadsheet into a CSV involves removing a header row and converting windows encoded line breaks if present.  There is a [script](https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/bin/prep_csv) to do this.
 
@@ -24,15 +24,15 @@ The process of converting the spreadsheet into a CSV involves removing a header 
 2. `cd govuk-app-deployment-secrets`
 3. `bin/prep_csv ~/Downloads/your-downloaded-file.csv`
 4. Create a pull request and get it reviewed & merged.
-5. Re-deploy search-api and email-alert-api via Jenkins.
-6. Run the `tag_metadata` rake task in search-api to index the contents of the new CSV, it should take 2 to 3 minutes:
+5. Re-deploy `search-api` and `email-alert-api` via Jenkins and the [Release app][release-app].
+6. Run the [`tag_metadata`](https://github.com/alphagov/search-api/blob/3eef678b897b86877b7a2676dd99110e3bad52df/lib/tasks/metadata_tagger.rake#L4) rake task in search-api to index the contents of the new CSV, it should take 2 to 3 minutes:
     * [integration][tag_metadata_integration]
     * [staging][tag_metadata_staging]
-    * [production (search-api)][tag_metadata_production]
+    * [production][tag_metadata_production]
 
     ![rake_task](images/rake.png)
 
-7. Check the results on e.g. [https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business](https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business)
+7. Check the results on e.g. [https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business][origin-integration-business-readiness]
 
 > These requests often come in through Zendesk and for pages that have only been created that same day, so you may only be able to check this in production.
 
@@ -47,17 +47,30 @@ There are also other useful [rake tasks][rake_tasks]. Remember to redeploy apps 
 
 Requests from Zendesk can specify that content is pinned within the finder. Pinning an item means that it appears at the top of whatever business finder facet(s) it is tagged to. The process for adding a pinned item:
 
-1. Using the base path of the content item to be pinned, get the content id. You can do this via the publishing-api:
-```Edition.includes(:document).where(base_path: paths).pluck(:content_id).uniq```
-2. Add the content id to the list of [ordered related items for the business finder](https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/shared_config/find-eu-exit-guidance-business.yml#L222-L244), within govuk-app-deployment-secrets.  Despite the name, the order of the `ordered_related_items` does not matter.
+1. Using the base path of the content item to be pinned, get the `content_id`. You can use  the [govuk-toolkit][govuk-toolkit] browser extension, or via the `publishing-api`:
+
+    ```
+    Edition.includes(:document).where(base_path: paths).pluck(:content_id).uniq
+    ```
+
+2. Add the content id to the list of [ordered related items for the business finder][ordered-related-items], within [`govuk-app-deployment-secrets`][govuk-app-deployment-secrets].  Despite the name, the order of the `ordered_related_items` does not matter.
 3. Create a pull request and get it reviewed & merged.
-4. Re-deploy search-api.
-5. Update the finder content by running the [`tag_metadata` rake task][staging-rake-task] in search-api to index the contents of the new CSV, it should take 2 to 3 minutes.
+4. Re-deploy `search-api` via Jenkins and the [Release app][release-app].
+5. Update the finder content by running the [`tag_metadata` rake task][tag_metadata_staging] in `search-api` to index the contents of the new CSV, it should take 2 to 3 minutes.
 6. [Republish the finder][republish_finder] so that the finder content item is updated.
-7. Check the results on e.g. [https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business](https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business)
+7. Check the results on e.g. [https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business][origin-integration-business-readiness]
 
-The same process applies for removing a pinned item: get the content item and remove it from the list within the ordered-related items.
+> Pinned items rely on the `finder-frontend` content item which has a cache time of 5 mins and is independent of cachebusting.
 
+
+## Removing pinned content to sections in the business readiness finder
+
+The same process [as above](#pinning-content-to-sections-in-the-business-readiness-finder) applies for removing a pinned item: get the content item and remove it from the list within the [ordered-related items][ordered-related-items].
+
+[origin-integration-business-readiness]: https://www-origin.integration.publishing.service.gov.uk/find-eu-exit-guidance-business
+[ordered-related-items]: https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/shared_config/find-eu-exit-guidance-business.yml#L263
+[release-app]: https://release.publishing.service.gov.uk/applications
+[govuk-toolkit]: https://github.com/alphagov/govuk-browser-extension
 [govuk-app-deployment-secrets]: https://github.com/alphagov/govuk-app-deployment-secrets
 [destroy-metadata]: https://github.com/alphagov/search-api/blob/605b08bc96999b58d3a5eb57967ffc7a8de1e41c/lib/tasks/metadata_tagger.rake#L9
 [metadata-rake-task]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=search-api&MACHINE_CLASS=search&RAKE_TASK=destroy_metadata_for_base_paths


### PR DESCRIPTION
Small amendments to the docs include:
- fixing some broken links
- fixing some styling/layout issues
- review of content now that we are using `search-api` rather than
`rummager`