### PR TITLE
Add helpful note for 2nd Line

### DIFF
--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -32,6 +32,8 @@ follow these steps:
 >
 > You might need to look at the timestamps or other information to figure
 > out which records to delete if two assets share the same filename.
+>
+> HM Courts & Tribunals Service (HMCTS) occasionally request this through Zendesk.
 
 [rake-delete]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete[]
 [rake-delete-and-remove-from-s3]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete_and_remove_from_s3[]


### PR DESCRIPTION
HMCTS often ask for us to remove PDFs from GOV.UK and Google because the file contains the name of someone who's asked for anonymity. You can follow this process when they do that, so I've added a note that hopefully indicates that!