### PR TITLE
Add migration guide for govuk-lint

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -49,7 +49,8 @@
       repos:
         - govuk_security_audit
         - govuk-rfcs
-        - govuk-lint
+        - rubocop-govuk
+        - scss-lint-govuk
         - publishing-e2e-tests
         - styleguides
 

--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -10,11 +10,11 @@ review_in: 12 months
 
 [Brakeman][brakeman] is a static analysis tool which checks Rails applications
 for security vulnerabilities. It is effectively a type of linter, similar to
-[govuk-lint][]. It is [configured to run automatically][automatic-brakeman] as
+[rubocop][]. It is [configured to run automatically][automatic-brakeman] as
 part of the CI build process of any Rails application.
 
 [brakeman]: https://github.com/presidentbeef/brakeman
-[govuk-lint]: https://github.com/alphagov/govuk-lint
+[rubocop]: https://github.com/rubocop-hq/rubocop 
 [automatic-brakeman]: https://github.com/alphagov/govuk-jenkinslib/pull/19
 
 ## Dealing with false positives

--- a/source/manual/lint-ruby-code.html.md
+++ b/source/manual/lint-ruby-code.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Lint your Ruby code with govuk-lint
+title: Lint your Ruby code
 section: Patterns & Style Guides
 layout: manual_layout
 parent: "/manual.html"
@@ -8,30 +8,16 @@ last_reviewed_on: 2019-07-02
 review_in: 6 months
 ---
 
