### PR TITLE
Add date to doc

### DIFF
--- a/source/manual/replicating-whitehall-data-with-docker.html.md
+++ b/source/manual/replicating-whitehall-data-with-docker.html.md
@@ -4,7 +4,7 @@ title: Locally replicating Whitehall data with Docker
 section: Docker
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on:
+last_reviewed_on: 2019-09-17
 review_in: 6 months
 ---
 


### PR DESCRIPTION
The docs build is failing with:

```
== Request: /manual/replicating-whitehall-data-with-docker.html
       error  build/manual/replicating-whitehall-data-with-docker.html
undefined method `strftime' for nil:NilClass
/var/lib/jenkins/bundles/deploy-developer-docs/ruby/2.6.0/gems/govuk_tech_docs-1.8.3/lib/govuk_tech_docs.rb:79:in `format_date'
```