### PR TITLE
Use Rake tasks to handle Whitehall overdue publications

### DIFF
--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md
@@ -4,11 +4,11 @@ title: Whitehall scheduled publishing
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-10-01
+last_reviewed_on: 2020-01-30
 review_in: 6 months
 ---
 
-### 'overdue publications in Whitehall'
+## 'overdue publications in Whitehall'
 
 This alert means that there are scheduled editions which have passed their
 publication due date but haven't been published by the scheduled publishing
@@ -22,9 +22,9 @@ state of the job using [Sidekiq monitoring apps][sidekiq-monitoring].
 
 You can verify that there are overdue published documents using:
 
-```sh
-$ fab $environment class:whitehall_backend whitehall.overdue_scheduled_publications
-```
+- [`publishing:overdue:list` on Integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:list)
+- [`publishing:overdue:list` on Staging](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:list)
+- [`publishing:overdue:list` on Production](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:list)
 
 You'll see output like this:
 
@@ -35,17 +35,16 @@ ID  Scheduled date             Title
 If there are overdue publications you can publish by running the
 following:
 
-```sh
-$ fab $environment class:whitehall_backend whitehall.schedule_publications
-```
+- [`publishing:overdue:publish` on Integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:publish)
+- [`publishing:overdue:publish` on Staging](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:publish)
+- [`publishing:overdue:publish` on Production](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:publish)
 
-#### After a database restore
+### After a database restore
 
 If the above rake tasks aren't working, it could be because the database was
 recently restored, perhaps due to the data sync. In that case, you can try
 running the following Rake task on a `whitehall_backend` machine:
 
-```sh
-$ cd /var/apps/whitehall
-$ sudo -u deploy govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs
-```
+- [`publishing:scheduled:requeue_all_jobs` on Integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:scheduled:requeue_all_jobs)
+- [`publishing:scheduled:requeue_all_jobs` on Staging](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:scheduled:requeue_all_jobs)
+- [`publishing:scheduled:requeue_all_jobs` on Production](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:scheduled:requeue_all_jobs)


### PR DESCRIPTION
This means we can link directly to the Rake tasks rather than having to use Fabric scripts.