### PR TITLE
Use YAML.load over YAML.safe_load

### DIFF
--- a/app/http.rb
+++ b/app/http.rb
@@ -3,7 +3,7 @@ require "faraday_middleware"
 
 module HTTP
   def self.get_yaml(url)
-    YAML.safe_load(get(url))
+    YAML.load(get(url)) # rubocop:disable Security/YAMLLoad
   end
 
   def self.get(url)


### PR DESCRIPTION
Similar to 48236cad38608b6a7bdf3dd29c575f59312a00de, this partially reverts 98cba9927c3e10d8a59a983c28d9b9e49cd952d6 which seems to have stopped us being able to deploy the developer docs.

We should be able to trust the YAML here as we always load from a hard coded string that we control, although ideally it would be good to investigate why we can't use `safe_load`.

This should [fix the error we're seeing](https://deploy.publishing.service.gov.uk/job/deploy-developer-docs/339/consoleFull):

```
Unknown alias: node_class
/usr/lib/rbenv/versions/2.6.3/lib/ruby/2.6.0/psych/visitors/to_ruby.rb:397:in `visit_Psych_Nodes_Alias'
...
/usr/lib/rbenv/versions/2.6.3/lib/ruby/2.6.0/psych.rb:360:in `safe_load'
/var/lib/jenkins/workspace/deploy-developer-docs/app/http.rb:6:in `get_yaml'
/var/lib/jenkins/workspace/deploy-developer-docs/app/app_docs.rb:25:in `aws_machines'
/var/lib/jenkins/workspace/deploy-developer-docs/app/app_docs.rb:57:in `aws_puppet_class'
```