### PR TITLE
Review Concourse pipeline docs

### DIFF
--- a/source/manual/add-a-secret-to-a-concourse-pipeline.html.md
+++ b/source/manual/add-a-secret-to-a-concourse-pipeline.html.md
@@ -4,7 +4,7 @@ title: Add a secret to a Concourse pipeline
 section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-06-27
+last_reviewed_on: 2019-09-30
 review_in: 3 months
 ---
 

--- a/source/manual/concourse.html.md
+++ b/source/manual/concourse.html.md
@@ -5,7 +5,7 @@ section: Infrastructure
 layout: manual_layout
 type: learn
 parent: "/manual.html"
-last_reviewed_on: 2019-06-27
+last_reviewed_on: 2019-09-30
 review_in: 3 months
 ---
 
@@ -31,6 +31,6 @@ GOV.UK currently has two pipelines named [info](https://cd.gds-reliability.engin
 
 We currently use the `operations` pipeline to [mirror all GOV.UK GitHub repositories to AWS CodeCommit](repository-mirroring.html).
 
-### The info pipeline
+### The info pipeline
 
 The `info` pipeline is a meta pipeline. Its main use is as a method to store secrets that can then be used in other pipelines. For example, the repository mirroring job uses GitHub and AWS credentials that are stored as secrets using this method.

--- a/source/manual/create-a-concourse-pipeline.html.md
+++ b/source/manual/create-a-concourse-pipeline.html.md
@@ -4,23 +4,24 @@ title: Create a Concourse pipeline
 section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-06-27
+last_reviewed_on: 2019-09-30
 review_in: 3 months
 ---
 
 ## Create a new pipeline
 
-You can use the [repo mirror pipeline](https://github.com/alphagov/govuk-repo-mirror/blob/master/concourse.yml) as an example - it uses GitHub, Slack and a bash script. Pivotal also provides a lot of [example pipelines](https://github.com/pivotalservices/concourse-pipeline-samples).
+You can use the [repo mirror pipeline](https://github.com/alphagov/govuk-repo-mirror/blob/master/concourse.yml) as an example - it uses GitHub, Slack and a bash script. Pivotal also provide a lot of [example pipelines](https://github.com/pivotalservices/concourse-pipeline-samples).
 
-## Apply a pipeline
+## Apply a pipeline
 
 Whenever a pipeline YAML is created or changed, it needs to be applied for the changes to take effect.
 
 To apply a pipeline:
 
 1. If this is your first time using Concourse, download the `fly` CLI by clicking the appropriate OS logo at the bottom right corner of the [team page](https://cd.gds-reliability.engineering/teams/govuk-tools) and move it to somewhere in your `$PATH`
-2. Navigate to the folder that contains the pipeline config YAML file
-3. Run `fly -t cd-govuk-tools set-pipeline -p [pipeline name] -c [pipeline config YAML file name]`
-4. Visit the provided URL to log in
-5. Double-check the diff to ensure you're happy with what is about to be applied
-6. Enter `y` to make the changes
+1. Set a target for the team you want to login to: `fly login -c https://cd.gds-reliability.engineering -n govuk-tools -t cd-govuk-tools`
+1. Navigate to the folder that contains the pipeline config YAML file
+1. Run `fly -t cd-govuk-tools set-pipeline -p [pipeline name] -c [pipeline config YAML file name]`
+1. Visit the provided URL to log in
+1. Double-check the diff to ensure you're happy with what is about to be applied
+1. Enter `y` to make the changes


### PR DESCRIPTION
- Bump the last reviewed date.
- Trim trailing whitespace.
- Where there are numbered lists, set each number to 1 to enable the
  magic Markdown auto-numbering.
- Add a line about how to set a target if `cd-govuk-tools` doesn't
  exist.