### PR TITLE
Redirect /manual/gds-cli.html to /manual/access-aws-console.html

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -46,6 +46,7 @@ redirects:
   /manual/emergency-publishing-redis.html: /manual/emergency-publishing.html
   /manual/fastly-error-rate.html: /manual/alerts/fastly-error-rate.html
   /manual/fix-problems-with-vagrant.html: /manual.html
+  /manual/gds-cli.html: /manual/access-aws-console.html
   /manual/howto-merge-a-pull-request-from-an-external-contributor.html: /manual/merge-pr.html
   /manual/howto-transition-a-site-to-govuk.html: /manual/transition-a-site.html
   /manual/migrate-testing-from-phantomjs-to-selenium-chrome.html: /manual.html


### PR DESCRIPTION
- We renamed this recently, but we didn't account for other places where
  the original doc was linked from. Oops!