### PR TITLE
Reassign docs from #govuk-2ndline

### DIFF
--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: How A/B testing works
 parent: "/manual.html"
 layout: manual_layout
 section: A/B testing
 type: learn
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-02-07
 review_in: 6 months
 ---

--- a/source/manual/access-aws-console.html.md
+++ b/source/manual/access-aws-console.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Access AWS Console
 section: AWS accounts
 layout: manual_layout

--- a/source/manual/access-jenkins.html.md
+++ b/source/manual/access-jenkins.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Get access to Jenkins
 section: Accounts
 layout: manual_layout

--- a/source/manual/add-a-new-document-type.html.md
+++ b/source/manual/add-a-new-document-type.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Add a new document type
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-01-17
 review_in: 6 months
 ---

--- a/source/manual/add-an-icinga-passive-check.html.md
+++ b/source/manual/add-an-icinga-passive-check.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Add an Icinga passive check to a Jenkins job
 section: Monitoring
 layout: manual_layout

--- a/source/manual/add-authentication-to-an-application.html.md
+++ b/source/manual/add-authentication-to-an-application.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Add authentication to an application
 parent: "/manual.html"
 layout: manual_layout
 section: Applications
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-06-27
 review_in: 6 months
 ---

--- a/source/manual/add-deployment-dashboard.html.md
+++ b/source/manual/add-deployment-dashboard.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Add a dashboard for an application
 section: Monitoring
 layout: manual_layout

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Add support for a new translation in Whitehall
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-01-27
 review_in: 9 months
 ---

--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Add a disk to a vCloud machine (Carrenza only)
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/alerts/smokey-json-older-than-30m.html.md
+++ b/source/manual/alerts/smokey-json-older-than-30m.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: smokey.json older than 30m
-section: Development VM
+section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-09-12

--- a/source/manual/alerts/unknown-error-with-postgresql-mapit.html.md
+++ b/source/manual/alerts/unknown-error-with-postgresql-mapit.html.md
@@ -1,9 +1,9 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Unknown error with postgresql in mapit
-section: Development VM
 layout: manual_layout
 parent: "/manual.html"
+section: Icinga alerts
 last_reviewed_on: 2019-09-12
 review_in: 6 months
 ---

--- a/source/manual/aws-iam-key-rotation.html.md
+++ b/source/manual/aws-iam-key-rotation.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: AWS IAM Key Rotation
 parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: AWS
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2020-01-20
 review_in: 6 months
 ---

--- a/source/manual/blocking-apps-from-release.html.md
+++ b/source/manual/blocking-apps-from-release.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Block apps from being deployed
 section: Deployment
 layout: manual_layout

--- a/source/manual/bowl-error.html.md
+++ b/source/manual/bowl-error.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Fix bundler errors when running `bowl`
 section: Development VM
 layout: manual_layout

--- a/source/manual/browser-support.html.md
+++ b/source/manual/browser-support.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-frontenders"
 title: Which browsers we support
 parent: "/manual.html"
 layout: manual_layout
 section: Frontend
 type: learn
-owner_slack: "#govuk-frontenders"
 last_reviewed_on: 2019-10-08
 review_in: 12 months
 ---

--- a/source/manual/cant-connect-to-mongo.html.md
+++ b/source/manual/cant-connect-to-mongo.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Can't connect to Mongo in VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Our content delivery network (CDN)
 section: CDN & Caching
 type: learn

--- a/source/manual/change-base-path-in-specialist-publisher.html.md
+++ b/source/manual/change-base-path-in-specialist-publisher.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Change a specialist document base path
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-12-05
 review_in: 3 months
 ---

--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Change an organisation's slug
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Check for a 'gone' route
 section: Routing
 layout: manual_layout

--- a/source/manual/clone-mysql-slave.html.md
+++ b/source/manual/clone-mysql-slave.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Clone a MySQL instance from one slave to another (Carrenza only)
 section: Databases
 layout: manual_layout

--- a/source/manual/concourse.html.md
+++ b/source/manual/concourse.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Concourse
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Configure a GitHub repo
 parent: /manual.html
 layout: manual_layout
 section: GitHub
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-10-21
 review_in: 6 months
 ---

