### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,8 @@
 require "govuk_tech_docs"
+require "rspec/core/rake_task"
 require_relative "./app/requires"
 
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-rescue LoadError
-end
+RSpec::Core::RakeTask.new(:spec)
 
 task default: [:spec]
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
-require 'govuk_tech_docs'
-require_relative './app/requires'
+require "govuk_tech_docs"
+require_relative "./app/requires"
 
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
 end
@@ -17,14 +17,14 @@ end
 
 namespace :assets do
   task :precompile do
-    sh 'git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build'
+    sh "git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build"
   end
 end
 
 desc "Find deployable applications that are not in this repo"
 task :verify_deployable_apps do
   common_yaml = HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml")
-  deployable_applications = common_yaml["deployable_applications"].map { |k, v| v['repository'] || k }
+  deployable_applications = common_yaml["deployable_applications"].map { |k, v| v["repository"] || k }
   our_applications = AppDocs.pages.map(&:github_repo_name)
 
   intentionally_missing =

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,5 @@
-require 'govuk_tech_docs'
-require_relative './app/requires'
+require "govuk_tech_docs"
+require_relative "./app/requires"
 
 GovukTechDocs.configure(self)
 
@@ -21,7 +21,7 @@ end
 # Configure the sitemap for Google
 set :url_root, config[:tech_docs][:host]
 activate :search_engine_sitemap,
-  default_change_frequency: 'weekly'
+         default_change_frequency: "weekly"
 
 helpers do
   def dashboard
@@ -53,11 +53,11 @@ helpers do
   end
 
   def page_title
-    (defined?(locals) && locals[:title]) || [current_page.data.title, current_page.data.section].compact.join(' - ')
+    (defined?(locals) && locals[:title]) || [current_page.data.title, current_page.data.section].compact.join(" - ")
   end
 end
 
-ignore 'templates/*'
+ignore "templates/*"
 
 PublishingApiDocs.pages.each do |page|
   proxy "/apis/publishing-api/#{page.filename}.html", "templates/publishing_api_template.html", locals: {

--- a/config.ru
+++ b/config.ru
@@ -1,18 +1,18 @@
 # For hosting on Heroku
-require 'rack'
-require 'rack/contrib/try_static'
+require "rack"
+require "rack/contrib/try_static"
 
 # "restrict" access for now
 use Rack::Auth::Basic, "Restricted Area" do |username, password|
-  [username, password] == [ENV['AUTH_USERNAME'], ENV['AUTH_PASSWORD']]
+  [username, password] == [ENV["AUTH_USERNAME"], ENV["AUTH_PASSWORD"]]
 end
 
 # Serve files from the build directory
 use Rack::TryStatic,
-  root: 'build',
-  urls: %w[/],
-  try: ['.html', 'index.html', '/index.html']
+    root: "build",
+    urls: %w[/],
+    try: [".html", "index.html", "/index.html"]
 
 run lambda { |_env|
-  [404, { 'Content-Type' => 'text/html' }, ["404 Not Found"]]
+  [404, { "Content-Type" => "text/html" }, ["404 Not Found"]]
 }


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.