### PR TITLE
Add some guidance for mongo-specific backups

### DIFF
--- a/source/manual/alerts/backup-passive-checks.html.md
+++ b/source/manual/alerts/backup-passive-checks.html.md
@@ -17,3 +17,13 @@ backups do not run.
 
 The backups are triggered at 10AM UTC, so the alerts should resolve themselves
 around that time.
+
+## MongoDB
+
+If the backup has failed, you can try re-running it on the associated machine.
+
+```shell
+sudo su govuk-backup -c '/usr/bin/setlock /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily'
+```
+
+> **NOTE**: You might want to run this in a `screen` session, as it can take a while.


### PR DESCRIPTION
This adds some more guidance for the generic alert doc about passive
backup failures, as it's not currently clear what to do if the Mongo S3
backups fail.