### PR TITLE
Adds rake clean:remove_empty_subscriberlists to email alert docs

### DIFF
--- a/source/manual/manage-email-subscribers.html.md
+++ b/source/manual/manage-email-subscribers.html.md
@@ -46,8 +46,16 @@ This is useful for changes such as departmental name changes, where new lists ar
 
 [⚙ Run rake task on production][move]
 
+## Remove empty subscriber lists.
+
+[⚙ Run rake task on production][clean]
+
+Sometimes subscriber lists are created without any subscribers. This task can be run to get rid of these.
+
+
 [email-manage]: https://www.gov.uk/email/manage
 [drug-updates]: https://www.gov.uk/drug-safety-update
 [change]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:change_email_address[from@example.org,to@example.org]
 [unsub]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:unsubscribe_single[email@example.org]
 [move]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:move_all_subscribers[<slug-of-old-list>,<slug-of-new-list>]
+[clean]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=clean:remove_empty_subscriberlists%20DRY_RUN=no


### PR DESCRIPTION
This is a task to remove superfluous subscriber lists.