### PR TITLE
Use pre-commit within the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,10 @@ node {
     }
 
     stage("Lint documentation") {
-      sh "vale --glob='*.md' ."
+      sh '''
+        curl https://pre-commit.com/install-local.py | python -
+        git diff-tree --no-commit-id --name-only -r $(git rev-parse HEAD) | xargs pre-commit run --files
+      '''
     }
 
     stage("Tests") {


### PR DESCRIPTION
https://pre-commit.com/#usage-in-continuous-integration provides a way to run the same command in the CI therefore it's not required a different approach to run the same script but using the pre-commit wrapper itself.

Besides, this implementation will only monitor the changes for that particular git commit. In other words, it does not require to evaluate all the files every time but only the ones which have changed in the PR itself.