### PR TITLE
Remove spurious colon in rake task code block

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -65,7 +65,7 @@ ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).m
 #### Check failed email ids and failure reasons for a content change
 
 ```sh
- $ bundle exec rake report::content_change_failed_emails[<content_change_id>]
+ $ bundle exec rake report:content_change_failed_emails[<content_change_id>]
 ```
 
 ## Unprocessed digest runs (digest_runs)


### PR DESCRIPTION
Not that we ever cut and paste into the command line. But were we to do
so, namespacing in rake tasks should only contain a single colon.