### PR TITLE
Rewrite instructions for removing a machine in AWS

### DIFF
--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -4,12 +4,14 @@ title: Remove a machine
 parent: "/manual.html"
 layout: manual_layout
 section: Infrastructure
-last_reviewed_on: 2019-05-17
+last_reviewed_on: 2019-11-13
 review_in: 6 months
 ---
 
 Before you start, make sure that the machines you are removing are no longer 
 needed for anything.
+
+## Carrenza
 
 ## 1. Remove the node from the puppetmaster
 
@@ -25,15 +27,6 @@ Next, SSH into the puppetmaster for the environment:
 $ ssh puppetmaster-1.management.production
 ```
 
-for Carrenza, or
-
-```console
-$ govukcli set-context integration
-$ govukcli ssh puppetmaster
-```
-
-for AWS.
-
 Then run this on each machine:
 
 ```console
@@ -41,7 +34,6 @@ $ govuk_node_clean <machine_name>
 ```
 
 Where `<machine_name>` might be `machine-name-1.vdc-name.production` (Carrenza)
-or `ip-a-b-c-d.eu-west-1.compute.internal` (AWS).
 To find the names of the machines, you can list the nodes on puppetmaster:
 
 ```console
@@ -67,28 +59,20 @@ $ govuk_puppet --test
 You may need to wait a few minutes, but it should then disappear from
 the "Host Detail" page in Icinga.
 
-## 2. Remove from puppet
-
-If you are removing a class of machines, you will need to [remove the definitions][def] from Puppet.
-
-[def]: https://github.com/alphagov/govuk-puppet/commit/8a971370a4b35de09a2e1a83ce3421f41f5d0520
-
-## Carrenza
-
-### 3. Remove from vCloud Director
+### 2. Remove from vCloud Director
 
 Sign in to the vCloud Director instance for the given environment.
 Go to 'My Cloud', search for the given machine, stop it, and then
 delete it.
 
-### 4. Remove from govuk-provisioning
+### 3. Remove from govuk-provisioning
 
 If your machine class matches a vDC, be careful not to remove firewall
 rules that apply to the vDC.
 
 ## AWS
 
-### 3. Remove from Terraform
+### 1. Remove from Terraform
 
 If you're removing a class of machines, first [deploy Terraform][terraform]
 for the relevant project using the `destroy` action. This will remove all the
@@ -96,11 +80,39 @@ EC2 instances.
 
 Then, remove the project itself from [govuk-aws][].
 
-If you're removing a single machine, change the `asg_size` for the relevant
-project in [govuk-aws-data][] ([example][whitehall-backend-asg-size]) and
-deploy Terraform.
+If you're removing a single machine, change the `asg_size` for the
+relevant project in [govuk-aws-data][]
+([example][whitehall-backend-asg-size]) and deploy Terraform.  Unlike
+Carrenza, it is not possible to disable alerts for the machine before
+it is removed, as the ASG will terminate arbitrary instances to shrink
+to the desired size.
 
 [terraform]: /manual/deploying-terraform.html#ci-jenkins
 [govuk-aws]: https://github.com/alphagov/govuk-aws/tree/master/terraform/projects
 [govuk-aws-data]: https://github.com/alphagov/govuk-aws-data/tree/master/data
 [whitehall-backend-asg-size]: https://github.com/alphagov/govuk-aws-data/blob/master/data/app-whitehall-backend/production/common.tfvars#L4
+
+### 2. Remove the node from the puppetmaster
+
+Icinga will forget about the machine after Puppet runs on the
+puppetmaster and then on the monitoring machine, which could be up to
+an hour.  You can force this by running Puppet on the puppetmaster:
+
+```console
+$ govukcli set-context <environment>
+$ govukcli ssh puppetmaster
+$ govuk_puppet --verbose
+```
+
+And then on the monitoring machine:
+
+```console
+$ govukcli ssh monitoring
+$ govuk_puppet --verbose
+```
+
+## Removing a class of machine
+
+If you are removing a class of machines, you will need to [remove the definitions][def] from Puppet.
+
+[def]: https://github.com/alphagov/govuk-puppet/commit/8a971370a4b35de09a2e1a83ce3421f41f5d0520


### PR DESCRIPTION
Monitoring cannot be disabled for machines in AWS first, because
arbitrary instances will be terminated to reach the desired capacity.
This means that the node has to be removed from the puppetmaster
afterwards.