### PR TITLE
Change app ownership for content-publisher

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -52,7 +52,7 @@
   - Publisher
 - github_repo_name: content-publisher
   type: Publishing apps
-  team: "#govuk-platform-health"
+  team: "#govuk-pub-workflow"
   production_hosted_on: carrenza
   dependencies:
     content-publisher:


### PR DESCRIPTION
This app should be owned by the GOV.UK Publishing Workflow team. 

[Trello](https://trello.com/c/z9o9vBAf/1487-1-make-publishing-workflow-team-the-owners-of-content-publisher)