### PR TITLE
Change finder-frontend ownership to Search and Nav

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -471,7 +471,7 @@
       description: ''
 - github_repo_name: finder-frontend
   type: Frontend apps
-  team: "#govuk-platform-health"
+  team: "#govuk-searchandnav"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
   dependencies:


### PR DESCRIPTION
Ran this past Simon and Bevan but we feel it's only fair that Search & Nav look after finder-frontend, since we're the ones tinkering with it.

There's probably other PRs for me to raise off the back of this. Seal? Anywhere else?