### PR TITLE
Add link to APIs in collections

### DIFF
--- a/source/apis/collections.html.md.erb
+++ b/source/apis/collections.html.md.erb
@@ -1,0 +1,8 @@
+---
+layout: api_layout
+title: Collections
+parent: /apps.html
+source_url: https://github.com/alphagov/collections/blob/master/docs/api.md
+---
+
+<%= ExternalDoc.fetch(repository: 'alphagov/collections', path: 'docs/api.md') %>


### PR DESCRIPTION
This is being added in https://github.com/alphagov/collections/pull/1195