### PR TITLE
Remove @fields prefixes from kibana examples

### DIFF
--- a/source/manual/add-deployment-dashboard.html.md
+++ b/source/manual/add-deployment-dashboard.html.md
@@ -65,9 +65,9 @@ Parameters:
 
 - `has_workers`: Adds a row with worker failure and success panels. This is required for applications that have Sidekiq workers. Defaults to `false`.
 
-- `show_controller_errors`: Adds a row which graphs 5XX responses broken down by Rails controller and action. For this graph to contain data, the application must report response statuses to Kibana as `@fields.status`, and also report the controller and action as `@fields.controller` and `@fields.action`. You may wish to set this to `false` for apps with very low request rates to avoid having an empty and potentially confusing graph. Defaults to `true`.
+- `show_controller_errors`: Adds a row which graphs 5XX responses broken down by Rails controller and action. For this graph to contain data, the application must report response statuses to Kibana as `status`, and also report the controller and action as `controller` and `action`. You may wish to set this to `false` for apps with very low request rates to avoid having an empty and potentially confusing graph. Defaults to `true`.
 
-- `show_slow_requests`: Adds a row which graphs response times broken down by Rails controller. For this graph to contain data, the application must report response times to Kibana as `@fields.duration` and the controller as `@fields.controller`. You may wish to set this to `false` for apps with very low request rates to avoid having an empty and potentially confusing graph. Defaults to `true`.
+- `show_slow_requests`: Adds a row which graphs response times broken down by Rails controller. For this graph to contain data, the application must report response times to Kibana as `duration` and the controller as `controller`. You may wish to set this to `false` for apps with very low request rates to avoid having an empty and potentially confusing graph. Defaults to `true`.
 
 - `docs_name`: This is the name of the application used in the developer documentation. Often the same as the repository name on GitHub. This defaults to the `app_name`.
 

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -65,7 +65,7 @@ tags:"nginx" AND application:frontend*
 
 > **Note**
 >
-> The `@timestamp` field records the request END time. To calculate request start time subtract `@fields.request_time`.
+> The `@timestamp` field records the request END time. To calculate request start time subtract `request_time`.
 
 ### Application upstart logs
 
@@ -108,7 +108,7 @@ syslog_program:"govuk_sync_mirror"
 ### Publishing API timeouts
 
 ```rb
-@fields.error:"TimedOutException" AND (application:"specialist-publisher" OR application:"whitehall" OR application:"content-tagger")
+message:"TimedOutException" AND (application:"specialist-publisher" OR application:"whitehall" OR application:"content-tagger")
 ```
 
 ## Syslog program names
@@ -116,11 +116,11 @@ syslog_program:"govuk_sync_mirror"
 If you're looking for specific program outputs, use `syslog_program:FOO`:
 
 - `audispd`:	This is used to see all audit logs from various servers. You can refer to README for searching particular types of audit logs. The program name with combination of source_host and message can be helped for looking at various specific audit log lines on a server.
-- `clamd`	 
-- `cron`	 
+- `clamd`
+- `cron`
 - `govuk_sync_mirror`: Records information from govuk_sync_mirror script
 - `puppet-agent`:	Records output for govuk_puppet script on various servers
-- `puppet-master`	 
+- `puppet-master`
 - `smokey`
 
 ## Gotchas

--- a/source/manual/monitor-docs-traffic.html.md
+++ b/source/manual/monitor-docs-traffic.html.md
@@ -15,19 +15,19 @@ You can inspect the traffic forwarded in [Kibana][kibana]. The data goes back a 
 ## All traffic
 
 ```rb
-@fields.http_host:"docs.publishing.service.gov.uk"
+http_host:"docs.publishing.service.gov.uk"
 ```
 
 ## All 404s
 
 ```rb
-@fields.http_host:"docs.publishing.service.gov.uk" AND @fields.status:404
+http_host:"docs.publishing.service.gov.uk" AND status:404
 ```
 
 ## Particular page
 
 ```rb
-@fields.http_host:"docs.publishing.service.gov.uk" AND @fields.request:"/manual/emergency-publishing.html"
+http_host:"docs.publishing.service.gov.uk" AND request:"/manual/emergency-publishing.html"
 ```
 
 [proxy]: https://github.com/alphagov/govuk-puppet/blob/d9f32be24890a47e0ed7368efccec7fb70ecab50/modules/govuk/manifests/node/s_backend_lb.pp#L132-L139

--- a/source/manual/setting-up-request-tracing.html.md
+++ b/source/manual/setting-up-request-tracing.html.md
@@ -28,7 +28,7 @@ originating request.
 
 For example, the nginx logs in `/var/log/nginx/<service>-json.event.access.log`
 will include a `govuk_request_id` field. You can also filter on
-`@fields.govuk_request_id` in [Kibana][].
+`govuk_request_id` in [Kibana][].
 
 [gds-api-adapters]: https://github.com/alphagov/gds-api-adapters
 [Kibana]: /manual/logit.html#viewing-kibana


### PR DESCRIPTION
We used to prefix some log fields with `@fields.`, but gradually removed them to converge on a standard approach (as documented in the [GDS way logging manual](https://gds-way.cloudapps.digital/manuals/logging.html#naming-conventions)).

There are a couple of remaining apps (like Router) that still use a `@fields.` prefix, but these examples will no longer work unless we correct them.