### PR TITLE
Fix rendering of 'Local frontend development' page

### DIFF
--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -79,6 +79,7 @@ Edit the docker-compose.yml live config to depend on static and remove the live 
 ```
 
 We can now run the frontend application as normal:
+
 ```shell
 cd /govuk/govuk-docker
 make government-frontend


### PR DESCRIPTION
An absence of a line break before a code block meant that the rendered markdown was displaying a little strangely, with a comment inside the code block being interpreted as a heading. Adding the line break before the code block prevents this small bit of weirdness.

## Before:

<img width="804" alt="Screenshot 2020-01-20 at 16 11 56" src="https://user-images.githubusercontent.com/1732331/72741546-c63dd000-3b9f-11ea-8f9f-7ca675565b24.png">

## After:

<img width="820" alt="Screenshot 2020-01-20 at 16 11 21" src="https://user-images.githubusercontent.com/1732331/72741552-ca69ed80-3b9f-11ea-9c9f-858697847c62.png">
