### PR TITLE
Move some docs from How To to Learn

### DIFF
--- a/source/manual/analytics.html.md
+++ b/source/manual/analytics.html.md
@@ -3,6 +3,7 @@ owner_slack: "#govuk-frontenders"
 title: 'Analytics on GOV.UK'
 section: Analytics
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-10-29
 review_in: 6 months

--- a/source/manual/data-gov-uk-map-previews.html.md
+++ b/source/manual/data-gov-uk-map-previews.html.md
@@ -3,6 +3,7 @@ owner_slack: "#govuk-platform-health"
 title: WMS map previews on data.gov.uk
 section: data.gov.uk
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-10-09
 review_in: 6 months

--- a/source/manual/docs-style-guide.html.md
+++ b/source/manual/docs-style-guide.html.md
@@ -3,6 +3,7 @@ owner_slack: "#govuk-developers"
 title: Documentation style guide
 section: Documentation
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-05-16
 review_in: 12 months

--- a/source/manual/intro-to-docker-even-more.html.md
+++ b/source/manual/intro-to-docker-even-more.html.md
@@ -2,6 +2,7 @@
 title: Intro to Docker (Even More)
 section: Docker
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
 review_in: 6 months

--- a/source/manual/intro-to-docker.html.md
+++ b/source/manual/intro-to-docker.html.md
@@ -2,6 +2,7 @@
 title: Intro to Docker
 section: Docker
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
 review_in: 6 months

--- a/source/manual/non-ha-node-classes.html.md
+++ b/source/manual/non-ha-node-classes.html.md
@@ -2,6 +2,7 @@
 owner_slack: "#re-govuk"
 title: Node classes without redundancy
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 section: Applications
 important: true


### PR DESCRIPTION
I haven't reviewed these docs, or gone through the full manual, but these seem more Learn docs than How Tos to me.