### PR TITLE
Fix linting errors

### DIFF
--- a/app/app_data.rb
+++ b/app/app_data.rb
@@ -1,5 +1,5 @@
 class AppData
-  SEARCH_URL = 'https://www.gov.uk/api/search.json?facet_publishing_app=100,examples:10,example_scope:global&facet_rendering_app=100,examples:10,example_scope:global&count=0'.freeze
+  SEARCH_URL = "https://www.gov.uk/api/search.json?facet_publishing_app=100,examples:10,example_scope:global&facet_rendering_app=100,examples:10,example_scope:global&count=0".freeze
 
   def publishing_examples
     extract_examples_from_search_result("publishing_app")

--- a/app/app_diagrams_generator.rb
+++ b/app/app_diagrams_generator.rb
@@ -1,6 +1,6 @@
-require 'yaml'
-require 'fileutils'
-require 'active_support/all'
+require "yaml"
+require "fileutils"
+require "active_support/all"
 
 class AppDiagramGenerator
   def initialize
@@ -28,7 +28,7 @@ class AppDiagramGenerator
           apps.map { |app| app["actors"] }
           .flatten
           .reject(&:nil?)
-          .uniq
+          .uniq,
         ]
       }.to_h
   end

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -14,7 +14,7 @@ class AppDocs
   end
 
   def self.app_data
-    @publishing_app_data ||= AppData.new
+    @app_data ||= AppData.new
   end
 
   def self.topics_on_github

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -8,7 +8,7 @@ class AppDocs
   }.freeze
 
   def self.pages
-    @pages ||= YAML.load_file('data/applications.yml').map do |app_data|
+    @pages ||= YAML.load_file("data/applications.yml").map do |app_data|
       App.new(app_data)
     end
   end
@@ -22,12 +22,12 @@ class AppDocs
   end
 
   def self.aws_machines
-    @common_aws ||= HTTP.get_yaml('https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml')
+    @common_aws ||= HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml")
     @common_aws["node_class"]
   end
 
   def self.carrenza_machines
-    @common ||= HTTP.get_yaml('https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml')
+    @common ||= HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml")
     @common["node_class"]
   end
 
@@ -49,7 +49,7 @@ class AppDocs
           html_url: html_url,
           repo_url: repo_url,
           sentry_url: sentry_url,
-        }
+        },
       }
     end
 
@@ -59,7 +59,7 @@ class AppDocs
           return puppet_class
         end
       end
-      'Unknown - have you configured and merged your app in govuk-puppet/hieradata_aws/common.yaml'
+      "Unknown - have you configured and merged your app in govuk-puppet/hieradata_aws/common.yaml"
     end
 
     def carrenza_machine
@@ -68,7 +68,7 @@ class AppDocs
           return puppet_class
         end
       end
-      'Unknown - have you configured and merged your app in govuk-puppet/hieradata/common.yaml'
+      "Unknown - have you configured and merged your app in govuk-puppet/hieradata/common.yaml"
     end
 
     def machine_class
@@ -209,6 +209,7 @@ class AppDocs
 
     def github_repo_data
       return {} if private_repo?
+
       @github_repo_data ||= GitHubRepoFetcher.client.repo(github_repo_name)
     end
   end

--- a/app/applications_by_team.rb
+++ b/app/applications_by_team.rb
@@ -18,7 +18,7 @@ class ApplicationsByTeam
   end
 
   def self.applications
-    @_applications ||=
+    @applications ||=
       YAML.load_file("data/applications.yml")
         .map { |app_data| App.new(app_data) }
         .reject(&:retired?)

--- a/app/applications_by_team.rb
+++ b/app/applications_by_team.rb
@@ -19,7 +19,7 @@ class ApplicationsByTeam
 
   def self.applications
     @_applications ||=
-      YAML.load_file('data/applications.yml')
+      YAML.load_file("data/applications.yml")
         .map { |app_data| App.new(app_data) }
         .reject(&:retired?)
         .sort_by(&:app_name)

--- a/app/apps_csv.rb
+++ b/app/apps_csv.rb
@@ -1,4 +1,4 @@
-require 'csv'
+require "csv"
 
 class AppsCSV
   attr_reader :hash