--- a/source/manual/connect-to-vcloud-director.html.md
+++ b/source/manual/connect-to-vcloud-director.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Connect to vCloud Director (Carrenza only)
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/content-preview.html.md
+++ b/source/manual/content-preview.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: How the draft stack works
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/content-security-policy.html.md
+++ b/source/manual/content-security-policy.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: 'Content Security Policy on GOV.UK'
 section: Security
 layout: manual_layout

--- a/source/manual/content-store-times-out.html.md
+++ b/source/manual/content-store-times-out.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Content store times out in VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/cookie-consent-on-govuk.html.md
+++ b/source/manual/cookie-consent-on-govuk.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: Cookie consent on GOV.UK
 parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Cookies
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2019-12-19
 review_in: 6 months
 ---

--- a/source/manual/cookies-and-sessions-in-frontend-apps.html.md
+++ b/source/manual/cookies-and-sessions-in-frontend-apps.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-frontenders"
 title: Cookies and sessions in GOV.UK frontend apps
 parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Cookies
-owner_slack: "#govuk-frontenders"
 last_reviewed_on: 2019-11-28
 review_in: 6 months
 ---

--- a/source/manual/create-a-concourse-pipeline.html.md
+++ b/source/manual/create-a-concourse-pipeline.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Create a Concourse pipeline
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Create a GPG key
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-2ndline"
 title: Common 2nd line support tasks for data.gov.uk
 section: data.gov.uk
 layout: manual_layout

--- a/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
+++ b/source/manual/deploy-fixes-for-a-security-vulnerability.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Deploy fixes for a security vulnerability
 section: Deployment
 layout: manual_layout

--- a/source/manual/deploy-puppet.html.md
+++ b/source/manual/deploy-puppet.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Deploy Puppet
 section: Deployment
 layout: manual_layout

--- a/source/manual/deploying.html.md
+++ b/source/manual/deploying.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Deploy an application to GOV.UK
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Monitor your app during deployment
 section: Deployment
 layout: manual_layout

--- a/source/manual/development-disk-space.html.md
+++ b/source/manual/development-disk-space.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-dev-tools"
 title: Fix low disk space in development
 parent: "/manual.html"
 layout: manual_layout
 section: Development VM
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2019-10-08
 review_in: 6 months
 ---

--- a/source/manual/development-pipeline.html.md
+++ b/source/manual/development-pipeline.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: The development and deployment pipeline
 parent: "/manual.html"
 layout: manual_layout
 section: Deployment
 type: learn
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-08-28
 review_in: 6 months
 ---

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Edit an existing route in the Router
 section: Routing
 layout: manual_layout

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: "Email notifications: how they work"
 section: Emails
 type: learn

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Handle encrypted hieradata
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: GOV.UK's environments (integration, staging, production)
 section: Infrastructure
 type: learn

--- a/source/manual/error-reporting.html.md
+++ b/source/manual/error-reporting.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Error reporting with Sentry
 parent: "/manual.html"
 layout: manual_layout
 section: Monitoring
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---

--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: How to deal with errors
 section: Monitoring
 layout: manual_layout

--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-2ndline"
 title: Fall back to AWS CloudFront
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-06-28
 review_in: 6 months
 ---

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-2ndline"
 title: Fall back to the static mirrors
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-08-22
 review_in: 6 months
 ---

--- a/source/manual/fetching-packages.html.md
+++ b/source/manual/fetching-packages.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Problems provisioning and fetching packages in VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/fix-signature-expired-errors.html.md
+++ b/source/manual/fix-signature-expired-errors.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-dev-tools"
 title: Fix `Signature expired` errors
 section: Development VM
 layout: manual_layout

--- a/source/manual/frontend-architecture.html.md
+++ b/source/manual/frontend-architecture.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-frontenders"
 title: Frontend architecture
 parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Frontend
-owner_slack: "#govuk-frontenders"
 last_reviewed_on: 2020-01-17
 review_in: 3 months
 related_applications:

