### PR TITLE
Update marking of private repos

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -30,7 +30,6 @@
     signon:
       description: ''
 - github_repo_name: content-tagger
-  private_repo: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: carrenza
@@ -278,7 +277,6 @@
 - github_repo_name: search-api
   type: APIs
   team: "#govuk-searchandnav"
-  private_repo: true
   api_docs_url: /apis/search-api.html
   production_hosted_on: aws
   dependencies:
@@ -488,7 +486,6 @@
     static:
       description: ''
 - github_repo_name: frontend
-  private_repo: true
   type: Frontend apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -571,7 +568,6 @@
     static:
       description: ''
 - github_repo_name: static
-  private_repo: true
   type: Frontend apps
   team: "#govuk-platform-health"
   production_hosted_on: aws


### PR DESCRIPTION
These repos are now public again, so this removes the `private_repo` label.