--- a/app/content_schema.rb
+++ b/app/content_schema.rb
@@ -1,4 +1,4 @@
-require 'govuk_schemas'
+require "govuk_schemas"
 
 class ContentSchema
   attr_reader :schema_name
@@ -42,7 +42,7 @@ class ContentSchema
     end
 
     def properties
-      Utils.inline_definitions(raw_schema['properties'], raw_schema['definitions'])
+      Utils.inline_definitions(raw_schema["properties"], raw_schema["definitions"])
     end
 
   private
@@ -69,7 +69,7 @@ class ContentSchema
     end
 
     def properties
-      Utils.inline_definitions(raw_schema['properties'], raw_schema['definitions'])
+      Utils.inline_definitions(raw_schema["properties"], raw_schema["definitions"])
     end
 
   private
@@ -96,7 +96,7 @@ class ContentSchema
     end
 
     def properties
-      Utils.inline_definitions(raw_schema['properties'], raw_schema['definitions'])
+      Utils.inline_definitions(raw_schema["properties"], raw_schema["definitions"])
     end
 
   private
@@ -110,16 +110,18 @@ class ContentSchema
     # Inline any keys that use definitions
     def self.inline_definitions(original_properties, definitions)
       original_properties.to_h.each do |k, v|
-        next unless v['$ref']
-        original_properties[k] = definitions[v['$ref'].gsub('#/definitions/', '')]
+        next unless v["$ref"]
+
+        original_properties[k] = definitions[v["$ref"].gsub("#/definitions/", "")]
       end
 
       # Inline any keys that use definitions
-      if original_properties.to_h.dig('details', 'properties')
-        original_properties['details']['properties'].each do |k, v|
-          next unless v['$ref']
-          definition_name = v['$ref'].gsub('#/definitions/', '')
-          original_properties['details']['properties'][k] = definitions.fetch(definition_name)
+      if original_properties.to_h.dig("details", "properties")
+        original_properties["details"]["properties"].each do |k, v|
+          next unless v["$ref"]
+
+          definition_name = v["$ref"].gsub("#/definitions/", "")
+          original_properties["details"]["properties"][k] = definitions.fetch(definition_name)
         end
       end
 

--- a/app/dashboard.rb
+++ b/app/dashboard.rb
@@ -14,11 +14,11 @@ class Dashboard
     end
 
     def name
-      data.fetch('name')
+      data.fetch("name")
     end
 
     def id
-      data.fetch('name').parameterize
+      data.fetch("name").parameterize
     end
 
     def description
@@ -28,7 +28,7 @@ class Dashboard
 
   class Chapter < Thing
     def sections
-      data['sections'].map { |section| Section.new(section) }
+      data["sections"].map { |section| Section.new(section) }
     end
   end
 
@@ -51,14 +51,14 @@ class Dashboard
     end
 
     def repos
-      data['repos'].to_a.map do |app_name|
+      data["repos"].to_a.map do |app_name|
         repo = GitHubRepoFetcher.client.repo(app_name)
         Repo.new(repo)
       end
     end
 
     def sites
-      data['sites'].to_a.map do |site_data|
+      data["sites"].to_a.map do |site_data|
         Site.new(site_data)
       end
     end

--- a/app/developer_docs_renderer.rb
+++ b/app/developer_docs_renderer.rb
@@ -1,4 +1,4 @@
-require_relative './string_to_id'
+require_relative "./string_to_id"
 
 class DeveloperDocsRenderer < GovukTechDocs::TechDocsHTMLRenderer
   def header(text, header_level)

--- a/app/document_types.rb
+++ b/app/document_types.rb
@@ -1,6 +1,6 @@
 class DocumentTypes
-  FACET_QUERY = 'https://www.gov.uk/api/search.json?facet_content_store_document_type=500,examples:10,example_scope:global&count=0'.freeze
-  DOCUMENT_TYPES_URL = 'https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml'.freeze
+  FACET_QUERY = "https://www.gov.uk/api/search.json?facet_content_store_document_type=500,examples:10,example_scope:global&count=0".freeze
+  DOCUMENT_TYPES_URL = "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml".freeze
 
   def self.pages
     @@pages ||= begin

--- a/app/document_types_csv.rb
+++ b/app/document_types_csv.rb
@@ -1,4 +1,4 @@
-require 'csv'
+require "csv"
 
 class DocumentTypesCsv
   def initialize(pages)