--- a/source/manual/frontend-performance.html.md
+++ b/source/manual/frontend-performance.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-frontenders"
 title: Track frontend performance with SpeedCurve
 parent: "/manual.html"
 layout: manual_layout
 section: Frontend
-owner_slack: "#govuk-frontenders"
 last_reviewed_on: 2019-07-16
 review_in: 12 months
 ---

--- a/source/manual/gem-file-permission-errors.html.md
+++ b/source/manual/gem-file-permission-errors.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-dev-tools"
 title: Fix issues with installing Ruby gems using Bundler
 section: Development VM
 layout: manual_layout

--- a/source/manual/get-ssh-access.html.md
+++ b/source/manual/get-ssh-access.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Get SSH access to integration
 layout: manual_layout
 section: Accounts

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Get started on GOV.UK
 description: Guide for new developers on GOV.UK
 layout: manual_layout

--- a/source/manual/github-setup.html.md
+++ b/source/manual/github-setup.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Set up your GitHub account
 layout: manual_layout
 section: Learning GOV.UK

--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: How we use GitHub
 parent: /manual.html
 layout: manual_layout
 section: GitHub
 type: learn
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2019-10-21
 review_in: 6 months
 ---

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Government Changes
 section: Publishing
 layout: manual_layout

--- a/source/manual/grafana.html.md
+++ b/source/manual/grafana.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Grafana
 section: Monitoring
 type: learn

--- a/source/manual/graphite-and-deployment-dashboards.html.md
+++ b/source/manual/graphite-and-deployment-dashboards.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Graphite and deployment dashboards
 section: Monitoring
 type: learn

--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Access apps on the shared Heroku account
 section: Accounts
 layout: manual_layout

--- a/source/manual/howto-change-slug-and-create-redirect.html.md
+++ b/source/manual/howto-change-slug-and-create-redirect.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Change a slug and create redirect in Whitehall
 section: Publishing
 layout: manual_layout

--- a/source/manual/howto-find-hardcoded-markup-govspeak.html.md
+++ b/source/manual/howto-find-hardcoded-markup-govspeak.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: '#govuk-2ndline'
+owner_slack: '#govuk-developers'
 title: Find hardcoded markup in GovSpeak
 section: Publishing
 layout: manual_layout

--- a/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
+++ b/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Redirect an HTML attachment's URL in Whitehall
 section: Publishing
 layout: manual_layout

--- a/source/manual/howto-remove-change-note-from-whitehall.html.md
+++ b/source/manual/howto-remove-change-note-from-whitehall.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Remove a change note in Whitehall
 section: Publishing
 layout: manual_layout

--- a/source/manual/howto-ssh-to-machines-in-aws.html.md
+++ b/source/manual/howto-ssh-to-machines-in-aws.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: SSH into AWS machines
 section: AWS accounts
 layout: manual_layout

--- a/source/manual/howto-switch-off-app.html.md
+++ b/source/manual/howto-switch-off-app.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Switch an app off temporarily
 layout: manual_layout
 section: Deployment

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-searchandnav"
 title: Content that doesn't show up correctly in search or list pages
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#govuk-searchandnav"
 last_reviewed_on: 2020-02-04
 review_in: 6 months
 related_applications: [search-api]

--- a/source/manual/install-development-vm.html.md
+++ b/source/manual/install-development-vm.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: GOV.UK Development VM setup instructions
 description: Get started with the development VM (deprecated)
 layout: manual_layout

--- a/source/manual/intro-to-docker-even-more.html.md
+++ b/source/manual/intro-to-docker-even-more.html.md
@@ -1,4 +1,5 @@
 ---
+owner_slack: "#govuk-dev-tools"
 title: Intro to Docker (Even More)
 section: Docker
 layout: manual_layout
@@ -6,7 +7,6 @@ type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
 review_in: 6 months
-owner_slack: "#govuk-developers"
 ---
 
 In the [Intro to Docker tutorial](/manual/intro-to-docker.html) we began with a generic container running the `ruby` image, and finished with a powerful `docker-compose` command to run the [content-publisher][] tests against a Postgres DB.

