### PR TITLE
Move "how to" docs around and fiddle with titles

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -49,6 +49,7 @@ redirects:
   /manual/gds-cli.html: /manual/access-aws-console.html
   /manual/howto-merge-a-pull-request-from-an-external-contributor.html: /manual/merge-pr.html
   /manual/howto-transition-a-site-to-govuk.html: /manual/transition-a-site.html
+  /manual/intro-to-docker-even-more.html: /manual/how-govuk-docker-works.html
   /manual/migrate-testing-from-phantomjs-to-selenium-chrome.html: /manual.html
   /manual/mirror-fallback.html: /manual/fall-back-to-mirror.html
   /manual/nagios.html: /manual.html

--- a/source/manual/access-aws-console.html.md
+++ b/source/manual/access-aws-console.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Access AWS Console
+title: Access the AWS Console
 section: AWS accounts
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/auto-scaling-groups.html.md
+++ b/source/manual/auto-scaling-groups.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#re-govuk"
-title: Auto Scaling Groups
+title: Manually resize ASGs (auto scaling groups)
 section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -3,6 +3,7 @@ owner_slack: "#govuk-developers"
 title: Brakeman
 section: Testing
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-02-15
 review_in: 12 months

--- a/source/manual/cant-connect-to-mongo.html.md
+++ b/source/manual/cant-connect-to-mongo.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: Can't connect to Mongo in VM
+title: Fix Mongo connection issues
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/content-store-times-out.html.md
+++ b/source/manual/content-store-times-out.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: Content store times out in VM
+title: Fix Content Store timeout issues
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/debug-underperforming-search.html.md
+++ b/source/manual/debug-underperforming-search.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-searchandnav"
-title: How to debug underperforming search
+title: Debug underperforming search
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/documents-are-published-but-links-arent-updated.html.md
+++ b/source/manual/documents-are-published-but-links-arent-updated.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Documents are published, but the links aren't up to date
+title: Debug published documents with incorrect links
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/email-alert-api-callback-from-notify-fails.html.md
+++ b/source/manual/email-alert-api-callback-from-notify-fails.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Email callbacks from Notify fails
+title: Manually query the status of emails
 section: Emails
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/error-reporting.html.md
+++ b/source/manual/error-reporting.html.md
@@ -4,6 +4,7 @@ title: Error reporting with Sentry
 parent: "/manual.html"
 layout: manual_layout
 section: Monitoring
+type: learn
 last_reviewed_on: 2019-11-05
 review_in: 6 months
 ---

--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: How to deal with errors
+title: Triage and handle errors
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/fetching-packages.html.md
+++ b/source/manual/fetching-packages.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: Problems provisioning and fetching packages in VM
+title: Fix package installation problems
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Government Changes
+title: Support government changes
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/how-govuk-docker-works.html.md
+++ b/source/manual/how-govuk-docker-works.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: Intro to Docker (Even More)
+title: How govuk-docker works
 section: Docker
 layout: manual_layout
 type: learn

--- a/source/manual/install-development-vm.html.md
+++ b/source/manual/install-development-vm.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: GOV.UK Development VM setup instructions
+title: Install the development VM
 description: Get started with the development VM (deprecated)
 layout: manual_layout
 section: Development VM

--- a/source/manual/load-testing.html.md.erb
+++ b/source/manual/load-testing.html.md.erb
@@ -3,6 +3,7 @@ owner_slack: "#govuk-platform-health"
 title: Load Testing
 parent: "/manual.html"
 layout: manual_layout
+type: learn
 section: Infrastructure
 last_reviewed_on: 2019-09-06
 review_in: 12 months

--- a/source/manual/nagios-nrpe-connection-failures.html.md
+++ b/source/manual/nagios-nrpe-connection-failures.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Nagios NRPE connection failures
+title: Debug Nagios NRPE connection failures
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/nagstamon.html.md
+++ b/source/manual/nagstamon.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "@christopherbaines"
-title: Nagstamon
+title: Use Nagstamon for monitoring Icinga
 section: AWS accounts
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/packer-vagrant-image-creation.html.md
+++ b/source/manual/packer-vagrant-image-creation.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Packer Vagrant Dev VM / Image Creation
+title: Use Packer for the dev VM
 section: Packaging
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/publishing-e2e-tests.html.md
+++ b/source/manual/publishing-e2e-tests.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: End to end testing publishing apps
+title: Work with the end to end publishing tests
 section: Testing
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/ram-vm.html.md
+++ b/source/manual/ram-vm.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: Not enough RAM for the VM
+title: Give the VM more RAM
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -3,6 +3,7 @@ owner_slack: "#govuk-developers"
 title: READMEs for GOV.UK applications
 section: Patterns & Style Guides
 layout: manual_layout
+type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-11-04
 review_in: 12 months

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -2,6 +2,7 @@
 owner_slack: "#govuk-developers"
 title: Screens that we have in the office
 parent: "/manual.html"
+type: learn
 layout: manual_layout
 section: Monitoring
 last_reviewed_on: 2019-04-24

--- a/source/manual/unable-to-mount-virtualbox-shared-folders.html.md
+++ b/source/manual/unable-to-mount-virtualbox-shared-folders.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-dev-tools"
-title: Unable to mount VirtualBox shared folders
+title: Fix 'unable to mount VirtualBox shared folders'
 section: Development VM
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/which-gem-to-use.html.md
+++ b/source/manual/which-gem-to-use.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Which gem to use
+title: Figure out which gem to use
 section: Patterns & Style Guides
 layout: manual_layout
 parent: "/manual.html"


### PR DESCRIPTION
This commit does a basic review of all the "how to" docs:

- is it actually a how-to?  if not, make it a "learn" doc
- is the title action-oriented?  if not, make it so

---

[Trello card](https://trello.com/c/YEPSn3cR/1371-tlc-for-dev-docs)