### PR TITLE
Fix "run rake task" links for apps in AWS.

### DIFF
--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -115,9 +115,16 @@ ssh -A -t jumpbox.production.govuk.digital 'ssh `govuk_node_list -c <%= applicat
 <% if application.can_run_rake_tasks_in_jenkins? %>
   <h3>Run a rake task</h3>
 
+  <% case application.production_hosted_on %>
+  <% when "aws" %>
+  - <%= link_to "Run on Integration Jenkins", "https://deploy.blue.integration.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
+  - <%= link_to "Run on Staging Jenkins", "https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
+  - <%= link_to "Run on Production Jenkins", "https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
+  <% when "carrenza" %>
   - <%= link_to "Run on Integration Jenkins", "https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
   - <%= link_to "Run on Staging Jenkins", "https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
   - <%= link_to "Run on Production Jenkins", "https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=#{application.app_name}&MACHINE_CLASS=#{application.machine_class}" %>
+  <% end %>
 <%end %>
 
 <% if application.example_published_pages %>


### PR DESCRIPTION
These used to link to Carrenza Jenkins even for apps in AWS, which was exceedingly unhelpful.

I really really don't like that I've had to specify `blue.` in the domain names here, but it's necessary until we fix the problem with the GitHub OAuth config so that deep links in Jenkins work without the `blue` (stackname) part.