### PR TITLE
Add link to moved info about govuk_env_sync.

### DIFF
--- a/source/manual/govuk-env-sync.html.md
+++ b/source/manual/govuk-env-sync.html.md
@@ -117,6 +117,10 @@ path="postgresql-backend"
 ### Lock
 The govuk_env_sync cron jobs prevent automated reboots by `unattended-upgrades` by running under `/usr/local/bin/with_reboot_lock`, which creates the file `/etc/unattended-reboot/no-reboot/govuk_env_sync` and removes it when the process exits.
 
+### Cron jobs and Icinga checks
+
+See [data sync playbook](alerts/data-sync.html#govuk_env_sync-the-new-way).
+
 > **Traffic replay using [Gor](alerts/gor.html) is disabled between 23:00 and
 > 05:45 daily whilst the data sync pull jobs take place. This is to prevent
 > lots of errors while we are dropping databases.**


### PR DESCRIPTION
The sections about govuk_env_sync cron jobs and Icinga checks were moved to a playbook page in #2368. Add a link so that the information is still discoverable from the govuk_env_sync documentation.