### PR TITLE
Add docs for the state of service resolution during migration

### DIFF
--- a/source/manual/govuk-app-domain-handling-during-migration.html.md
+++ b/source/manual/govuk-app-domain-handling-during-migration.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#re-govuk"
+title: app_domain handling in GOV.UK during migration to AWS
+section: Infrastructure
+layout: manual_layout
+type: learn
+parent: "/manual.html"
+last_reviewed_on: 2019-10-21
+review_in: 3 months
+---
+
+The app-by-app migration plan to move GOV.UK to AWS introduced the need to introduce an `$app_domain_internal` parameter in addition to the `$app_domain` used prior. This is due to the fact that in AWS, we use a `<environment>.govuk-internal.digital` domain in addition to the `<environment>.govuk.digital` domain.
+
+Furthermore, the `app_domain` parameter may be set to the `<environment>.publishing.service.gov.uk` for migrated apps as well. The exact configration depends on the current state of the migrated app as well as its dependencies. For example, migrated backend applications, such as Support, may be configured to use the `<environment>.publishing.service.gov.uk` `$app_domain` to facilitate access to Signon over the internet. Applications in Carrenza which talk to AWS over the VPN need to be able to resolve the `<environment>.govuk-internal.digital`. This internal domain is resolved to the private IP CIDR in AWS (at the moment this is only done for RabbitMQ exchange federation).
+
+As a rule of thumb:
+
+- Applications which have been moved to AWS and have all their dependencies in AWS will use `$app_domain=<environment>.govuk.digital` and `<$app_domain_internal=<environment>.govuk-internal.digital` consistently.
+- Applications which remain in Carrenza, including all their dependencies, will only use `app_domain=<environment>.publishing.service.gov.uk`.
+- Applications having dependencies in both AWS and Carrenza will require some customisation of service resolution in form of a Plek URI override and may use either `$app_domain=<environment>.govuk.digital` or `$app_domain=<environment>.publishing.service.gov.uk`.
+
+Since setting the correct service discovery environment for a particular app is complicated due to the migration to AWS, please take extra care to make sure you understand the effects of changes to the app_domain parameter and Plek URI overrides via environment variables. If in doubt, please liaise with RE:GOV.UK, e.g. via Slack #re-govuk to make sure your changes do not have unintended side effects.

--- a/source/manual/govuk-in-aws.html.md
+++ b/source/manual/govuk-in-aws.html.md
@@ -45,6 +45,10 @@ Please see [the documentation](howto-ssh-to-machines-in-aws.html) about accessin
 
 #### Service resolution
 
+> Please note
+> During the migration to AWS, the presence and value of the app_domain, app_domain_internal and Plek service environment variables are dependent on the migration state of an application as well as its dependencies and can be non-intuitive.
+> If in doubt, please talk to RE:GOV.UK (e.g. in Slack #re-govuk) to make sure your configuration change is consistent with your intention.
+
 Traditionally resolving a service name to an IP would be handled by hardcoding names and IPs in `/etc/hosts`.
 
 To make use of the dynamic environment in AWS, we are using [Amazon Route 53](https://aws.amazon.com/route53/) to resolve service names to their appropriate ELB. Each node group (a set of instances within an autoscaling group) will resolve a main service name, along with any application service names that belong to that group. For example, the `calculators-frontend` node group, will resolve `calculators-frontend` as the service name:


### PR DESCRIPTION
- Due to the app by app strategy of the migration into AWS, the current
service discovery may be configured with significant differences
reflecting the state of the migration of an app as well as its
dependencies.
- We add rough documentation on the edge cases to raise awareness that
changes may not be as straightforward as expected by developers.