@@ -22,14 +22,14 @@ class DocumentTypesCsv
       csv << row
 
       @pages.each do |page|
-        example_url = page.examples.first ? "https://www.gov.uk" + page.examples.first['link'] : nil
+        example_url = page.examples.first ? "https://www.gov.uk" + page.examples.first["link"] : nil
 
         row = [
           page.name,
           page.url,
           page.total_count,
           example_url,
-          page.rendering_apps.join(', '),
+          page.rendering_apps.join(", "),
         ]
 
         Supertypes.all.each do |supertype|

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -1,6 +1,6 @@
-require 'html/pipeline'
-require 'uri'
-require_relative './string_to_id'
+require "html/pipeline"
+require "uri"
+require_relative "./string_to_id"
 
 class ExternalDoc
   def self.fetch(repository:, path:)
@@ -12,21 +12,21 @@ class ExternalDoc
       # Turn off hardbreaks as they behave different to github rendering
       gfm: false,
       base_url: URI.join(
-        'https://github.com',
+        "https://github.com",
         "#{repository}/blob/master/",
       ),
 
       image_base_url: URI.join(
-        'https://raw.githubusercontent.com',
+        "https://raw.githubusercontent.com",
         "#{repository}/master/",
       ),
     }
 
     context[:subpage_url] =
-      URI.join(context[:base_url], File.join('.', File.dirname(path), '/'))
+      URI.join(context[:base_url], File.join(".", File.dirname(path), "/"))
 
     context[:image_subpage_url] =
