### PR TITLE
Add doc for datagovuk_publish healthcheck

### DIFF
--- a/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
@@ -1,0 +1,23 @@
+---
+owner_slack: "#govuk-2ndline"
+title: datagovuk_publish app healthcheck not ok
+parent: "/manual.html"
+layout: manual_layout
+section: Icinga alerts
+last_reviewed_on: 2019-05-17
+review_in: 3 months
+---
+
+[datagovuk_publish](https://github.com/alphagov/datagovuk_publish)
+has a healthcheck that monitors two Sidekiq jobs,
+[`ckan_v26_package_sync`](https://github.com/alphagov/datagovuk_publish/blob/master/app/workers/ckan/v26/package_sync_worker.rb)
+and [`ckan_v26_ckan_org_sync`](https://github.com/alphagov/datagovuk_publish/blob/master/app/workers/ckan/v26/ckan_org_sync_worker.rb).
+
+The healthcheck alert notifies us if one or both of these jobs are not running in
+the expected timeframe set. This means latest [dataset](https://ckan.publishing.service.gov.uk/dataset)
+or [publisher](https://ckan.publishing.service.gov.uk/publisher) updates are
+not appearing on data.gov.uk - see [Troubleshoot data.gov.uk](https://docs.publishing.service.gov.uk/manual/data-gov-uk-troubleshooting.html#datasets-published-in-ckan-are-not-appearing-on-find)
+
+You can monitor the number of jobs in the Sidekiq queue
+[using the console](https://docs.publishing.service.gov.uk/manual/data-gov-uk-monitoring.html#sidekiq-publish)
+or accessing the [SidekiqUI](https://docs.publishing.service.gov.uk/manual/data-gov-uk-monitoring.html#sidekiq-ui-publish).

--- a/source/manual/data-gov-uk-monitoring.html.md
+++ b/source/manual/data-gov-uk-monitoring.html.md
@@ -59,7 +59,7 @@ Sidekiq UI is only accessible to the `localhost` domain, so you'll need an SSH t
 cf ssh -L 9000:localhost:8080 publish-data-beta-staging
 ```
 
-Then go to [localhost:9000/sidekiq](http://localhost:9000/sidekiq) in your browser to see active jobs, retries and to manually modify the schedule.
+Then go to [localhost:9000/sidekiq/recurring-jobs](http://localhost:9000/sidekiq/recurring-jobs) in your browser to see active jobs, retries and to manually modify the schedule.
 
 ## Analytics
 


### PR DESCRIPTION
We recently added an [Icinga healthcheck](https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/checks/datagovuk_publish.pp)
for `datagovuk_publish`. This is the doc that the alert links to
in icinga.

Related PR: https://github.com/alphagov/govuk-puppet/pull/9161

Trello card: https://trello.com/c/ba8SOqEM/960-add-an-icinga-alert-to-notify-us-if-any-of-the-scheduled-dgu-sync-jobs-are-disabled