### PR TITLE
Review docs (one isn't just a date bump!)

### DIFF
--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md
@@ -4,7 +4,7 @@ title: content-data-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-06-27
+last_reviewed_on: 2020-01-13
 review_in: 6 months
 ---
 

--- a/source/manual/concourse.html.md
+++ b/source/manual/concourse.html.md
@@ -5,7 +5,7 @@ section: Infrastructure
 layout: manual_layout
 type: learn
 parent: "/manual.html"
-last_reviewed_on: 2019-09-30
+last_reviewed_on: 2020-01-13
 review_in: 3 months
 ---
 

--- a/source/manual/create-a-concourse-pipeline.html.md
+++ b/source/manual/create-a-concourse-pipeline.html.md
@@ -4,7 +4,7 @@ title: Create a Concourse pipeline
 section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-09-30
+last_reviewed_on: 2020-01-13
 review_in: 3 months
 ---
 

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -4,7 +4,7 @@ title: Support tasks for CKAN
 section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-05-30
+last_reviewed_on: 2020-01-13
 review_in: 6 months
 ---
 [ckan]: https://ckan.org

--- a/source/manual/use-terraboard-to-monitor-terraform-state.html.md
+++ b/source/manual/use-terraboard-to-monitor-terraform-state.html.md
@@ -4,8 +4,8 @@ title: Use Terraboard to monitor Terraform state
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-07-06
-review_in: 6 months
+last_reviewed_on: 2020-01-13
+review_in: 1 month
 ---
 
 We use [Terraboard](https://camptocamp.github.io/terraboard/) for monitoring
@@ -48,7 +48,7 @@ from the configured S3 bucket (`govuk-terraform-steppingstone-<environment>`)
 and caches their content in the PostgreSQL database. This decreases the amount
 of S3 traffic and makes the app faster.
 
-### Authentication
+### Authentication
 
 OAuth2 Proxy is configured to authenticate users using GitHub. A GitHub OAuth
 app for each environment exists and is owned by `alphagov`, which provides the
@@ -65,6 +65,10 @@ then proxies all authenticated requests on to port 8080 of the Terraboard
 container.
 
 ### Docker image for OAuth2 Proxy
+
+> The following section needs improvement and engineering work. See
+> [PR 2227](https://github.com/alphagov/govuk-developer-docs/pull/2227)
+> for things you can do to fix it!
 
 Since there is no official Docker image for OAuth2 Proxy, the
 [govuk-oauth2-proxy-docker](https://github.com/alphagov/govuk-oauth2-proxy-docker)


### PR DESCRIPTION
Four of these are standard date bumps because the content is still OK.
But I'll copypaste the contents of 1e527ed3 here because it's the most
important.

---

terraboard: Bump review date but reduce time between reviews

- There are some things here that I'm not completely comfortable with,
  but that require engineering effort to change. And an assurance that
  Terraboard is still being used. These things are:
  - We currently have our own Docker image for oauth2_proxy, based on
    the original creators of oauth2_proxy. Our repo (linked in the doc
    still) is archived, as is the upstream repo that we cribbed from. The
    current maintainers of oauth2_proxy are now on version 4.1.0 - but
    we're still on 2.2.0.
  - There's some work here not just on these docs but to stop us
    maintaining so much code ourselves when the new project maintainers
    now publish an official Docker image
    (https://quay.io/repository/pusher/oauth2_proxy).
  - Also, anecdotal evidence suggests that devs get confused when trying
    to restart the Smokey process on the monitoring box - there's a
    PostgreSQL database for Terraboard on that box running as the `smokey`
    user?!

- Once these issues are resolved, I'll be happy to bump the review date
up to 6 months again, but right now referencing archived repos doesn't
look great to outsiders looking in, or to people trying to find more
about how this stuff works!