### PR TITLE
Add page for email-alert-api incomplete digest runs icinga alert

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -83,17 +83,6 @@ own email address in these environments.
 
 ## Common alerts
 
-### Unprocessed digest runs (digest_runs)
-
-This means that there are some digest runs which haven't been processed within
-the time we would expect. Some useful queries:
-
-#### Check which digest runs are affected
-
-```ruby
-DigestRun.where("created_at < ?", 1.hour.ago).where(completed_at: nil)
-```
-
 ### High queue size (queue_size)
 
 This means that there are a high number of items in the queue. This may

--- a/source/manual/alerts/email-alert-api-incomplete-digest-runs.html.md
+++ b/source/manual/alerts/email-alert-api-incomplete-digest-runs.html.md
@@ -1,0 +1,27 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: Incomplete digest runs'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-08
+review_in: 6 months
+---
+
+### Incomplete digest runs (digest_runs)
+
+This means that there are some digest runs which haven't been processed within
+the time we would expect.
+
+* `warning` - `digest_runs` unprocessed for over 20 minutes
+* `critical` - `digest_runs` unprocessed for over 1 hour
+
+See the [DigestEmailGenerationWorker][digest-email-generation-worker] for more information.
+
+#### Check which digest runs are affected
+
+```ruby
+DigestRun.where("created_at < ?", 1.hour.ago).where(completed_at: nil)
+```
+
+[digest-email-generation-worker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/digest_email_generation_worker.rb


### PR DESCRIPTION
We have introduced this new alert to reduce the responsibilities of the `email-alert-api health-check-not-ok` alert, to make our alerts more specific and reliable.

[Trello](https://trello.com/c/vmcbj23s/1662-5-extract-the-digestruns-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)