### PR TITLE
Rename DGU PaaS organisation name

### DIFF
--- a/source/manual/data-gov-uk-monitoring.html.md
+++ b/source/manual/data-gov-uk-monitoring.html.md
@@ -39,7 +39,7 @@ Pingdom monitors `https://data.gov.uk` uptime and alerts [PagerDuty] when downti
 
 ## Log.it
 
-Each application sends logs to [Logit]. [Publish] and [Find] use the corresponding [PaaS Service][logit-paas]. Example query: `source_host: "gds-data-discovery.data-gov-uk.find-data-beta" && access.response_code: 500`.
+Each application sends logs to [Logit]. [Publish] and [Find] use the corresponding [PaaS Service][logit-paas]. Example query: `source_host: "gds-data-gov-uk.data-gov-uk.find-data-beta" && access.response_code: 500`.
 
 ## Sidekiq ([Publish])
 


### PR DESCRIPTION
The organisation name has been renamed in the PaaS.

[Trello Card](https://trello.com/c/032AYbj3/1037-change-the-org-name-in-the-paas)