-      URI.join(context[:image_base_url], File.join('.', File.dirname(path), '/'))
+      URI.join(context[:image_base_url], File.join(".", File.dirname(path), "/"))
 
     filters = [
       HTML::Pipeline::MarkdownFilter,
@@ -51,21 +51,21 @@ class ExternalDoc
   # https://github.com/alphagov/publishing-api/blob/master/lib/link_expansion.rb
   class AbsoluteLinkFilter < HTML::Pipeline::Filter
     def call
-      doc.search('a').each do |element|
-        next if element['href'].nil? || element['href'].empty?
+      doc.search("a").each do |element|
+        next if element["href"].nil? || element["href"].empty?
 
-        href = element['href'].strip
+        href = element["href"].strip
         uri = URI.parse(href)
         path = uri.path
 
-        unless uri.scheme || href.start_with?('#') || path.end_with?('.md')
-          base = if path.start_with? '/'
+        unless uri.scheme || href.start_with?("#") || path.end_with?(".md")
+          base = if path.start_with? "/"
                    base_url
                  else
                    subpage_url
                  end
 
-          element['href'] = URI.join(base, href).to_s
+          element["href"] = URI.join(base, href).to_s
         end
       end
 
@@ -87,15 +87,15 @@ class ExternalDoc
   # `link-expansion.html`
   class MarkdownLinkFilter < HTML::Pipeline::Filter
     def call
-      doc.search('a').each do |element|
-        next if element['href'].nil? || element['href'].empty?
+      doc.search("a").each do |element|
+        next if element["href"].nil? || element["href"].empty?
 
-        href = element['href'].strip
+        href = element["href"].strip
         uri = URI.parse(href)
 
-        if uri.path.end_with?('.md')
-          uri.path.sub!(/.md$/, '.html')
-          element['href'] = uri.to_s
+        if uri.path.end_with?(".md")
+          uri.path.sub!(/.md$/, ".html")
+          element["href"] = uri.to_s
         end
       end
 
@@ -106,7 +106,7 @@ class ExternalDoc
   # Removes the H1 from the page so that we can choose our own title
   class PrimaryHeadingFilter < HTML::Pipeline::Filter
     def call
-      doc.at('h1:first-of-type').unlink
+      doc.at("h1:first-of-type").unlink
       doc
     end
   end
@@ -117,7 +117,7 @@ class ExternalDoc
     def call
       headers = Hash.new(0)
 
-      doc.css('h1, h2, h3, h4, h5, h6').each do |node|
+      doc.css("h1, h2, h3, h4, h5, h6").each do |node|
         text = node.text
         id = StringToId.convert(text)
 

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -1,4 +1,4 @@
-require 'octokit'
+require "octokit"
 
 class GitHubRepoFetcher
   # Fetch a repo from GitHub.
@@ -42,7 +42,7 @@ private
       Octokit.middleware = stack
       Octokit.default_media_type = "application/vnd.github.mercy-preview+json"
 
-      github_client = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'])
+      github_client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
       github_client.auto_paginate = true
       github_client
     end

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -30,7 +30,7 @@ private
   end
 
   def client
-    @_github_client ||= begin
+    @client ||= begin
       stack = Faraday::RackBuilder.new do |builder|
         builder.response :logger
         builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false

--- a/app/http.rb
+++ b/app/http.rb
@@ -1,9 +1,9 @@
-require 'faraday-http-cache'
-require 'faraday_middleware'
+require "faraday-http-cache"
+require "faraday_middleware"
 
 module HTTP
   def self.get_yaml(url)
-    YAML.load(get(url))
+    YAML.safe_load(get(url))
   end
 
   def self.get(url)

--- a/app/manual.rb
+++ b/app/manual.rb
@@ -39,7 +39,7 @@ private
   def manual_pages
     sitemap.resources
       .reject { |page| page.data.section == ICINGA_ALERTS }
-      .select { |page| page.path.start_with?('manual/') && page.path.end_with?('.html') && page.data.title }
+      .select { |page| page.path.start_with?("manual/") && page.path.end_with?(".html") && page.data.title }
       .sort_by { |page| page.data.title.downcase }
   end
 end

--- a/app/publishing_api_docs.rb
+++ b/app/publishing_api_docs.rb
@@ -27,7 +27,7 @@ class PublishingApiDocs
     end
 
     def repository
-      'alphagov/publishing-api'
+      "alphagov/publishing-api"
     end
   end
 end

--- a/app/requires.rb
+++ b/app/requires.rb
@@ -1,10 +1,10 @@
-require 'active_support/all'
-require 'tilt'
-require 'middleman-core'
-require 'yaml'
-require 'json'
+require "active_support/all"
+require "tilt"
+require "middleman-core"
+require "yaml"
+require "json"
 
 CACHE = ActiveSupport::Cache::FileStore.new(".cache")
 
-Dir[File.dirname(__FILE__) + '/../lib/*.rb'].each { |file| require file }
-Dir[File.dirname(__FILE__) + '/**/*.rb'].each { |file| require file }
+Dir[File.dirname(__FILE__) + "/../lib/*.rb"].each { |file| require file }
+Dir[File.dirname(__FILE__) + "/**/*.rb"].each { |file| require file }

--- a/app/snippet.rb
+++ b/app/snippet.rb
@@ -1,7 +1,7 @@
 class Snippet
   def self.generate(html)
     body_text = html
-      .split('</h1>')[1..-1].join # make sure we skip anything before <h1>
+      .split("</h1>")[1..-1].join # make sure we skip anything before <h1>
       .gsub(/<h.+?>.+?<\/h.>/, "") # remove headings
       .gsub(/<\/?[^>]*>/, "") # remove other HTML but keep the contents
       .squish # remove whitespace

--- a/app/string_to_id.rb
+++ b/app/string_to_id.rb
@@ -6,9 +6,9 @@ class StringToId
   def self.convert(string)
     string
       .downcase # lower case
-      .gsub(/<[^>]*>/, '') # crudely remove html tags
-      .gsub(/[^\w\-\. ]/, '') # remove any non-word, non-hyphen & non-period characters
-      .gsub(/[ \.]/, '-') # replace spaces & periods with hyphens
-      .gsub(/-{2,}/, '-') # replace two (or more) subsequent hyphens with single hyphens
+      .gsub(/<[^>]*>/, "") # crudely remove html tags
+      .gsub(/[^\w\-\. ]/, "") # remove any non-word, non-hyphen & non-period characters
+      .gsub(/[ \.]/, "-") # replace spaces & periods with hyphens
+      .gsub(/-{2,}/, "-") # replace two (or more) subsequent hyphens with single hyphens
   end
 end

--- a/app/supertypes.rb
+++ b/app/supertypes.rb
@@ -1,6 +1,6 @@
 class Supertypes
   def self.all
-    @all_supertypes ||= begin
+    @all ||= begin
       data = HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk_document_types/master/data/supertypes.yml")
       data.map { |id, config| Supertype.new(id, config) }
     end

--- a/app/supertypes.rb
+++ b/app/supertypes.rb
@@ -19,7 +19,7 @@ class Supertypes
 
     def for_document_type(document_type)
       document_type_item = items.find { |item| item.fetch("document_types").include?(document_type) }
-      document_type_item ? document_type_item['id'] : default
+      document_type_item ? document_type_item["id"] : default
     end
   end
 end

--- a/helpers/navigation_helpers.rb
+++ b/helpers/navigation_helpers.rb
@@ -1,12 +1,12 @@
 module NavigationHelpers
   def active_page?(page_path)
-    (current_page.path == 'index.html' && page_path == '/') ||
+    (current_page.path == "index.html" && page_path == "/") ||
       "/" + current_page.path == page_path ||
       current_page.data.parent == page_path
   end
 
   def sidebar_link(name, page_path)
-    link_to(page_path, class: page_path == "/#{current_page.path}" ? 'toc-link--in-view' : nil) do
+    link_to(page_path, class: page_path == "/#{current_page.path}" ? "toc-link--in-view" : nil) do
       content_tag(:span, name)
     end
   end

--- a/helpers/properties_table_helpers.rb
+++ b/helpers/properties_table_helpers.rb
@@ -14,22 +14,25 @@ private
   def display_attribute_value(attrs)
     return unless attrs
 
-    if attrs['properties']
-      table_of_properties(attrs['properties'])
+    if attrs["properties"]
+      table_of_properties(attrs["properties"])
     else
-      [attrs['description'], enums(attrs)].join("<br/>")
+      [attrs["description"], enums(attrs)].join("<br/>")
     end
   end
 
   def enums(attrs)
-    return unless attrs['enum']
-    "Allowed values: " + attrs['enum'].map { |value| "<code>#{value}</code>" }.join(", ")
+    return unless attrs["enum"]
+
+    "Allowed values: " + attrs["enum"].map { |value| "<code>#{value}</code>" }.join(", ")
   end
 
   def possible_types(attrs)
     return unless attrs
-    possible_types = attrs['type'] ? [attrs] : attrs['anyOf']
+
+    possible_types = attrs["type"] ? [attrs] : attrs["anyOf"]
     return unless possible_types
+
     possible_types.map { |a| "<code>#{a['type']}</code>" }.join(" or ")
   end
 end

--- a/spec/app/app_diagrams_generator_spec.rb
+++ b/spec/app/app_diagrams_generator_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe AppDiagramGenerator do
     # generate actual diagrams
     dg = AppDiagramGenerator.new
     dg.generate
-    @files = Dir.glob('diagrams/*.puml')
+    @files = Dir.glob("diagrams/*.puml")
     @parsed_diagrams = []
     parse_output
   end

--- a/spec/app/content_schema_spec.rb
+++ b/spec/app/content_schema_spec.rb
@@ -1,51 +1,51 @@
 RSpec.describe ContentSchema do
-  describe '#frontend_schema' do
+  describe "#frontend_schema" do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").frontend_schema
 
-      expect(schema.link_to_github).to eql('https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/frontend/schema.json')
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/frontend/schema.json")
     end
 
     it "it has a random example" do
       schema = ContentSchema.new("generic").frontend_schema
 
-      expect(schema.random_example['content_id']).not_to be_nil
+      expect(schema.random_example["content_id"]).not_to be_nil
     end
 
     it "it has properties with inlined definitions" do
       schema = ContentSchema.new("generic").frontend_schema
 
-      expect(schema.properties['base_path']["$ref"]).to eql(nil)
-      expect(schema.properties['base_path']["type"]).to eql("string")
+      expect(schema.properties["base_path"]["$ref"]).to eql(nil)
+      expect(schema.properties["base_path"]["type"]).to eql("string")
     end
   end
 
-  describe '#publisher_content_schema' do
+  describe "#publisher_content_schema" do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").publisher_content_schema
 
-      expect(schema.link_to_github).to eql('https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/publisher/schema.json')
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/publisher/schema.json")
     end
 
     it "it has a random example" do
       schema = ContentSchema.new("generic").publisher_content_schema
 
-      expect(schema.random_example['base_path']).not_to be_nil
+      expect(schema.random_example["base_path"]).not_to be_nil
     end
 
     it "it has properties with inlined definitions" do
       schema = ContentSchema.new("generic").publisher_content_schema
 
-      expect(schema.properties['base_path']["$ref"]).to eql(nil)
-      expect(schema.properties['base_path']["type"]).to eql("string")
+      expect(schema.properties["base_path"]["$ref"]).to eql(nil)
+      expect(schema.properties["base_path"]["type"]).to eql("string")
     end
   end
 
-  describe '#publisher_links_schema' do
+  describe "#publisher_links_schema" do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").publisher_links_schema
 
-      expect(schema.link_to_github).to eql('https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/publisher/links.json')
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/publisher/links.json")
     end
   end
 end

--- a/spec/app/document_types_csv_spec.rb
+++ b/spec/app/document_types_csv_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe DocumentTypesCsv do
         to_return(
           body: File.read("spec/fixtures/search-api-app-search-response.json"),
           headers: {
-            content_type: "application/json"
-          }
+            content_type: "application/json",
+          },
         )
 
       stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml").
