### PR TITLE
Review and update 'Email alerts not sent' page

### DIFF
--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -4,7 +4,7 @@ title: Email alerts not sent
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-02-14
+last_reviewed_on: 2019-08-20
 review_in: 6 months
 ---
 
@@ -13,22 +13,37 @@ There is [a check][email-check] to verify that emails are sent for
 are run via Jenkins: [Drug and medical device alerts check][drug-alerts-check]
 and [Travel advice alerts check][travel-advice-check].
 
-If a check fails:
+If a check fails, there are a few things to check in order to figure out what
+went wrong. A similar process applies if a user gets in touch to complain they
+haven't received an email they're subscribed to - skip to [General techniques
+for debugging unsent emails](#general-techniques-for-debugging-unsent-emails).
 
-* You can inspect the console logs for the Jenkins job to confirm the reason
-  for the failure.
-* You can check the mailbox that is used for the check to rule out an issue
-  searching for the message. We have an email address
-  `govuk_email_check@digital.cabinet-office.gov.uk` which is subscribed to
-  travel advice alerts and drug and medical device alerts. The credentials
-  for this account is in the [2nd line password store][] under
-  `google-accounts/govuk_email_check@digital.cabinet-office.gov.uk`.
-* You can check whether the email was sent to the
-  [courtesy copies google group][] - presence here doesn't mean that the email
-  was sent to users, just that Email Alert API processed the content change.
-* You can investigate further whether the email was sent by accessing the
-  Email Alert API console.
-  * `ContentChange.where(content_id: "<items-content-id>")` to look up the
+## Troubleshooting Icinga alerts for unsent emails
+
+* Inspect the console logs for the Jenkins job to confirm the reason for the
+  failure.
+* Check the mailbox that is used for the check to rule out an issue searching
+  for the message: `govuk_email_check@digital.cabinet-office.gov.uk`
+  This email address is subscribed to travel advice alerts and drug and medical
+  device alerts. Its credentials can be found in the [2nd line password store][]
+  under `google-accounts/govuk_email_check@digital.cabinet-office.gov.uk`.
+* If the email has been received by the mailbox but the subject of the email
+  doesn't match the title of the content item, this means that the title of the
+  content was updated after it was first published and after the emails went out.
+  To stop the check from constantly failing, add the subject of the email to the
+  [acknowledged email list][] and then re-run the Jenkins job.
+
+If the above didn't help you troubleshoot the alert, continue on to the next section.
+
+## General techniques for debugging unsent emails
+
+* Check whether the email was sent to the [courtesy copies google group][]. Its
+  presence here doesn't mean that the email was sent to users, just that Email
+  Alert API processed the content change.
+
+Check whether the email was sent by accessing the Email Alert API console:
+
+* `ContentChange.where(content_id: "<items-content-id>")` to look up the
      content changes Email Alert API has received for a particular content-id
   * Given a particular content change you can monitor whether this should have
     been sent to people by querying
@@ -36,18 +51,19 @@ If a check fails:
     to look up the email data directly
   * You can look up emails sending or sent to a particular address with
     `Email.where(address: "<address>")`
-  * You can find [unprocessed content changes][unprocessed-content-changes] and
-    check whether the content change for the failed alert is in the list of [affected content changes][affected-content-changes]
+
+Check if there is a backlog of unsent emails in the email alert API:
+
+* You can find [unprocessed content changes][unprocessed-content-changes] and
+    check whether the content change for the failed alert is in the list of [affected
+    content changes][affected-content-changes]
   * If you find the content change has not been processed, check the [number of
-    subscription contents][number-subs-contents] built for the content change a few times (the number should increase)
+    subscription contents][number-subs-contents] built for the content change.
+    Run this a few times - the number should increase.
   * If the number of subscription contents is not increasing, it is possible the
     sidekiq job has terminated ungracefully. You can [resend the content
-    change][resend-content-change]. This will ignore any that have already gone
-    out so it is safe to execute
-* If the email has been received by `govuk_email_check@digital.cabinet-office.gov.uk` but the subject of the email doesn't
-  match the title of the content item, this means that the title of the content was updated after it was first published and after
-  the emails went out. To stop the check from constantly failing, add the subject of the email to the list here:
-  [acknowledged email list][] and then re-run the Jenkins job to get rid of the alert.  
+    change][resend-content-change]. (This will ignore any that have already gone
+    out so it is safe to execute).
 
 ## Resending travel advice emails
 
@@ -57,16 +73,16 @@ is a rake task in Travel Advice Publisher, which you can run using
 travel advice content item can be found in the URL of the country's edit
 page in Travel Advice Publisher and looks like `fedc13e231ccd7d63e1abf65`.
 
-[email-check]: https://github.com/alphagov/email-alert-monitoring
-[drug and medical device alerts]: https://www.gov.uk/drug-device-alerts
-[travel advice updates]: https://www.gov.uk/foreign-travel-advice
-[drug-alerts-check]: https://deploy.publishing.service.gov.uk/job/email-alert-check/
-[travel-advice-check]: https://deploy.publishing.service.gov.uk/job/travel-advice-email-alert-check/
 [2nd line password store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline
-[courtesy copies google group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
-[resend-travel-advice-job]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D
+[acknowledged email list]: https://github.com/alphagov/email-alert-monitoring/blob/master/lib/email_verifier.rb#L6-L14
 [affected-content-changes]: /manual/alerts/email-alert-api-app-healthcheck-not-ok.html#check-which-content-changes-are-affected
+[courtesy copies google group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
+[drug-alerts-check]: https://deploy.publishing.service.gov.uk/job/email-alert-check/
+[drug and medical device alerts]: https://www.gov.uk/drug-device-alerts
+[email-check]: https://github.com/alphagov/email-alert-monitoring
 [number-subs-contents]: /manual/alerts/email-alert-api-app-healthcheck-not-ok.html#check-number-of-subscription-contents-built-for-a-content-change-you-would-expect-this-number-to-keep-going-up
 [resend-content-change]: /manual/alerts/email-alert-api-app-healthcheck-not-ok.html#resend-the-emails-for-a-content-change-ignore-ones-that-have-already-gone-out
+[resend-travel-advice-job]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D
+[travel-advice-check]: https://deploy.publishing.service.gov.uk/job/travel-advice-email-alert-check/
+[travel advice updates]: https://www.gov.uk/foreign-travel-advice
 [unprocessed-content-changes]: /manual/alerts/email-alert-api-app-healthcheck-not-ok.html#unprocessed-content-changes-content_changes
-[acknowledged email list]: https://github.com/alphagov/email-alert-monitoring/blob/master/lib/email_verifier.rb#L6-L14


### PR DESCRIPTION
- Clarified that these instructions are useful for both investigating Icinga alerts and responding to user queries
- Split out into two sections; one for specific troubleshooting for Travel/Drug/Medical alert emails, and one general troubleshooting guide
- Keeps line length consistent
- Cuts down duplicate references to `govuk_email_check@digital.cabinet-office.gov.uk` and encapsulates these instructions in the Icinga alerts section
- Reorders URLs A-Z