-The [govuk-lint](https://github.com/alphagov/govuk-lint) gem uses Rubocop to
-enforce consistency with the GOV.UK style guide.
+To lint Ruby code we recommend using [Rubocop](https://github.com/bbatsov/rubocop).
+It is an open-source gem that performs static analysis of Ruby code according to
+rules that can be granularly configured. Each validation, or rule, is called a "cop".
+Some of those cops come with the ability to auto-correct issues.
 
-[Rubocop](https://github.com/bbatsov/rubocop) is an open-source gem that
-performs static analysis of Ruby code according to rules that can be granularly
-configured. Each validation, or rule, is called a "cop". Some of those cops
-come with the ability to auto-correct issues.
-
-## How to use govuk-lint
-
-- Add `govuk-lint` to your Gemfile
-- Run `govuk-lint-ruby` in your project root folder
-
-## Existing projects
-
-If you have an existing Ruby project that has a number of violations of the
-GOV.UK style guide, a way of addressing those issues is:
-
-1. Run `govuk-lint-ruby --auto-correct` in your project root folder, check that
-   you are happy with those changes and commit.
-2. For the remainder of the violations, manually fix the issues before
-   committing the code containing those fixes.
+The [rubocop-govuk](https://github.com/alphagov/rubocop-govuk) gem is a set of Rubocop
+style rules to enforce consistency with the GOV.UK style guide. See the readme for
+details on installation and usage.
 
 ## Jenkins builds
 
-The default Jenkins build script will detect if you are using `govuk-lint` and
+The default Jenkins build script will detect if you are using `rubocop` and
 will run it automatically.

--- a/source/manual/migrate-from-govuk-lint.html.md
+++ b/source/manual/migrate-from-govuk-lint.html.md
@@ -1,0 +1,79 @@
+---
+owner_slack: "#govuk-developers"
+title: Migrate from govuk-lint
+section: Team tools
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2019-07-02
+review_in: 6 months
+---
+This is a guide to help you migrate from [govuk-lint][govuk-lint],
+which has been deprecated in favour of [rubocop-govuk][rubocop-govuk] and
+[scss-lint-govuk][scss-lint-govuk]. 
+
+## Ruby Projects
+
+Previously, `govuk-lint` provided a set of RuboCop style rules and a
+CLI wrapper for RuboCop called `govuk-lint-ruby`.
+
+We now recommend using [RuboCop][rubocop] directly, instead of the CLI wrapper. The style rules
+previously in `govuk-lint` have moved to `rubocop-govuk` and can be imported when using
+RuboCop.
+
+Changes you may have to make to your project include:
+
+- Replace the `govuk-lint` gem with the `rubocop-govuk` gem in your Gemfile:
+
+```diff
+# Gemfile
+- gem 'govuk-lint'
++ gem 'rubocop-govuk'
+```
+
+- Add the following lines to your project's `.rubocop` config file (you may need to create this):
+
+```yaml
+# .rubocop
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml # add this line for Rails projects
+```
+
+- Replace usage of `govuk-lint-ruby` with `rubocop` in your project. 
+All flags and options should be supported, except the `--diff` flag which should be
+removed.
+
+## SASS Projects
+
+Previously, `govuk-lint` provided a set of scss-lint style rules and a
+CLI wrapper for scss-lint called `govuk-lint-scss`.
+
+We now recommend using [scss-lint][scss-lint] directly, instead of the CLI wrapper. The style rules
+previously in `govuk-lint` have moved to `scss-lint-govuk` and can be imported when using
+`scss-lint`.
+
+Changes you may have to make to your project include:
+
+- Replace the `govuk-lint` gem with the `scss-lint-govuk` gem in your Gemfile:
+
+```diff
+# Gemfile
+- gem 'govuk-lint'
++ gem 'scss_lint-govuk'
+```
+
+- Add the following lines to your project's `.rubocop` config file (you may need to create this):
+
+```yaml
+# .scss-lint.yml
+plugin_gems: ['scss_lint-govuk']
+```
+
+- Replace usage of `govuk-lint-scss` with `scss-lint` in your project. 
+
+[govuk-lint]: https://github.com/alphagov/govuk-lint
+[rubocop]: https://github.com/bbatsov/rubocop
+[rubocop-govuk]: https://github.com/alphagov/rubocop-govuk
+[scss-lint]: https://github.com/sds/scss-lint
+[scss-lint-govuk]: https://github.com/alphagov/scss-lint-govuk

--- a/source/manual/migrate-from-govuk-lint.html.md
+++ b/source/manual/migrate-from-govuk-lint.html.md
@@ -30,10 +30,10 @@ Changes you may have to make to your project include:
 + gem 'rubocop-govuk'
 ```
 
-- Add the following lines to your project's `.rubocop` config file (you may need to create this):
+- Add the following lines to your project's `.rubocop.yml` config file (you may need to create this):
 
 ```yaml
-# .rubocop
+# .rubocop.yml
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
@@ -55,7 +55,7 @@ previously in `govuk-lint` have moved to `scss-lint-govuk` and can be imported w
 
 Changes you may have to make to your project include:
 
-- Replace the `govuk-lint` gem with the `scss-lint-govuk` gem in your Gemfile:
+- Replace the `govuk-lint` gem with the `scss_lint-govuk` gem in your Gemfile:
 
 ```diff
 # Gemfile
@@ -63,7 +63,7 @@ Changes you may have to make to your project include:
 + gem 'scss_lint-govuk'
 ```
 
-- Add the following lines to your project's `.rubocop` config file (you may need to create this):
+- Add the following lines to your project's `.rubocop.yml` config file (you may need to create this):
 
 ```yaml
 # .scss-lint.yml

--- a/source/manual/publishing-a-ruby-gem.html.md
+++ b/source/manual/publishing-a-ruby-gem.html.md
@@ -46,7 +46,7 @@ railscast](http://railscasts.com/episodes/245-new-gem-with-bundler?view=asciicas
 
 The default Jenkins build script will automatically detect the presence of a
 `gemspec` file and publish the gem to rubygems.org. See the
-[Jenkinsfile for govuk-lint](https://github.com/alphagov/govuk-lint/blob/master/Jenkinsfile)
+[Jenkinsfile for rubocop-govuk](https://github.com/alphagov/rubocop-govuk/blob/master/Jenkinsfile)
 for an example.
 
 ## Clearing the gemstash cache

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -54,8 +54,9 @@ end
 
 group :development, :test do
   gem "byebug", "~> 10"
-  gem "govuk-lint", "~> 3"
   gem "rspec-rails", "~> 3"
+  gem "rubocop-govuk"
+  gem "scss-lint-govuk"
 end
 ```
 
@@ -132,10 +133,10 @@ end
 Now is a good time to run `bin/setup`. Lastly, create `lib/tasks/lint.rake` with this.
 
 ```
-desc "Run govuk-lint on all files"
+desc "Lint files"
 task "lint" do
-  sh "govuk-lint-ruby --format clang"
-  sh "govuk-lint-sass app/assets/stylesheets"
+  sh "rubocop --format clang"
+  sh "scss-lint app/assets/stylesheets"
 end
 ```
 

--- a/source/manual/which-gem-to-use.html.md
+++ b/source/manual/which-gem-to-use.html.md
@@ -19,10 +19,10 @@ tests into RSpec tests, but never mix RSpec and MiniTest in projects.
 
 ## Linting Ruby code
 
-- Projects must use [govuk-lint](https://github.com/alphagov/govuk-lint).
+- Projects must use [RuboCop](https://github.com/rubocop-hq/rubocop) with
+[rubocop-govuk](https://github.com/alphagov/rubocop-govuk) style rules.
 
-See [Lint your Ruby code with govuk-lint](/manual/lint-ruby-code.html) for more
-instructions.
+See [Lint your Ruby code](/manual/lint-ruby-code.html) for more instructions.
 
 ## Background processing
 


### PR DESCRIPTION
This guide helps user migrate from [govuk-lint](https://github.com/alphagov/govuk-lint) which has been deprecated to [rubocop-govuk](https://github.com/alphagov/rubocop-govuk) and [scss-lint-govuk](https://github.com/alphagov/scss-lint-govuk).

Also removes old references to `govuk-lint`.