@@ -17,7 +17,7 @@ RSpec.describe DocumentTypesCsv do
 
       csv = DocumentTypes.to_csv
 
-      expect(csv).to eql(File.read('spec/fixtures/document-types-export.csv'))
+      expect(csv).to eql(File.read("spec/fixtures/document-types-export.csv"))
     end
   end
 end

--- a/spec/app/document_types_spec.rb
+++ b/spec/app/document_types_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe DocumentTypes do
         to_return(
           body: File.read("spec/fixtures/search-api-app-search-response.json"),
           headers: {
-            content_type: "application/json"
-          }
+            content_type: "application/json",
+          },
         )
 
       stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml").

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -1,46 +1,46 @@
-require 'capybara/rspec'
+require "capybara/rspec"
 
 RSpec.describe ExternalDoc do
-  describe '.fetch' do
+  describe ".fetch" do
     subject(:html) do
       Capybara.string(described_class.fetch(repository: repository, path: path))
     end
 
-    let(:repository) { 'example/lipsum' }
-    let(:path) { 'markdown.md' }
+    let(:repository) { "example/lipsum" }
+    let(:path) { "markdown.md" }
 
     before do
-      stub_request(:get, 'https://raw.githubusercontent.com/example/lipsum/master/markdown.md').
-        to_return(body: File.read('spec/fixtures/markdown.md'))
+      stub_request(:get, "https://raw.githubusercontent.com/example/lipsum/master/markdown.md").
+        to_return(body: File.read("spec/fixtures/markdown.md"))
     end
 
