### PR TITLE
Centralise alert docs for data sync

### DIFF
--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -4,9 +4,39 @@ title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-02-24
+last_reviewed_on: 2020-03-05
 review_in: 6 months
 ---
+
+## govuk_env_sync (the new way)
+
+If you get an Icinga alert about a failing task, check `/var/log/syslog` and `/var/log/syslog.1` on the machine which runs the job. If the logs don't help, you can try re-running the sync job.
+
+The data sync operations are executed as cron-jobs attached to the `govuk-backup` user. Run the following commands to get an overview of the jobs being run on a machine.
+
+```bash
+$ sudo su - govuk-backup
+$ crontab -l
+
+# Puppet Name: pull_content_data_admin_production_daily
+18 0 * * * /usr/bin/ionice -c 2 -n 6 /usr/local/bin/with_reboot_lock /usr/bin/envdir /etc/govuk_env_sync/env.d /usr/local/bin/govuk_env_sync.sh -f /etc/govuk_env_sync/pull_content_data_admin_production_daily.cfg
+...
+
+```
+
+The cron job command does the following:
+
+1. Runs the data sync job at low I/O priority:
+`/usr/bin/ionice -c 2 -n 6`. This only really matters when running on a database server, as opposed to a `db_admin` bastion host, but the command is the same in both cases.
+2. Prevents reboot by `unattended-upgrades` while the sync job is running:
+`/usr/local/bin/with_reboot_lock`
+3. Runs the data sync job with the appropriate configuration file:
+`/usr/local/bin/govuk_env_sync.sh -f /etc/govuk_env_sync/pull_content_data_admin_production_daily.cfg`
+
+To re-run a given sync job, copy the part of the cron-job corresponding to (3) and examine the output for any errors. For more information, check the general manual for [govuk_env_sync](/manual/govuk-env-sync.html).
+
+## env-sync-and-backup (the old way)
+
 > **Note on AWS**
 >
 > For databases migrated to AWS RDS, the env-sync-and-backup was replaced by the [govuk_env_sync](/manual/govuk-env-sync.html).


### PR DESCRIPTION
Previously the docs to support alerts for env-sync-and-backup were
mixed with the general documentation about the tool. The section about
the Icinga alert also didn't cover all the steps necessary to fix an
issue. This moves the parts of the general manual on env-sync-and-backup
to the existing docs for data-sync alerts, and modifies the text to
provide a clearer sequence of steps for 2ndline to follow.

Follow up work: modify Puppet to point env-sync-and-backup alerts to
the existing data-sync alert doc, instead of the general manual.