### PR TITLE
Instructions for gaining access to the GA platform

### DIFF
--- a/source/manual/analytics.html.md
+++ b/source/manual/analytics.html.md
@@ -9,7 +9,9 @@ review_in: 6 months
 related_applications: [govuk_frontend_toolkit static frontend government-frontend]
 ---
 
-GOV.UK uses Google Analytics to track user journeys through the site. The tracking data is available to anyone with Google Analytics Suite access for GOV.UK. You can request access to this from the analytics team.
+GOV.UK uses Google Analytics to track user journeys through the site. The tracking
+data is available to anyone with Google Analytics Suite access for GOV.UK. You can
+request access to this by following the [steps in the GDS wiki](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice/data-analysis/tools-technical/access-to-google-analytics).
 
 ## GOV.UK analytics code
 

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -21,6 +21,14 @@ review_in: 12 months
 - Uses content from GitHub and public APIs to generate documentation
 - Contains content on architecture, common tasks and alerts
 
+## GDS Wiki
+
+<https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/>
+
+- Internal IT
+- Estates, meeting rooms etc
+- News and Communities
+
 ## Confluence Wiki
 
 <https://gov-uk.atlassian.net/wiki> (private)


### PR DESCRIPTION
Instructions live in the GDS Wiki, which I realised we haven't yet linked to from the Dev Docs.
Spoke with Simon Hughesdon and we agreed it makes sense to add the link to the documentation sources at https://docs.publishing.service.gov.uk/manual/where-to-find-what.html, so I've added that too.