### PR TITLE
Adds additional notice for redirection URL

### DIFF
--- a/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
+++ b/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
@@ -43,6 +43,7 @@ $ bundle exec 'publishing_api:redirect_html_attachments:dry[document_content_id,
 ```
 publishing_api:redirect_html_attachments:dry[f8781a75-9fb7-409a-a37d-3a5877ad28fb,/government/collections/trading-with-the-eu-if-the-uk-leaves-without-a-deal]
 ```
+> Note: Please make sure the REDIRECTION_URL starts with a `/`, otherwise the redirection will not work.
 
 This attempts to locate the HtmlAttachments for the latest unpublished Edition of the Document, and if found, report to the user the HtmlAttachment's slugs and where they would have been redirected to.
 


### PR DESCRIPTION
Added guidance for redirection URL. The job return success in Jenkins but fails to actually take effect if there is no `/` at the beginning of the URL.