### PR TITLE
This adds a guidance how to request access to GCP 

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -18,6 +18,7 @@ These rules apply to developers in the GOV.UK programme and SREs in the TechOps 
 - Access to Production Deploy Jenkins and Staging Deploy Jenkins to deploy applications via the [GOV.UK Production GitHub team](https://github.com/orgs/alphagov/teams/gov-uk-production)
 - SSH access to production and staging servers via [govuk-puppet](https://github.com/alphagov/govuk-puppet)
 - AWS [PowerUser Access](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/production/common.tfvars) via the `role_poweruser_user_arns` role
+- [Google Cloud Platform](/manual/set-up-gcp-account.html) (GCP) access with `Storage Admin` role to manage [static mirrors](/manual/fall-back-to-mirror.html)
 - Signon "Super Admin" access in production
 
 ## When you get production access

--- a/source/manual/set-up-gcp-account.html.md
+++ b/source/manual/set-up-gcp-account.html.md
@@ -1,0 +1,20 @@
+---
+owner_slack: "#govuk-developers"
+title: Set up your GCP account
+section: AWS accounts
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2019-02-20
+review_in: 6 months
+---
+
+[Static mirrors of GOV.UK](/manual/fall-back-to-mirror.html) are hosted in storage buckets within AWS and Google Cloud Platform (GCP). You may need login to GCP to [remove an asset](/manual/howto-manually-remove-assets.html) or [emergency publish content using static mirror](manual/fall-back-to-mirror.html#emergency-publishing-using-the-static-mirror).
+
+## 1. Request GCP access
+
+Permission to Google Cloud Platform (GCP) is managed by RE GOV.UK team. Access to GCP is granted when [permanent Production access](manual/rules-for-getting-production-access.html) is approved and merged to 
+[GOV.UK user reviewer](https://github.com/alphagov/govuk-user-reviewer) repository. 
+
+To request GCP access, [raise a Zendesk ticket with Reliability Engineering](https://docs.publishing.service.gov.uk/manual/raising-issues-with-reliability-engineering.html#raising-a-zendesk-ticket-with-reliability-engineering). Include the user reviewer PR in the ticket body.
+
+You'll be notified when GCP access granted and able to login to [GCP console](https://console.cloud.google.com/) using your `@digital.cabinet-office.gov.uk` email address. 


### PR DESCRIPTION
One of static copies of GOV.UK is stored within Google Cloud Platform. This quick guide clarifies how and when GOV.UK Developers should request access.