### PR TITLE
Update Grafana dashboard link

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -186,6 +186,6 @@ decreased. If it's decreasing, then it means that emails are going out and
 there's probably a lot being processed. You can also check the
 [Email Alert API Metrics dashboard][dashboard].
 
-[dashboard]: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+[dashboard]: https://grafana.staging.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
 [password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify


### PR DESCRIPTION
email-alert-api has now migrated to AWS.