### PR TITLE
Update the current state diagram

### DIFF
--- a/source/manual/frontend-architecture.html.md
+++ b/source/manual/frontend-architecture.html.md
@@ -5,7 +5,7 @@ layout: manual_layout
 type: learn
 section: Frontend
 owner_slack: "#govuk-frontenders"
-last_reviewed_on: 2019-06-12
+last_reviewed_on: 2019-09-20
 review_in: 3 months
 related_applications:
  - static


### PR DESCRIPTION
This page was due for review, but since `govuk-developer-docs` uses a hotlink to the updated diagram no changes were actually required in the file.

## Brief update on frontend architecture
- `govuk_publishing_components` is not dependent on `govuk_frontend_toolkit` anymore (although a direct dependency on `govuk_frontend_toolkit` still remains for most public frontend apps)
- there is ongoing work to remove dependencies on `govuk_elements` and `govuk_frontend_toolkit` from public frontend apps
- some work has been done towards removing dependencies on `govuk_template` and `govuk_frontend_toolkit` from `static`
- two 'new' admin frontend apps were build using `govuk_publishing_components` (`content-data-admin` and `content-publisher`) instead of `govuk_admin_template`
- admin frontend apps are starting to migrate towards using `govuk_publishing_components` instead of `govuk_admin_template` (`collections-publisher` and `signon`)

### Before
<img width="840" alt="Screen Shot 2019-09-20 at 15 02 25" src="https://user-images.githubusercontent.com/788096/65332958-8a760800-dbb7-11e9-9748-591938cad259.png">

### After
<img width="840" alt="Screen Shot 2019-09-20 at 15 44 03" src="https://user-images.githubusercontent.com/788096/65335907-3b32d600-dbbd-11e9-9a53-cb4338ece4ac.png">
