### PR TITLE
Add page for subscription contents alert

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -19,8 +19,7 @@ sent out by looking at the [Email Alert API Metrics Grafana dashboard][dashboard
 
 This affects the following alerts:
 
-* Unprocessed content changes
-* Subscription content
+* Unprocessed content change
 * High queue alerts (all)
 
 In this case you can wait until the emails have all been sent out.
@@ -168,23 +167,6 @@ out due to a content change.
 This means that we haven’t received status updates from Notify on some emails
 and it’s been 72 hours since the emails were sent out. This could mean there is
 a problem with our system, or there could be a problem with Notify.
-
-### Subscription contents without emails (subscription_content)
-
-This means that there are subscription contents being created without emails
-associated with them, this implies that emails aren't being sent out. Some
-useful queries:
-
-#### Check which subscription contents this affects
-
-```ruby
-SubscriptionContent.where("subscription_contents.created_at < ?", 1.minute.ago).where(email: nil).joins(:subscription).merge(Subscription.active)
-```
-
-Check the count, then run the above query again to see if the count has
-decreased. If it's decreasing, then it means that emails are going out and
-there's probably a lot being processed. You can also check the
-[Email Alert API Metrics dashboard][dashboard].
 
 [dashboard]: https://grafana.staging.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies

--- a/source/manual/alerts/email-alert-api-unprocessed-subscription-contents.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-subscription-contents.html.md
@@ -1,0 +1,40 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: Unprocessed subscription contents'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-07
+review_in: 6 months
+---
+
+This means there there are subscription contents being created without emails
+associated with them, and implies that emails aren't being sent out.
+
+### Icinga checks
+
+* `warning` - `subscription_contents` created over 10 minutes ago (or 35 minutes
+  ago if during publishing times)
+* `critical` - `subscription_contents` created over 15 minutes ago (or 50 minutes
+  during publishing times)
+
+See the [subscription_contents_worker][subscription-content-worker]
+for more information.
+
+### Check which subscription contents this affects
+
+```ruby
+SubscriptionContent.where("subscription_contents.created_at < ?", 10.minutes.ago).where(email: nil).joins(:subscription).merge(Subscription.active)
+```
+
+Check the count, then run the above query again to see if the count has
+decreased. If it's decreasing, then it means that emails are going out and
+there's probably a lot being processed.
+If it's not decreasing the Sidekiq worker might be stuck, see the [sidekiq][sidekiq]
+section on how to view the Sidekiq queues.
+
+ You can also check the [Email Alert API Metrics dashboard][dashboard].
+
+[subscription-content-worker]: https://github.com/alphagov/email-alert-api/blob/21e0af3e640963415e02506d927387088061ddd0/app/workers/subscription_contents_worker.rb
+[dashboard]: https://grafana.staging.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+[sidekiq]: /manual/sidekiq.html#sidekiq-web


### PR DESCRIPTION
This is a new alert which replaces one of our `email-alert-api`
heathchecks. See https://github.com/alphagov/email-alert-api/pull/1096
for more information.

Trello card: https://trello.com/c/dtdY0kAK/1606-5-extract-the-subscriptioncontents-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check