### PR TITLE
Remove CONFIRM_INDEX_MIGRATION_START

### DIFF
--- a/source/manual/alerts/search-reindex-failed.html.md
+++ b/source/manual/alerts/search-reindex-failed.html.md
@@ -19,7 +19,7 @@ If this process fails then please escalate to Platform Health for further invest
 This task can be manually run with the following command:
 
 ```
-bundle exec rake search:migrate_schema CONFIRM_INDEX_MIGRATION_START=true SEARCH_INDEX=<index_alias_name>
+bundle exec rake search:migrate_schema SEARCH_INDEX=<index_alias_name>
 ```
 
 [reindexing]: /manual/reindex-elasticsearch.html

--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -40,7 +40,7 @@ complete.
 To reindex, run the `search:migrate_schema` rake task:
 
 ```
-bundle exec rake search:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 SEARCH_INDEX=alias_of_index_to_migrate
+bundle exec rake search:migrate_schema SEARCH_INDEX=alias_of_index_to_migrate
 ```
 
 If you set the last parameter to `SEARCH_INDEX=all`, search-api will reindex all


### PR DESCRIPTION
This doesn't actually add any safety because the jenkins job which
invokes this task does it automatically - it just adds an extra step
for people invoking `rake` directly.

---

Depends on https://github.com/alphagov/search-api/pull/1585