### PR TITLE
Update to gor documentation

### DIFF
--- a/source/manual/alerts/gor.html.md
+++ b/source/manual/alerts/gor.html.md
@@ -4,7 +4,7 @@ title: Gor
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-02-12
+last_reviewed_on: 2019-08-16
 review_in: 6 months
 ---
 
@@ -14,8 +14,9 @@ production to staging to give us greater confidence that our deploys are ok.
 Alerts for Gor might let you know that it's not running, in which case we have
 to be much more cautious with our deploys.
 
-The nightly data sync stops Gor while data is syncing, so that we don't get
-lots of errors in staging while we're dropping databases.
+Currently the [govuk_env_sync](/manual/govuk-env-sync.html) data sync jobs in AWS
+take place between 23:00 and 5:30 and Gor is disabled during this time period
+to prevent lots of errors while we are dropping databases.
 
 Puppet will [remove these alerts while the data sync runs][govuk-gor-data-sync]
 but you may see the alerts at the beginning of a data sync, before Puppet has

--- a/source/manual/govuk-env-sync.html.md
+++ b/source/manual/govuk-env-sync.html.md
@@ -109,7 +109,7 @@ The data sync operations are executed as cron-jobs attached to the `govuk-backup
 
 ```
 
-Wherein we are 
+Wherein we are
 
 1. Executing the data sync job ionice:
 `/usr/bin/ionice -c 2 -n 6`
@@ -117,6 +117,10 @@ Wherein we are
 `/usr/bin/setlock /etc/unattended-reboot/no-reboot/govuk_env_sync`
 3. Execute the data sync job with the configuration file as argument
 `/usr/local/bin/govuk_env_sync.sh -f /etc/govuk_env_sync/pull_content_data_admin_production_daily.cfg`
+
+> Traffic replay using [Gor]() is disabled between 23:00 and 5:45 daily whilst the
+data sync pull jobs take place. This is to prevent lots of errors while we are
+dropping databases.
 
 ### Icinga checks
 For every `govuk_env_sync::task:`, a passive Icinga alert `GOV.UK environment sync <title>` is created. They are updated on exit of the sync script.


### PR DESCRIPTION
Some additional configuration has been added in Puppet to disable
traffic replay whilst the `govuk_env_sync` jobs are running - https://github.com/alphagov/govuk-puppet/pull/9489

Trello card - https://trello.com/c/tfBZywz4/1188-disable-the-traffic-replay-to-integration-and-staging-during-data-replication