### PR TITLE
Mention revert_entirely_unsafe

### DIFF
--- a/source/manual/remove-redirected-url-from-transition.html.md
+++ b/source/manual/remove-redirected-url-from-transition.html.md
@@ -4,7 +4,7 @@ title: Remove redirected URLs from Transition
 parent: "/manual.html"
 layout: manual_layout
 section: Transition
-last_reviewed_on: 2019-07-11
+last_reviewed_on: 2019-07-29
 review_in: 12 months
 ---
 
@@ -12,24 +12,22 @@ review_in: 12 months
 
 [Example PR](https://github.com/alphagov/transition-config/pull/1306)
 
-First remove the relevant yml files and get your PR merged.
+First remove the relevant YAML files and get your PR merged.
 
 ## 2. Run rake task
 
 Once your changes have been merged, run the following rake task with the abbr to be deleted:
 
-```
-import:revert:sites[spva]
+```rake
+import:revert:sites[site_abbr]
 ```
 
-This task will only work for sites with zero mappings and zero hits - ie no associated data beyond that which was created by importing the site YAML file. It will also trigger another task to load the config to Transition (Transition_load_site_config).
+This task will only work for sites with zero mappings and zero hits - i.e. no associated data beyond that which was created by importing the site YAML file. It will also trigger another task to load the config to Transition (Transition_load_site_config).
 
-If you need to remove a redirect with mappings or hits you'll have to do it manually. Open a console in the Transition machine and run the following:
+If you need to remove a redirect with mappings or hits you can run the following Rake task:
 
-```
-site = Site.find_by(abbr: abbr)
-site.hosts.each(&:destroy)
-site.destroy
+```rake
+import:revert_entirely_unsafe[site_abbr]
 ```
 
 Check [here](https://transition.publishing.service.gov.uk/organisations) if it worked. It may take up to an hour for cache to be cleared and you should see the following message when it does:


### PR DESCRIPTION
Rather than manually removing the models we can actually just run this Rake task instead:
https://github.com/alphagov/transition/blob/4a13421139095842364be0f7fa597bea55b559fc/lib/tasks/import/revert_entirely_unsafe.rake

[Thanks @jennyd!](https://github.com/alphagov/govuk-developer-docs/pull/1856#issuecomment-515700916)