### PR TITLE
Add a page about load testing

### DIFF
--- a/source/manual/load-testing.html.md.erb
+++ b/source/manual/load-testing.html.md.erb
@@ -1,0 +1,18 @@
+---
+owner_slack: "#govuk-platform-health"
+title: Load Testing
+parent: "/manual.html"
+layout: manual_layout
+section: Infrastructure
+last_reviewed_on: 2019-09-06
+review_in: 12 months
+---
+
+We sometimes need to run load tests against GOV.UK and for that we use a tool
+called [Gatling][gatling]. All the information on how to perform load testing
+is stored in the [govuk-load-testing repository][govuk-load-testing].
+
+<%= ExternalDoc.fetch(repository: 'alphagov/govuk-load-testing', path: 'README.md') %>
+
+[gatling]: https://gatling.io/
+[govuk-load-testing]: https://github.com/alphagov/govuk-load-testing


### PR DESCRIPTION
I've set the review date for one years time because most of this page is copied from the `README.md` of the govuk-load-testing repo.

[Trello Card](https://trello.com/c/Juuu8OvE/1251-5-host-the-gatling-reports-graphs-somewhere)