### PR TITLE
Update alert documentation for content data admin

### DIFF
--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -46,7 +46,7 @@ To fix this problem [re-run the master process again][1]
 
 ## ETL :: no pviews for yesterday
 
-This means the [the ETL master process][1] that runs daily has failed to collect `pageview` metrics from Google Analytics. The issue may originate from the ETL processor responsible for collecting core metrics.
+This means the [the ETL master process][1] that runs daily has failed to collect `pageview` metrics from Google Analytics. The issue may originate from the [ETL processor responsible for collecting core metrics][9].
 
 To fix this problem run the [following rake task][2]:
 
@@ -56,7 +56,7 @@ rake etl:repopulate_views["YYYY-MM-DD","YYYY-MM-DD"]
 
 ## ETL :: no upviews for yesterday
 
-This means the [the ETL master process][1] that runs daily has failed to collect `unique pageview` metrics from Google Analytics. The issue may originate from the ETL processor responsible for collecting core metrics.
+This means the [the ETL master process][1] that runs daily has failed to collect `unique pageview` metrics from Google Analytics. The issue may originate from the [ETL processor responsible for collecting core metrics][9].
 
 To fix this problem run the [following rake task][2]:
 
@@ -66,7 +66,7 @@ rake etl:repopulate_views["YYYY-MM-DD","YYYY-MM-DD"]
 
 ## ETL :: no searches for yesterday
 
-This means the [the ETL master process][1] that runs daily has failed to collect `number of searches` metrics from Google Analytics. The issue may originate from the ETL processor responsible for collecting Internal Searches.
+This means the [the ETL master process][1] that runs daily has failed to collect `number of searches` metrics from Google Analytics. The issue may originate from the [ETL processor responsible for collecting Internal Searches][10].
 
 To fix this problem run the [following rake task][3]:
 
@@ -76,7 +76,7 @@ rake etl:repopulate_searches["YYYY-MM-DD","YYYY-MM-DD"]
 
 ## ETL :: no feedex for yesterday
 
-This means the [the ETL master process][1] that runs daily has failed to collect `feedex` metrics from `support-api`. The issue may originate from the ETL processor responsible for collecting Feedex comments.
+This means the [the ETL master process][1] that runs daily has failed to collect `feedex` metrics from `support-api`. The issue may originate from the [ETL processor responsible for collecting Feedex comments][11].
 
 To fix this problem run the [following rake task][4]:
 
@@ -98,3 +98,6 @@ You can also check for any errors in [Sentry][7] or the [logs in kibana][8]
 [6]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L25
 [7]: https://sentry.io/organizations/govuk/issues/?environment=production&project=1461890
 [8]: https://kibana.logit.io/s/283f08f6-d117-48df-9667-c4aa492b81f9/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'application:%20content-data-api')),sort:!('@timestamp',desc))
+[9]: https://github.com/alphagov/content-data-api/blob/master/app/domain/etl/ga/views_and_navigation_processor.rb
+[10]: https://github.com/alphagov/content-data-api/blob/master/app/domain/etl/ga/internal_search_processor.rb
+[11]: https://github.com/alphagov/content-data-api/blob/master/app/domain/etl/feedex/processor.rb

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -4,7 +4,7 @@ title: content-data-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-02-04
+last_reviewed_on: 2019-06-27
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-data-informed"
+owner_slack: "#govuk-platform-health"
 title: content-data-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -10,6 +10,14 @@ review_in: 6 months
 
 If there is a health check error showing for Content Data API, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
 
+#### Note
+
+* The ETL process runs at 7am (UK time) in production.
+* The ETL process runs at 11am (UK time) in staging.
+* The ETL process runs at 1pm (UK time) in integration.
+* All dates for the rake tasks below are inclusive.
+
+
 ## ETL :: no monthly aggregations of metrics for yesterday
 
 This means that [the ETL master process][1] that runs daily that creates aggregations of the metrics failed.
