### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 Style/ClassVars:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ ruby File.read('.ruby-version').chomp
 gem 'capybara', '~> 3.29.0'
 gem 'rake'
 gem 'rspec', '~> 3.9'
+gem 'rubocop-govuk'
 gem 'webmock', '~> 3.7'
 gem 'activesupport', '~> 5.0'
-gem 'govuk-lint', '~> 4.2'
 gem 'simplecov'
 
 gem 'govuk_tech_docs'

--- a/Gemfile
+++ b/Gemfile
@@ -1,29 +1,29 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby File.read('.ruby-version').chomp
+ruby File.read(".ruby-version").chomp
 
-gem 'capybara', '~> 3.29.0'
-gem 'rake'
-gem 'rspec', '~> 3.9'
-gem 'rubocop-govuk'
-gem 'webmock', '~> 3.7'
-gem 'activesupport', '~> 5.0'
-gem 'simplecov'
+gem "capybara", "~> 3.29.0"
+gem "rake"
+gem "rspec", "~> 3.9"
+gem "rubocop-govuk"
+gem "webmock", "~> 3.7"
+gem "activesupport", "~> 5.0"
+gem "simplecov"
 
-gem 'govuk_tech_docs'
-gem 'middleman', '~> 4.3.5'
-gem 'middleman-search_engine_sitemap', '~> 1.4'
+gem "govuk_tech_docs"
+gem "middleman", "~> 4.3.5"
+gem "middleman-search_engine_sitemap", "~> 1.4"
 
-gem 'github-markdown'
-gem 'html-pipeline', '~> 2.5.0'
-gem 'redcarpet', '~> 3.3.2'
+gem "github-markdown"
+gem "html-pipeline", "~> 2.5.0"
+gem "redcarpet", "~> 3.3.2"
 
-gem 'govuk_schemas', '~> 4.0.0'
+gem "govuk_schemas", "~> 4.0.0"
 
 # GitHub API
-gem 'octokit', '~> 4.14.0'
-gem 'faraday-http-cache', '~> 2.0.0'
-gem 'faraday_middleware', '~> 0.13.1'
+gem "octokit", "~> 4.14.0"
+gem "faraday-http-cache", "~> 2.0.0"
+gem "faraday_middleware", "~> 0.13.1"
 
 # For hosting on Heroku
-gem 'rack-contrib', '~> 2.1.0'
+gem "rack-contrib", "~> 2.1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,13 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
+gem "activesupport", "~> 5.0"
 gem "capybara", "~> 3.29.0"
 gem "rake"
 gem "rspec", "~> 3.9"
 gem "rubocop-govuk"
-gem "webmock", "~> 3.7"
-gem "activesupport", "~> 5.0"
 gem "simplecov"
+gem "webmock", "~> 3.7"
 
 gem "govuk_tech_docs"
 gem "middleman", "~> 4.3.5"
@@ -21,9 +21,9 @@ gem "redcarpet", "~> 3.3.2"
 gem "govuk_schemas", "~> 4.0.0"
 
 # GitHub API
-gem "octokit", "~> 4.14.0"
 gem "faraday-http-cache", "~> 2.0.0"
 gem "faraday_middleware", "~> 0.13.1"
+gem "octokit", "~> 4.14.0"
 
 # For hosting on Heroku
 gem "rack-contrib", "~> 2.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,11 +65,6 @@ GEM
     fastimage (2.1.7)
     ffi (1.11.2)
     github-markdown (0.6.9)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_schemas (4.0.0)
       json-schema (~> 2.8.0)
     govuk_tech_docs (2.0.8)
@@ -196,8 +191,7 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -225,6 +219,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -240,9 +238,6 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    scss_lint (0.43.2)
-      rainbow (~> 2.0)
-      sass (~> 3.4.15)
     servolux (0.13.0)
     simplecov (0.17.1)
       docile (~> 1.1)
@@ -277,7 +272,6 @@ DEPENDENCIES
   faraday-http-cache (~> 2.0.0)
   faraday_middleware (~> 0.13.1)
   github-markdown
-  govuk-lint (~> 4.2)
   govuk_schemas (~> 4.0.0)
   govuk_tech_docs
   html-pipeline (~> 2.5.0)
@@ -288,6 +282,7 @@ DEPENDENCIES
   rake
   redcarpet (~> 3.3.2)
   rspec (~> 3.9)
+  rubocop-govuk
   simplecov
   webmock (~> 3.7)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,56 +2,6 @@
 
 library("govuk")
 
-REPOSITORY = 'govuk-developer-docs'
-
 node {
-
-  properties([
-    buildDiscarder(
-      logRotator(
-        numToKeepStr: '50')
-      ),
-    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
-  ])
-
-  try {
-    stage("Checkout") {
-      govuk.checkoutFromGitHubWithSSH(REPOSITORY)
-    }
-
-    stage("Clean up workspace") {
-      govuk.cleanupGit()
-    }
-
-    stage("Merge master") {
-      govuk.mergeMasterBranch()
-    }
-
-    stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
-    }
-
-    stage("bundle install") {
-      govuk.bundleApp()
-    }
-
-    stage("Lint Ruby") {
-      govuk.rubyLinter("app lib helpers spec bin")
-    }
-
-    stage("Lint documentation") {
-      sh "vale --glob='*.md' ."
-    }
-
-    stage("Tests") {
-      govuk.runTests()
-    }
-  } catch (e) {
-    currentBuild.result = "FAILED"
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject()
 }


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk