### PR TITLE
Review and update some docs

### DIFF
--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -4,7 +4,7 @@ title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-05-02
+last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---
 > **Note on AWS**
@@ -33,7 +33,6 @@ The Jenkins jobs included in the sync are:
 * [Copy Attachments to Staging](https://deploy.publishing.service.gov.uk/job/Copy_Attachments_to_Staging/)
 * [Copy Data to Integration](https://deploy.publishing.service.gov.uk/job/Copy_Data_to_Integration/)
 * [Copy Attachments to Integration](https://deploy.publishing.service.gov.uk/job/Copy_Attachments_to_Integration/)
-* [Copy Licensify Data to Staging](https://deploy.publishing.service.gov.uk/job/Copy_Licensify_Data_to_Staging/)
 * [Copy and Sync sanitised whitehall database](https://deploy.publishing.service.gov.uk/job/copy_sanitised_whitehall_database/) (production to integration only)
 
 See the [source code](https://github.com/alphagov/env-sync-and-backup/tree/master/jobs) of the jobs for more information about how they work.

--- a/source/manual/change-in-hours-time-period-for-dst.html.md
+++ b/source/manual/change-in-hours-time-period-for-dst.html.md
@@ -5,7 +5,7 @@ section: 2nd line
 layout: manual_layout
 type: learn
 parent: "/manual.html"
-last_reviewed_on: 2019-08-05
+last_reviewed_on: 2019-11-04
 review_in: 81 days
 ---
 

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -11,6 +11,8 @@ review_in: 3 months
 
 GOV.UK has several environments with different purposes.
 
+For a quick view of what's where, you can use the release app.
+
 ## Continuous integration (CI)
 
 Runs tests for applications. Hosted by Carrenza.

--- a/source/manual/error-reporting.html.md
+++ b/source/manual/error-reporting.html.md
@@ -4,7 +4,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Monitoring
 owner_slack: "#govuk-2ndline"
-last_reviewed_on: 2019-05-02
+last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---
 

--- a/source/manual/learn-govuk.html.md.erb
+++ b/source/manual/learn-govuk.html.md.erb
@@ -4,7 +4,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Learning GOV.UK
 owner_slack: "#govuk-2ndline"
-last_reviewed_on: 2019-05-02
+last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---
 

--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -4,7 +4,7 @@ title: Query CDN logs
 section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-05-02
+last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---
 


### PR DESCRIPTION
Specific changes other than to the review date:

Remove link to lincensify jenkins job in staging since it's using a different mechanism now.

Add a little bit of information pointing people to the release app to find out what environment their applications are running in.