### PR TITLE
Fix typo in application name

### DIFF
--- a/source/manual/restrict-paas-applications-to-gds-office-ips.html.md
+++ b/source/manual/restrict-paas-applications-to-gds-office-ips.html.md
@@ -4,7 +4,7 @@ title: Restrict PaaS applications to GDS office IPs
 parent: /manual.html
 layout: manual_layout
 section: PaaS
-last_reviewed_on: 2020-02-06
+last_reviewed_on: 2020-02-12
 review_in: 6 months
 ---
 When deploying applications to the PaaS, it is possible to limit access to the application to GDS office IPs only.
@@ -14,7 +14,7 @@ You need to create your application on the PaaS and then bind the route to the [
 To bind the route to your application to the route service, do the following:
 
 ```
-cf bind-route-service cloudapps.digital govuk-paas-office-ip-route-service --hostname APP_NAME
+cf bind-route-service cloudapps.digital govuk-paas-office-ip-router-service --hostname APP_NAME
 ```
 
 Comprehensive documentation can be found in the [PaaS tech docs](https://docs.cloud.service.gov.uk/deploying_services/route_services/#example-route-service-to-add-ip-address-authentication).


### PR DESCRIPTION
This PR fixes a typo in the application name, from `govuk-paas-office-ip-route-service` to `govuk-paas-office-ip-router-service` in the example for binding the route service to your app.