### PR TITLE
Stop mentioning govuk-cli on the Nagstamon page

### DIFF
--- a/source/manual/nagstamon.html.md
+++ b/source/manual/nagstamon.html.md
@@ -37,7 +37,6 @@ and resolve issues.
 
 To configure an SSH action:
 
-- Install the `govuk-cli` which includes the `govuk connect` tool via `brew install alphagov/gds/govuk-cli`.
 - Go in to the Settings
 - Select the "Actions" tab
 - Delete all the existing actions (SSH, RDP, ...)
@@ -45,8 +44,13 @@ To configure an SSH action:
 - Select "Command" as the Action type.
 - Put "SSH " as the Name
 - The command depends on what operating system you're using:
-    - For macOS, enter the following command in the "String" field:
-        - `osascript -e 'tell app "Terminal" to do script "govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$"'`
-    - For GNU/Linux, with the Gnome Terminal installed, use the following command:
+    - For MacOS, enter the following command in the "String" field:
+        - `osascript -e 'tell app "Terminal" to do script "~/govuk/govuk-guix/bin/govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$"'`
+        - This assumes you have the `govuk-guix` Git repository cloned in
+         `~/govuk/govuk-guix`, and that you've got `govuk connect` working.
+    - For GNU/Linux, with the Gnome Terminal installed (which includes
+      Ubuntu), use the following command:
         - `/usr/bin/gnome-terminal -x govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$`
+        - This assumes you have the `govuk` wrapper script on your PATH,
+          and you've got `govuk connect` working
 - Click "OK"

--- a/source/manual/nagstamon.html.md
+++ b/source/manual/nagstamon.html.md
@@ -44,7 +44,7 @@ To configure an SSH action:
 - Select "Command" as the Action type.
 - Put "SSH " as the Name
 - The command depends on what operating system you're using:
-    - For MacOS, enter the following command in the "String" field:
+    - For macOS, enter the following command in the "String" field:
         - `osascript -e 'tell app "Terminal" to do script "~/govuk/govuk-guix/bin/govuk connect ssh --hosting-and-environment-from-alert-url $MONITOR$ $ADDRESS$"'`
         - This assumes you have the `govuk-guix` Git repository cloned in
          `~/govuk/govuk-guix`, and that you've got `govuk connect` working.


### PR DESCRIPTION
govuk-cli was a failed attempt at moving the `govuk connect` script
out of govuk-guix, so revert to the previous state in the docs.

This reverts commit 9c9cffc5f9d2fde032e293e1f4a36739fe76ef51.