### PR TITLE
correct aws_machines not obtained correctly

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -22,8 +22,8 @@ class AppDocs
   end
 
   def self.aws_machines
-    @common ||= HTTP.get_yaml('https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml')
-    @common["node_class"]
+    @common_aws ||= HTTP.get_yaml('https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml')
+    @common_aws["node_class"]
   end
 
   def self.carrenza_machines


### PR DESCRIPTION
# Context

The ssh section `transition` [page](https://docs.publishing.service.gov.uk/apps/transition.html#ssh-access-aws) is not rendered properly: the puppet node class is rendered as an error `Unknown - have you configured and merged your app in govuk-puppet/hieradata_aws/common.yaml`.
rather than `backend`

This is due to an error in the aws_machines function of the app_docs.rb where a `common` variable is reused and not updated as not empty.

# Decisions
1. use another variable other than `common` to hold the puppet class for aws machines

# Tests
1. correct rendering can be viewed here: https://govuk-developer-docs-f-pr-1872.herokuapp.com/apps/transition.html#ssh-access-aws
 