### PR TITLE
Expand local frontend development docs

### DIFF
--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -5,7 +5,7 @@ layout: manual_layout
 section: Frontend
 type: learn
 owner_slack: "#govuk-2ndline"
-last_reviewed_on: 2019-12-27
+last_reviewed_on: 2020-01-09
 review_in: 6 months
 ---
 

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -56,39 +56,35 @@ govuk-docker up government-frontend-app-live
 
 If you want to test changes in static against a frontend app, you need to tell Docker to look at your local version of static rather than live:
 
-1. Repoint static and frontend to the local version of `govuk_app_config`:
+```shell
+cd /var/govuk/govuk-docker/projects/government-frontend
+vim docker-compose.yml
+```
+Edit the docker-compose.yml live config to depend on static and remove the live static environment:
 
-  ```ruby
-  gem 'govuk_app_config', path: '../govuk_app_config'
-  ```
+```yaml
+  government-frontend-app-live:
+    <<: *government-frontend-app
+  depends_on:
+    ...
+    - static-app # This tells docker that the app relies on static running locally
+  environment:
+    ...
+    # Comment out this line to stop pointing to live static
+    #PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
+```
 
-2. Repoint frontend to local `govuk_publishing_components` if you are making changes there:
+We can now run the frontend application as normal:
+```shell
+cd /var/govuk/govuk-docker
+make government-frontend
 
-  ```ruby
-  gem 'govuk_publishing_components', path: '../govuk_publishing_components'
-  ```
+cd /var/govuk/government-frontend
+govuk-docker up government-frontend-app-live
+```
 
-3. Update in `govuk_app_config` the file `govuk_content_security_policy.rb` to allow all domains:
-
-  ```ruby
-  GOVUK_DOMAINS = [
-  '.publishing.service.gov.uk',
-  ".#{ENV['GOVUK_APP_DOMAIN_EXTERNAL'] || ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'}",
-  ".dev.gov.uk",
-  ""
-  ].uniq.freeze
-  ```
-
-4. Set `config.assets.debug` to `false` in `development.rb` for static and frontend
-5. Run from govuk-docker directory:
-
-  ```shell
-  $ make frontend
-  $ govuk-docker-up frontend-app
-  ```
-
-  (or you can run the last command from the frontend directory as just `govuk-docker-up`)
-6. Changes should be ok for http://frontend.dev.gov.uk/help
+## Troubleshooting
+Set `config.assets.debug` to `false` in `development.rb` for static and frontend
 
 > Note: You might sometimes find that you have something running on a port still, which stops you from starting up an app. To kill a process running on a port:
 

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -15,6 +15,7 @@ If you are making changes to a frontend app and nothing else, you can view these
 ```shell
 cd /govuk/frontend
 ./startup.sh --live
+# Check the output to see what port the app is running on, e.g: localhost:3005
 ```
 
 If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile and then run the startup script:
@@ -26,6 +27,7 @@ gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 ```shell
 bundle install
 ./startup.sh --live
+# Check the output to see what port the app is running on, e.g: localhost:3005
 ```
 
 ## Using govuk-docker
@@ -40,6 +42,7 @@ make government-frontend
 
 cd /govuk/government-frontend
 govuk-docker up government-frontend-app-live
+# You can now view the app on government-frontend.dev.gov.uk
 ```
 
 If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile first:
@@ -52,6 +55,7 @@ gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 cd /govuk/government-frontend
 bundle install
 govuk-docker up government-frontend-app-live
+# You can now view the app on government-frontend.dev.gov.uk
 ```
 
 If you want to test changes in static against a frontend app, you need to tell Docker to look at your local version of static rather than live:
@@ -81,6 +85,7 @@ make government-frontend
 
 cd /govuk/government-frontend
 govuk-docker up government-frontend-app-live
+# You can now view the app on government-frontend.dev.gov.uk
 ```
 
 ## Components pulled in by Static

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -13,7 +13,7 @@ review_in: 6 months
 If you are making changes to a frontend app and nothing else, you can view these changes by running the application `./startup.sh` script:
 
 ```shell
