### PR TITLE
Add short description of AKA domains

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -4,7 +4,7 @@ title: Transition a site to GOV.UK
 section: Transition
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-10-08
+last_reviewed_on: 2019-10-30
 review_in: 6 months
 related_applications: [bouncer, transition]
 ---
@@ -40,7 +40,22 @@ around this.
 
 Follow the instructions in the [transition-config README][transition-config].
 
-### 3) Get a list of old URLs
+### 3) Consider AKA domains
+
+If the department want to use the side-by-side browser to preview how their
+redirects will appear after transitioning they will need to set up AKA domains.
+
+They will need one new CNAME DNS entry for each domain/subdomain they wish to
+preview according to the following pattern:
+
+- www.domain.gov.uk → aka.domain.gov.uk
+- sub.domain.gov.uk → aka-sub.domain.gov.uk
+
+There are lots of examples of these in [hosts currently configured in Transition](https://transition.publishing.service.gov.uk/hosts)
+
+These AKA domains should be CNAMEd to: `redirector-cdn.production.govuk.service.gov.uk`
+
+### 4) Get a list of old URLs
 
 In order for us to redirect anything but the homepage, we need a list of URLs
 for the old site so that they can be mapped. In the past, this is something
@@ -66,7 +81,7 @@ $ anemone url-list 'transitioning-site.gov.uk'
 
 > **Note:** This will include 404s, 301s, etc.
 
-### 4) Clean up URLs
+### 5) Clean up URLs
 
 **Strip paths and pattern**
 
@@ -101,7 +116,7 @@ Some common examples of non-significant parameters:
 -   analytics
 -   search queries
 
-### 5) Add the old URLs as mappings
+### 6) Add the old URLs as mappings
 
 Ideally, any significant query string parameters should be identified and
 added to the site before adding the mappings. This is because URLs are
@@ -119,7 +134,7 @@ rather than just ones belonging to your organisation. You can then go
 the [transition app](https://transition.publishing.service.gov.uk), find
 the site and click `Add mappings` to add them in bulk.
 
-### 6) Get the organisation to do the mapping work
+### 7) Get the organisation to do the mapping work
 
 By default, the mappings will present an archive page to users visiting
 the old URL. The objective is to get users to somewhere that best serves
@@ -127,7 +142,7 @@ the need fulfilled by the old page. Usually this means redirecting them
 to the page on GOV.UK or elsewhere. It is really important that this is
 done by people who understand the users and content.
 
-### 7) Get the organisation to lower the TTL on the DNS records a day ahead
+### 8) Get the organisation to lower the TTL on the DNS records a day ahead
 
 In order to cleanly switch the domain from the old site, the TTL needs
 to be low enough that there isn't a significant period where some users
@@ -138,7 +153,7 @@ advance, and to be lowered to 300 seconds (5 minutes). It can be raised
 again once everyone is happy there is no need to switch back - normally
 the day after.
 
-### 8) Point the domain at us
+### 9) Point the domain at us
 
 Once the site has been imported successfully, the domain can be pointed
 at us by the organisation. For hostnames which can have a `CNAME`
@@ -150,7 +165,7 @@ addresses](https://github.com/alphagov/transition/blob/016c3d30e190c41eaa912ed55
 If the site is one that was [administered by GDS](https://github.com/alphagov/gds-dns-config/tree/master/zones)
 (e.g. theorytest.direct.gov.uk), you will need to [update and re-deploy the DNS config](/manual/dns.html#making-changes-to-publishing-service-gov-uk).
 
-### 9) Get the organisation to monitor the traffic data in the Transition app
+### 10) Get the organisation to monitor the traffic data in the Transition app
 
 There are two things that need to be responded to:
 


### PR DESCRIPTION
They are necessary if you want to use the [side-by-side browser](https://github.com/alphagov/side-by-side-browser) when transitioning a site.