### PR TITLE
Update Nagstamon docs now that `govuk connect` is available elsewhere

### DIFF
--- a/source/manual/nagstamon.html.md
+++ b/source/manual/nagstamon.html.md
@@ -37,6 +37,7 @@ and resolve issues.
 
 To configure an SSH action:
 
+- Install the `govuk-cli` which includes the `govuk connect` tool via `brew install alphagov/gds/govuk-cli`.
 - Go in to the Settings
 - Select the "Actions" tab
 - Delete all the existing actions (SSH, RDP, ...)
@@ -44,13 +45,8 @@ To configure an SSH action:
 - Select "Command" as the Action type.
 - Put "SSH " as the Name
 - The command depends on what operating system you're using:
-    - For MacOS, enter the following command in the "String" field:
-        - `osascript -e 'tell app "Terminal" to do script "~/govuk/govuk-guix/bin/govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$"'`
-        - This assumes you have the `govuk-guix` Git repository cloned in
-         `~/govuk/govuk-guix`, and that you've got `govuk connect` working.
-    - For GNU/Linux, with the Gnome Terminal installed (which includes
-      Ubuntu), use the following command:
+    - For macOS, enter the following command in the "String" field:
+        - `osascript -e 'tell app "Terminal" to do script "govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$"'`
+    - For GNU/Linux, with the Gnome Terminal installed, use the following command:
         - `/usr/bin/gnome-terminal -x govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$`
-        - This assumes you have the `govuk` wrapper script on your PATH,
-          and you've got `govuk connect` working
 - Click "OK"


### PR DESCRIPTION
- People can now install `govuk connect` via Homebrew:
  `brew install alphagov/gds/govuk-cli`.
- Power users may want to still use the `govuk connect` from the
  `govuk-guix` repo, and this is fine.
- But we don't need this much text specifying where `govuk connect`
  comes from these days.