### PR TITLE
Add redirect for the search api healthcheck

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -33,6 +33,7 @@ redirects:
   /manual/alerts/data-sources-for-transition.html: /manual/transition-architecture.html
   /manual/alerts/rummager-queue-latency.html: /manual/alerts/search-api-queue-latency.html
   /manual/alerts/rummager-index-size-change.html: /manual/alerts/search-api-index-size-change.html
+  /manual/alerts/search-api-app-healthcheck-not-ok.html: /manual/alerts/search-api-healthcheck-failed.html
   /manual/alerts/whitehall-app-health-check-not-ok.html: /manual/alerts/whitehall-app-healthcheck-not-ok.html
   /manual/access-ci.html: /manual/access-jenkins.html
   /manual/archiving-and-redirecting-content.html: /manual/redirect-routes.html


### PR DESCRIPTION
At the moment clicking a link on icinga for the search-api-app-healthcheck-not-ok leads to a page not found error. This redirects it to the correct page.