### PR TITLE
Change Publishing Workflow channel name

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -3,7 +3,7 @@
 - github_repo_name: collections-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pub-workflow"
+  dependencies_team: "#govuk-pubworkflow-dev"
   production_hosted_on: carrenza
   dependencies:
     publishing-api:
@@ -53,7 +53,7 @@
   - Publisher
 - github_repo_name: content-publisher
   type: Publishing apps
-  team: "#govuk-pub-workflow"
+  team: "#govuk-pubworkflow-dev"
   production_hosted_on: carrenza
   dependencies:
     content-publisher:
@@ -199,7 +199,7 @@
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pub-workflow"
+  dependencies_team: "#govuk-pubworkflow-dev"
   api_docs_url: "/apis/whitehall.html"
   production_hosted_on: carrenza
   dependencies:
@@ -238,7 +238,7 @@
 - github_repo_name: content-store
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pub-workflow"
+  dependencies_team: "#govuk-pubworkflow-dev"
   api_docs_url: "/apis/content-store.html"
   production_hosted_on: aws
   dependencies:
@@ -274,7 +274,7 @@
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pub-workflow"
+  dependencies_team: "#govuk-pubworkflow-dev"
   api_docs_url: "/apis/publishing-api.html"
   production_hosted_on: aws
   dependencies:
@@ -295,7 +295,7 @@
 - github_repo_name: asset-manager
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pub-workflow"
+  dependencies_team: "#govuk-pubworkflow-dev"
   production_hosted_on: carrenza
   dependencies:
     signon:
@@ -408,7 +408,7 @@
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pub-workflow"
+  dependencies_team: "#govuk-pubworkflow-dev"
   production_hosted_on: aws
 - github_repo_name: release
   type: Supporting apps


### PR DESCRIPTION
This is so the dev channel is alerted about Dependabot rather than the
wider team channel.