### PR TITLE
Update link to email-alert-api metrics dashboard

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -247,7 +247,7 @@
 - github_repo_name: email-alert-api
   type: APIs
   team: "#govuk-platform-health"
-  metrics_dashboard_url: https://grafana.publishing.service.gov.uk/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+  metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: aws
   dependencies:
     signon:


### PR DESCRIPTION
This updates the link, which changed when email-alert-api was moved to AWS

[Trello card](https://trello.com/c/1FPV9PIo/1687-fix-the-dev-docs-link-to-the-email-alert-api-metrics-dashboard)