### PR TITLE
Review High Priority Tests documentation

### DIFF
--- a/source/manual/alerts/high-priority-tests.html.md
+++ b/source/manual/alerts/high-priority-tests.html.md
@@ -4,7 +4,7 @@ title: Run high priority tests
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-04-17
+last_reviewed_on: 2019-10-24
 review_in: 6 months
 ---
 
@@ -22,7 +22,7 @@ $ fab $environment class:monitoring app.reload:nginx
 $ fab $environment class:monitoring app.restart:smokey-loop
 ```
 
-### `Traceback (most recent call last):`
+### `Traceback (most recent call last):` or `/tmp/smokey.json is older than 30m`
 
 If you see this error in Icinga, it may mean that the `smokey-loop` process has died. You can try looking through the
 logs or restarting the process.
@@ -34,16 +34,9 @@ $ ssh monitoring-1.production
 
 If you see recent log entries like `HTTP status code 550 (RestClient::RequestFailed)` this usually means that
 the BrowserMob Proxy java process is running as part of a previously aborted smokey-loop and the new smoke tests
-cannot start a new proxy. It's necessary to kill the existing java process.
+cannot start a new proxy. It's necessary to kill the existing java process and restart smokey-loop.
 
-```shell
-$ ps -ef | grep java
-> smokey    6385  6380 26 14:58 ?        00:00:54 java -Dapp.name=browsermob-proxy -Dbasedir=/opt/smokey -jar /opt/smokey/lib/browsermob-dist-2.1.4.jar --port 3222
-$ sudo kill -9 6385
-```
-(replacing process numbers as appropriate).
-
-It's also useful to ensure no java proxy processes are left running when restarting smokey-loop.
+Replace process numbers as appropriate:
 
 ```shell
 $ ssh monitoring-1.production


### PR DESCRIPTION
This adds a recently seen error which can be fixed using the same commands as
for the 'Traceback' error. There's also some repeition of killing the existing
Java process which doesn't seem necessary - having just worked through this
issue it seems doing so in conjunction with stopping and starting the
smokey-loop process does the trick.