### PR TITLE
2 small fixes: govuk_tech_docs update & README tweak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       scss_lint
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
-    govuk_tech_docs (1.8.2)
+    govuk_tech_docs (1.8.3)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will create a bunch of static files in `/build`.
 
 ### Deployment
 
-This project is re-deployed by a Jenkins task every hour (to pick up external
+This project is re-deployed by a production Jenkins task every hour between 9am and 7pm (to pick up external
 changes). It is [hosted on S3][terraform].
 
 ## Pre-commit hooks


### PR DESCRIPTION
1. Pull in v1.8.3 of tech docs gem to fix [search results 'new tab' issue](https://github.com/alphagov/tech-docs-gem/pull/86)
2. Clarify location of Jenkins job (took me a minute or two of exploring the different Jenkins instances) and timings (found it interesting we don't deploy overnight!)