### PR TITLE
Move commands for deploying into deploy script

### DIFF
--- a/bin/deploy-to-s3
+++ b/bin/deploy-to-s3
@@ -9,3 +9,6 @@ export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 NO_CONTRACTS=true bundle exec middleman build --verbose
 s3cmd sync -v --acl-public --guess-mime-type --add-header='Cache-Control: max-age=3600, public' --delete-removed build/ s3://govuk-developer-documentation-production/
+s3cmd put -m "text/css" --add-header='Cache-Control: max-age=3600, public' --acl-public build/stylesheets/screen.css s3://govuk-developer-documentation-production/stylesheets/screen.css
+s3cmd put -m "text/css" --add-header='Cache-Control: max-age=3600, public' --acl-public build/stylesheets/print.css s3://govuk-developer-documentation-production/stylesheets/print.css
+s3cmd put -m "application/json" --add-header='Cache-Control: max-age=3600, public' --acl-public build/search.json s3://govuk-developer-documentation-production/search.json


### PR DESCRIPTION
These commands are currently [manually set in the Jenkins job](https://deploy.publishing.service.gov.uk/job/govuk-developer-docs/configure). I'm putting the job in govuk-puppet, so moving the commands here makes the Jenkins job cleaner.