--- a/source/manual/intro-to-docker.html.md
+++ b/source/manual/intro-to-docker.html.md
@@ -1,4 +1,5 @@
 ---
+owner_slack: "#govuk-dev-tools"
 title: Intro to Docker
 section: Docker
 layout: manual_layout
@@ -6,7 +7,6 @@ type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
 review_in: 6 months
-owner_slack: "#govuk-developers"
 ---
 
 We use [govuk-docker] to help us develop stuff on GOV.UK. If you're new to Docker, this will provide useful insights into how we use it in the context of the GOV.UK stack.

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Jenkins CI infrastructure
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Policy on keeping software current
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/knowledge-graph.html.md
+++ b/source/manual/knowledge-graph.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-data-labs"
 title: Knowledge Graph
 parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Knowledge Graph
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2019-10-25
 review_in: 6 months
 ---

--- a/source/manual/learn-govuk.html.md.erb
+++ b/source/manual/learn-govuk.html.md.erb
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Learn how GOV.UK works
 parent: "/manual.html"
 layout: manual_layout
 section: Learning GOV.UK
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: Local frontend development
 parent: "/manual.html"
 layout: manual_layout
 section: Frontend
 type: learn
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-01-09
 review_in: 6 months
 ---

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: How logging works on GOV.UK
 section: Logging
 layout: manual_layout

--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Use Logit for GOV.UK
 section: Logging
 layout: manual_layout

--- a/source/manual/make-a-new-document-type-available-to-search.html.md
+++ b/source/manual/make-a-new-document-type-available-to-search.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-searchandnav"
 title: Make a new document type available to search
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#govuk-searchandnav"
 last_reviewed_on: 2020-02-04
 review_in: 3 months
 related_applications: [search-api]

--- a/source/manual/make-github-repo-private.html.md
+++ b/source/manual/make-github-repo-private.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Make a GitHub repo private
 parent: /manual.html
 layout: manual_layout
 section: GitHub
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2019-10-31
 review_in: 6 months
 ---

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Merge a Pull Request
 section: GitHub
 layout: manual_layout

--- a/source/manual/metrics.html.md
+++ b/source/manual/metrics.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Metrics
 section: Monitoring
 type: learn

--- a/source/manual/monitor-docs-traffic.html.md
+++ b/source/manual/monitor-docs-traffic.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Monitor docs traffic
 section: Documentation
 layout: manual_layout

--- a/source/manual/naming.html.md
+++ b/source/manual/naming.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Name a new application or gem
 section: Applications
 layout: manual_layout

--- a/source/manual/nfs-errors-vm.html.md
+++ b/source/manual/nfs-errors-vm.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Fix NFS errors in VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/packer-vagrant-image-creation.html.md
+++ b/source/manual/packer-vagrant-image-creation.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Packer Vagrant Dev VM / Image Creation
 section: Packaging
 layout: manual_layout

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Pact Broker
 section: Testing
 type: learn

--- a/source/manual/pgbouncer.html.md
+++ b/source/manual/pgbouncer.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: PgBouncer
 section: Databases
 type: learn

--- a/source/manual/postgresql-advisory-locks.html.md
+++ b/source/manual/postgresql-advisory-locks.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: PostgreSQL Advisory Locks
 section: Databases
 layout: manual_layout

--- a/source/manual/provision-machines-for-data-science-research.html.md
+++ b/source/manual/provision-machines-for-data-science-research.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-data-labs"
 title: Provision machines for data science research
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Publish special routes
 section: Deployment
 layout: manual_layout

--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Publish to Puppet Forge
 section: Packaging
 layout: manual_layout

--- a/source/manual/publishing-a-facet-group.html.md
+++ b/source/manual/publishing-a-facet-group.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-searchandnav"
 title: How to publish a facet group
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 type: learn
-owner_slack: "#govuk-searchandnav"
 last_reviewed_on: 2020-02-04
 review_in: 3 months
 related_applications: [content-tagger]

--- a/source/manual/publishing-e2e-tests.html.md
+++ b/source/manual/publishing-e2e-tests.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: End to end testing publishing apps
 section: Testing
 layout: manual_layout
 parent: "/manual.html"
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2019-09-11
 review_in: 6 months
 ---

