### PR TITLE
Rename "1 year" to "12 months"

### DIFF
--- a/source/manual/troubleshooting-jenkins-performance.html.md
+++ b/source/manual/troubleshooting-jenkins-performance.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Testing
 last_reviewed_on: 2019-03-17
-review_in: 1 year
+review_in: 12 months
 ---
 
 There are many reasons Jenkins could perform poorly, this document attempts to

--- a/source/manual/which-gem-to-use.html.md
+++ b/source/manual/which-gem-to-use.html.md
@@ -5,7 +5,7 @@ section: Patterns & Style Guides
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-07-10
-review_in: 1 year
+review_in: 12 months
 ---
 
 ## Testing a Ruby project


### PR DESCRIPTION
We seem to use the latter much more often. I'm changing this only for
consistency and I'm not currently reviewing the content of these two doc
pages so I'm leaving the dates untouched.