@@ -76,9 +84,17 @@ To fix this problem run the [following rake task][4]:
 rake etl:repopulate_feedex["YYYY-MM-DD","YYYY-MM-DD"]
 ```
 
+## Other troubleshooting tips
+
+For problems in the ETL process, you can check the output in [Jenkins][1].
+
+You can also check for any errors in [Sentry][7] or the [logs in kibana][8]
+
 [1]: https://deploy.blue.production.govuk.digital/job/content_data_api_import_etl_master_process/
 [2]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L32
 [3]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L45
 [4]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L71
 [5]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L10
 [6]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L25
+[7]: https://sentry.io/organizations/govuk/issues/?environment=production&project=1461890
+[8]: https://kibana.logit.io/s/283f08f6-d117-48df-9667-c4aa492b81f9/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'application:%20content-data-api')),sort:!('@timestamp',desc))

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -66,7 +66,7 @@ rake etl:repopulate_views["YYYY-MM-DD","YYYY-MM-DD"]
 
 ## ETL :: no searches for yesterday
 
-This means the [the ETL master process][1] that runs daily has failed to collect `number of searches` metrics from Google Analytics. The issue may originate from the ELT processor responsible for collecting Internal Searches.
+This means the [the ETL master process][1] that runs daily has failed to collect `number of searches` metrics from Google Analytics. The issue may originate from the ETL processor responsible for collecting Internal Searches.
 
 To fix this problem run the [following rake task][3]:
 

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -8,8 +8,6 @@ last_reviewed_on: 2019-02-04
 review_in: 6 months
 ---
 
-Please notify Data Informed Content via Slack `#govuk-data-informed` about the alarm. The product is currently in private beta, so the development team will help solve any issues.
-
 If there is a health check error showing for Content Data API, you can click on the alert to find out more details about what’s wrong. Here are the possible problems you may see:
 
 ## ETL :: no monthly aggregations of metrics for yesterday

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -77,8 +77,8 @@ rake etl:repopulate_feedex["2018-01-01","2018-01-01"]
 ```
 
 [1]: https://deploy.blue.production.govuk.digital/job/content_data_api_import_etl_master_process/
-[2]: https://github.com/alphagov/content-data-api/blob/87116d3ab6f75c0d3dd8be9d4aff80865702f1b9/lib/tasks/etl.rake#L8
-[3]: https://github.com/alphagov/content-data-api/blob/8dd689e6917d7bbbf23a99387b85bfe1ce04d7b1/lib/tasks/etl.rake#L18
-[4]: https://github.com/alphagov/content-data-api/blob/b886c5489c79a6b5a58190e305ea9746fd7db666/lib/tasks/etl.rake#L29
-[5]: https://github.com/alphagov/content-data-api/blob/1dc3f7becf146bbd5f346634e98d05ad76477a8e/lib/tasks/etl.rake#L7
-[6]: https://github.com/alphagov/content-data-api/blob/3c73c534d1a42208d6b2bdaef57d3b79d1998ea3/lib/tasks/etl.rake
+[2]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L32
+[3]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L45
+[4]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L71
+[5]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L10
+[6]: https://github.com/alphagov/content-data-api/blob/master/lib/tasks/etl.rake#L25

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -17,6 +17,7 @@ If there is a health check error showing for Content Data API, you can click on 
 This means that [the ETL master process][1] that runs daily that creates aggregations of the metrics failed.
 
 To fix this problem run the [following rake task][5]:
+
 ```bash
 etl:repopulate_aggregations_month["2019-02-14", "2019-02-14"]
 ```
@@ -26,6 +27,7 @@ etl:repopulate_aggregations_month["2019-02-14", "2019-02-14"]
 This means that [the Etl process][1] that runs daily and refreshes the Materialized Views failed to update those views.
 
 To fix this problem run the [following rake task][6]:
+
 ```bash
 etl:repopulate_aggregations_search
 ```

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -68,7 +68,7 @@ rake etl:repopulate_searches["2018-01-01","2018-01-02"]
 
 ## ETL :: no feedex for yesterday
 
-This means the [the ETL master process][1] that runs daily has failed to collect `feedex` metrics from Google Analytics. The issue may originate from the ETL processor responsible for collecting Feedex comments.
+This means the [the ETL master process][1] that runs daily has failed to collect `feedex` metrics from `support-api`. The issue may originate from the ETL processor responsible for collecting Feedex comments.
 
 To fix this problem run the [following rake task][4]:
 

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -17,7 +17,7 @@ This means that [the ETL master process][1] that runs daily that creates aggrega
 To fix this problem run the [following rake task][5]:
 
 ```bash
-etl:repopulate_aggregations_month["2019-02-14", "2019-02-14"]
+etl:repopulate_aggregations_month["YYYY-MM-DD", "YYYY-MM-DD"]
 ```
 
 ## ETL :: no <range> searches updated from yesterday
@@ -43,7 +43,7 @@ This means the [the ETL master process][1] that runs daily has failed to collect
 To fix this problem run the [following rake task][2]:
 
 ```bash
-rake etl:repopulate_views["2018-01-01","2018-01-01"]
+rake etl:repopulate_views["YYYY-MM-DD","YYYY-MM-DD"]
 ```
 
 ## ETL :: no upviews for yesterday
@@ -53,7 +53,7 @@ This means the [the ETL master process][1] that runs daily has failed to collect
 To fix this problem run the [following rake task][2]:
 
 ```bash
-rake etl:repopulate_views["2018-01-01","2018-01-01"]
+rake etl:repopulate_views["YYYY-MM-DD","YYYY-MM-DD"]
 ```
 
 ## ETL :: no searches for yesterday
@@ -63,7 +63,7 @@ This means the [the ETL master process][1] that runs daily has failed to collect
 To fix this problem run the [following rake task][3]:
 
 ```bash
-rake etl:repopulate_searches["2018-01-01","2018-01-02"]
+rake etl:repopulate_searches["YYYY-MM-DD","YYYY-MM-DD"]
 ```
 
 ## ETL :: no feedex for yesterday
@@ -73,7 +73,7 @@ This means the [the ETL master process][1] that runs daily has failed to collect
 To fix this problem run the [following rake task][4]:
 
 ```bash
-rake etl:repopulate_feedex["2018-01-01","2018-01-01"]
+rake etl:repopulate_feedex["YYYY-MM-DD","YYYY-MM-DD"]
 ```
 
 [1]: https://deploy.blue.production.govuk.digital/job/content_data_api_import_etl_master_process/


### PR DESCRIPTION
We need better documentation of the alerts thrown by `content-data-api`

This commit updates the docs.