### PR TITLE
Add Fix For Issue 1827

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -55,7 +55,7 @@ class AppDocs
 
     def aws_puppet_class
       AppDocs.aws_machines.each do |puppet_class, keys|
-        if keys["apps"].include?(app_name)
+        if keys["apps"].include?(app_name) || keys["apps"].include?(puppet_name)
           return puppet_class
         end
       end
@@ -64,7 +64,7 @@ class AppDocs
 
     def carrenza_machine
       AppDocs.carrenza_machines.each do |puppet_class, keys|
-        if keys["apps"].include?(app_name)
+        if keys["apps"].include?(app_name) || keys["apps"].include?(puppet_name)
           return puppet_class
         end
       end


### PR DESCRIPTION
Some of the SSH commands in the Developer Documentation are broken.
The common theme seems to be that they all have a different puppet_name
and app_name. The fix ensures the code checks for both variables before
rendering an error.

More information on this issue can be found here:
https://github.com/alphagov/govuk-developer-docs/issues/1827

Fixes #1827