### PR TITLE
Add a section about manual related links

### DIFF
--- a/source/manual/related-links-on-govuk.html.md
+++ b/source/manual/related-links-on-govuk.html.md
@@ -3,7 +3,7 @@ title: Related links on GOV.UK
 parent: "/manual.html"
 layout: manual_layout
 type: learn
-section: Related links
+section: Publishing
 owner_slack: "#govuk-developers"
 last_reviewed_on: 2019-08-16
 review_in: 6 months

--- a/source/manual/related-links-on-govuk.html.md
+++ b/source/manual/related-links-on-govuk.html.md
@@ -9,7 +9,22 @@ last_reviewed_on: 2019-08-16
 review_in: 6 months
 ---
 
-## Overview
+## Manual
+
+Related links can be added or removed manually through [Content Tagger][].
+To do this, you can click on the **Edit a page** link at the top and enter the
+base path of the content item you need to edit. You will then see a section
+titled **Related content items** where you can edit the links.
+
+If a request comes in a from a content designer to edit the related links of a
+page, you can send them to Content Tagger so they can edit the links
+themselves.
+
+[Content Tagger]: https://content-tagger.publishing.service.gov.uk
+
+## Automatic
+
+### Overview
 
 Since July 2019, related links on GOV.UK have been supplemented by links generated through an automated machine learning pipeline. The first job in this pipeline uses data on how pages are linked together (the structural network) and analytics from users' behaviour on the site (the functional network) to create a set of most relevant related links for a subset of pages.
 
@@ -17,7 +32,7 @@ Once these links have been created, a second job ingests the links via the Publi
 
 The code for the process of generating and ingesting related links can be found in the [govuk-related-links-recommender repository on GitHub](https://github.com/alphagov/govuk-related-links-recommender).
 
-## When we show the new related links
+### When we show the new related links
 
 Machine learning generated related links are created exclusively for Whitehall content, with a number of measures in place to ensure that we always show manually curated links set by publishers.
 
@@ -27,11 +42,11 @@ Machine learning generated related links are created exclusively for Whitehall c
 - Requests need to have the header `Govuk-Use-Recommended-Related-Links` header set to `True` in order to show suggested related links - [this is set by the CDN for all requests](https://github.com/alphagov/govuk-cdn-config/blob/master/vcl_templates/www.vcl.erb#L238).
 
 
-## Concourse pipeline details
+### Concourse pipeline details
 
 Related links are generated and ingested via the following jobs, which are defined in the [govuk-related-links pipeline on Concourse](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-related-links).
 
-### `link-generation`
+#### `link-generation`
 
 This job runs the process to generate new related links for a subset of pages on GOV.UK, via the `provision-generation-machine` and `run_link_generation` scripts, which in turn triggers the Python script `run_all.py`.
 
@@ -39,7 +54,7 @@ The related links generated from this process are stored in an S3 environment-sp
 
 Currently, this job is scheduled to run once every three weeks via a `time` resource attached to the production `run-generation-production` step.
 
-### `link-ingestion`
+#### `link-ingestion`
 
 This job runs the process of ingesting related links via the Publishing API.
 
@@ -47,22 +62,22 @@ Links are retrieved from the environment-specific S3 bucket mentioned previously
 
 Currently, this job is triggered manually after reviewing a spreadsheet of the generated related links; it will be scheduled to run automatically by the end of September 2019.
 
-## Rolling back Links
+### Rolling back Links
 
 Should we ever need to roll back any suggested related links, there are a number of ways we can do this.
 
-### Links for individual pages
+#### Links for individual pages
 
 To rollback suggested related links for an individual page (to show the original related links), use the [Run rake task job on Jenkins](https://deploy.publishing.service.gov.uk/job/run-rake-task/) with the following parameters set:
   - `TARGET_APPLICATION: publishing-api`
   - `MACHINE_CLASS: publishing_api`
   - `RAKE_TASK: content:reset_related_links_for_pages['CONTENT_ID’]`, where `CONTENT_ID` is the content id of the page to remove suggested links from
 
-### Links for certain document types
+#### Links for certain document types
 
 To exclude a document type or page from having links generated _to_ it, _from_ it, or both, [update the exclusions in the GitHub repository](https://github.com/alphagov/govuk-related-links-recommender/tree/master/src/config). Note: this will take effect from the _next_ time the related links generation process is run, and will not affect current links.
 
-### Suspending all suggested related links
+#### Suspending all suggested related links
 
 To immediately and temporarily stop showing all suggested related links (for example, if a problem has led to bad links being generated for a large percentage of content / high traffic content), you will need to update the CDN to set the `Govuk-Use-Recommended-Related-Links` header to `False` and then [deploy the CDN](https://deploy.publishing.service.gov.uk/job/Deploy_CDN/) for `vhost: www`.
 

--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -5,7 +5,7 @@ layout: manual_layout
 type: learn
 section: Publishing
 owner_slack: "#govuk-developers"
-last_reviewed_on: 2019-08-16
+last_reviewed_on: 2020-01-07
 review_in: 6 months
 ---
 

--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -1,5 +1,5 @@
 ---
-title: Related links on GOV.UK
+title: Related links
 parent: "/manual.html"
 layout: manual_layout
 type: learn


### PR DESCRIPTION
We had a content request to modify the related links of a page and we thought this was a dev task but it turned out that the content designer could do this themselves using Content Tagger.