### PR TITLE
Add details for the new govuk-internal-administrators role

### DIFF
--- a/source/manual/aws-console-access.html.md
+++ b/source/manual/aws-console-access.html.md
@@ -37,6 +37,7 @@ Options for "Account":
 Options for "Role":
 
 - `govuk-administrators`
+- `govuk-internal-administrators`
 - `govuk-powerusers`
 - `govuk-platformhealth-powerusers`
 - `govuk-users`

--- a/source/manual/deploying-terraform.html.md
+++ b/source/manual/deploying-terraform.html.md
@@ -18,7 +18,7 @@ to our AWS environments. Specifically, the level of access your Amazon Resource 
 
 - `govuk-users` (`role_user_user_arns`) can't deploy anything
 - `govuk-powerusers` (`role_poweruser_user_arns`) and `govuk-platformhealth-powerusers` (`role_platformhealth_poweruser_user_arns`) can deploy everything except IAM (users and policies).
-- `govuk-administrators` (role_admin_user_arns) can deploy everything including IAM.
+- `govuk-administrators` (`role_admin_user_arns`) and `govuk-internal-administrators` (`role_internal_admin_user_arns`) can deploy everything including IAM.
 
 You can find which class of user you are (what your arn has been assigned to) [in the infra-security
 project in

--- a/source/manual/set-up-aws-account.html.md
+++ b/source/manual/set-up-aws-account.html.md
@@ -59,9 +59,10 @@ Follow steps 1 - 7 in [Set up your MFA](#3-set-up-your-mfa). Then:
 
 An account in AWS doesn't give you access to anything, you'll need to be given rights.
 
-Add yourself to a lists of users found in [the data for the infra-security project][infra-terra]. There are 4 groups:
+Add yourself to a lists of users found in [the data for the infra-security project][infra-terra]. There are 5 groups:
 
-- `govuk-administrators`: people in Reliability Engineering who are working on GOV.UK infrastructure, Architects and Lead Developers of GOV.UK and anyone else working on the AWS migration
+- `govuk-administrators`: people in Reliability Engineering who are working on GOV.UK infrastructure
+- `govuk-internal-administrators`: people in GOV.UK who are working on GOV.UK infrastructure including Architects, Lead Developers and anyone else working on the AWS migration
 - `govuk-powerusers`: anyone else who can have production access on GOV.UK
 - `govuk-platformhealth-powerusers`: as above but for members of the GOV.UK Platform Health team
 - `govuk-users`: anyone else who needs integration access on GOV.UK
@@ -73,7 +74,9 @@ to the [users page in AWS IAM][iam] and selecting your profile.
 arn:aws:iam::<account-id>:user/<firstname.lastname>@digital.cabinet-office.gov.uk
 ```
 
-After your PR has been merged, someone from the `govuk-administrators` group needs to deploy the `infra-security` project.
+After your PR has been merged, someone from the `govuk-administrators`
+or `govuk-internal-administrators` group needs to deploy the
+`infra-security` project.
 
 👉 [Deploy AWS infrastructure with Terraform](/manual/deploying-terraform.html)
 


### PR DESCRIPTION
This is a new role, with the same permissions as the
govuk-administrators role. Like govuk-powerusers, there were too many
people for a single role, so the admins internal to GOV.UK were moved
to a new role.