### PR TITLE
On-call: Remove the 'access to govuk_mirror-puppet' line

### DIFF
--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -40,7 +40,6 @@ You should do these things before going on call so you're prepared.
    on your phone.
 1. Ensure you can [decrypt secrets][govuk-secrets] with your GPG setup.
 1. Ensure you can access [vCloud Director][vcloud] in production.
-1. Ensure you can access [govuk_mirror-puppet][] by [adding your SSH key to hierdata](https://github.com/alphagov/govuk_mirror-puppet/blob/master/hieradata/common.yaml#L126).
 1. Read these documents:
     - [So, you're having an incident](/manual/incident-what-to-do.html)
     - [Falling back to the static mirror](/manual/fall-back-to-mirror.html)


### PR DESCRIPTION
- The `govuk_mirror-puppet` repo is archived, so no-one new can add
  themselves to it. Also they don't need to, because the mirrors
  architecture has
  [changed](https://docs.publishing.service.gov.uk/manual/fall-back-to-mirror.html#hosting)
  (https://github.com/alphagov/govuk-developer-docs/pull/1835).