### PR TITLE
Add page for email-alert-api unprocessed content changes icinga alert

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -18,8 +18,6 @@ Some alerts tend to trigger when emails are sent out. Check to see if emails hav
 sent out by looking at the [Email Alert API Metrics Grafana dashboard][dashboard].
 
 This affects the following alerts:
-
-* Unprocessed content change
 * High queue alerts (all)
 
 In this case you can wait until the emails have all been sent out.
@@ -84,49 +82,6 @@ sent to a small number of email addresses so you cannot test using your
 own email address in these environments.
 
 ## Common alerts
-
-### Unprocessed content changes (content_changes)
-
-This means that there are some content changes which haven't been processed
-within the time we would expect. This may be fine and the emails will
-eventually go out, but it's worth some investigation. Some useful queries and
-Rake tasks:
-
-#### Check which content changes are affected
-
-```ruby
-ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil)
-```
-
-#### Check number of subscription contents built for a content change (you would expect this number to keep going up)
-
-```ruby
-SubscriptionContent.where(content_change: content_change).count
-```
-
-#### Resend the emails for a content change (ignore ones that have already gone out)
-
-```ruby
-ProcessContentChangeWorker.new.perform(content_change.id)
-```
-
-#### Resend the emails for a content change in bulk (ignore ones that have already gone out)
-
-```ruby
-ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).map { |content_change| ProcessContentChangeWorker.new.perform(content_change.id)  }
-```
-
-#### Check sent, pending and failed email counts for a content change
-
-```sh
- $ bundle exec rake report:content_change_email_status_count[<content_change_id>]
-```
-
-#### Check failed email ids and failure reasons for a content change
-
-```sh
- $ bundle exec rake report:content_change_failed_emails[<content_change_id>]
-```
 
 ### Unprocessed digest runs (digest_runs)
 

--- a/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
@@ -1,0 +1,58 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: Unprocessed content changes'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-08
+review_in: 6 months
+---
+
+This means that there are some emails informing users of content changes
+which haven't been processed within the time we would expect.
+This may be fine and the emails will eventually go out, but it's worth some investigation.
+
+* `warning` - `content_changes` unprocessed for over 5 minutes
+* `critical` - `content_changes` unprocessed for over 10 minutes
+
+See the [ProcessContentChangeWorker][content-change-worker] for more information.
+
+Some useful queries and Rake tasks:
+
+#### Check which content changes are affected
+
+```ruby
+ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil)
+```
+
+#### Check number of subscription contents built for a content change (you would expect this number to keep going up)
+
+```ruby
+SubscriptionContent.where(content_change: content_change).count
+```
+
+#### Resend the emails for a content change (ignore ones that have already gone out)
+
+```ruby
+ProcessContentChangeWorker.new.perform(content_change.id)
+```
+
+#### Resend the emails for a content change in bulk (ignore ones that have already gone out)
+
+```ruby
+ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).map { |content_change| ProcessContentChangeWorker.new.perform(content_change.id)  }
+```
+
+#### Check sent, pending and failed email counts for a content change
+
+```sh
+ $ bundle exec rake report:content_change_email_status_count[<content_change_id>]
+```
+
+#### Check failed email ids and failure reasons for a content change
+
+```sh
+ $ bundle exec rake report:content_change_failed_emails[<content_change_id>]
+```
+
+[content-change-worker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_content_change_worker.rb


### PR DESCRIPTION
We have introduced this new alert to reduce the responsibilities of the 
`email-alert-api health-check-not-ok`alert, to make our alerts more specific 
and reliable.

[Trello](https://trello.com/c/c6mWg9jP/1627-3-extract-the-contentchanges-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)