### PR TITLE
add a note to say that aws should be accessed on a GDS network

### DIFF
--- a/source/manual/aws-cli-access.html.md
+++ b/source/manual/aws-cli-access.html.md
@@ -11,7 +11,8 @@ review_in: 3 months
 Prerequisites:
 
 - Access to the GOV.UK AWS Accounts (If you haven't done so before, [set up your AWS access][set-up-account])
-- [Installed the AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
+- [Installed the AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)  
+- **ensure that you are on a GDS approved network or otherwise, Cyber will be alerted**
 
 ---
 

--- a/source/manual/aws-console-access.html.md
+++ b/source/manual/aws-console-access.html.md
@@ -10,7 +10,12 @@ old_paths:
   - /manual/seeing-things-in-the-aws-console.html
 ---
 
-💡 Before you can access something in AWS, you [need to set up your AWS account](/manual/set-up-aws-account.html).
+💡 Before you can access something in AWS, you need:
+
+1. [to set up your AWS account](/manual/set-up-aws-account.html)
+
+2. **ensure that you are on a GDS approved network or otherwise, Cyber will
+   be alerted**
 
 ---
 


### PR DESCRIPTION
Now, Cyber has started to monitor the IPs which are used to access AWS. It is advised to use only approved GDS network if you are accessing AWS either via console or cli.