### PR TITLE
2nd line dev docs update

### DIFF
--- a/source/manual/before-you-start.html.md
+++ b/source/manual/before-you-start.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
 type: learn
-last_reviewed_on: 2019-04-18
+last_reviewed_on: 2019-05-13
 review_in: 2 months
 ---
 
@@ -31,7 +31,7 @@ Most alerts have some documentation in our [developer docs](https://docs.publish
 [Zendesk](https://govuk.zendesk.com) is our support ticketing system.
 [Create an account](https://govuk.zendesk.com/auth/v2/login/registration?auth_origin=3194076%2Cfalse%2Ctrue&amp;brand_id=3194076&amp;return_to=https%3A%2F%2Fgovuk.zendesk.com%2Fhc%2Fen-us&amp;theme=hc) if you don't have one yet. Then ask a fellow 2nd liner to add a new ticket assigned to _2nd/3rd Line—Zendesk Administration_ asking to give you access to _2nd Line - GOV.UK Alerts and Issues_.
 
-This [diagram shows you how to process tickets](https://docs.google.com/presentation/d/1H8F9sTv283N_5j-3-LT2OW8Xvx0NrfCG1IjNA10vu2g/edit?usp=sharing).
+This [diagram shows you how to process tickets](https://drive.google.com/a/digital.cabinet-office.gov.uk/file/d/0B72Q_z4wkLglYkVQd01LSWYwNjNha3NrYVVIMF91eXk3NU1r/view?usp=sharing).
 
 This [page is on how to manage Zendesk tickets](/https://docs.publishing.service.gov.uk/manual/managing-product-support-tickets-zendesk.html).
 

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -4,7 +4,7 @@ title: Upload HMRC PAYE files
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-04-18
+last_reviewed_on: 2019-05-10
 review_in: 6 months
 ---
 
@@ -76,7 +76,7 @@ the previous version of the software.
     item](https://www.gov.uk/basic-paye-tools) and [Welsh
     translation](https://www.gov.uk/lawrlwytho-offer-twe-sylfaenol-cthem)
     can be prepped by the content team with the new links, file sizes and version
-    number, ready to publish at the launch time. Pass the Zendesk ticket over to content support by reassigning it to '3rd line--GOV.UK Content' and adding the green team tag, 'business_defence_environment' . 
+    number, ready to publish at the launch time. Pass the Zendesk ticket over to content support by reassigning it to '3rd line--GOV.UK Content' and adding the green team tag, 'business_defence_environment' .
 
 8.  When the launch time comes (which should be specified in the Zendesk
     ticket), re-load the test file to the production path:

--- a/source/manual/managing-product-support-tickets-zendesk.html.md
+++ b/source/manual/managing-product-support-tickets-zendesk.html.md
@@ -4,7 +4,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
 owner_slack: "#govuk-2ndline"
-last_reviewed_on: 2019-04-19
+last_reviewed_on: 2019-05-13
 review_in: 6 months
 ---
 2nd line Zendesk tickets are technical errors reported by our users, including government publishers and should be trusted by default. Any questions on the legitimacy or urgency of a ticket should be deferred to the delivery manager.
@@ -49,5 +49,5 @@ General rule of thumb: don’t write anything you wouldn’t say to someone publ
 2. Work on solving ‘Open tickets’ in the ‘high’ priority queue, starting with the oldest by date.  
   1. If external assistance from outside 2nd line is required then assign it to them on the ticket and move on to the next ticket (keep the ticket in the 2nd line queue)
   2. If you’re working on a long-running ticket, let your 2nd line crew know so they can keep an eye on the alerts.
-3. Apply the set macro: GOV.UK 2nd line tech: reply and close ticket as ‘pending’ for 5 days.  for tickets in ‘Normal’ and ‘High’ that have been ‘pending’ a response for more than 5 days.
-4. If the volume of Zendesk tickets is overwhelming, talk to the delivery manager or a senior tech member for assistance. 
+3. Apply the set macro: 'GOV.UK 2nd line tech:pending for 5+ days' to close tickets in ‘Normal’ and ‘High’ that have been 'pending’ a response for more than 5 days.
+4. If the volume of Zendesk tickets is overwhelming, talk to the delivery manager or a senior tech member for assistance.

--- a/source/manual/raising-issues-with-reliability-engineering.html.md
+++ b/source/manual/raising-issues-with-reliability-engineering.html.md
@@ -4,7 +4,7 @@ title: Raise issues with Reliability Engineering
 parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
-last_reviewed_on: 2019-02-11
+last_reviewed_on: 2019-05-13
 review_in: 3 months
 ---
 
@@ -13,24 +13,36 @@ infrastructure that most GDS software runs on and the underlying network
 configuration. They also provide shared software services used by
 various GDS programmes such as logging and monitoring tools.
 
-When on 2nd line you may experience an issue with GOV.UK that requires asking
-Reliability Engineering for assistance.
+When on 2nd line you may experience an issue with GOV.UK that requires asking the RE GOV.UK team in Reliability Engineering for assistance.
 
 There are [Reliability Engineering docs](https://reliability-engineering.cloudapps.digital/) for users of their systems. There are also [other Reliability Engineering docs](https://re-team-manual.cloudapps.digital/) for use by the team, these may contain more technical details.
 
 ## If you require urgent assistance
 
-Reliability Engineering have a Slack channel - #reliability-eng - and they
+The RE GOV.UK have a Slack channel - #re-govuk - and they
 have an assigned interruptible person. By posting in that channel you can get
 their attention. This channel can be used for general queries too so do
 indicate in your message that a problem is time critical.
 
-Failing slack communication you can also walk over to Reliability Engineering
-desks and talk to the interruptible person directly - they are currently on
-the 6th floor near bank 27-28.
+Failing slack communication you can also walk over to the RE GOV.UK team desks and talk to the interruptible person directly - they are currently on the 6th floor near bank 27-28.
 
 You may be advised to create a
 [Zendesk ticket](#raising-a-zendesk-ticket-with-reliability-engineering).
+
+## If you need to handover a long-standing incident
+
+If this is in-hours:
+A Site Reliabilty Engineer from the RE GOV.UK team should take over the incident lead role.
+A 2nd line GOV.UK engineer will continue the comms lead role.
+
+
+If this is out-of-hours:
+The primary GOV.UK engineer should be the incident lead and support the RE GOV.UK out of hours engineer to fix the problem. The secondary GOV.UK engineer should be the comms lead.
+
+To escalate an incident to the RE GOV.UK engineer via PagerDuty:
+
+1. Click on the incident in PagerDuty
+2. Click on ‘Run a play’ to select ‘call the RE GOV.UK on-call person’
 
 ## If a problem is not urgent
 

--- a/source/manual/who-do-i-ask-for-support.html.md
+++ b/source/manual/who-do-i-ask-for-support.html.md
@@ -4,7 +4,7 @@ title: Ask for help
 parent: "/manual.html"
 layout: manual_layout
 section: Learning GOV.UK
-last_reviewed_on: 2018-11-20
+last_reviewed_on: 2019-05-13
 review_in: 6 months
 ---
 
@@ -36,6 +36,6 @@ If you and your colleagues can’t resolve a technical issue, problem or questio
 2. The Lead Developer on the programme
 3. The Lead Architect
 
-If 2nd Line instructs you to escalate something to Reliability Engineering, raise a ticket on Zendesk and assign it to the `3rd Line--Infrastructure` queue. You should also raise a ticket if the issue is related to an ongoing incident for tracking purposes, but you can speak to the team directly to get it more immediate attention.
+If 2nd Line instructs you to escalate something to Reliability Engineering, raise a ticket on Zendesk and assign it to the `3rd Line--GDS Reliability Engineering` queue. You should also raise a ticket if the issue is related to an ongoing incident for tracking purposes, but you can speak to the team directly to get it more immediate attention.
 
 If you speak to Reliability Engineering about a process only they know about, they will work with you to document the process for all of GOV.UK.

--- a/source/manual/working-on-2nd-line.html.md
+++ b/source/manual/working-on-2nd-line.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
 type: learn
-last_reviewed_on: 2019-02-15
+last_reviewed_on: 2019-05-13
 review_in: 3 months
 ---
 
@@ -15,7 +15,7 @@ When working on 2nd line, we look at Normal and High priority tickets in the Zen
 We respond to alerts on our environments and deal with (in priority order) critical issues and warnings. We acknowledge alerts that are not actionable or causing problems for the platform.
 
 ## Triaging Zendesk tickets
-See the [diagram for how 2nd line triage Zendesk tickets](https://docs.google.com/presentation/d/1H8F9sTv283N_5j-3-LT2OW8Xvx0NrfCG1IjNA10vu2g/edit?usp=sharing) - there is a printout on the 2nd line desk.
+See the [diagram for how 2nd line triage Zendesk tickets](https://drive.google.com/a/digital.cabinet-office.gov.uk/file/d/0B72Q_z4wkLglYkVQd01LSWYwNjNha3NrYVVIMF91eXk3NU1r/view?usp=sharing) - there is a printout on the 2nd line desk.
 
 Other things to know:
 


### PR DESCRIPTION
Main update:

Added instructions on how to escalate a long-standing incident to the RE GOV.UK team to 'working with Reliability Engineering'.

Small updates to other pages:

Added a link to the new Zendesk flow diagram to pages linking to the old version. 
Updated the name of the 3rd line Zendesk queue for tickets we triage to RE GOV.UK. 