### PR TITLE
Fix onboarding instructions for setting up 'govukcli'

### DIFF
--- a/source/manual/get-ssh-access.html.md
+++ b/source/manual/get-ssh-access.html.md
@@ -56,7 +56,17 @@ Create a pull request with these changes. Once it has been [reviewed by a member
 [integration-hiera]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata/integration.yaml
 [merging]: /manual/merge-pr.html
 
-## 3. Access remote environments
+## 3. Set up govukcli
+
+Clone the `govuk-aws` repository and add a symlink to make `govukcli` executable globally:
+
+```sh
+cd ~/govuk
+git clone https://github.com/alphagov/govuk-aws
+ln -s ~/govuk/govuk-aws/tools/govukcli /usr/local/bin/govukcli
+```
+
+## 4. Access remote environments
 
 Your pull request from earlier will hopefully have been merged by now. It's time to test your access to servers via SSH.
 
@@ -64,8 +74,7 @@ Your pull request from earlier will hopefully have been merged by now. It's time
 
 While the applications are available directly via the public internet, SSH access to remote environments is via a ‘jumpbox’. You’ll need to configure your machine to use this jumpbox and use `govukcli` to SSH into server.
 
-1. Copy the [example SSH config file][ssh-config] into the `~/.ssh/config` file on your host machine.
-1. Run `ln -s ~/govuk/govuk-aws/tools/govukcli /usr/local/bin/govukcli` on your host machine to be able to use the `govukcli` tool from any directory.
+Copy the [example SSH config file][ssh-config] into the `~/.ssh/config` file on your host machine.
 
 Test that it works by running:
 

--- a/source/manual/get-ssh-access.html.md
+++ b/source/manual/get-ssh-access.html.md
@@ -62,7 +62,7 @@ Clone the `govuk-aws` repository and add a symlink to make `govukcli` executable
 
 ```sh
 cd ~/govuk
-git clone https://github.com/alphagov/govuk-aws
+git clone git@github.com:alphagov/govuk-aws
 ln -s ~/govuk/govuk-aws/tools/govukcli /usr/local/bin/govukcli
 ```
 

--- a/source/manual/howto-find-hardcoded-markup-govspeak.html.md
+++ b/source/manual/howto-find-hardcoded-markup-govspeak.html.md
@@ -62,6 +62,6 @@ Edition.where.not(content_store: nil).find_each { |e| puts "https://gov.uk#{e.ba
 
 
 [Govspeak]: http://govspeak-preview.herokuapp.com/
-[Getting Started]: /manual/get-started.html#6-access-remote-environments
+[Getting Started]: /manual/get-started.html
 [publishing-api]: https://github.com/alphagov/publishing-api
 [Find instances of a keyword on GOV.UK]: https://gov-uk.atlassian.net/wiki/spaces/CC/pages/1314488405/Find+instances+of+a+keyword+on+GOV.UK

--- a/source/manual/howto-ssh-to-machines-in-aws.html.md
+++ b/source/manual/howto-ssh-to-machines-in-aws.html.md
@@ -26,16 +26,7 @@ context, any subsequent `govukcli` commands will be tied to the environment you 
 
 ## Setup
 
-Clone the `govuk-aws` repository and add a symlink to make `govukcli` executable globally:
-
-```sh
-cd ~/govuk
-git clone https://github.com/alphagov/govuk-aws
-ln -s ~/govuk/govuk-aws/tools/govukcli /usr/local/bin/govukcli
-```
-
-You will also need to have followed the [Get SSH access to integration](/manual/get-ssh-access.html)
-instructions.
+Follow the [set up govukcli](/manual/get-ssh-access.html#3-set-up-govukcli) instructions.
 
 ## Usage
 


### PR DESCRIPTION
It was being referred to in 'howto-ssh-to-machines-in-aws.html.md', which
is not in the standard flow of setup instructions for new joiners. Other
instructions expect govukcli to be set up already, which tripped up our
new starter.
We now move the setup instructions closer to the beginning of the
onboarding journey so that the step cannot be missed.

There's also a commit for removing an anchor link to a section that no longer
exists, which I discovered while double-checking my change doesn't affect
other files.