### PR TITLE
Advise removing `venv` if failing to install Python deps

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -185,13 +185,7 @@ There are also some Python apps, which use [pip][]. You’ll probably need to in
 
     dev$ ./update-pip.sh
 
-If installing the Python dependencies for fabric-scripts fails, your version of setuptools may be too old:
-
-    dev$ cd /var/govuk/fabric-scripts
-    dev$ virtualenv .venv
-    dev$ source .venv/bin/activate
-    dev$ pip install --upgrade setuptools
-    dev$ pip install -r requirements.txt
+If installing the Python dependencies fails, try and `cd` into each failing repository (e.g. `cd /var/govuk/fabric-scripts`) and remove the `.venv` directory (`rm -rf .venv`) before running the script again.
 
 > `~/govuk/` on your host machine is mounted as `/var/govuk` inside the VM. Any app repositories you clone should go here.
 


### PR DESCRIPTION
There were instructions for working around a failing Python install by doing:

```
dev$ cd /var/govuk/fabric-scripts
dev$ virtualenv .venv
dev$ source .venv/bin/activate
dev$ pip install --upgrade setuptools
dev$ pip install -r requirements.txt
```

...which single-update-pip.sh was doing anyway.

When following those instructions, it didn't fix my issue, which was this:

```
Updating fabric-scripts...
fabric-scripts                            failed to upgrade setuptools with pip output:
Traceback (most recent call last):
  File "/var/govuk/fabric-scripts/.venv/bin/pip", line 6, in <module>
    from pip._internal import main
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/__init__.py", line 40, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/cli/autocompletion.py", line 8, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/cli/cmdoptions.py", line 22, in <module>
    from pip._internal.utils.hashes import STRONG_HASHES
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/utils/hashes.py", line 10, in <module>
    from pip._internal.utils.misc import read_chunks
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/utils/misc.py", line 25, in <module>
    from pip._vendor.six.moves import input, shlex_quote
ImportError: cannot import name shlex_quote
```

Error seems to be something to do with a corrupt `venv` in the offending repositories.

Removing the `venv` before running the install fixes the issue.