### PR TITLE
Update Dependabot guidance

### DIFF
--- a/source/manual/manage-ruby-dependencies.html.md
+++ b/source/manual/manage-ruby-dependencies.html.md
@@ -13,18 +13,6 @@ We're [obliged to keep our software current][current].
 
 To help with this, we use a service called [Dependabot][] to perform automated dependency upgrades.
 
-## Who can merge Dependabot PRs
-
-- GOV.UK-owned gems (govuk_app_config, govspeak for example) need 1 reviewer
-- Gems found in the `test` block in the `Gemfile` (Capybara for example) need 1 reviewer
-- All other gems (Rails for example) are [considered to be from a external contributor][ext] and need 2 reviews
-
-> **Note:** there is currently [an rfc](https://github.com/alphagov/govuk-rfcs/pull/103) open to discuss merging in Dependabot PRs with only a single review.
-
-You can ignore pull requests from the bot by replying `@dependabot ignore this major version`, but you have to add the PR to the [tech debt Trello board][tech-debt]
-
-If a PR contains a mixture of GOV.UK-owned gems and other gems (which are not solely included in the `test` block of the Gemfile), it will need 2 reviews.
-
 ## Add Dependabot to a repo
 
 1. Give Dependabot [access to the repo][access] (only GitHub org owners can do this)
@@ -41,7 +29,6 @@ Go to [Dependabot admin][admin] and click "Bump now" for your project
 There are 2 safeguards to prevent unauthorised code changes. Firstly, Dependabot can only update the repositories that we [explicitly allow on GitHub][access]. This prevents code changes to other repos. Secondly, we've [set up branch protection](/manual/configure-github-repo.html#auto-configuration) for all repos with the `govuk` label. This prevents Dependabot from writing directly to master.
 
 [ext]: https://docs.publishing.service.gov.uk/manual/merge-pr.html
-[tech-debt]: https://trello.com/b/oPnw6v3r
 [access]: https://github.com/organizations/alphagov/settings/installations/87197
 [current]: /manual/keeping-software-current.html
 [Dependabot]: https://dependabot.com

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -68,11 +68,21 @@ Change `thomasjhughes` to the GitHub username of the contributor and `patch-1` t
 
 #### Dependabot
 
-Dependabot raises PRs whenever it sees new versions of gems available that are required by our applications.
+As Dependabot changes the Gemfile/Gemfile.lock, or some other package
+management related manifests in the repository, when reviewing the
+diff, you should especially check if this is the case. Dependabot
+shouldn't be making changes other than these.
 
-Dependabot is an external contributor and is therefore subject to the same due diligence checks set out above as any other external contributor would have to go through, requiring two people from GDS to approve the PR before it can be merged. Particular attention should be paid to the changelog(s) of the upgraded gem(s) to ensure that no unintended side-effects are introduced.
+As well as reviewing the diff, take note of the version changes
+involved, and consider looking at the release notes or changelog for
+the affected packages.
 
-The exception to the number of GDS people required to review the PR is if the gems being upgraded consist of **only** GOV.UK-owned gems or gems in the `test` block of the Gemfile. If the PR includes _any_ external gems which are not in the `test` block of the Gemfile, two approvals must be obtained. See [Manage Ruby dependencies with Dependabot](/manual/manage-ruby-dependencies.html) for more information.
+If you decide that particular versions are inappropriate, then you can
+inform Dependabot through commands like `@dependabot ignore this major
+version`. If you do this, add the PR to the [tech debt Trello
+board][tech-debt].
+
+[tech-debt]: https://trello.com/b/oPnw6v3r
 
 ### A change where two people worked on the same branch
 


### PR DESCRIPTION
Following on from RFC 103 [1], Dependabot Pull Requests can now be
merged with only a single review.

Therefore, update the guidance on merging Dependabot Pull Requests to
talk more about what to pay attention to when reviewing Pull Requests
by Dependabot, rather than how many people should approve the Pull
Request before it can be merged.

1: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-103-merge-dependabot-pull-requests-with-a-single-review.md