### PR TITLE
Fix deploy URL in AWS

### DIFF
--- a/source/manual/cache-flush.html.md
+++ b/source/manual/cache-flush.html.md
@@ -30,9 +30,9 @@ the various caches manually:
 - **Fastly**: [`rake cache:clear_fastly[/your-path-here]`][jenkins-fastly-task]
 - **Both**: [`rake cache:clear[/your-path-here]`][jenkins-both-task]
 
-[jenkins-varnish-task]: https://deploy.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear_varnish[/your-path-here]
-[jenkins-fastly-task]: https://deploy.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear_fastly[/your-path-here]
-[jenkins-both-task]: https://deploy.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear[/your-path-here]
+[jenkins-varnish-task]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear_varnish[/your-path-here]
+[jenkins-fastly-task]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear_fastly[/your-path-here]
+[jenkins-both-task]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=cache-clearing-service&MACHINE_CLASS=backend&RAKE_TASK=cache:clear[/your-path-here]
 
 ### Assets
 

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -38,8 +38,8 @@ The data for the emergency banner is stored in Redis. Jenkins is used to set the
 1. Go to the Jenkins task:
 
   - [Deploy the emergency banner on Integration](https://deploy.integration.publishing.service.gov.uk/job/deploy-emergency-banner/)
-  - [Deploy the emergency banner on Staging](https://deploy.staging.govuk.digital/job/deploy-emergency-banner/)
-  - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.production.govuk.digital/job/deploy-emergency-banner/)
+  - [Deploy the emergency banner on Staging](https://deploy.blue.staging.govuk.digital/job/deploy-emergency-banner/)
+  - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.blue.production.govuk.digital/job/deploy-emergency-banner/)
 
 2. Fill in the appropriate variables using the form presented by Jenkins
 
@@ -92,8 +92,8 @@ Once all caches have had time to clear, check that the emergency banner is visib
 1. Navigate to the appropriate deploy Jenkins environment (integration, staging or production):
 
   - [Remove the emergency banner from Integration](https://deploy.integration.publishing.service.gov.uk/job/remove-emergency-banner/)
-  - [Remove the emergency banner from Staging](https://deploy.staging.govuk.digital/job/remove-emergency-banner/)
-  - [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.production.govuk.digital/job/remove-emergency-banner/)
+  - [Remove the emergency banner from Staging](https://deploy.blue.staging.govuk.digital/job/remove-emergency-banner/)
+  - [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.blue.production.govuk.digital/job/remove-emergency-banner/)
 
 2. Click `Build now` in the left hand menu.
 


### PR DESCRIPTION
These were not including the stack name in the URL, therefore were being redirected to the default stack.  The redirection lost the query string and path.