### PR TITLE
Change search api healthcheck docs title

### DIFF
--- a/source/manual/alerts/search-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/search-api-app-healthcheck-not-ok.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Search API healthcheck failed
+title: Search API app healthcheck not ok
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts


### PR DESCRIPTION
Related to https://github.com/alphagov/govuk-developer-docs/pull/1887
Filename was changed due to a redirect issue but the title within wasn't.