### PR TITLE
Add a page on Email Alert API Delivery Attempt statuses

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -125,27 +125,4 @@ decreased. If it's decreasing, then it means that emails are going out and
 there's probably a lot being processed. You can also check the
 [Email Alert API Metrics dashboard][dashboard].
 
-## Technical failures (technical_failure)
-
-This means that we’ve received a technical failure status code back from Notify
-or a request to send an email via Notify failed within the last hour. This
-means that there may be a problem with our system or that Notify is unable to
-send emails.
-
-In non-production environments, this failure may also mean that we’re
-attempting to send emails to people who are not members of the Notify team for
-the relevant environment.
-
-In this case, ensure the contents of the
-`govuk::apps::email_alert_api::email_address_override_whitelist` key in
-[hieradata](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml)
-and [hieradata_aws](https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml)
-matches the members of the staging/integration Notify teams.
-
-You can login to the Notify account by going to the
-[GOV.UK Notify Admin Interface](https://www.notifications.service.gov.uk).
-The login credentials are in the [2nd line password store][password-store]
-under `govuk-notify/2nd-line-support`.
-
 [dashboard]: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
-[password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify

--- a/source/manual/alerts/email-alert-api-delivery-attempt-status.html.md
+++ b/source/manual/alerts/email-alert-api-delivery-attempt-status.html.md
@@ -1,0 +1,41 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: High number of delivery attempts'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2019-11-05
+review_in: 6 months
+---
+
+## Internal failures (`internal_failure`)
+
+This means that we’ve failed to make a request to Notify within the last hour
+due to a problem in our code. The reason for this failure should be visible in
+Sentry.
+
+## Technical failures (`technical_failure`)
+
+This means that we’ve received a technical failure status code back from Notify
+or a request to send an email via Notify failed within the last hour. This
+means that there may be a problem with our system or that Notify is unable to
+send emails.
+
+In non-production environments, this failure may also mean that we’re
+attempting to send emails to people who are not members of the Notify team for
+the relevant environment.
+
+In this case, ensure the contents of the
+`govuk::apps::email_alert_api::email_address_override_whitelist` key in
+[hieradata][] and [hieradata_aws][] matches the members of the
+staging/integration Notify teams.
+
+You can login to the Notify account by going to the
+[GOV.UK Notify Admin Interface][notify]. The login credentials are in the
+[2nd line password store][password-store] under
+`govuk-notify/2nd-line-support`.
+
+[notify]: https://www.notifications.service.gov.uk
+[hieradata]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml
+[hieradata_aws]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml
+[password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify


### PR DESCRIPTION
This is a new alert which replaces two of the healthchecks. See https://github.com/alphagov/govuk-puppet/pull/9786 for more details on why we've replaced part of the healthcheck with individual alerts.

[Trello Card](https://trello.com/c/abNGpq1l/1480-5-extract-the-technicalfailures-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)