### PR TITLE
Review old docs 20200227

### DIFF
--- a/source/manual/alerts/cannot-ping-across-AWS-Carrenza-VPN.html.md
+++ b/source/manual/alerts/cannot-ping-across-AWS-Carrenza-VPN.html.md
@@ -1,19 +1,17 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Cannot ping across AWS-Carrenza VPN
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-06-27
-review_in: 6 months
+last_reviewed_on: 2020-02-28
+review_in: 3 months
 ---
 
 There is a VPN tunnel between AWS and Carrenza for both the Staging and
 Production environment.
 
-To check the status and obtain troubleshooting information about the VPN,
-please consult the document
-[here](https://docs.publishing.service.gov.uk/manual/vpn.html)
+You can [check the status and troubleshoot the VPN](https://docs.publishing.service.gov.uk/manual/vpn.html).
 
 If the VPN is up/active and the ping probes are failing, check the following:
 

--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -4,7 +4,7 @@ title: Low available disk space
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-07-02
+last_reviewed_on: 2020-02-28
 review_in: 6 months
 ---
 

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -5,7 +5,7 @@ layout: manual_layout
 parent: "/manual.html"
 section: Logging
 important: true
-last_reviewed_on: 2019-02-27
+last_reviewed_on: 2020-02-28
 review_in: 6 months
 ---
 All logs for GOV.UK on all environments are collected in Kibana, which you can

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -1,12 +1,12 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#re-govuk"
 title: GOV.UK and Virtual Private Networks (VPNs)
 section: Infrastructure
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-07-20
-review_in: 6 months
+last_reviewed_on: 2020-02-28
+review_in: 3 months
 ---
 
 GOV.UK uses several VPNs to connect environments. This page explains what they


### PR DESCRIPTION
Kibana docs were reviewed in faac40d but the wrong date was entered. 🙈

Review some VPN alert and troubleshooting docs. Update the review date. Set owner to be re-govuk. Set review timeline to be 3 months because we are actively migrating things so these might become obsolete sooner than 6 months.

Review low available disk space.