### PR TITLE
Remove obsolete VM symlink instruction for govukcli

### DIFF
--- a/source/manual/get-ssh-access.html.md
+++ b/source/manual/get-ssh-access.html.md
@@ -72,9 +72,8 @@ Test that it works by running:
     mac$ govukcli set-context integration
     mac$ govukcli ssh backend
 
-Next, you'll need to do the same thing inside your VM:
+You should be able to do the same thing in your VM:
 
-    dev$ sudo ln -s /var/govuk/govuk-aws/tools/govukcli /usr/local/bin/govukcli
     dev$ govukcli set-context integration
     dev$ govukcli ssh backend
 


### PR DESCRIPTION
As of https://github.com/alphagov/govuk-puppet/pull/9209, we no
longer need to manually symlink the `govukcli` command inside the VM.
This is now done for us automatically.