### PR TITLE
Document new RuboCop `inherit_mode` config option

### DIFF
--- a/source/manual/migrate-from-govuk-lint.html.md
+++ b/source/manual/migrate-from-govuk-lint.html.md
@@ -38,6 +38,13 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml # add this line for Rails projects
+
+# If RuboCop finds any more Excludes: directives in rails.yml or in
+# the app's `.rubocop.yml`, merge them with the original ones instead of
+# overwriting.
+inherit_mode:
+  merge:
+    - Exclude
 ```
 
 - Replace usage of `govuk-lint-ruby` with `rubocop` in your project.


### PR DESCRIPTION
- These docs are somewhat irrelevant now as nothing is using
  govuk-lint, but they're a good central place to see what RuboCop
  config apps _should_ be using based on the `rubocop-govuk` gem.
- We found that for apps that used Ruby-only cops, the recent changes in
  gem version 3.1.0 to exclude `bin/` files from linting worked fine.
- For apps that used Rails cops as well, the changes didn't work for
  `bin/` but they did work for `db/schema.rb` which is excluded from
  linting in `config/rails.yml`.
- This is because RuboCop by default *overwrites* any previous
  definitions of a config option when it detects a later one:
  https://rubocop.readthedocs.io/en/latest/configuration/#merging-arrays-using-inherit_mode.
- Unfortunately, we'll have to specify this `inherit_mode` stanza in
  every app.

https://trello.com/c/i72oq9Xa/1810-fix-rubocop-config-file-inheritance-in-all-the-apps