### PR TITLE
Fix links in manual

### DIFF
--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -13,7 +13,7 @@ title: Manual
     <ul>
       <% manual.manual_pages_grouped_by_section.each do |section_name, pages| %>
         <li>
-          <a href="##{section_name.parameterize}">
+          <a href="<%= "##{section_name.parameterize}" %>">
             <span><%= section_name %></span>
           </a>
         </li>


### PR DESCRIPTION
Fixes links in the manual section.

Fixes https://github.com/alphagov/govuk-developer-docs/issues/2018
