### PR TITLE
Change section to '2nd line'

### DIFF
--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-platform-health"
 title: Common 2nd line support requests for data.gov.uk
-section: data.gov.uk
+section: 2nd line
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-03-27


### PR DESCRIPTION
Previous section was 'data.gov.uk', which is applicable as these are data.gov.uk
requests, but I think the section is better suited to '2nd line'. When visiting
https://docs.publishing.service.gov.uk/manual.html, I'd expect to see this page
under 2nd line.

I hope we can add more 'Common 2nd line' type pages for things like alerts, tech
support, content changes etc.