### PR TITLE
Update "Which browsers we support"

### DIFF
--- a/source/manual/browser-support.html.md
+++ b/source/manual/browser-support.html.md
@@ -5,8 +5,12 @@ layout: manual_layout
 section: Frontend
 type: learn
 owner_slack: "#govuk-frontenders"
-last_reviewed_on: 2018-08-29
+last_reviewed_on: 2019-10-08
 review_in: 12 months
 ---
 
-For browser support, see the Service Manual page about [Designing for different browsers and devices](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
+GOV.UK [shares the same browser support matrix with GOV.UK Frontend](https://github.com/alphagov/govuk-frontend#browser-support) for pages served to the general public.
+
+If the application you are working on is aimed at internal users rather than the general public you should look at your analytics data and check which browsers your users are using. Then you can then make an informed decision about which browsers to test with.
+
+For more information around browser support, see the Service Manual page about [Designing for different browsers and devices](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).


### PR DESCRIPTION
This page was due to be reviewed.

I added reference to GOV.UK Frontend browser support matrix (since it was defined looking at analytics data on GOV.UK) and it reflects the current state of frontend applications that serve pages to the general public.

I also added a paragraph about informing browser support with analytics data for applications that are not serving pages for the general public (e.g. admin apps).