### PR TITLE
Adds detail about bulk document retagging

### DIFF
--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -143,7 +143,7 @@ order):
 | Column Header | Description |
 | --- | --- |
 | `Slug` | The slug of the document. |
-| `New leading organisations` | The slugs of the new leading organisations (separated by a comma). |
-| `New supporting organisations` | The slugs of the new supporting organisations (separated by a comma). |
+| `New leading organisations` | The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations. |
+| `New supporting organisations` | The slugs of the new supporting organisations (separated by a comma). These will replace any existing organisations. |
 
 [whitehall-bulk-update-organisation]: https://github.com/alphagov/whitehall/blob/917085dca58fb58dbf65c7e226ad445cc1f27bdd/lib/tasks/data_hygiene.rake#L37


### PR DESCRIPTION
Clarify that new organisations replace old ones when bulk retagging content. 

[Trello card](https://trello.com/c/Bcet3LjB/1749-add-clarification-to-docs-about-bulk-retagging-content)