### PR TITLE
Rename the content-performance-manager app healthcheck page

### DIFF
--- a/source/manual/alerts/content-data-api-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-healthcheck-not-ok.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-data-informed"
-title: content-performance-manager app healthcheck not ok
+title: content-data-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
@@ -10,7 +10,7 @@ review_in: 6 months
 
 Please notify Data Informed Content via Slack `#govuk-data-informed` about the alarm. The product is currently in private beta, so the development team will help solve any issues.
 
-If there is a health check error showing for Content Performance Manager, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
+If there is a health check error showing for Content Data API, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
 
 ## ETL :: no monthly aggregations of metrics for yesterday
 
@@ -76,7 +76,7 @@ To fix this problem run the [following rake task][4]:
 rake etl:repopulate_feedex["2018-01-01","2018-01-01"]
 ```
 
-[1]: https://deploy.publishing.service.gov.uk/job/content_performance_manager_import_etl_master_process/
+[1]: https://deploy.publishing.service.gov.uk/job/content_data_api_import_etl_master_process/
 [2]: https://github.com/alphagov/content-performance-manager/blob/87116d3ab6f75c0d3dd8be9d4aff80865702f1b9/lib/tasks/etl.rake#L8
 [3]: https://github.com/alphagov/content-performance-manager/blob/8dd689e6917d7bbbf23a99387b85bfe1ce04d7b1/lib/tasks/etl.rake#L18
 [4]: https://github.com/alphagov/content-performance-manager/blob/b886c5489c79a6b5a58190e305ea9746fd7db666/lib/tasks/etl.rake#L29


### PR DESCRIPTION
With the migration to AWS, the Content Performance Manager has been
renamed to the Content Data API. This includes the healthcheck alert,
so update the documentation page accordingly.