### PR TITLE
Provide example of "short name" on AWS

### DIFF
--- a/source/manual/alerts/puppet-last-run-errors.html.md
+++ b/source/manual/alerts/puppet-last-run-errors.html.md
@@ -4,7 +4,7 @@ title: Puppet last run errors
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-01-23
+last_reviewed_on: 2019-5-13
 review_in: 6 months
 ---
 
@@ -12,7 +12,7 @@ This alert triggers when there's an error while running Puppet on a machine.
 
 To view the errors in Kibana, first login to [Logit](/manual/logit.html), and then
 run the following query (where `$hostname` is the short name of the machine
-linked to the alert, for example `backend-1`):
+linked to the alert, for example `backend-1` in Carrenza or `10-1-2-3` in AWS):
 
 `syslog_program:"puppet-agent" AND host:$hostname`
 


### PR DESCRIPTION
The instructions need you to specify a "short name", so it's nice to provide an example of what this looks like in each hosting environment.