### PR TITLE
Add page for high number of message for email-alert-api sidekiq retry queues

### DIFF
--- a/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/email-alert-api-app-healthcheck-not-ok.html.md
@@ -78,17 +78,6 @@ first. The integration and staging environments only allow email to be
 sent to a small number of email addresses so you cannot test using your
 own email address in these environments.
 
-## Common alerts
-
-### High retry queue size (retry_size)
-
-This means there are a high number of items in the retry queue. The Email Alert
-API relies on the retry queue for rate limiting, so it’s not unusual to see
-items in the queue, but if it is very high it suggests that there may be a
-problem down the line which is preventing jobs from being processed. It may
-also imply the threshold is too low if a large number of emails have been sent
-out due to a content change.
-
 [dashboard]: https://grafana.staging.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
 [password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify

--- a/source/manual/alerts/email-alert-api-high-queue-size.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-size.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: 'High number of messages on sidekiq queue'
+title: 'Email Alert API: High number of messages on sidekiq queue'
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/alerts/email-alert-api-high-retry-queue-size.html.md
+++ b/source/manual/alerts/email-alert-api-high-retry-queue-size.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#govuk-2ndline"
+title: 'Email Alert API: High number of messages on sidekiq retry queue'
+section: Icinga alerts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-01-21
+review_in: 6 months
+---
+
+### High retry queue size (retry_size)
+
+This means there are a high number of items in the retry queue. The Email Alert
+API relies on the retry queue for rate limiting, so it’s not unusual to see
+items in the queue, but if it is very high it suggests that there may be a
+problem down the line which is preventing jobs from being processed. It may
+also imply the threshold is too low if a large number of emails have been sent
+out due to a content change.
+
+See the [sidekiq][sidekiq] section for more information about the Sidekiq queues.
+
+[sidekiq]: /manual/sidekiq.html


### PR DESCRIPTION
This alert has been extracted from the email-alert-api healthcheck.

[Trello](https://trello.com/c/EfKW5u1T/1682-2-extract-the-retrysize-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)