### PR TITLE
Add a page about Subject Access Requests (SAR)

### DIFF
--- a/source/manual/subject-access-requests.html.md
+++ b/source/manual/subject-access-requests.html.md
@@ -1,0 +1,35 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Subject Access Requests
+parent: "/manual.html"
+layout: manual_layout
+section: 2nd line
+last_reviewed_on: 2020-03-18
+review_in: 6 months
+related_applications: [email-alert-api]
+---
+
+Subject Access Requests (often referred to as a 'SAR') allow members of the
+public to get information being held about them by an organisation.
+
+2nd line might be needed to answer some of the questions in the request, and
+this will usually come in through the form of a Zendesk ticket. Once 2nd line
+has found the necessary information, the request might need to be passed to
+another team to fully complete the request, for example, Licensing.
+
+## Known requests
+
+So far we've received requests that have asked for information on:
+
+### Email subscriptions
+
+We've had requests to get information on what is held about an email address
+in terms of subscriptions. We have [some documented queries that can help get
+this][email-alert-api-analytics].
+
+[email-alert-api-analytics]: /manual/email-alert-api-analytics.html
+
+### Others
+
+If any other information is requested, we should update this documentation so
+they become easier to deal with in the future.


### PR DESCRIPTION
2nd line are frequently getting these requests and it's not always clear what needs to be done. This page adds a bit of background into what they are and what needs to be done about them.

[Trello Card](https://trello.com/c/PqRTfvcB/1840-3-document-actions-needed-for-subject-access-requests-sar)