### PR TITLE
Amend HMRC PAYE tool instructions

### DIFF
--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -53,34 +53,36 @@ the previous version of the software.
 
 1.  HMRC submit a ticket via Zendesk
     ([example](https://govuk.zendesk.com/tickets/771694))
-2.  Download all zip files and XML file in the ticket
-3.  Upload the new files:
+1.  Check that GOV.UK content teams are aware of the ticket.  They may
+    need to request further tickets to be raised to cover the content updates.
+1.  Download all zip files and XML file in the ticket
+1.  Upload the new files:
 
         ssh backend-1.production "mkdir -p /tmp/hmrc-paye && rm -rf /tmp/hmrc-paye/*"
         scp *.zip backend-1.production:/tmp/hmrc-paye
         scp *.xml backend-1.production:/tmp/hmrc-paye
 
-4.  Load the files into the Asset Manager, with "test-" at the start of the manifest file's name:
+1.  Load the files into the Asset Manager, with "test-" at the start of the manifest file's name:
 
         ssh backend-1.production
         cd /var/apps/asset-manager
         sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_zips[/tmp/hmrc-paye]
         sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_asset[/tmp/hmrc-paye/realtimepayetools-update-vXX.xml,test-realtimepayetools-update-vXX.xml]
 
-5.  [Purge the cache](https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets) for the test file.
+1.  [Purge the cache](https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets) for the test file.
 
-6.  Reply to the Zendesk ticket, providing the `test-*.xml` URL of:
+1.  Reply to the Zendesk ticket, providing the `test-*.xml` URL of:
 
         https://www.gov.uk/government/uploads/uploaded/hmrc/test-realtimepayetools-update-vXX.xml
 
-7.  When Aspire or one of the other suppliers replies that the file
+1.  When Aspire or one of the other suppliers replies that the file
     works fine, the new edition of the [mainstream content
     item](https://www.gov.uk/basic-paye-tools) and [Welsh
     translation](https://www.gov.uk/lawrlwytho-offer-twe-sylfaenol-cthem)
     can be prepped by the content team with the new links, file sizes and version
     number, ready to publish at the launch time.
 
-8.  When the launch time comes (which should be specified in the Zendesk
+1.  When the launch time comes (which should be specified in the Zendesk
     ticket), re-load the test file to the production path:
 
         ssh backend-1.production
@@ -89,8 +91,8 @@ the previous version of the software.
 
     You will have to copy the file to the server again if it has been deleted since it was first uploaded.
 
-9. Publish the content items.
+1. Publish the content items.
 
-10. [Purge the cache](https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets) for the new file.
+1. [Purge the cache](https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets) for the new file.
 
-11.  Update and resolve the Zendesk ticket
+1.  Update and resolve the Zendesk ticket


### PR DESCRIPTION
It's useful if the content team knows about this as soon as we do so they can schedule the work in.

Also updated the numbering so that it's easier to fiddle with the steps from now on.  (It still works)