### PR TITLE
Remove instruction to deploy A/B VCL to mirror

### DIFF
--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -64,7 +64,7 @@ need more data.
 1. Add your test to the [A/B test register][register].
 1. If you want to use Google Analytics to monitor the A/B test, talk to a performance analyst and pick a [GA dimension][analytics-dimensions] to use for your test.
 1. Create dictionary and A/B test files in [the govuk-cdn-config repo][govuk-cdn-config]. See an [example for the dictionaries][dictionary-config-example] and an [example for the A/B configuration][cdn-config-example] (these used to be in a different repo). For more details, see the [dictionaries README][dictionaries-readme].
-1. Deploy the dictionary changes to each environment using the [Update_CDN_Dictionaries][update-cdn-dictionaries] Jenkins job. The API key is in the [govuk-secrets repo][govuk-secrets-fastly] and the dictionaries must be deployed to all the vhosts (`www` and `mirror` in production and staging, `www` in integration).
+1. Deploy the dictionary changes to each environment using the [Update_CDN_Dictionaries][update-cdn-dictionaries] Jenkins job. The API key is in the [govuk-secrets repo][govuk-secrets-fastly] and the dictionaries must be deployed to the `www` vhost.
 1. Deploy the Fastly configuration to each environment using the [Deploy_CDN][deploy-cdn] Jenkins job. Use the same parameters as in step 4. You can test it on staging by visiting <https://www.staging.publishing.service.gov.uk>. Changes should appear almost immediately - there is no caching of the CDN config.
 1. Use the [govuk_ab_testing gem][govuk_ab_testing] to serve different versions to your users. It can be configured with the analytics dimension selected in step 2.
 1. To activate or deactivate the test, or to change the B percentage, update your test in [the govuk-cdn-config repo][govuk-cdn-config] and deploy the dictionaries.


### PR DESCRIPTION
See govuk-cdn-config#227