### PR TITLE
Vale: Only try to lint Markdown files

### DIFF
--- a/.vale
+++ b/.vale
@@ -2,7 +2,7 @@ StylesPath = styles/
 MinAlertLevel = error
 
 # Global settings (applied to every syntax)
-[*]
+[*.md]
 # List of styles to load
 BasedOnStyles = vale, PlainLanguage
 


### PR DESCRIPTION
- I ran `vale source/manual/` in here and it complained about repeated
  "n" characters in PNGs.