### PR TITLE
Remove reference to out of date spreadsheet

### DIFF
--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -29,9 +29,3 @@ New versions of Ruby bring us improved performance and nicer syntax for certain 
 
 - Be running on the current major version
 - Maintain our applications at the current or next-to-current minor version
-
-### Current state
-
-The current state of the Ruby and Rails versions is [listed in this versions spreadsheet][sheet].
-
-[sheet]: https://docs.google.com/spreadsheets/d/1FJmr39c9eXgpA-qHUU6GAbbJrnenc0P7JcyY2NB9PgU


### PR DESCRIPTION
The versions therein are no longer accurate, and no longer maintained (last edit July 2018
by 'Deleted user'). An automated dashboard would be a better solution in future so that it
stays up to date without manual intervention.