### PR TITLE
Mark alphagov/frontend as private

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -488,6 +488,7 @@
     static:
       description: ''
 - github_repo_name: frontend
+  private_repo: true
   type: Frontend apps
   team: "#govuk-platform-health"
   production_hosted_on: aws


### PR DESCRIPTION
This is currently causing the build to fail: https://deploy.publishing.service.gov.uk/job/deploy-developer-docs/80/console