### PR TITLE
Add page for delivery attempts Icinga check

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -117,11 +117,22 @@ problem down the line which is preventing jobs from being processed. It may
 also imply the threshold is too low if a large number of emails have been sent
 out due to a content change.
 
-### Status updates (status_update)
+### Subscription contents without emails (subscription_content)
 
-This means that we haven’t received status updates from Notify on some emails
-and it’s been 72 hours since the emails were sent out. This could mean there is
-a problem with our system, or there could be a problem with Notify.
+This means that there are subscription contents being created without emails
+associated with them, this implies that emails aren't being sent out. Some
+useful queries:
+
+#### Check which subscription contents this affects
+
+```ruby
+SubscriptionContent.where("subscription_contents.created_at < ?", 1.minute.ago).where(email: nil).joins(:subscription).merge(Subscription.active)
+```
+
+Check the count, then run the above query again to see if the count has
+decreased. If it's decreasing, then it means that emails are going out and
+there's probably a lot being processed. You can also check the
+[Email Alert API Metrics dashboard][dashboard].
 
 [dashboard]: https://grafana.staging.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies

--- a/source/manual/alerts/email-alert-api-delivery-attempts-status-updates.html.md
+++ b/source/manual/alerts/email-alert-api-delivery-attempts-status-updates.html.md
@@ -1,0 +1,35 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: High number of delivery attempts have not received status updates'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-07
+review_in: 6 months
+---
+
+Delivery attempts include status updates from Notify on whether emails have been
+sent successfully. You can read more about them in [Notify's documentation][notify-documentation].
+
+The alert is triggered when a proportion of delivery attempts are still `pending`
+and we have not received the status updates from Notify within the past hour.
+This could mean there is a problem with our system, or there could be a problem
+with Notify.
+
+### Check which delivery attempts are affected
+
+```ruby
+  DeliveryAttempt.where("created_at > ?", (1.hour + 10.minutes).ago).where(status: 0)
+```
+
+### Monitor the dashboard
+
+You can also check the [Email Alert API Metrics dashboard][dashboard] to see if
+we are still receiving updates from Notify.
+
+See the [General troubleshooting tips][troubleshooting] section for more information.
+
+[notify-documentation]: https://docs.notifications.service.gov.uk/ruby.html#status-text-and-email
+[dashboard]: https://grafana.staging.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+[troubleshooting]: /manual/alerts/email-alert-api-app-healthcheck-not-ok.html#general-troubleshooting-tips
+[sidekiq]: /manual/sidekiq.html#sidekiq-web


### PR DESCRIPTION
This is a new alert which replaces one of our email-alert-api
heathchecks. See https://github.com/alphagov/email-alert-api/pull/1073
for more information.