-cd /var/govuk/frontend
+cd /govuk/frontend
 ./startup.sh --live
 ```
 
@@ -35,10 +35,10 @@ This assumes that you have already installed and setup [govuk-docker]. We will u
 If you are making changes to a frontend app and nothing else, you can view these changes by running the following:
 
 ```shell
-cd /var/govuk-docker
+cd /govuk/govuk-docker
 make government-frontend
 
-cd /var/govuk/government-frontend
+cd /govuk/government-frontend
 govuk-docker up government-frontend-app-live
 ```
 
@@ -49,7 +49,7 @@ gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 ```
 
 ```shell
-cd /var/govuk/government-frontend
+cd /govuk/government-frontend
 bundle install
 govuk-docker up government-frontend-app-live
 ```
@@ -57,7 +57,7 @@ govuk-docker up government-frontend-app-live
 If you want to test changes in static against a frontend app, you need to tell Docker to look at your local version of static rather than live:
 
 ```shell
-cd /var/govuk/govuk-docker/projects/government-frontend
+cd /govuk/govuk-docker/projects/government-frontend
 vim docker-compose.yml
 ```
 Edit the docker-compose.yml live config to depend on static and remove the live static environment:
@@ -76,10 +76,10 @@ Edit the docker-compose.yml live config to depend on static and remove the live 
 
 We can now run the frontend application as normal:
 ```shell
-cd /var/govuk/govuk-docker
+cd /govuk/govuk-docker
 make government-frontend
 
-cd /var/govuk/government-frontend
+cd /govuk/government-frontend
 govuk-docker up government-frontend-app-live
 ```
 

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -42,6 +42,18 @@ cd /var/govuk/government-frontend
 govuk-docker up government-frontend-app-live
 ```
 
+If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile first:
+
+```ruby
+gem 'govuk_publishing_components', path: '../govuk_publishing_components'
+```
+
+```shell
+cd /var/govuk/government-frontend
+bundle install
+govuk-docker up government-frontend-app-live
+```
+
 If you want to test changes in static against a frontend app, you need to tell Docker to look at your local version of static rather than live:
 
 1. Repoint static and frontend to the local version of `govuk_app_config`:

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -83,6 +83,9 @@ cd /var/govuk/government-frontend
 govuk-docker up government-frontend-app-live
 ```
 
+## Components pulled in by Static
+Some components, such as the cookie banner, are pulled in by Static. To test changes to this component locally, we need to run a frontend app against both local static and local [govuk_publishing_components]. This can be done by combining the approaches above - just remember to update the Gemfile in Static too!
+
 ## Troubleshooting
 
 ### 504 Timeout Errors

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -9,11 +9,26 @@ last_reviewed_on: 2019-12-27
 review_in: 6 months
 ---
 
-Make the following changes to your setup if you are making changes to frontend apps and need to view those changes locally.
+## Using startup scripts
+If you are making changes to a frontend app and nothing else, you can view these changes by running the application `./startup.sh` script:
 
-In the instructions below we are running the [frontend] app, but this would work for any of the other frontend apps such as [government-frontend].
+```shell
+cd /var/govuk/frontend
+./startup.sh --live
+```
 
-## Under docker
+If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile and then run the startup script:
+
+```ruby
+gem 'govuk_publishing_components', path: '../govuk_publishing_components'
+```
+
+```shell
+bundle install
+./startup.sh --live
+```
+
+## Using govuk-docker
 
 1. Repoint static and frontend to the local version of `govuk_app_config`:
 
@@ -48,66 +63,6 @@ In the instructions below we are running the [frontend] app, but this would work
 
   (or you can run the last command from the frontend directory as just `govuk-docker-up`)
 6. Changes should be ok for http://frontend.dev.gov.uk/help
