### PR TITLE
Update DDoSDetected playbook entry.

### DIFF
--- a/source/manual/alerts/ddosdetected.html.md
+++ b/source/manual/alerts/ddosdetected.html.md
@@ -4,18 +4,19 @@ title: DDOS Detected
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-07-24
+last_reviewed_on: 2019-11-14
 review_in: 6 months
 ---
 
 If there is a Distributed Denial of Service (DDoS) alert in Icinga this means that AWS have detected a probable DDoS attack on one or more of the AWS Shield Advanced
 protected resources.
 
-If the alert is `UNKNOWN`, this means that the alert is not working. This is a known issue which happens when there is no data for the CloudWatch metric that this alert is based on. The alert needs to be changed so that it doesn't fire when there are no data points.
+If the alert is `UNKNOWN`, this means that the alert is not working properly.
 
 If the alert is `CRITICAL`, you should take the following actions to investigate the issue:
 
 1. Check the [CloudWatch dashboard](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#cw:dashboard=DDoSProtection). This should show the rate of DDoS requests, data throughput and packets which Amazon is detecting.
+    * The dashboard might not display any graphs at all if no DDoS activity has been detected recently. This is a known issue and there is a [support ticket](https://console.aws.amazon.com/support/cases#/6554017771/en) open with Amazon about it. If the DDoSDetected alert is firing and the graphs are still not displayed, contact AWS support.
 1. If the attack is ongoing, contact AWS support: https://console.aws.amazon.com/support/home
 1. Inform them that the DDOSDetected alarm has been triggered.
 1. Enquire about the nature of the attack.


### PR DESCRIPTION
The bug in the alert which led to frequent `UNKNOWN`s is fixed, so remove the specific note about it.

Add a note about why the graphs might not show up on the Amazon Shield service dashboard, since Amazon have told us that this is known issue which happens when there are no metrics (which happens when there hasn't been any DDoS-like activity detected for a long time).