### PR TITLE
Update Location of Publishing API & Email Alert API to AWS

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -241,7 +241,7 @@
   type: APIs
   team: "#govuk-platform-health"
   metrics_dashboard_url: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     signon:
       description: ''
@@ -268,7 +268,7 @@
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: "/apis/publishing-api.html"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     signon:
       description: ''
@@ -343,7 +343,7 @@
 - github_repo_name: email-alert-service
   type: Services
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     email-alert-api:
       description: ''


### PR DESCRIPTION
We have now migrated the following apps to AWS:
email-alert-api
email-alert-service
publishing-api