### PR TITLE
Remove GA tracking

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,8 +16,6 @@ header_links:
   Schemas: /content-schemas.html
   Document types: /document-types.html
 
-ga_tracking_id: UA-91585274-1
-
 show_contribution_banner: true
 github_repo: alphagov/govuk-developer-docs
 


### PR DESCRIPTION
It's not something we look at, and we don't have an appropriate cookie policy.