### PR TITLE
Sort pages by type and title

### DIFF
--- a/app/manual.rb
+++ b/app/manual.rb
@@ -40,6 +40,6 @@ private
     sitemap.resources
       .reject { |page| page.data.section == ICINGA_ALERTS }
       .select { |page| page.path.start_with?("manual/") && page.path.end_with?(".html") && page.data.title }
-      .sort_by { |page| page.data.title.downcase }
+      .sort_by { |page| [page.data.type || "how to", page.data.title.downcase] }
   end
 end

--- a/source/manual.html.erb
+++ b/source/manual.html.erb
@@ -27,7 +27,7 @@ title: Manual
 <% manual.manual_pages_grouped_by_section.each do |section_name, pages| %>
   <h2 id='<%= section_name.parameterize %>'><%= section_name %></h2>
 
-  <% pages.sort_by { |page| page.data.type || 'how to' }.group_by { |page| page.data.type }.each do |type, pages| %>
+  <% pages.group_by { |page| page.data.type }.each do |type, pages| %>
     <h3><%= type == "learn" ? "Learn" : "How to..." %></h3>
     <ul>
       <% pages.each do |page| %>

--- a/spec/app/manual_spec.rb
+++ b/spec/app/manual_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Manual do
   describe "#manual_pages_grouped_by_section" do
     it "returns the correct groups" do
       sitemap = double(resources: [
-        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo")),
-        double(path: "manual/foo.html", data: double(title: "Foo", important: true, review_by: Date.today, section: "Foo")),
-        double(path: "manual/bar.html", data: double(title: "Bar", important: true, review_by: Date.today, section: "Bar")),
+        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo", type: nil)),
+        double(path: "manual/foo.html", data: double(title: "Foo", important: true, review_by: Date.today, section: "Foo", type: nil)),
+        double(path: "manual/bar.html", data: double(title: "Bar", important: true, review_by: Date.today, section: "Bar", type: nil)),
       ])
 
       manual_pages_grouped_by_section = Manual.new(sitemap).manual_pages_grouped_by_section
@@ -15,13 +15,13 @@ RSpec.describe Manual do
 
   describe "#other_pages_from_section" do
     it "returns the correct groups" do
-      one = double(path: "manual/foo.html", data: double(title: "Foo", important: true, section: "A section"))
-      other = double(path: "manual/bar.html", data: double(title: "Bar", important: true, section: "A section"))
+      one = double(path: "manual/foo.html", data: double(title: "Foo", important: true, section: "A section", type: nil))
+      other = double(path: "manual/bar.html", data: double(title: "Bar", important: true, section: "A section", type: nil))
 
       sitemap = double(resources: [
         one,
         other,
-        double(path: "manual/baz.html", data: double(title: "Baz", section: "B section")),
+        double(path: "manual/baz.html", data: double(title: "Baz", section: "B section", type: nil)),
       ])
 
       other_pages_from_section = Manual.new(sitemap).other_pages_from_section(one)
@@ -33,9 +33,9 @@ RSpec.describe Manual do
   describe "#pages_for_application" do
     it "returns the pages that are relevant to an application" do
       sitemap = double(resources: [
-        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo")),
-        double(path: "manual/foo.html", data: double(title: "Foo", related_applications: %w[publisher], section: "Foo")),
-        double(path: "manual/bar.html", data: double(title: "Bar", related_applications: %w[collections], section: "Bar")),
+        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo", type: nil)),
+        double(path: "manual/foo.html", data: double(title: "Foo", related_applications: %w[publisher], section: "Foo", type: nil)),
+        double(path: "manual/bar.html", data: double(title: "Bar", related_applications: %w[collections], section: "Bar", type: nil)),
       ])
 
       pages_for_application = Manual.new(sitemap).pages_for_application("publisher")


### PR DESCRIPTION
It seems Ruby's sort_by isn't a stable sort, so sorting by type loses
the sorting by title.  Fix that by sorting lexicographically.