### PR TITLE
Correctly set machine class for running rake tasks

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -71,6 +71,10 @@ class AppDocs
       'Unknown - have you configured and merged your app in govuk-puppet/hieradata/common.yaml'
     end
 
+    def machine_class
+      production_hosted_on == "aws" ? aws_puppet_class : carrenza_machine
+    end
+
     def production_hosted_on
       app_data["production_hosted_on"]
     end

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -111,9 +111,9 @@ ssh -A -t jumpbox.production.govuk.digital 'ssh `govuk_node_list -c <%= applicat
 <% if application.can_run_rake_tasks_in_jenkins? %>
   <h3>Run a rake task</h3>
 
-  - <%= link_to "Run on Integration Jenkins", "https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.carrenza_machine}" %>
-  - <%= link_to "Run on Staging Jenkins", "https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.carrenza_machine}" %>
-  - <%= link_to "Run on Production Jenkins", "https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.carrenza_machine}" %>
+  - <%= link_to "Run on Integration Jenkins", "https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
+  - <%= link_to "Run on Staging Jenkins", "https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
+  - <%= link_to "Run on Production Jenkins", "https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
 <%end %>
 
 <% if application.example_published_pages %>


### PR DESCRIPTION
Previously it was only setting the machine class correctly for apps hosted on carrenza.

It will now set the machine class for carrenza and AWS correctly.