-    it 'removes the title of the page' do
-      expect(html).not_to have_selector('h1', text: 'Lorem ipsum')
+    it "removes the title of the page" do
+      expect(html).not_to have_selector("h1", text: "Lorem ipsum")
     end
 
-    it 'rewrites links to markdown pages' do
-      expect(html).to have_link('turpis ultrices', href: '/ultrices.html')
+    it "rewrites links to markdown pages" do
+      expect(html).to have_link("turpis ultrices", href: "/ultrices.html")
     end
 
-    it 'rewrites relative images' do
+    it "rewrites relative images" do
       expect(html).to have_css('img[src="https://raw.githubusercontent.com/example/lipsum/master/suspendisse_iaculis.png"]')
     end
 
-    it 'rewrites relative URLs' do
-      expect(html).to have_link('tincidunt leo', href: 'https://github.com/example/lipsum/blob/master/lib/tincidunt_leo.rb')
+    it "rewrites relative URLs" do
+      expect(html).to have_link("tincidunt leo", href: "https://github.com/example/lipsum/blob/master/lib/tincidunt_leo.rb")
     end
 
-    it 'maintains anchor links' do
-      expect(html).to have_link('Suspendisse iaculis', href: '#suspendisse-iaculis')
+    it "maintains anchor links" do
+      expect(html).to have_link("Suspendisse iaculis", href: "#suspendisse-iaculis")
     end
 
-    it 'adds an id attribute to all headers so they can be accessed from a table of contents' do
-      expect(html).to have_selector('h2#tldr')
+    it "adds an id attribute to all headers so they can be accessed from a table of contents" do
+      expect(html).to have_selector("h2#tldr")
     end
 
