### PR TITLE
Update the publish/update business finder docs

### DIFF
--- a/source/manual/business-readiness-publish-changes.html.md
+++ b/source/manual/business-readiness-publish-changes.html.md
@@ -5,13 +5,13 @@ section: Business readiness finder
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2019-05-01
+last_reviewed_on: 2019-06-21
 review_in: 3 months
 ---
 
 *If you are trying to update the content returned by the business readiness finder, see: [Update content for the business readiness finder](/manual/business-readiness-update-content.html)*
 
-The full journey for the  [business readiness finder][business-readiness-finder] is made up of the following content items:
+The full journey for the [business readiness finder][business-readiness-finder] is made up of the following content items:
 
 1. The start page: [`/business-uk-leaving-eu`](https://www.gov.uk/business-uk-leaving-eu)
 2. The Q&A: [`/prepare-business-uk-leaving-eu`](https://www.gov.uk/prepare-business-uk-leaving-eu)
@@ -23,6 +23,10 @@ The content for the start page can be updated in Mainstream Publisher as you wou
 The content item for the Q&A doesn't actually contain any details. The titles of the questions are defined in a YAML file in [finder frontend][finder-frontend]. However the body of the question, for example the options if the question is a checkbox, are read from the content item of the finder itself (content item 3 in the list). Finder frontend searches the content item for a facet "key" that matches the question, e.g. `sector_business_area` to find the question content.
 
 The content item for the finder is updated from a [YAML file][search-api]. Any changes to this YAML file affect both the facets in the finder and the options in the Q&A.
+
+## Updating the start page
+
+This is a Mainstream Publisher page and can be edited like any transaction page.
 
 ## Updating question titles
 
@@ -46,9 +50,18 @@ The content item for the business readiness finder and its email signup page are
 
 9. If you are making changes to the schema, you may also need to [reindex elasticsearch](/manual/reindex-elasticsearch.html).
 
+## Updating the email signup page
+
+1. Update the [search-api email YAML file][search-api-email]
+2. Merge the changes
+3. Deploy search-api
+4. Run the [`publishing_api:publish_facet_group_eu_exit_business_finder` rake task][staging-rake-task-facet-group] in `search-api` to publish the changes
+
+N.B. this will also publish the finder.
 
 [business-readiness-finder]: https://www.gov.uk/find-eu-exit-guidance-business
 [content-tagger]: https://github.com/alphagov/content-tagger/blob/master/lib/data/find-eu-exit-guidance-business.yml
 [finder-frontend]: https://github.com/alphagov/finder-frontend/blob/3d7f25ddca4bedd9d9fb750fb1d651964cf2a34b/lib/prepare_business_uk_leaving_eu.yaml
 [search-api]: https://github.com/alphagov/search-api/blob/master/config/find-eu-exit-guidance-business.yml
+[search-api-email]: https://github.com/alphagov/search-api/blob/master/config/find-eu-exit-guidance-business-email-signup.yml
 [staging-rake-task-facet-group]:https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=search-api&MACHINE_CLASS=search&RAKE_TASK=publishing_api:publish_facet_group_eu_exit_business_finder

--- a/source/manual/business-readiness-update-content.html.md
+++ b/source/manual/business-readiness-update-content.html.md
@@ -5,9 +5,11 @@ section: Business readiness finder
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2019-04-16
+last_reviewed_on: 2019-06-21
 review_in: 3 months
 ---
+
+*If you are trying to update the business finder facets or questions, see: [Publish changes to the business readiness finder](/manual/business-readiness-publish-changes.html)*
 
 Business readiness facet tagging happens in [content-tagger](https://content-tagger.integration.publishing.service.gov.uk/facet_groups).
 


### PR DESCRIPTION
- The 'update content' document links back to the 'publish changes' document. It seems sensible to provide a link back, given we're helping people who may accidentally be looking in the wrong place for their answer.
- The 'publish changes' document now describes how to publish changes to the start page and email signup page, which felt like it was missing as they're explicitly mentioned as part of the 'full journey of the finder'.

NB, there was a lot more in the original PR, but that content was moved to finder-frontend: https://github.com/alphagov/finder-frontend/pull/1203

Trello card: https://trello.com/c/czkf0pRT