### PR TITLE
Adds `section` 'breadcrumb' link to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ NO_CONTRACTS=true bundle exec middleman build
 
 This will create a bunch of static files in `/build`.
 
+### Testing
+
+`bundle exec rake`
+
 ### Deployment
 
 This project is re-deployed by a Jenkins task every hour (to pick up external

--- a/app/developer_docs_renderer.rb
+++ b/app/developer_docs_renderer.rb
@@ -1,19 +1,9 @@
+require_relative './string_to_id'
+
 class DeveloperDocsRenderer < GovukTechDocs::TechDocsHTMLRenderer
   def header(text, header_level)
-    anchor = githubify_fragment_id(text)
+    anchor = StringToId.convert(text)
     tag = "h" + header_level.to_s
     "<#{tag} id='#{anchor}'>#{text}</#{tag}>"
-  end
-
-  # Redcarpet uses a different algo to create fragment ids than github
-  # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
-  # this implementation modified for our purposes from version at jch/html-pipeline
-  # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
-  def githubify_fragment_id(text)
-    text
-      .downcase # lower case
-      .gsub(/<[^>]*>/, '') # crudely remove html tags
-      .gsub(/[^\w\- ]/, '') # remove any non-word characters
-      .tr(' ', '-') # replace spaces with hyphens
   end
 end

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -1,5 +1,6 @@
 require 'html/pipeline'
 require 'uri'
+require_relative './string_to_id'
 
 class ExternalDoc
   def self.fetch(repository:, path:)
@@ -118,11 +119,7 @@ class ExternalDoc
 
       doc.css('h1, h2, h3, h4, h5, h6').each do |node|
         text = node.text
-        id = text
-               .downcase # lower case
-               .gsub(/<[^>]*>/, '') # crudely remove html tags
-               .gsub(/[^\w\- ]/, '') # remove any non-word characters
-               .tr(' ', '-') # replace spaces with hyphens
+        id = StringToId.convert(text)
 
         headers[id] += 1
 

--- a/app/string_to_id.rb
+++ b/app/string_to_id.rb
@@ -1,0 +1,14 @@
+class StringToId
+  # Redcarpet uses a different algo to create fragment ids than github
+  # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
+  # this implementation modified for our purposes from version at jch/html-pipeline
+  # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
+  def self.convert(string)
+    string
+      .downcase # lower case
+      .gsub(/<[^>]*>/, '') # crudely remove html tags
+      .gsub(/[^\w\-\. ]/, '') # remove any non-word, non-hyphen & non-period characters
+      .gsub(/[ \.]/, '-') # replace spaces & periods with hyphens
+      .gsub(/-{2,}/, '-') # replace two (or more) subsequent hyphens with single hyphens
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -48,6 +48,10 @@ helpers do
     @related_things ||= RelatedThings.new(manual, current_page)
   end
 
+  def section_url
+    StringToId.convert(current_page.data.section)
+  end
+
   def page_title
     (defined?(locals) && locals[:title]) || [current_page.data.title, current_page.data.section].compact.join(' - ')
   end

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -1,4 +1,5 @@
-<% html = "<h1 id='header'>#{current_page.data.title}</h1>#{yield}" %>
+<% breadcrumb = "<p><a href='/manual.html##{section_url}'>#{current_page.data.section}</a></p>" %>
+<% html = "#{breadcrumb} <h1 id='header'>#{current_page.data.title}</h1>#{yield}" %>
 
 <% content_for :page_description, Snippet.generate(html) %>
 

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -37,5 +37,10 @@ RSpec.describe ExternalDoc do
     it 'adds an id attribute to all headers so they can be accessed from a table of contents' do
       expect(html).to have_selector('h2#tldr')
     end
+
+    it 'converts heading IDs properly' do
+      expect(html).to have_selector('h3#data-gov-uk')
+      expect(html).to have_selector('h3#patterns-style-guides')
+    end
   end
 end

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -11,3 +11,9 @@ neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
 ![Suspendisse iaculis](suspendisse_iaculis.png)
 
 [tincidunt leo]: ./lib/tincidunt_leo.rb
+
+## Other headings to test
+
+### data.gov.uk
+
+### Patterns & Style Guides


### PR DESCRIPTION
## Summary of changes

This PR adds a section link to the top of dev doc pages, so that we can see what `section` a page is assigned to and can easily get to the manual page linking to other pages of that `section`. Example:

> ![Screen Shot 2019-06-12 at 11 51 17](https://user-images.githubusercontent.com/5111927/59345629-6c6f5080-8d08-11e9-9118-a7378ba95b4d.png)

Visual change before and after:

| Before | After |
|--------|------|
|![Screen Shot 2019-06-12 at 11 49 38](https://user-images.githubusercontent.com/5111927/59345543-434ec000-8d08-11e9-9b51-a2e2dee43ef5.png)|![Screen Shot 2019-06-12 at 11 49 15](https://user-images.githubusercontent.com/5111927/59345558-48137400-8d08-11e9-887b-1e5c4734a0e5.png)|

The links to the anchor in the manual:

> ![Screen Shot 2019-06-12 at 11 49 24](https://user-images.githubusercontent.com/5111927/59345599-582b5380-8d08-11e9-889a-0f3b160dec3f.png)

In addition, this PR consolidates into one place the functionality which converts a title to a heading ID, which was previously repeated in two places (and would have been repeated a third time in this PR).

### Why not use the breadcrumb component?

I did consider using the [breadcrumb component](https://design-system.service.gov.uk/components/breadcrumbs/) for this, but that would involve adding govuk_publishing_components and/or govuk-frontend dependencies, and given that this isn't a Rails project, would require some manual gluing together too. Given that I really only want to add a link to the section - and not a full breadcrumbs trail - and that there is already a wider conversation happening around how we expose govuk components, I decided to leave as-is. We can think about applying the breadcrumb style / pattern later.