--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Query CDN logs
 section: CDN & Caching
 layout: manual_layout

--- a/source/manual/ram-vm.html.md
+++ b/source/manual/ram-vm.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Not enough RAM for the VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Receive emails from Email Alert API in integration and staging
 section: Emails
 layout: manual_layout

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Redirect a route
 section: Routing
 layout: manual_layout

--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-data-labs"
 title: Related links
 parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Publishing
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2020-01-07
 review_in: 6 months
 ---

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Remove a machine
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/remove-redirected-url-from-transition.html.md
+++ b/source/manual/remove-redirected-url-from-transition.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Remove redirected URLs from Transition
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Rename a country
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-02-10
 review_in: 6 months
 related_applications: [travel-advice-publisher, content-tagger, whitehall]

--- a/source/manual/repository-mirroring.html.md
+++ b/source/manual/repository-mirroring.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Repository mirroring
 section: GitHub
 layout: manual_layout

--- a/source/manual/reprovision.html.md
+++ b/source/manual/reprovision.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Reprovision a machine
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/restrict-paas-applications-to-gds-office-ips.html.md
+++ b/source/manual/restrict-paas-applications-to-gds-office-ips.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-2ndline"
 title: Restrict PaaS applications to GDS office IPs
 parent: /manual.html
 layout: manual_layout
 section: PaaS
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-02-06
 review_in: 6 months
 ---

--- a/source/manual/resync-postgres-standby.html.md
+++ b/source/manual/resync-postgres-standby.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Resync a PostgreSQL Standby in Carrenza/6DG
 section: Databases
 layout: manual_layout

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Retire an application
 section: Applications
 layout: manual_layout

