### PR TITLE
Fix links on 'Monitor your app during deployment'

### DIFF
--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -4,7 +4,7 @@ title: Monitor your app during deployment
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2018-11-23
+last_reviewed_on: 2019-06-28
 review_in: 6 months
 ---
 
@@ -15,12 +15,12 @@ for the deployment process.
 
 They can be found in [Grafana](tools.html#grafana), and they are all named
 "Deployment dashboard - application name", such as
-[Deployment dashboard - Whitehall](whitehall-dashboard).
+[Deployment dashboard - Whitehall][whitehall-dashboard].
 
 The existing deployment dashboards are written by Puppet every 30 minutes and
 loaded when Grafana starts. Don’t change them directly.
 
-You can also see further tips on [how we use Graphite](graphite-dashboards)
+You can also see further tips on [how we use Graphite][graphite-dashboards]
 to present the data below.
 
 ## Panels
@@ -35,7 +35,7 @@ These toggle vertical lines on the panels that show when events happened.
 
 Implementation note:
 
-Deployment lines use Graphite [events](events) data as deployment data in
+Deployment lines use Graphite [events][events] data as deployment data in
 Graphite's normal time-series format is not available in all environments.
 
 ### Processes
@@ -128,7 +128,7 @@ dashboard time range.
 
 ## Deploy the Dashboards
 
-Please refer to [add a deployment dashboard](add-dashboard) for details on
+Please refer to [add a deployment dashboard][add-dashboard] for details on
 adding or updating dashboards.
 
 [whitehall-dashboard]: https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json


### PR DESCRIPTION
A review turned up that the links on the page about deployment dashboards had links that weren't working correctly; the links are now fixed.

Updated review date.