### PR TITLE
Add how to block pages showing global banner

### DIFF
--- a/source/manual/global-banner.html.md
+++ b/source/manual/global-banner.html.md
@@ -30,6 +30,10 @@ The usual rules apply with static template caching.
 
 ![screenshot](images/global_banner.png)
 
+## Add the target page to blocklist
+
+The target page linked to from the banner will automatically hide the banner. Add any other pages that don't need to show the banner to the `urlBlockList` in `app/assets/javascripts/global-bar-init.js`.
+
 ### Versioning the global banner
 
 The number of times a user has viewed the banner is stored in a `global_bar_seen` cookie. Once the view count reaches 3, a user will not see the cookie again, even if the banner is re-deployed. The only way a user will see the banner again is if 1) the `global_bar_seen` cookie expires or 2) the global banner is versioned.


### PR DESCRIPTION
We recently deployed a new non-emergency global banner, but didn't know to block the page from certain pages. This info is now part of the doc.