### PR TITLE
The github repository for Collections Frontend will be private

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -438,6 +438,7 @@
   team: "#govuk-platform-health"
   component_guide_url: https://govuk-collections.herokuapp.com/component-guide
   production_hosted_on: aws
+  private_repo: true
   dependencies:
     static:
       description: ''


### PR DESCRIPTION
We need to temporarily make the Github repository for Collections
Frontend private - this commit makes the developer docs aware of
this.