### PR TITLE
Pull in content store README

### DIFF
--- a/source/apis/content-store.html.md.erb
+++ b/source/apis/content-store.html.md.erb
@@ -4,23 +4,19 @@ title: Content Store
 parent: /apis.html
 ---
 
-The [Content Store][content-store-repo] is the store for all published content on
-GOV.UK. When given a path, it responds with the content that should be displayed
-on that path.
+<%= ExternalDoc.fetch(repository: 'alphagov/content-store', path: 'README.md') %>
 
-Limitations:
+## Limitations of the content API
 
 - Not all content is in the content-store yet. There are pages that
 don't use the publishing platform and can't be found in the content store
-(at the time of writing, [pages about past prime ministers](https://www.gov.uk/government/history/past-prime-ministers/gordon-brown)).
-- For some pages the content store will not return all the content on the page (an [organisation page](https://www.gov.uk/api/content/government/organisations/hm-revenue-customs) for example)
+(at the time of writing, [pages about past prime ministers][past-prime-ministers]).
+- For some pages the content store will not return all the content on the page (an
+[organisation page][organisation-page] for example).
+- Not all content in the store has a publicly queryable path, e.g. facets. They can
+only be queried via their ID, using the search API:
+  - https://www.gov.uk/api/search.json?filter_content_id=894a7c88-40bb-46-a234-b7e15d8a0c21
+  - https://www.gov.uk/api/search.json?filter_facet_values=77764805-73e6-4d47-9f20-aedd6de7dab9
 
-While it is primarily intended for the use of the frontend apps, it is also
-exposed externally at `https://www.gov.uk/api/content/<path>`, where `<path>` is
-the full path of the item on GOV.UK.
-
-For more detailed documentation on the API exposed by the Content Store, you can
-[read through the GOV.UK Content API Documentation][content-api-docs].
-
-[content-store-repo]: https://github.com/alphagov/content-store
-[content-api-docs]: https://content-api.publishing.service.gov.uk
+[organisation-page]: https://www.gov.uk/api/content/government/organisations/hm-revenue-customs
+[past-prime-ministers]: https://www.gov.uk/government/history/past-prime-ministers/gordon-brown


### PR DESCRIPTION
Pulls in content-store README:

In order to keep the information in one place and reduce duplication,
and to keep the documentation closer to the code, I've followed the
style of the [step by step docs](https://github.com/alphagov/govuk-developer-docs/blob/master/source/manual/side-by-side-browser.html.md.erb)
and pull in an external README instead.

I've decided to keep the 'limitations' part separate for the time being
as it covers areas outside of the content-store itself and provides a
bit of context more than anything.

Dependent on: https://github.com/alphagov/content-store/pull/579