### PR TITLE
Update hosting for the Data Informed Content apps

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -153,7 +153,7 @@
 - github_repo_name: content-performance-manager
   type: Supporting apps
   team: "#govuk-data-informed"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 
 - github_repo_name: content-audit-tool
   type: Supporting apps
@@ -163,7 +163,7 @@
 - github_repo_name: content-data-admin
   type: Supporting apps
   team: "#govuk-data-informed"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 
 - github_repo_name: search-admin
   type: Supporting apps


### PR DESCRIPTION
They've both been moved to AWS.