### PR TITLE
Fix an outdated reference to self-hosted Kibana.

### DIFF
--- a/source/manual/monitor-docs-traffic.html.md
+++ b/source/manual/monitor-docs-traffic.html.md
@@ -31,4 +31,4 @@ http_host:"docs.publishing.service.gov.uk" AND request:"/manual/emergency-publis
 ```
 
 [proxy]: https://github.com/alphagov/govuk-puppet/blob/d9f32be24890a47e0ed7368efccec7fb70ecab50/modules/govuk/manifests/node/s_backend_lb.pp#L132-L139
-[kibana]: https://kibana.publishing.service.gov.uk/
+[kibana]: /manual/logit.html


### PR DESCRIPTION
`kibana.publishing.service.gov.uk` was replaced by LogIt in 2018. This cleans up the last remaining reference to it in Developer Docs.