### PR TITLE
Review a few more overdue developer docs

### DIFF
--- a/source/manual/alerts/nginx-429-too-many-requests.html.md
+++ b/source/manual/alerts/nginx-429-too-many-requests.html.md
@@ -4,7 +4,7 @@ title: Nginx 429 too many requests
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-07-30
+last_reviewed_on: 2020-03-10
 review_in: 6 months
 ---
 

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -5,8 +5,8 @@ parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
 type: learn
-last_reviewed_on: 2019-10-23
-review_in: 3 months
+last_reviewed_on: 2020-03-10
+review_in: 12 months
 ---
 
 These rules apply to developers in the GOV.UK programme and SREs in the TechOps programme.


### PR DESCRIPTION
https://trello.com/c/h2vhDRVZ/826-review-pages-that-have-been-due-for-review-for-30-days-or-more

This increases the review period for production access rules to one
year, as it seems unlikely the process will change without this manual
being changed also. It's unclear why it was 3 months in the first place.