### PR TITLE
Signpost Docker docs better when getting started

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -25,7 +25,9 @@ If you're having trouble with this guide, you can ask your colleagues or the #go
 
 The easiest way to develop on GOV.UK is to use [govuk-docker][]. Until July 2019 we used a [GOV.UK Vagrant development VM](/manual/install-development-vm.html), but this is now deprecated.
 
-👉 [See the govuk-docker README][govuk-docker]
+👉 [Learn about how we use Docker](/manual/intro-to-docker.html)
+
+👉 [Get setup with govuk-docker][govuk-docker]
 
 ## 3. Get SSH access to integration
 

--- a/source/manual/intro-to-docker.html.md
+++ b/source/manual/intro-to-docker.html.md
@@ -8,11 +8,14 @@ review_in: 6 months
 owner_slack: "#govuk-developers"
 ---
 
-This is a tutorial where we run a few things to get [content-publisher] up and running in Docker. If you are new to Docker, you can use this as a quick intro, in the context of the GOV.UK stack.
+We use [govuk-docker] to help us develop stuff on GOV.UK. If you're new to Docker, this will provide useful insights into how we use it in the context of the GOV.UK stack.
 
-We're going to be doing stuff from first-principles, so what follows is a bit convoluted but it will help to explain and familiarise the concepts involved. Before you start, make sure you:
+We're going to be doing stuff from first-principles, so what follows is a bit convoluted but it will help to explain and familiarise the concepts involved.
+
+Before you start, make sure you:
 
 *   [Download Docker](https://www.docker.com/get-started)
+*   [Clone the content-publisher repo][content-publisher]
 *   [Take a quick look at the Docker for Mac intro](https://docs.docker.com/docker-for-mac/)
 *   [Take a look at this video: Docker, FROM scratch](https://www.youtube.com/watch?v=i7yoXqlg48M) - first 30 minutes
 


### PR DESCRIPTION
This tweaks the doc to 'Get started on GOV.UK' to better signpost the
Docker training manual, and update that for people landing on it.