-    it 'converts heading IDs properly' do
-      expect(html).to have_selector('h3#data-gov-uk')
-      expect(html).to have_selector('h3#patterns-style-guides')
+    it "converts heading IDs properly" do
+      expect(html).to have_selector("h3#data-gov-uk")
+      expect(html).to have_selector("h3#patterns-style-guides")
     end
   end
 end

--- a/spec/app/manual_spec.rb
+++ b/spec/app/manual_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Manual do
-  describe '#manual_pages_grouped_by_section' do
+  describe "#manual_pages_grouped_by_section" do
     it "returns the correct groups" do
       sitemap = double(resources: [
         double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo")),
@@ -13,7 +13,7 @@ RSpec.describe Manual do
     end
   end
 
-  describe '#other_pages_from_section' do
+  describe "#other_pages_from_section" do
     it "returns the correct groups" do
       one = double(path: "manual/foo.html", data: double(title: "Foo", important: true, section: "A section"))
       other = double(path: "manual/bar.html", data: double(title: "Bar", important: true, section: "A section"))
@@ -30,7 +30,7 @@ RSpec.describe Manual do
     end
   end
 
-  describe '#pages_for_application' do
+  describe "#pages_for_application" do
     it "returns the pages that are relevant to an application" do
       sitemap = double(resources: [
         double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo")),

--- a/spec/app/snippet_spec.rb
+++ b/spec/app/snippet_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Snippet do
   describe ".generate" do
     it "generates a proper snippet without the opsmanual warning" do
-      html = <<~html
+      html = <<~HTML
         <blockquote>
         <p><strong>This page was imported from <a href="https://github.com/alphagov/govuk-legacy-opsmanual">the opsmanual on GitHub Enterprise</a></strong>.
         It hasn&rsquo;t been reviewed for accuracy yet.
@@ -10,7 +10,7 @@ RSpec.describe Snippet do
         <h1 id='remove-an-asset'>Remove an asset</h1>
         <p>If you need to remove an asset manually from <code>assets.publishing.sevice.gov.uk</code>,
         follow these steps:</p>
-      html
+      HTML
 
       snippet = Snippet.generate(html)
 
@@ -18,7 +18,7 @@ RSpec.describe Snippet do
     end
 
     it "removes headings" do
-      html = <<~html
+      html = <<~HTML
         <h1 id='deploy-an-application-to-govuk'>Deploy an application to GOV.UK</h1>
         <h2 id='introduction'>Introduction</h2>
         <p>2nd line is responsible for:</p>
@@ -31,7 +31,7 @@ RSpec.describe Snippet do
         <p>As far as possible, teams are responsible for deploying their own work. We believe that
         <a href="https://gds.blog.gov.uk/2012/11/02/regular-releases-reduce-risk/">regular releases minimise the risk of major problems</a> and
         improve recovery time.</p>
-      html
+      HTML
 
       snippet = Snippet.generate(html)
 

--- a/spec/app/snippet_spec.rb
+++ b/spec/app/snippet_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Snippet do
-  describe '.generate' do
-    it 'generates a proper snippet without the opsmanual warning' do
+  describe ".generate" do
+    it "generates a proper snippet without the opsmanual warning" do
       html = <<~html
         <blockquote>
         <p><strong>This page was imported from <a href="https://github.com/alphagov/govuk-legacy-opsmanual">the opsmanual on GitHub Enterprise</a></strong>.
@@ -17,7 +17,7 @@ RSpec.describe Snippet do
       expect(snippet).to eql("If you need to remove an asset manually from assets.publishing.sevice.gov.uk, follow these steps:")
     end
 
-    it 'removes headings' do
+    it "removes headings" do
       html = <<~html
         <h1 id='deploy-an-application-to-govuk'>Deploy an application to GOV.UK</h1>
         <h2 id='introduction'>Introduction</h2>

--- a/spec/app/source_url_spec.rb
+++ b/spec/app/source_url_spec.rb
@@ -1,4 +1,4 @@
-Dir.glob(::File.expand_path('../../helpers/**/*.rb', __FILE__)).each { |f| require_relative f }
+Dir.glob(::File.expand_path("../../helpers/**/*.rb", __FILE__)).each { |f| require_relative f }
 
 RSpec.describe SourceUrl do
   describe "#source_url" do
@@ -19,7 +19,7 @@ RSpec.describe SourceUrl do
     end
 
     it "returns the source from this repository" do
-      current_page = double(data: double(source_url: nil), file_descriptor: { relative_path: 'foo.html.md' })
+      current_page = double(data: double(source_url: nil), file_descriptor: { relative_path: "foo.html.md" })
 
       source_url = SourceUrl.new({}, current_page).source_url
 

--- a/spec/app/supertypes_spec.rb
+++ b/spec/app/supertypes_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Supertypes do
-  describe '.all' do
-    it 'works' do
+  describe ".all" do
+    it "works" do
       stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk_document_types/master/data/supertypes.yml").
         to_return(body: File.read("spec/fixtures/supertypes.yml"))
 

--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -1,7 +1,9 @@
 Dir.glob("source/manual/**/*.md").each do |filename|
   RSpec.describe filename do
     raw = File.read(filename)
-    frontmatter = YAML.safe_load(raw.split("---")[1])
+    # rubocop:disable Security/YAMLLoad
+    frontmatter = YAML.load(raw.split("---")[1])
+    # rubocop:enable Security/YAMLLoad
 
     it "uses the correct spelling of GOV.UK" do
       expect(raw).not_to match "Gov.uk"

--- a/spec/pages/manual_page_spec.rb
+++ b/spec/pages/manual_page_spec.rb
@@ -1,31 +1,31 @@
 Dir.glob("source/manual/**/*.md").each do |filename|
   RSpec.describe filename do
     raw = File.read(filename)
-    frontmatter = YAML.load(raw.split('---')[1])
+    frontmatter = YAML.safe_load(raw.split("---")[1])
 
     it "uses the correct spelling of GOV.UK" do
       expect(raw).not_to match "Gov.uk"
     end
 
     it "has a review date in the past" do
-      next unless frontmatter['last_reviewed_on']
+      next unless frontmatter["last_reviewed_on"]
 
-      expect(frontmatter['last_reviewed_on']).not_to be_in_the_future
+      expect(frontmatter["last_reviewed_on"]).not_to be_in_the_future
     end
 
     it "has an owner" do
-      expect(frontmatter['owner_slack']).to be_present, "Page doesn't have `owner_slack` set"
-      expect(frontmatter['owner_slack'][0]).to be_in(%[# @]), "`owner_slack` should be a @username or #channel"
+      expect(frontmatter["owner_slack"]).to be_present, "Page doesn't have `owner_slack` set"
+      expect(frontmatter["owner_slack"][0]).to be_in(%[# @]), "`owner_slack` should be a @username or #channel"
     end
 
     it "has a title" do
-      expect(frontmatter['title']).to be_present, "Page doesn't have `title` set"
+      expect(frontmatter["title"]).to be_present, "Page doesn't have `title` set"
     end
 
     unless frontmatter["section"] == "Icinga alerts"
       it "follows the styleguide" do
-        expect(frontmatter['title'].split(" ").first).not_to end_with("ing"),
-          "Page title `#{frontmatter['title']}`: don't use 'ing' at the end of verbs - https://docs.publishing.service.gov.uk/manual/docs-style-guide.html#title"
+        expect(frontmatter["title"].split(" ").first).not_to end_with("ing"),
+                                                             "Page title `#{frontmatter['title']}`: don't use 'ing' at the end of verbs - https://docs.publishing.service.gov.uk/manual/docs-style-guide.html#title"
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
-require 'webmock/rspec'
+require "webmock/rspec"
 
-require 'govuk_tech_docs'
-require_relative './../app/requires'
+require "govuk_tech_docs"
+require_relative "./../app/requires"
 
 RSpec.configure do |config|
   config.before do
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   if config.files_to_run.one?
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   config.order = :random


### PR DESCRIPTION
Ran `bundle exec govuk-lint-ruby -a app lib spec helpers` to autofix a bunch of stuff

Manually fixed "memoized variable names must match surrounding method names"

Manually uppercased heredoc delimiters

Allowed us to use `YAML.load` rather than `safe_load` because it was breaking tests.  The Yaml sources are trusted, so this should still be OK.