--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Set up Heroku review apps for pull requests
 section: Deployment
 layout: manual_layout

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -10,7 +10,7 @@ review_in: 12 months
 
 We have [a system to make sure we regularly review pages](https://github.com/alphagov/tech-docs-monitor) in the manual.
 
-Main pages in the manual are reviewed every 3-12 months, mostly by the 2nd line team.
+Main pages in the manual are reviewed every 3-12 months.
 
 We also document Icinga alerts. These explain what to do when a certain alert triggers ([example](/manual/alerts/fastly-error-rate.html)). Because these can be very rare and hard to review, we should review these around the same time every six months. This is best done by people with a lot of 2nd line context. To make sure we've documented all alerts, you can [run `rake lint_alert_docs` in govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/master/lib/tasks/lint_alert_docs.rake), which will output alerts that can be removed/need to be added.
 

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Add a new Ruby version
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -1,9 +1,9 @@
 ---
+owner_slack: "#govuk-developers"
 title: Run an A/B or multivariate test
 parent: "/manual.html"
 layout: manual_layout
 section: A/B testing
-owner_slack: "#govuk-2ndline"
 last_reviewed_on: 2020-02-07
 review_in: 6 months
 ---

--- a/source/manual/run-application.html.md
+++ b/source/manual/run-application.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Run an application in the VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Run a rake task
 section: Deployment
 layout: manual_layout

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Screens that we have in the office
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/send-test-email.html.md
+++ b/source/manual/send-test-email.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Send a test email via Notify
 section: Development VM
 layout: manual_layout

--- a/source/manual/set-up-aws-account.html.md
+++ b/source/manual/set-up-aws-account.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Set up your AWS account
 section: AWS accounts
 layout: manual_layout

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Set up a new Rails application
 section: Applications
 layout: manual_layout

--- a/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
+++ b/source/manual/setting-up-new-sidekiq-monitoring-app.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Add sidekiq-monitoring to your application
 section: Monitoring
 layout: manual_layout

--- a/source/manual/setting-up-request-tracing.html.md
+++ b/source/manual/setting-up-request-tracing.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Set up request tracing
 section: Logging
 layout: manual_layout

--- a/source/manual/sidekiq.html.md
+++ b/source/manual/sidekiq.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Sidekiq
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/ssh-from-vm.html.md
+++ b/source/manual/ssh-from-vm.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: SSH into GOV.UK servers from the VM
 section: Development VM
 layout: manual_layout

--- a/source/manual/ssh-into-vm.html.md
+++ b/source/manual/ssh-into-vm.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: SSH into your VM directly
 section: Development VM
 layout: manual_layout

--- a/source/manual/tag-content-with-facet-values.html.md
+++ b/source/manual/tag-content-with-facet-values.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-searchandnav"
 title: How to tag content with facet values
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 type: learn
-owner_slack: "#govuk-searchandnav"
 last_reviewed_on: 2019-10-08
 review_in: 6 months
 related_applications: [content-tagger]

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: How the topic taxonomy works
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 type: learn
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2020-01-23
 review_in: 6 months
 related_applications: [content-tagger]

--- a/source/manual/testing-projects.html.md
+++ b/source/manual/testing-projects.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Test & build a project on Jenkins CI
 section: Testing
 layout: manual_layout

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: 'Tools: Icinga, Grafana and Graphite, Kibana and Fabric'
 section: Monitoring
 type: learn

--- a/source/manual/unable-to-mount-virtualbox-shared-folders.html.md
+++ b/source/manual/unable-to-mount-virtualbox-shared-folders.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Unable to mount VirtualBox shared folders
 section: Development VM
 layout: manual_layout

--- a/source/manual/upgrading-mysql.html.md
+++ b/source/manual/upgrading-mysql.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Upgrade MySQL in production and staging (Carrenza only)
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/uptime-metrics.html.md
+++ b/source/manual/uptime-metrics.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: Uptime Metrics
 section: Monitoring
 type: learn

--- a/source/manual/vagrant-dns.html.md
+++ b/source/manual/vagrant-dns.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Fix issues with vagrant-dns
 section: Development VM
 layout: manual_layout

--- a/source/manual/vm-vpn-issues.html.md
+++ b/source/manual/vm-vpn-issues.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-dev-tools"
 title: Access the VM after using the VPN
 section: Development VM
 layout: manual_layout

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#govuk-developers"
 title: GOV.UK and Virtual Private Networks (VPNs)
 section: Infrastructure
 type: learn

--- a/source/manual/web_application_firewall_rules.html.md
+++ b/source/manual/web_application_firewall_rules.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: 'Web Application Firewall (WAF) configuration'
 section: Security
 layout: manual_layout

--- a/source/manual/world-taxonomy.html.md
+++ b/source/manual/world-taxonomy.html.md
@@ -1,10 +1,10 @@
 ---
+owner_slack: "#govuk-developers"
 title: How the world taxonomy works
 parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 type: learn
-owner_slack: "#govuk-developers"
 last_reviewed_on: 2020-02-05
 review_in: 6 months
 related_applications: [content-tagger]


### PR DESCRIPTION
We have a lot of docs assigned to #govuk-2ndline, but reviewing docs
is the lowest-priority 2ndline task.  There's always something else to
do.

So, as a result, the docs build up.  And up.  And up.  And we end up
with a huge intimidating list which is discouraging even when someone
does get some free time, because it feels like there's no point.  My
hope is that by reassigning the docs to other channels, there will be
enough people who get annoyed by the daily slack reminder that people
do start chipping away at them.

So now docs have been assigned to:

- #govuk-dev-tools (new channel) if they're govuk-docker or dev VM
  related
- #govuk-2ndline if they're alert/2ndline/oncall related
- #re-govuk if they're infra related
- #govuk-developers otherwise

Doc assignment for the manual (excluding alerts) is now:

```
$ grep owner_slack * | sed 's/"//g' | sed "s/'//g" | cut -d: -f3 | sort | uniq -c | sort
   1  @christopherbaines
   3  #govuk-data-labs
   4  @nila.patel
   6  #govuk-frontenders
   9  #govuk-searchandnav
  16  #govuk-platform-health
  19  #govuk-dev-tools
  29  #re-govuk
  38  #govuk-2ndline
 105  #govuk-developers
```

---

[Trello card](https://trello.com/c/YEPSn3cR/1371-tlc-for-dev-docs)