### PR TITLE
Update how to work on frontends locally

### DIFF
--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -5,7 +5,7 @@ layout: manual_layout
 section: Frontend
 type: learn
 owner_slack: "#govuk-2ndline"
-last_reviewed_on: 2019-07-08
+last_reviewed_on: 2019-12-27
 review_in: 6 months
 ---
 
@@ -13,14 +13,54 @@ Make the following changes to your setup if you are making changes to frontend a
 
 In the instructions below we are running the [frontend] app, but this would work for any of the other frontend apps such as [government-frontend].
 
-## Running just a frontend app against live data
+## Under docker
+
+1. repoint static and frontend to the local version of `govuk_app_config`:
+
+  ```ruby
+  gem 'govuk_app_config', path: '../govuk_app_config'
+  ```
+
+2. Repoint frontend to local `govuk_publishing_components` if you are making changes there:
+
+  ```ruby
+  gem 'govuk_publishing_components', path: '../govuk_publishing_components'
+  ```
+
+3. Update in `govuk_app_config` the file `govuk_content_security_policy.rb` to allow all domains:
+
+  ```ruby
+  GOVUK_DOMAINS = [
+  '.publishing.service.gov.uk',
+  ".#{ENV['GOVUK_APP_DOMAIN_EXTERNAL'] || ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'}",
+  ".dev.gov.uk",
+  ""
+  ].uniq.freeze
+  ```
+
+4. set `config.assets.debug` to `false` in `development.rb` for static and frontend
+5. run from govuk-docker directory:
+
+  ```shell
+  $ make frontend
+  $ govuk-docker-up frontend-app
+  ```
+
+  (or you can run the last command from the frontend directory as just `govuk-docker-up`)
+6. changes should be ok for http://frontend.dev.gov.uk/help
+
+## Without docker
+
+A small numver of frontend devs prefer to not use Docker locally, so we are keeping these instructions for a little while longer.
+
+### Running just a frontend app against live data
 
 ```shell
 cd /var/govuk/frontend
 ./startup.sh --live
 ```
 
-## Running a frontend app against changes in `govuk_publishing_components`
+### Running a frontend app against changes in `govuk_publishing_components`
 
 Update the Gemfile for the frontend app to point to your local `govuk_publishing_components` gem:
 
@@ -34,7 +74,7 @@ Then run your frontend app again pointing to live:
 ./startup.sh --live
 ```
 
-## Running a frontend app against changes in `static`
+### Running a frontend app against changes in `static`
 
 Make changes to the Gemfile of the frontend app you're working on as per [changes to govuk_publishing_components above](#running-a-frontend-app-against-changes-in-govuk_publishing_components), then set in `development.rb`:
 


### PR DESCRIPTION
Instructions did not include up to date docs when using govuk-docker.

However some frontend devs are no using docker yet, so we are keeping both sets of instructions for now.