### PR TITLE
Prevent review dates in the future

### DIFF
--- a/source/manual/change-in-hours-time-period-for-dst.html.md
+++ b/source/manual/change-in-hours-time-period-for-dst.html.md
@@ -5,8 +5,8 @@ section: 2nd line
 layout: manual_layout
 type: learn
 parent: "/manual.html"
-last_reviewed_on: 2019-10-25
-review_in: 1 day
+last_reviewed_on: 2019-08-05
+review_in: 81 days
 ---
 
 We call people for different things in-hours and out-of-hours.  The

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -4,7 +4,7 @@ title: Merge a Pull Request
 section: GitHub
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-08-28
+last_reviewed_on: 2019-08-05
 review_in: 6 months
 ---
 

--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -7,6 +7,12 @@ Dir.glob("source/manual/**/*.md").each do |filename|
       expect(raw).not_to match "Gov.uk"
     end
 
+    it "has a review date in the past" do
+      next unless frontmatter['last_reviewed_on']
+
+      expect(frontmatter['last_reviewed_on']).not_to be_in_the_future
+    end
+
     it "has an owner" do
       expect(frontmatter['owner_slack']).to be_present, "Page doesn't have `owner_slack` set"
       expect(frontmatter['owner_slack'][0]).to be_in(%[# @]), "`owner_slack` should be a @username or #channel"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,4 +31,10 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+
+  class Date
+    def in_the_future?
+      self > Date.today
+    end
+  end
 end


### PR DESCRIPTION
This adds a test to prevent review dates from being set in the future. 

![](https://media.giphy.com/media/l0Iyo78NhvUrzbEqs/giphy.gif)

Also fixes two dates in the future, including one which closes https://github.com/alphagov/govuk-developer-docs/issues/1894.

