### PR TITLE
Exclude tmp directory from rubocopping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,4 @@ Style/ClassVars:
 AllCops:
   Exclude:
     - 'vendor/**/*'
+    - 'tmp/**/*'


### PR DESCRIPTION
This is causing the build to fail due to linter errors in govuk-content-schemas (which may or may not need to be ignored anyway)