### PR TITLE
Improve ckan docs

### DIFF
--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -132,32 +132,9 @@ $ pry
 > The added schema will appear in the Schema/Vocabulary dropdown in [https://ckan.publishing.service.gov.uk/dataset/new](https://ckan.publishing.service.gov.uk/dataset/new).
 
 ## Harvesting
-Harvesting is where publishers can automatically import their data to data.gov.uk without having to manually enter it into the web interface.  They can be set up to run automatically at specified periods, or run manually on-demand.
+Harvesting is where publishers can automatically import their data to data.gov.uk without having to manually enter it into the web interface. They can be set up to run automatically at specified periods, or run manually on-demand.
 
-### Get the status of a harvester
-1. Login to [CKAN][ckan] as a sysadmin user (credentials are available in the `govuk-secrets` password store, under `datagovuk/ckan`).
-2. Navigate to the relevant harvester (use the 'Harvest' button in the header).
-3. You will see a list of the datasets imported by this harvest source.
-4. Click the 'Manage' button to get the status.
-5. A summary of the current status will be shown.  Individual runs (and the error messages logged) can be access from the 'Jobs' tab.
-
-### Restart a harvester
-1. Login to [CKAN][ckan] as a sysadmin user (credentials are available in the `govuk-secrets` password store, under `datagovuk/ckan`).
-2. Navigate to the relevant harvester (use the 'Harvest' button in the header).
-3. You will see a list of the datasets imported by this harvest source.
-4. Click the 'Manage' button.
-5. If the harvester is currently running, click the 'Stop' button to stop it.  Once it has stopped, or if it is not currently running, click the 'Reharvest' button.  You will know if the harvester is running because the 'Reharvest' button will be disabled.
-
-### Harvest job is hanging
-If the harvest job is hanging and the 'Stop' button is not responding you will have to log on to the `ckan` machine and run the harvest job manually.
-
-1. Log on to `ckan` machine using `govukcli`.
-2. Assume the deploy user - `sudo su deploy`
-3. Activate the virtual environment - `. /var/apps/ckan/venv/bin/activate`
-4. Run the harvest job manually - `paster --plugin=ckanext-harvest harvester run_test <harvest source> -c /var/ckan/ckan.ini`
-  - where `harvest source` is from the url when visiting the harvest source page, it will be something like `cabinet-office`
-
-If the job fails to complete the ticket should be updated with comments and prioritised to low for the product owner to review.
+See the ["Harvesting" section in "Support tasks for CKAN"](data-gov-uk-supporting-ckan.html#harvesting) for troubleshooting.
 
 ## Organogram Publishing
 Organograms are files that allow the people structure of an organisation to be visualised.  They are split into two files: one for senior staff (grades SCS1, SCS2 and SCS3, or equivalent) and another for junior staff (all other grades).  The senior staff file is more detailed than the junior staff file, with staff names included for posts classified as grades SCS2 and SCS3.
@@ -179,4 +156,3 @@ There is a [revision log](https://ckan.publishing.service.gov.uk/revision) which
 
 [schemas]: https://github.com/alphagov/ckanext-datagovuk/blob/master/ckanext/datagovuk/helpers.py#L119-L213
 [test-schemas]: https://github.com/alphagov/ckanext-datagovuk/blob/master/ckanext/datagovuk/tests/test_helpers.py#L63-L157
-[ckanext-datagovuk]: https://github.com/alphagov/ckanext-datagovuk

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -272,9 +272,11 @@ paster --plugin=ckanext-harvest harvester jobs -c /var/ckan/ckan.ini
 ```
 
 It may be faster to run a SQL query to get the ID of a specific harvest job.
+You can do this by running the command from [Accessing the database](#accessing-the-database)
+and passing a `-c` argument:
 
 ```
-psql ckan_production -c "SELECT id FROM harvest_source WHERE name = '[NAME]'"
+<psql_ckan_production_command> -c "SELECT id FROM harvest_source WHERE name = '[NAME]'"
 ```
 
 #### Cancelling a current job
@@ -291,7 +293,7 @@ paster --plugin=ckanext-harvest harvester job_abort JOB_ID -c /var/ckan/ckan.ini
 This can also be done by running SQL:
 
 ```
-psql ckan_production -c "UPDATE harvest_job SET finished = NOW(), status = 'Finished' WHERE source_id = '[UUID]' AND NOT status = 'Finished';"
+<psql_ckan_production_command> -c "UPDATE harvest_job SET finished = NOW(), status = 'Finished' WHERE source_id = '[UUID]' AND NOT status = 'Finished';"
 ```
 
 #### Purging all currently queued tasks

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -155,7 +155,19 @@ paster --plugin=ckan user remove USERNAME -c /var/ckan/ckan.ini
 paster --plugin=ckan user setpass USERNAME -c /var/ckan/ckan.ini
 ```
 
-### Deleting a dataset
+### Managing publishers
+
+#### Change a publisher's name
+
+Change the name in the publisher page then reindex that publisher:
+
+```
+paster --plugin=ckan search-index rebuild-publisher [PUBLISHER] -c /var/ckan/ckan.ini
+```
+
+### Managing datasets
+
+#### Deleting a dataset
 
 [CKAN] has two types of deletions, the default soft-delete, and a purge.  The soft delete gives the option of
 undeleting a dataset but the purge will remove all trace of it from the system.
@@ -187,6 +199,10 @@ while read p; do curl --request POST --data "{\"id\": \"$p\"}" --header "Authori
 
 After deleting or purging a dataset, it will take up to 10 minutes to update on Find, due to the sync process.
 
+#### Register a brownfield dataset
+
+See the [supporting manual](https://docs.google.com/document/d/1SxzN9Ihat75TXo-fMwFqW_qBS-bPKHRs-a-tAO-qA1c/edit?usp=sharing).
+
 ### Rebuilding the search index
 
 [CKAN] uses Solr for its search index, and occasionally it may be necessary to interact with it
@@ -216,10 +232,12 @@ Only reindex those packages that are not currently indexed:
 paster --plugin=ckan search-index -o rebuild -c /var/ckan/ckan.ini
 ```
 
-### `csw` endpoint unavailable
+### `csw` endpoint
 
 The `csw` endpoint should be available on <https://data.gov.uk/csw> which
 should redirect to <https://ckan.publishing.service.gov.uk/csw>.
+
+#### `csw` endpoint unavailable
 
 If it is not showing xml with an error `Missing keyword: service` you can check
 that it is running on the `ckan` machine:
@@ -247,7 +265,7 @@ $ tail -f /var/log/ckan/pycsw.err.log
 
 You can get a summary of `csw` records available from this url https://ckan.publishing.service.gov.uk/csw?service=CSW&version=2.0.2&request=GetRecords&typenames=csw:Record&elementsetname=brief
 
-### Syncing the `csw` records with `ckan` datasets
+#### Syncing the `csw` records with `ckan` datasets
 
 Normally the sync between `csw` and `ckan` will start at 6 each day, but in
 case it should fail or if the sync needs to happen sooner you can manually
@@ -388,15 +406,3 @@ running, so is safe to run immediately if you suspect the process has crashed:
 ```bash
 $ fab aws_production class:ckan ckan.restart_harvester
 ```
-
-### Change a publisher's name
-
-Change the name in the publisher page then reindex that publisher:
-
-```
-paster --plugin=ckan search-index rebuild-publisher [PUBLISHER] -c /var/ckan/ckan.ini
-```
-
-### Register a brownfield dataset
-
-See the [supporting manual](https://docs.google.com/document/d/1SxzN9Ihat75TXo-fMwFqW_qBS-bPKHRs-a-tAO-qA1c/edit?usp=sharing).

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -60,7 +60,9 @@ In order to access the CKAN database to run queries on the `db_admin` machine:
 
 `psql -U ckan -h postgresql-primary -p 5432 ckan_production`
 
-The password can be found in the `/var/ckan/ckan.ini` file on the `ckan` machine for the environment you are targeting.
+The password can be extracted from the configuration file on the `ckan` machine for the environment you are targeting:
+
+`more /var/ckan/ckan.ini | grep sqlalchemy`
 
 ### Accessing the CKAN API
 

--- a/source/manual/data-gov-uk-troubleshooting.html.md
+++ b/source/manual/data-gov-uk-troubleshooting.html.md
@@ -50,39 +50,3 @@ A [reindex](/manual/data-gov-uk-operations.html#reindexing-find) must then be do
 Check the Sidekiq queue (see [monitoring section](/manual/data-gov-uk-monitoring.html#sidekiq-publish)) length to ensure the queue length is not too long.  You should not be seeing more jobs than the number of datasets in CKAN.
 
 If the queue is too long, you should clear the queue.  The next sync process will repopulate the queue with any relevant datasets that require updating.
-
-## Harvesters not processing or seem stuck
-
-The harvesting process runs as a single threaded program, if any harvesting
-process crashes by raising an exception, it will take out the entire process.
-We have configured Upstart to restart the process automatically, but if the
-service keeps crashing, Upstart will decide it's unhealthy and stop that after
-a while.
-
-You can check whether the process is still running by checking if entries are
-still being written to the log file on the `ckan` machine:
-
-```bash
-$ govukcli set-context production-aws
-$ govukcli ssh ckan
-```
-
-```bash
-$ sudo tail -f /var/log/ckan/procfile_harvester_fetch_consumer.err.log
-```
-
-Or you could check that the services are all showing as `started` on the `ckan`
-machine:
-
-```bash
-$ sudo initctl list | grep harvester
-```
-
-If the server has stopped, there is a Fabric script that will restart it for
-you. This script first checks whether the harvesting process is running or not
-so if you suspect the process has crashed, you can run this script first to
-try and restart the process.
-
-```bash
-$ fab aws_production class:ckan ckan.restart_harvester
-```


### PR DESCRIPTION
Our docs for Harvesters are duplicated in a few places (I’ve just had to cancel a harvest job that got stuck and found 3 similar pages).

This PR looks at consolidating CKAN harvester information in one page.


