### PR TITLE
Get rid of some small sections

### DIFF
--- a/source/manual/access-aws-console.html.md
+++ b/source/manual/access-aws-console.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Access the AWS Console
-section: AWS accounts
+section: AWS
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-11-08

--- a/source/manual/analytics.html.md
+++ b/source/manual/analytics.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-frontenders"
 title: 'Analytics on GOV.UK'
-section: Analytics
+section: Frontend
 layout: manual_layout
 type: learn
 parent: "/manual.html"

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#re-govuk"
 title: Domain Name System (DNS) records
-section: DNS
+section: Infrastructure
 type: learn
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/govuk-in-aws.html.md
+++ b/source/manual/govuk-in-aws.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#re-govuk"
 title: Migration to AWS
-section: Infrastructure
+section: AWS
 layout: manual_layout
 type: learn
 parent: "/manual.html"

--- a/source/manual/howto-ssh-to-machines-in-aws.html.md
+++ b/source/manual/howto-ssh-to-machines-in-aws.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: SSH into AWS machines
-section: AWS accounts
+section: AWS
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-10

--- a/source/manual/nagstamon.html.md
+++ b/source/manual/nagstamon.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "@christopherbaines"
 title: Use Nagstamon for monitoring Icinga
-section: AWS accounts
+section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-14

--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: READMEs for GOV.UK applications
-section: Patterns & Style Guides
+section: Documentation
 layout: manual_layout
 type: learn
 parent: "/manual.html"

--- a/source/manual/set-up-aws-account.html.md
+++ b/source/manual/set-up-aws-account.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Set up your AWS account
-section: AWS accounts
+section: AWS
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-09-24

--- a/source/manual/set-up-gcp-account.html.md
+++ b/source/manual/set-up-gcp-account.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Set up your GCP account
-section: AWS accounts
+section: AWS
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-26

--- a/source/manual/which-gem-to-use.html.md
+++ b/source/manual/which-gem-to-use.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Figure out which gem to use
-section: Patterns & Style Guides
+section: Dependencies
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-07-10


### PR DESCRIPTION
We have a bunch of sections with only one or two docs in, where I'm not convinced the granularity is worth it.  This PR shuffles some things around to reduce that:

- Analytics -> Frontend
- AWS accounts -> AWS
- DNS -> Infrastructure
- Patterns & Style Guides -> Documentation / Dependencies