### PR TITLE
Use application name to generate dashboard URLs

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -160,9 +160,9 @@ class AppDocs
 
       app_data["dashboard_url"] || (
         if production_hosted_on_aws?
-          "https://grafana.production.govuk.digital/dashboard/file/#{puppet_name}.json"
+          "https://grafana.production.govuk.digital/dashboard/file/#{app_name}.json"
         else
-          "https://grafana.publishing.service.gov.uk/dashboard/file/#{puppet_name}.json"
+          "https://grafana.publishing.service.gov.uk/dashboard/file/#{app_name}.json"
         end
       )
     end

--- a/spec/app/app_docs_spec.rb
+++ b/spec/app/app_docs_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AppDocs::App do
     let(:app) do
       described_class.new(
         "type" => "Publishing app",
-        "puppet_name" => "my_app",
+        "github_repo_name" => "my-app",
         "production_hosted_on" => production_hosted_on,
       )
     end
@@ -26,12 +26,12 @@ RSpec.describe AppDocs::App do
 
     describe "hosted on AWS" do
       let(:production_hosted_on) { "aws" }
-      it { is_expected.to eql("https://grafana.production.govuk.digital/dashboard/file/my_app.json") }
+      it { is_expected.to eql("https://grafana.production.govuk.digital/dashboard/file/my-app.json") }
     end
 
     describe "hosted on Carrenza" do
       let(:production_hosted_on) { "carrenza" }
-      it { is_expected.to eql("https://grafana.publishing.service.gov.uk/dashboard/file/my_app.json") }
+      it { is_expected.to eql("https://grafana.publishing.service.gov.uk/dashboard/file/my-app.json") }
     end
   end
 


### PR DESCRIPTION
The puppet name uses underscores whereas our dashboards use hyphens, for example: https://grafana.blue.production.govuk.digital/dashboard/file/email-alert-api.json?refresh=5s&orgId=1

[Trello Card](https://trello.com/c/3S3UCsgK/1465-make-developer-docs-link-to-the-correct-deployment-dashboard-for-applications)