### PR TITLE
Move infra-heavy manual to RE GOV.UK to monitor

### DIFF
--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline"
+owner_slack: "#re-govuk"
 title: Fall back to AWS CloudFront
 section: Deployment
 layout: manual_layout


### PR DESCRIPTION
https://trello.com/c/h2vhDRVZ/826-review-pages-that-have-been-due-for-review-for-30-days-or-more

This manual looks heavily reliant on intervention by RE if we were
ever to make use of it, not least because it says the level of access
required means most people can't run it themselves. It's also missing
a lot of detail about the individual steps involved.