### PR TITLE
Simplify docs on how to run CI on external contributors' PRs

### DIFF
--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -55,16 +55,14 @@ You should also thank the contributor with an amount of emoji proportional to th
 Finally, clean up by deleting the branch you created.
 
 ```bash
-git pull
+brew install hub
 
-git fetch https://github.com/thomasjhughes/publisher patch-1:thomasjhughes-patch-1
+hub pr checkout <PR-NUMBER>
 
-git checkout thomasjhughes-patch-1
-
-git push --set-upstream origin thomasjhughes-patch-1
+git push --set-upstream origin <BRANCH-NAME>
 ```
 
-Change `thomasjhughes` to the GitHub username of the contributor and `patch-1` to the name of the branch in their fork.
+where <BRANCH-NAME> is the name of the branch that's checked out.
 
 #### Dependabot
 


### PR DESCRIPTION
- With GitHub's `hub` CLI tool, there's no more faffing about finding
  the GitHub username and forked repo and branch of the contributor, one
  can simply `hub pr checkout` in the repo, then push that branch to
  origin.