### PR TITLE
Add page for email-alert-api queue latency Icinga check

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -80,13 +80,6 @@ own email address in these environments.
 
 ## Common alerts
 
-### High queue latency (queue_latency)
-
-This means the time it takes for a job to be processed is unusually high. This
-may indicate a problem down the line which is preventing workers from being
-processed. It may also imply the threshold is too low if a large number of
-emails have being sent out due to a content change.
-
 ### High retry queue size (retry_size)
 
 This means there are a high number of items in the retry queue. The Email Alert

--- a/source/manual/alerts/email-alert-api-high-queue-latency.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-latency.html.md
@@ -1,0 +1,20 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: high latency for sidekiq queue'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-21
+review_in: 6 months
+---
+
+### High queue latency (queue_latency)
+
+This means the time it takes for a job to be processed is unusually high. This
+may indicate a problem down the line which is preventing workers from being
+processed. It may also imply the threshold is too low if a large number of
+emails have being sent out due to a content change.
+
+See the [sidekiq][sidekiq] section for more information about the Sidekiq queues.
+
+[sidekiq]: /manual/sidekiq.html


### PR DESCRIPTION
This is a new alert which replaces one of our `email-alert-api`
healthchecks. See https://github.com/alphagov/govuk-puppet/pull/10069
for more information.

Trello card: https://trello.com/c/A4RfUXGG/1680-2-extract-the-queuelatency-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check-5