### PR TITLE
Resend content changes in bulk

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -43,6 +43,12 @@ SubscriptionContent.where(content_change: content_change).count
 SubscriptionContentWorker.new.perform(content_change.id)
 ```
 
+#### Resend the emails for a content change in bulk (ignore ones that have already gone out)
+
+```ruby
+ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).map { |content_change| SubscriptionContentWorker.new.perform(content_change.id)  }
+```
+
 #### Check sent, pending and failed email counts for a content change
 ```bash
  $ bundle exec rake report:content_change_email_status_count[<content_change_id>]


### PR DESCRIPTION
When there is an email alert api error in icinga regarding content changes, this command will allow
bulk resend of content changes