### PR TITLE
Remove content audit tool

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -368,10 +368,6 @@
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-- github_repo_name: content-audit-tool
-  type: Supporting apps
-  team: "#govuk-platform-health"
-  production_hosted_on: carrenza
 - github_repo_name: content-data-admin
   type: Supporting apps
   team: "#govuk-platform-health"

--- a/diagrams/supporting_apps.puml
+++ b/diagrams/supporting_apps.puml
@@ -3,7 +3,6 @@
 
 System_Boundary(supporting_apps, "Supporting apps"){
 Container(authenticating_proxy, "authenticating-proxy", "optional technology", "")
-Container(content_audit_tool, "content-audit-tool", "optional technology", "")
 Container(content_data_admin, "content-data-admin", "optional technology", "")
 Container(content_data_api, "content-data-api", "optional technology", "")
 Container(release, "release", "optional technology", "")


### PR DESCRIPTION
Content Audit Tool is a legacy application created before Content Data. It was used to help tag content - it shared a codebase with Content Performance Manager.

It is being retired as it should no longer be used, to clean up references to it in our codebase, and remove the need for developers to maintain it.

[trello](https://trello.com/c/V6bXwwtx/1700-3-retire-content-audit-app)