### PR TITLE
Merge pull request #2255 from alphagov/fix-link

### DIFF
--- a/source/manual/aws-iam-key-rotation.html.md
+++ b/source/manual/aws-iam-key-rotation.html.md
@@ -130,7 +130,7 @@ In production systems, this could prevent minor outages scaling into incidents.
 ### 7. Record where the key is used
 
 - Record your findings of where the key is used in the
-[GOV.UK AWS User Keys spreadsheet](user-keys-list)
+[GOV.UK AWS User Keys spreadsheet][user-keys-list].
 
 ## Command Line Interface
 


### PR DESCRIPTION
This is the correct way to link to an external url: 
https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links