### PR TITLE
Fix links to purge cache

### DIFF
--- a/source/manual/documents-arent-live-after-publishing.html.md
+++ b/source/manual/documents-arent-live-after-publishing.html.md
@@ -87,6 +87,6 @@ $ bundle exec rake routes:register[base_path]
 ## If the document isn't live after all this
 
 If the document appears to be correct in all these places, it may just be
-necessary to [clear the cache](cache-flush.html) for that document. 404 pages
+necessary to [clear the cache](purge-cache.html) for that document. 404 pages
 will be cached, although with a shorter expiration time, so if a publisher
 tries to view the page before it's live, they may end up caching the 404 page.

--- a/source/manual/help-with-publishing-content.html.md
+++ b/source/manual/help-with-publishing-content.html.md
@@ -30,7 +30,7 @@ on some pages.
 You may need to do this if the content is not showing on the live site quick
 enough.
 
-[cache]: cache-flush.html
+[cache]: purge-cache.html
 
 ### [If guidance pages are expected to show on taxon pages but aren't][search]
 

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -67,7 +67,7 @@ the previous version of the software.
         sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_zips[/tmp/hmrc-paye]
         sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_asset[/tmp/hmrc-paye/realtimepayetools-update-vXX.xml,test-realtimepayetools-update-vXX.xml]
 
-1.  [Purge the cache](https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets) for the test file.
+1.  [Purge the cache](https://docs.publishing.service.gov.uk/manual/purge-cache.html#assets) for the test file.
 
 1.  Reply to the Zendesk ticket, providing the `test-*.xml` URL of:
 
@@ -91,6 +91,6 @@ the previous version of the software.
 
 1. Publish the content items.
 
-1. [Purge the cache](https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets) for the new file.
+1. [Purge the cache](https://docs.publishing.service.gov.uk/manual/purge-cache.html#assets) for the new file.
 
 1.  Update and resolve the Zendesk ticket

--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -4,7 +4,7 @@ title: Remove an asset
 section: Assets
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-09-02
+last_reviewed_on: 2019-10-08
 review_in: 6 months
 ---
 
@@ -37,4 +37,4 @@ follow these steps:
 
 [rake-delete]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete[]
 [rake-delete-and-remove-from-s3]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete_and_remove_from_s3[]
-[clear-cache]: https://docs.publishing.service.gov.uk/manual/cache-flush.html#assets
+[clear-cache]: https://docs.publishing.service.gov.uk/manual/purge-cache.html#assets


### PR DESCRIPTION
The file name was recently changed, which caused the links to break.