### PR TITLE
Fix dashboard links in AWS

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -73,8 +73,12 @@ class AppDocs
       "Unknown - have you configured and merged your app in govuk-puppet/hieradata/common.yaml"
     end
 
+    def production_hosted_on_aws?
+      production_hosted_on == "aws"
+    end
+
     def machine_class
-      production_hosted_on == "aws" ? aws_puppet_class : carrenza_machine
+      production_hosted_on_aws? ? aws_puppet_class : carrenza_machine
     end
 
     def production_hosted_on
@@ -154,7 +158,13 @@ class AppDocs
     def dashboard_url
       return if app_data["dashboard_url"] == false
 
-      app_data["dashboard_url"] || "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_#{puppet_name}.json"
+      app_data["dashboard_url"] || (
+        if production_hosted_on_aws?
+          "https://grafana.production.govuk.digital/dashboard/file/#{puppet_name}.json"
+        else
+          "https://grafana.publishing.service.gov.uk/dashboard/file/#{puppet_name}.json"
+        end
+      )
     end
 
     def publishing_e2e_tests_url

--- a/spec/app/app_docs_spec.rb
+++ b/spec/app/app_docs_spec.rb
@@ -12,4 +12,26 @@ RSpec.describe AppDocs::App do
       expect(app.production_url).to eql("something else")
     end
   end
+
+  describe "dashboard_url" do
+    let(:production_hosted_on) { nil }
+    let(:app) do
+      described_class.new(
+        "type" => "Publishing app",
+        "puppet_name" => "my_app",
+        "production_hosted_on" => production_hosted_on,
+      )
+    end
+    subject(:dashboard_url) { app.dashboard_url }
+
+    describe "hosted on AWS" do
+      let(:production_hosted_on) { "aws" }
+      it { is_expected.to eql("https://grafana.production.govuk.digital/dashboard/file/my_app.json") }
+    end
+
+    describe "hosted on Carrenza" do
+      let(:production_hosted_on) { "carrenza" }
+      it { is_expected.to eql("https://grafana.publishing.service.gov.uk/dashboard/file/my_app.json") }
+    end
+  end
 end


### PR DESCRIPTION
This fixes the links to the application dashboards in AWS as they were previously hard coded to Carrenza.

[Trello Card](https://trello.com/c/3S3UCsgK/1465-make-developer-docs-link-to-the-correct-deployment-dashboard-for-applications)