### PR TITLE
reorder sections for readability

### DIFF
--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -82,6 +82,18 @@ Keep this section limited to core endpoints - if the app is complex link out to 
 - functionality is shown in screenshots and links to live services
 - it has quick start information for new developers or interested third parties
 
+## One-line summaries on GitHub repositories
+
+Who are these for? These are for people who scan the list in [alphagov](https://github.com/alphagov/) and need a quick overview.
+
+- Include information about whether it's on GOV.UK
+- Try to tone down technical language - 'Filtered search of content' is better than 'Faceted search interface'
+- Use the GitHub link field to link to the developer docs page for the repository, or otherwise the live service (if public facing)
+
+A good example:
+
+> GOV.UK filtered search of public content
+
 ## Things we shouldn't put in the README
 
 - Full documentation of the API - if the app is complex or has a complex API, use the `docs` directory liberally, and link out to it from the `README`
@@ -98,15 +110,3 @@ Keep this section limited to core endpoints - if the app is complex link out to 
   - When writing this document, always link to the [GOV.UK pull request style guide](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
   - Document any weirdness here (eg when to use Cucumber over something else)
 - Full licence - again, follow [GitHub convention](https://help.github.com/articles/open-source-licensing/#where-does-the-license-live-on-my-repository)
-
-## One-line summaries on GitHub repositories
-
-Who are these for? These are for people who scan the list in [alphagov](https://github.com/alphagov/) and need a quick overview.
-
-- Include information about whether it's on GOV.UK
-- Try to tone down technical language - 'Filtered search of content' is better than 'Faceted search interface'
-- Use the GitHub link field to link to the developer docs page for the repository, or otherwise the live service (if public facing)
-
-A good example:
-
-> GOV.UK filtered search of public content


### PR DESCRIPTION
Scanning the page, it looked as though "One-line summaries on GitHub repositories" came _under_ "Things we shouldn't put in the README". Took a few seconds to figure out that GovUK guidelines _encourage_ writing the one-line summaries, rather than discourage it!

Reordering the sections would remove those few seconds of doubt.