### PR TITLE
Hide search-api docs

### DIFF
--- a/source/apis/search/add-new-fields-or-document-types.html.md.erb
+++ b/source/apis/search/add-new-fields-or-document-types.html.md.erb
@@ -5,4 +5,4 @@ parent: /apis/search/
 source_url: https://github.com/alphagov/search-api/blob/master/doc/adding-new-fields.md
 ---
 
-<%= ExternalDoc.fetch(repository: 'alphagov/search-api', path: 'doc/adding-new-fields.md') %>
+<%= warning_text "Temporarily unavailable while search-api is private" %>

--- a/source/apis/search/content.html.md.erb
+++ b/source/apis/search/content.html.md.erb
@@ -5,4 +5,4 @@ parent: /search-api.html
 source_url: https://github.com/alphagov/search-api/blob/master/doc/content_overview.md
 ---
 
-<%= ExternalDoc.fetch(repository: 'alphagov/search-api', path: 'doc/content_overview.md') %>
+<%= warning_text "Temporarily unavailable while search-api is private" %>

--- a/source/apis/search/faceted-search.html.md.erb
+++ b/source/apis/search/faceted-search.html.md.erb
@@ -5,4 +5,4 @@ parent: /apis/search/
 source_url: https://github.com/alphagov/search-api/blob/master/doc/public-api/faceted-search.md
 ---
 
-<%= ExternalDoc.fetch(repository: 'alphagov/search-api', path: 'doc/public-api/faceted-search.md') %>
+<%= warning_text "Temporarily unavailable while search-api is private" %>

--- a/source/apis/search/fields.html.md.erb
+++ b/source/apis/search/fields.html.md.erb
@@ -12,4 +12,5 @@ incoming documents, and ensure that results it returns have all
 necessary fields.
 
 ## All fields
-<%= table_of_properties(SearchApiReference.fetch_field_definitions) %>
+
+<%= warning_text "Temporarily unavailable while search-api is private" %>

--- a/source/apis/search/search-api.html.md.erb
+++ b/source/apis/search/search-api.html.md.erb
@@ -5,4 +5,4 @@ parent: /apis.html
 source_url: https://github.com/alphagov/search-api/blob/master/doc/search-api.md
 ---
 
-<%= ExternalDoc.fetch(repository: 'alphagov/search-api', path: 'doc/search-api.md') %>
+<%= warning_text "Temporarily unavailable while search-api is private" %>

--- a/source/manual/make-github-repo-private.html.md
+++ b/source/manual/make-github-repo-private.html.md
@@ -40,8 +40,14 @@ To define the username and password, you will need [access to the shared Heroku 
 
 On the [Heroku dashboard](https://dashboard.heroku.com/), locate the relevant pipeline for your application. Add the authentication to the production deployment Heroku app by browsing to Settings -> Config Vars and adding a `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`. This will cascade down to review apps.
 
-## 2. Update the developer docs
+## 2. Update the application in the developer docs
+
 Mark the application as being in a private repo by adding `private_repo: true` to the relevant application within [`applications.yml`](https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml).
 
-## 3. Make the repository private
+## 3. Make sure the developer docs still work
+
+The developer docs might pull in data directly from the repo using `ExternalDoc`. Make sure that those things are removed, as the Jenkins job doesn't have access to this repos.
+
+## 4. Make the repository private
+
 Within Github, navigate to Settings. The option to 'Mark this repository private' should appear at the bottom of the page, within the 'Danger Zone'.


### PR DESCRIPTION
Search API is currently private, which means we can't pull in the API docs from the repo. This hides the docs and documents this in the page about private repos. This causes the docs build to crash currently.

The commit should be reverted once the repos can be opened.