### PR TITLE
Update email-alert-api app healthcheck documentation

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -40,13 +40,13 @@ SubscriptionContent.where(content_change: content_change).count
 #### Resend the emails for a content change (ignore ones that have already gone out)
 
 ```ruby
-SubscriptionContentWorker.new.perform(content_change.id)
+ProcessContentChangeWorker.new.perform(content_change.id)
 ```
 
 #### Resend the emails for a content change in bulk (ignore ones that have already gone out)
 
 ```ruby
-ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).map { |content_change| SubscriptionContentWorker.new.perform(content_change.id)  }
+ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).map { |content_change| ProcessContentChangeWorker.new.perform(content_change.id)  }
 ```
 
 #### Check sent, pending and failed email counts for a content change


### PR DESCRIPTION
Rename SubscriptionContentWorker to ProcessContentChangeWorker following this change:
https://github.com/alphagov/email-alert-api/commit/9b3e5b77f6256fca0579d27ecd71c61c93078f9a