### PR TITLE
Update Jenkin job urls

### DIFF
--- a/source/manual/alerts/search-benchmarking.html.md
+++ b/source/manual/alerts/search-benchmarking.html.md
@@ -4,11 +4,11 @@ title: Benchmark search queries failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-03-16
+last_reviewed_on: 2019-05-21
 review_in: 6 months
 ---
 
-Indicates that the Jenkins [search_benchmark healthcheck job] (https://deploy.publishing.service.gov.uk/job/search_benchmark/) has failed.
+Indicates that the Jenkins [search_benchmark healthcheck job] (https://deploy.blue.production.govuk.digital/job/search_benchmark/) has failed.
 
 The healthcheck sends queries to the search API and compares the results to the
 expected pages. It will only fail if something actually goes wrong - for example, if a request to the search API fails. Check the output of the job on the relevant environment for more information.

--- a/source/manual/alerts/search-spelling-suggestions.html.md
+++ b/source/manual/alerts/search-spelling-suggestions.html.md
@@ -4,12 +4,12 @@ title: Check for spelling suggestions failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-02-28
+last_reviewed_on: 2019-06-21
 review_in: 6 months
 ---
 
 Indicates that the Jenkins [search_test_spelling_suggestions healthcheck job]
-(https://deploy.publishing.service.gov.uk/job/search_test_spelling_suggestions/)
+(https://deploy.blue.production.govuk.digital/job/search_test_spelling_suggestions/)
 has failed.
 
 This job sends queries to the search API and checks that the response


### PR DESCRIPTION
They should be pointing to the AWS environments