### PR TITLE
Amend RabbitMQ High Water mark alert to reflect new error scenario

### DIFF
--- a/source/manual/alerts/rabbitmq-high-watermark.html.md
+++ b/source/manual/alerts/rabbitmq-high-watermark.html.md
@@ -18,5 +18,18 @@ If this alert is regularly triggered it is a sign that it is time to beef up
 the Rabbit boxes with more RAM. Alternatively, if you don't care about
 messages, you can try to purge messages or remove unused queues.
 
+It's also possible for this alert to trigger even if there are no free memory issues. 
+
+Under the hood, the alert queries the [RabbitMQ Management API](https://www.rabbitmq.com/management.html) and checks if the response contains `mem_alert` and `disk_free_alarm`.
+
+The RabbitMQ Management API depends on the `rabbitmq_management` plugin being enabled. If it isn't enabled then it won't generate response which contains `mem_alert` and `disk_free_alarm`.
+
+To enable the plugin, connect to the server which is alerting and first disable then enable the plugin:
+
+```shell script
+$ rabbitmq-plugins disable rabbitmq_management
+$ rabbitmq-plugins enable rabbitmq_management
+```
+
 Further information
 [can be found in the RabbitMQ docs](https://www.rabbitmq.com/memory.html).

--- a/source/manual/alerts/rabbitmq-high-watermark.html.md
+++ b/source/manual/alerts/rabbitmq-high-watermark.html.md
@@ -22,11 +22,11 @@ It's also possible for this alert to trigger even if there are no free memory is
 
 Under the hood, the alert queries the [RabbitMQ Management API](https://www.rabbitmq.com/management.html) and checks if the response contains `mem_alert` and `disk_free_alarm`.
 
-The RabbitMQ Management API depends on the `rabbitmq_management` plugin being enabled. If it isn't enabled then it won't generate response which contains `mem_alert` and `disk_free_alarm`.
+The RabbitMQ Management API depends on the `rabbitmq_management` plugin being enabled. If it isn't enabled then it won't generate a response which contains `mem_alert` and `disk_free_alarm`.
 
 To enable the plugin, connect to the server which is alerting and first disable then enable the plugin:
 
-```shell script
+```
 $ rabbitmq-plugins disable rabbitmq_management
 $ rabbitmq-plugins enable rabbitmq_management
 ```


### PR DESCRIPTION
* This alert can also trigger when there are no free memory issues but the `rabbitmq_management` plugin is not enabled.
* We have changed the documentation to include this error scenario and how to respond to it.
* Stephen and I noticed this in late November when we were shadowing second line.

Co-authored by: Sarah Young <sarah.young@digital.cabinet-office.gov.uk>
Co-authored by: Stephen Ford <stephen.ford@digital.cabinet-office.gov.uk>