### PR TITLE
Fix links to jenkins jobs to point to AWS instances

### DIFF
--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -5,7 +5,7 @@ section: Transition
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-03-18
+last_reviewed_on: 2019-07-01
 review_in: 6 months
 related_applications: [bouncer, transition]
 ---
@@ -29,13 +29,10 @@ All the repositories involved in transition have been [tagged with govuk-transit
 ### Components
 
 - [transition][] is the admin app that departments use to transition
-- [transition-config][] contains YAML files to configure transitioning websites. It's imported into the Transition database by the [Transition_load_site_config job][]
+- [transition-config][] contains YAML files to configure transitioning websites. It's imported into the Transition database by the [Transition_load_site_config job][config-import]
 - The [cloudwatch / athena / lambda][infra-fastly-logs] trio process the logs from Fastly to produce the statistics. Those are then loaded into Transition by the [Transition_load_all_data job][stats-import]
 - [bouncer][] is the application that does the actual redirecting
 - [govuk-cdn-config][] contains the script that the [Bouncer_CDN job][] uses to send the [hosts from transition][] to Fastly
-
-[process_transition_logs]: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_cdnlogs/templates/process_transition_logs.erb
-[Transition_load_site_config job]: https://deploy.publishing.service.gov.uk/job/Transition_load_site_config
 
 ## Transition data sources
 
@@ -49,9 +46,10 @@ to the `govuk-production-fastly-logs` S3 bucket and processed by a
 lambda function defined in the [infra-fastly-logs][] Terraform
 project.
 
-[config-import]: https://deploy.publishing.service.gov.uk/job/Transition_load_site_config
+[transition]: /apps/transition.html
+[config-import]: https://deploy.blue.production.govuk.digital/job/Transition_load_site_config
 [transition-config]: https://github.com/alphagov/transition-config
-[stats-import]: https://deploy.publishing.service.gov.uk/job/Transition_load_all_data/
+[stats-import]: https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/
 [infra-fastly-logs]: https://github.com/alphagov/govuk-aws/tree/master/terraform/projects/infra-fastly-logs
 
 ## Bouncer
@@ -143,7 +141,6 @@ to the machines when Bouncer is deployed.
 Bouncer does not support HTTPS for transitioned sites. This functionality is under investigation as of December 2018. This limitation should be investigated as part of any site transition, especially if the existing site uses HSTS to force secure connections.
 
 [Bouncer]: /apps/bouncer.html
-[transition]: /apps/transition.html
 [govuk-cdn-config]: https://github.com/alphagov/govuk-cdn-config
-[Bouncer_CDN job]: https://deploy.publishing.service.gov.uk/job/Bouncer_CDN
+[Bouncer_CDN job]: https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/
 [hosts from transition]: https://transition.publishing.service.gov.uk/hosts.json


### PR DESCRIPTION
Some of our jobs now run in our AWS infrastructure. Point our links
towards the AWS jobs so that they correctly reflect our current
architecture.

Remove some redundant links and consolidate some duplicates.

Move the link to the transition app in the dev docs up to a point in the
page where it is last used to consolidate it with other links that are
in that portion of the page.