### PR TITLE
Change app ownership for search-analytics and search-admin

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -349,7 +349,7 @@
       description: ''
 - github_repo_name: search-analytics
   type: Services
-  team: "#govuk-platform-health"
+  team: "#govuk-searchandnav"
   production_hosted_on: carrenza
 
 # Support
@@ -375,7 +375,7 @@
       description: ''
 - github_repo_name: search-admin
   type: Supporting apps
-  team: "#govuk-platform-health"
+  team: "#govuk-searchandnav"
   production_hosted_on: carrenza
 - github_repo_name: signon
   type: Supporting apps


### PR DESCRIPTION
These apps should be owned by the search and navigation team.

[Trello card](https://trello.com/c/kZcAODIZ/1486-make-search-and-nav-team-owners-of-some-applications)