### PR TITLE
Add page for email-alert-api high sidekiq queue size

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -80,13 +80,6 @@ own email address in these environments.
 
 ## Common alerts
 
-### High queue size (queue_size)
-
-This means that there are a high number of items in the queue. This may
-indicate a problem down the line which is preventing workers from being
-processed. It may also imply the threshold is too low if a large number of
-emails have being sent out due to a content change.
-
 ### High queue latency (queue_latency)
 
 This means the time it takes for a job to be processed is unusually high. This

--- a/source/manual/alerts/email-alert-api-high-queue-size.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-size.html.md
@@ -1,0 +1,20 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'High number of messages on sidekiq queue'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-21
+review_in: 6 months
+---
+
+### High queue size (queue_size)
+
+This means that there are a high number of items in the queue. This may
+indicate a problem down the line which is preventing workers from being
+processed. It may also imply the threshold is too low if a large number of
+emails have being sent out due to a content change.
+
+See the [sidekiq][sidekiq] section for more information about the Sidekiq queues.
+
+[sidekiq]: /manual/sidekiq.html


### PR DESCRIPTION
This alert has been extracted from the email-alert-api healthcheck.

Related to this [puppet change](https://github.com/alphagov/govuk-puppet/pull/10064)

[Trello](https://trello.com/c/lyTVPild/1681-2-extract-the-queuesize-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)