### PR TITLE
Sort pages by type

### DIFF
--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -27,7 +27,7 @@ title: Manual
 <% manual.manual_pages_grouped_by_section.each do |section_name, pages| %>
   <h2 id='<%= section_name.parameterize %>'><%= section_name %></h2>
 
-  <% pages.group_by { |page| page.data.type }.each do |type, pages| %>
+  <% pages.sort_by { |page| page.data.type || 'how to' }.group_by { |page| page.data.type }.each do |type, pages| %>
     <h3><%= type == "learn" ? "Learn" : "How to..." %></h3>
     <ul>
       <% pages.each do |page| %>


### PR DESCRIPTION
This ensures that, in every category, the order of subcategories ("Learn" or "How to...") will be consistent.

At the moment the order is determined somewhat arbitrarily (by the type of the lexicographically first page), so we have this situation:

<img width="537" alt="Screenshot 2020-02-11 at 13 59 43" src="https://user-images.githubusercontent.com/75235/74243012-d5afc500-4cd6-11ea-89e6-367c9eca5cb5.png">

Now we have:

<img width="503" alt="Screenshot 2020-02-11 at 14 08 20" src="https://user-images.githubusercontent.com/75235/74243632-047a6b00-4cd8-11ea-80db-1bbf1d7e03f5.png">

---

[Trello card](https://trello.com/c/YEPSn3cR/1371-tlc-for-dev-docs)