-
-## Without docker
-
-A small number of frontend devs prefer to not use Docker locally, so we are keeping these instructions for a little while longer.
-
-### Running just a frontend app against live data
-
-```shell
-cd /var/govuk/frontend
-./startup.sh --live
-```
-
-### Running a frontend app against changes in `govuk_publishing_components`
-
-Update the Gemfile for the frontend app to point to your local `govuk_publishing_components` gem:
-
-```ruby
-gem 'govuk_publishing_components', path: '../govuk_publishing_components'
-```
-
-Then run your frontend app again pointing to live:
-
-```shell
-./startup.sh --live
-```
-
-### Running a frontend app against changes in `static`
-
-Make changes to the Gemfile of the frontend app you're working on as per [changes to govuk_publishing_components above](#running-a-frontend-app-against-changes-in-govuk_publishing_components), then set in `development.rb`:
-
-```ruby
-...
-config.assets.debug = false
-...
-```
-
-If you're making changes to the [govuk_publishing_components] gem that affect [static] and are likely things across the whole site, e.g: cookie banner (and survey banner possibly), update the Gemfile of [static] to point to the gem:
-
-```ruby
-...
-gem 'govuk_publishing_components', path: '../govuk_publishing_components'
-...
-```
-
-Run up static:
-
-```shell
-cd /var/govuk/static
-govuk_setenv static ./startup.sh --live
-```
-
-Run up frontend against local static (the `--live` flag means the rest runs against live data):
-
-```shell
-PLEK_SERVICE_STATIC_URI=localhost:3013 ./startup.sh --live
-```
-
-And you can see frontend running up locally with the right local dependencies:
-
-[http://frontend.dev.gov.uk/](http://frontend.dev.gov.uk/)
 
 > Note: You might sometimes find that you have something running on a port still, which stops you from starting up an app. To kill a process running on a port:
 

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -30,6 +30,20 @@ bundle install
 
 ## Using govuk-docker
 
+This assumes that you have already installed and setup [govuk-docker]. We will use [government-frontend] as an example here, but these instructions apply to any frontend app.
+
+If you are making changes to a frontend app and nothing else, you can view these changes by running the following:
+
+```shell
+cd /var/govuk-docker
+make government-frontend
+
+cd /var/govuk/government-frontend
+govuk-docker up government-frontend-app-live
+```
+
+If you want to test changes in static against a frontend app, you need to tell Docker to look at your local version of static rather than live:
+
 1. Repoint static and frontend to the local version of `govuk_app_config`:
 
   ```ruby
@@ -76,3 +90,4 @@ sudo fuser -k [port number]/tcp
 [static]: https://github.com/alphagov/static
 [govuk_publishing_components]: https://github.com/alphagov/govuk_publishing_components
 [government-frontend]: https://github.com/alphagov/government-frontend
+[govuk-docker]: https://github.com/alphagov/govuk-docker/blob/master/docs/installation.md

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -84,9 +84,16 @@ govuk-docker up government-frontend-app-live
 ```
 
 ## Troubleshooting
-Set `config.assets.debug` to `false` in `development.rb` for static and frontend
 
-> Note: You might sometimes find that you have something running on a port still, which stops you from starting up an app. To kill a process running on a port:
+### 504 Timeout Errors
+Assets can load slowly, which means we get frequent timeouts when running apps locally. Some developers find that the following workaround can help:
+
+1. Set `config.assets.debug` to `false` in the `development.rb` file in your frontend app
+1. Run `bundle exec rake assets:precompile` manually
+1. Start your app as normal
+
+### Port already in use
+You might sometimes find that you have something running on a port still, which stops you from starting up an app. To kill a process running on a port:
 
 ```shell
 # replace [port number]


### PR DESCRIPTION
[View rendered file here](https://github.com/alphagov/govuk-developer-docs/blob/c8031edd8127913833f2ab523f3d1c2febc49fad/source/manual/local-frontend-development.html.md)

I've removed references to updating `govuk_app_config` - I tested the instructions locally and didn't need them. I'd be interested in getting someone else to test these instructions themselves to double check though.