### PR TITLE
Licensing is in AWS now!

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -3,6 +3,7 @@ class AppDocs
     "aws" => "AWS",
     "paas" => "GOV.UK PaaS",
     "carrenza" => "Carrenza",
+    "ukcloud" => "UK Cloud",
     "heroku" => "Heroku",
     "none" => "None",
   }.freeze

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -3,7 +3,6 @@ class AppDocs
     "aws" => "AWS",
     "paas" => "GOV.UK PaaS",
     "carrenza" => "Carrenza",
-    "ukcloud" => "UK Cloud",
     "heroku" => "Heroku",
     "none" => "None",
   }.freeze

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -638,7 +638,7 @@
 - github_repo_name: licensify
   private_repo: true
   type: Licensing apps
-  production_hosted_on: ukcloud
+  production_hosted_on: aws
   team: "#govuk-licensing"
   sentry_url: false
   deploy_url: false

--- a/source/manual/alerts/pingdom-homepage-check.html.md
+++ b/source/manual/alerts/pingdom-homepage-check.html.md
@@ -25,7 +25,5 @@ failure.
     CDN has global issues
 -   [Carrenza status](https://servicedesk.carrenza.com/) - check if our
     main provider has issues
--   [UKCloud](https://status.ukcloud.com/) - check if our
-    Licensing hosting provider has issues
 
 [Pingdom]: https://www.pingdom.com/

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -25,24 +25,6 @@ If it goes down, these things will happen:
    unreachable hosts in GOV.UK monitoring
 2. Data replication will pause
 
-## VPN between live organisation and Licensing
-
-Licensing is hosted in UKCloud.
-There's a VPN in each environment which connects it to the live (Carrenza)
-organisation. The VPN is managed by Carrenza and UKCloud.
-
-If it goes down, these things will happen:
-
-1. The machines on the disaster recovery (UKCloud) side of the connection will
-   appear as unreachable hosts in GOV.UK monitoring
-
-Applying for a licence should remain available because the connection between
-GOV.UK (the router and content store) and the Licensify organisation is made
-over the internet rather than over the VPN.
-
-[carrenza-secure]: connect-to-vcloud-director.html
-[gds-vpn]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/how-to/connect-to-the-aviation-house-vpn
-
 ## VPN between live organisation in Carrenza and AWS during AWS migration
 
 During the staged migration of the GOV.UK from Carrenza to AWS, there is a VPN


### PR DESCRIPTION
- Licensing was the last thing in UK Cloud, so we can remove the docs
  about that specific VPN, and the mapping of "ukcloud" to "UK Cloud".