### PR TITLE
Correct steps for leavers process

### DIFF
--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -15,19 +15,19 @@ user from Puppet itself. If the user is just removed from Puppet their files
 will remain on our servers forever more.
 
 1. First find the user manifest in: [modules/users/manifests][manifest-path].
-2. Add an entry to the govuk_user class of `ensure => absent`. Here is an
+1. Add an entry to the govuk_user class of `ensure => absent`. Here is an
    [example][absent-example].
-3. Once this has been raised as a PR and merged, deploy Puppet to all
+1. Once this has been raised as a PR and merged, deploy Puppet to all
    environments.
-4. Create another PR for Puppet that:
+1. Create a PR in [GOV.UK secrets][govuk-secrets] that:
+  - Removes the user from [production hieradata][production-hieradata]. Read [what to do when someone leaves][what-to-do-when-someone-leaves]
+  - Removes the user from [AWS production hieradata][aws-production-hieradata]. Read [what to do when someone leaves][what-to-do-when-someone-leaves]
+1. Create another PR for Puppet that:
   - Removes the user manifest file
   - Removes the user from [Integration users][integration-users]
   - Removes the user from [AWS training environment users][training-environment]
   - Removes the user from [CI users][ci-users]
-5. Create a PR in [GOV.UK secrets][govuk-secrets] that:
-  - Removes the user from [production hieradata][production-hieradata]. Read [what to do when someone leaves][what-to-do-when-someone-leaves]
-  - Removes the user from [AWS production hieradata][aws-production-hieradata]. Read [what to do when someone leaves][what-to-do-when-someone-leaves]
-6. Once these have been merged, deploy Puppet again to all environments.
+1. Once these have been merged, deploy Puppet again to all environments.
 
 [what-to-do-when-someone-leaves]: https://docs.publishing.service.gov.uk/manual/encrypted-hiera-data.html#what-to-do-when-someone-leaves
 [manifest-path]: https://github.com/alphagov/govuk-puppet/tree/master/modules/users/manifests


### PR DESCRIPTION
If we merge the second set of puppet PRs (that remove the user manifest
file) before we've removed the user from govuk-secrets, we risk errors
during a puppet deploy.

Rejig the ordering so that removing the user from govuk-secrets comes
before removing them from puppet. This makes it more explicit and will
encourage us to merge the secrets PR before the puppet PR.