### PR TITLE
Add option to show team responsible for dependencies

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -43,6 +43,7 @@ class AppDocs
       {
         app_name: app_name,
         team: team,
+        dependencies_team: dependencies_team,
         puppet_name: puppet_name,
         production_hosted_on: production_hosted_on,
         links: {
@@ -180,6 +181,11 @@ class AppDocs
 
     def team
       app_data["team"]
+    end
+
+    def dependencies_team
+      app_data
+        .fetch("dependencies_team", team)
     end
 
     def description

--- a/app/apps_csv.rb
+++ b/app/apps_csv.rb
@@ -9,12 +9,13 @@ class AppsCSV
 
   def to_csv
     CSV.generate do |csv|
-      csv << ["Name", "Team", "Docs URL", "Repo URL", "Hosted On"]
+      csv << ["Name", "Team", "Dependencies Team", "Docs URL", "Repo URL", "Hosted On"]
 
       @apps.each do |app|
         csv << [
           app.app_name,
           app.team,
+          app.dependencies_team,
           app.html_url,
           app.repo_url,
           app.production_hosted_on,

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -3,6 +3,7 @@
 - github_repo_name: collections-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-pub-workflow"
   production_hosted_on: carrenza
   dependencies:
     publishing-api:
@@ -81,6 +82,7 @@
 - github_repo_name: manuals-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: carrenza
   dependencies:
     router:
@@ -138,6 +140,7 @@
 - github_repo_name: service-manual-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: carrenza
   dependencies:
     service-manual-frontend:
@@ -153,10 +156,12 @@
 - github_repo_name: short-url-manager
   type: Publishing apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: carrenza
 - github_repo_name: specialist-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: carrenza
   dependencies:
     support:
@@ -194,6 +199,7 @@
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-pub-workflow"
   api_docs_url: "/apis/whitehall.html"
   production_hosted_on: carrenza
   dependencies:
@@ -232,6 +238,7 @@
 - github_repo_name: content-store
   type: APIs
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-pub-workflow"
   api_docs_url: "/apis/content-store.html"
   production_hosted_on: aws
   dependencies:
@@ -267,6 +274,7 @@
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-pub-workflow"
   api_docs_url: "/apis/publishing-api.html"
   production_hosted_on: aws
   dependencies:
@@ -287,6 +295,7 @@
 - github_repo_name: asset-manager
   type: APIs
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-pub-workflow"
   production_hosted_on: carrenza
   dependencies:
     signon:
@@ -296,6 +305,7 @@
 - github_repo_name: router-api
   type: APIs
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: aws
   dependencies: {}
 - github_repo_name: support-api
@@ -398,6 +408,7 @@
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-pub-workflow"
   production_hosted_on: aws
 - github_repo_name: release
   type: Supporting apps
@@ -487,6 +498,7 @@
 - github_repo_name: frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: aws
   dependencies:
     search-api:
@@ -506,6 +518,7 @@
 - github_repo_name: government-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
   dependencies:
@@ -516,6 +529,7 @@
 - github_repo_name: info-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: aws
   dependencies:
     static:
@@ -524,6 +538,7 @@
   type: Frontend apps
   puppet_name: licencefinder
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: aws
   dependencies:
     content-store:
@@ -535,6 +550,7 @@
 - github_repo_name: manuals-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: aws
   dependencies:
     content-store:
@@ -559,6 +575,7 @@
       description: ''
 - github_repo_name: service-manual-frontend
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   type: Frontend apps
   production_hosted_on: aws
   dependencies:
@@ -569,6 +586,7 @@
 - github_repo_name: static
   type: Frontend apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-searchandnav"
   production_hosted_on: aws
   dependencies:
     static:

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -27,6 +27,13 @@ GitHub topics: <%= application.topics.map { |topic| link_to(topic, "https://gith
 Owned by team **<%= application.team %>**.
 <% end %>
 
+<% if application.dependencies_team %>
+
+### Dependencies Team
+
+The team responsible for updating dependencies is **<%= application.dependencies_team %>**.
+<% end %>
+
 ### Hosting
 
 <% if application.hosting_name == "None" %>


### PR DESCRIPTION
This is to allow shared dependabot responsibilities between different
teams. This will allow teams to be notified by slack when a PR requires
merging.

Co-authored-by: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>

Trello: https://trello.com/c/2SYgweYT/1590-3-create-application-ownership-override-to-govuk-dependencies

![Screen Shot 2019-12-10 at 12 41 00](https://user-images.githubusercontent.com/6651749/70530277-71dc1500-1b4a-11ea-97f3-2375d27e2871.png)
![Screen Shot 2019-12-10 at 12 41 21](https://user-images.githubusercontent.com/6651749/70530279-7274ab80-1b4a-11ea-9a7b-f68e089acfc8.png)
![Screen Shot 2019-12-10 at 12 39 52](https://user-images.githubusercontent.com/6651749/70530287-76a0c900-1b4a-11ea-9db1-83b10ba614a2.png)
