### PR TITLE
Remove mention of copy_sanitised_whitehall_database job.

### DIFF
--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -4,7 +4,7 @@ title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-11-05
+last_reviewed_on: 2020-02-24
 review_in: 6 months
 ---
 > **Note on AWS**
@@ -33,6 +33,5 @@ The Jenkins jobs included in the sync are:
 * [Copy Attachments to Staging](https://deploy.publishing.service.gov.uk/job/Copy_Attachments_to_Staging/)
 * [Copy Data to Integration](https://deploy.publishing.service.gov.uk/job/Copy_Data_to_Integration/)
 * [Copy Attachments to Integration](https://deploy.publishing.service.gov.uk/job/Copy_Attachments_to_Integration/)
-* [Copy and Sync sanitised whitehall database](https://deploy.publishing.service.gov.uk/job/copy_sanitised_whitehall_database/) (production to integration only)
 
 See the [source code](https://github.com/alphagov/env-sync-and-backup/tree/master/jobs) of the jobs for more information about how they work.


### PR DESCRIPTION
This job is no more. It was replaced by a govuk_env_sync job in
alphagov/govuk-puppet#10163.