### PR TITLE
Bump pull request guide

### DIFF
--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -4,7 +4,7 @@ title: Merge a Pull Request
 section: GitHub
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-08-05
+last_reviewed_on: 2020-02-05
 review_in: 6 months
 ---
 


### PR DESCRIPTION
Just a bump, since it's all up to date.
 
Next review it could be worth swapping "unofficial" `hub` with official [`gh`](https://github.com/cli/cli) - `gh` is probably too early in development to be recommended at the moment.