### PR TITLE
Update mongodb backups doc

### DIFF
--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -34,9 +34,11 @@ The timings are defined by parameters [set in the manifest](https://github.com/a
 These backups are encrypted using GPG, but the functionality is similar to mongodump.
 
 ### Restoring
-Use the `/usr/local/bin/mongodb-restore-s3` script available on the MongoDB machine cluster. 
+Use the `/usr/local/bin/mongodb-restore-s3` script available on MongoDB machines which have S3 backup enabled. 
 
 This script grabs the latest backup from the S3 bucket, decrypts and unpacks it, and does a `mongo restore`.
+
+Machines which have enabled S3 backups and contain the script will have `mongodb::backup::s3_backups` set to `true` in the yaml configuration (see [`govuk-puppet`](https://github.com/alphagov/govuk-puppet)).
 
 ### mongodumps via `govuk_env_sync` in AWS
 

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -5,37 +5,43 @@ layout: manual_layout
 parent: "/manual.html"
 section: Backups
 type: learn
-last_reviewed_on: 2019-08-06
+last_reviewed_on: 2020-03-02
 review_in: 6 months
 ---
 
-We have 2 ways of taking MongoDB backups.
+There are two ways of taking MongoDB backups.
 
 ## automongodbbackup
 
-This is how MongoDB backups have traditionally been taken on the GOV.UK
-Infrastructure.
+This is how MongoDB backups have traditionally been taken on the GOV.UK Infrastructure.
 
-A third-party script called [automongodbbackup](https://github.com/micahwedemeyer/automongobackup) takes a `mongodump` every night and stores them on disk
-on a dedicated mount point on one of the MongoDB machines. This is likely [the first in the replicaset as defined in the Puppet manifest](https://github.com/alphagov/govuk-puppet/blob/master/modules/mongodb/manifests/backup.pp#L40-L44).
+A third-party script, [automongodbbackup](https://github.com/micahwedemeyer/automongobackup), takes a nightly `mongodump` and stores it on one of the MongoDB machines' dedicated mount points (likely [the first machine in the replicaset as defined in the Puppet manifest](https://github.com/alphagov/govuk-puppet/blob/master/modules/mongodb/manifests/backup.pp#L40-L44)).
 
-The onsite backup machine (backup-1.management) pulls the latest backup and stores it on disk. [Duplicity](http://duplicity.nongnu.org/)
-runs each night to send encrypted backups to an Amazon S3 bucket.
+The on-site backup machine (`backup-1.management`) pulls the latest backup and stores it on disk. [Duplicity](http://duplicity.nongnu.org/) runs nightly and sends encrypted backups to an AWS S3 bucket.
 
-To restore from this method:
+### Restoring
 
- - Fetch a backup from either the dedicated mount point, the onsite machine or the S3 bucket [using duplicity](restore-from-offsite-backups.html) (to decrypt you may need a password kept in the encrypted hieradata.
+ - Fetch a backup from either the dedicated mount point, the on-site machine, or the S3 bucket [using Duplicity](restore-from-offsite-backups.html) (you may need a password kept in the encrypted [hieradata](https://github.com/alphagov/govuk-secrets)).
  - Unzip the file. This will produce a directory of data.
- - `mongo restore --drop <directory>`
+ - Run the command: `mongo restore --drop <directory>`
 
 ## mongodumps to S3
 
-We also take backups that are sent to an Amazon S3 bucket. The timings are defined by parameters [set in the manifest](https://github.com/alphagov/govuk-puppet/blob/master/modules/mongodb/manifests/s3backup/cron.pp),
-but for important MongoDB clusters these may be taken every 15 minutes. The machines which take the backups are defined in hiera node classes.
-These backups are encrypted using GPG, but the functionality is just a straightforward mongodump.
+We also backup to an AWS S3 bucket. 
 
-To restore the very latest backup, there is a script available to use: `/usr/local/bin/mongodb-restore-s3`. The function essentially grabs the latest backup from the S3 bucket, decrypts and unpacks it, and does a `mongo restore`.
+The timings are defined by parameters [set in the manifest](https://github.com/alphagov/govuk-puppet/blob/master/modules/mongodb/manifests/s3backup/cron.pp), but for important MongoDB clusters these may be taken every 15 minutes. The machines which take the backups are defined in hiera node classes.
+
+These backups are encrypted using GPG, but the functionality is similar to mongodump.
+
+### Restoring
+Use the `/usr/local/bin/mongodb-restore-s3` script available on the MongoDB machine cluster. 
+
+This script grabs the latest backup from the S3 bucket, decrypts and unpacks it, and does a `mongo restore`.
 
 ### mongodumps via `govuk_env_sync` in AWS
 
-In AWS environments, the mongodump to S3 has been replaced by a very similar mechanism as part of the [`govuk_env_sync` environment sync][govuk-env-sync]. Here, the dump is not GPG encrypted anymore, but we rely on S3 for encryption at rest.
+In AWS environments, the mongodump to S3 has been replaced by a very similar mechanism as part of the [govuk-env-sync]. 
+
+The dump is not GPG encrypted anymore, instead we rely on S3 for encryption at rest.
+
+[govuk-env-sync]: govuk-env-sync.html

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -38,7 +38,7 @@ Use the `/usr/local/bin/mongodb-restore-s3` script available on MongoDB machines
 
 This script grabs the latest backup from the S3 bucket, decrypts and unpacks it, and does a `mongo restore`.
 
-Machines which have enabled S3 backups and contain the script will have `mongodb::backup::s3_backups` set to `true` in the yaml configuration (see [`govuk-puppet`](https://github.com/alphagov/govuk-puppet)).
+Machines which have enabled S3 backups and contain the script will have `mongodb::backup::s3_backups` set to `true` in their yaml configuration (see [`govuk-puppet`](https://github.com/alphagov/govuk-puppet)).
 
 ### mongodumps via `govuk_env_sync` in AWS
 


### PR DESCRIPTION
* Tighten language
* Fix broken link to another manual page
* Create "Restoring" sections to focus reader on relevant content
* Add a way for readers to ascertain which machines have enabled S3 backups and thus also contain the `mongodb-restore-s3` script.
* Replace Amazon with AWS for precision

I have tested the page locally and it looks OK.