### PR TITLE
Change link for triage diagram to a reference style

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -35,7 +35,7 @@ it).
 
 If you have any doubts as to the legitimacy or urgency of a ticket, it should be deferred to the delivery manager.
 
-Once you've established that a ticket is legitimate, you should follow [the process in this diagram](zendesk-triage-diagram).
+Once you've established that a ticket is legitimate, you should follow [the process in this diagram][zendesk-triage-diagram].
 There is a printout on the 2nd line desk.
 
 In all cases, 2nd line will respond to the ticket, even if it is simply a note to the user saying that


### PR DESCRIPTION
The link to the triage flowchart is currently erroring because the
format of the link is currently an inline style when it should be a
reference style link.