### PR TITLE
Retry GitHub server errors

### DIFF
--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -35,6 +35,7 @@ private
         builder.response :logger
         builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
         builder.use Octokit::Response::RaiseError
+        builder.use Faraday::Request::Retry, exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError]
         builder.adapter Faraday.default_adapter
       end
 


### PR DESCRIPTION
This retries errors when talking to GitHub, which should cut down on the number of failing builds like https://deploy.publishing.service.gov.uk/job/govuk-developer-docs/7417/console.

Faraday's default is also to retry timeouts:

https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb