### PR TITLE
Remove duplicate reference to rubocop-govuk

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -51,7 +51,6 @@
         - rubocop-govuk
         - scss-lint-govuk
         - publishing-e2e-tests
-        - rubocop-govuk
         - styleguides
 
 - name: Infrastructure


### PR DESCRIPTION
Looks like this was accidentally [duplicated here](https://github.com/alphagov/govuk-developer-docs/commit/0735ada71b4572779e0bc3ea07894c6170a980d0) when we removed the old reference to `scss-lint-govuk`