### PR TITLE
Fix broken integration rake task links

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -219,7 +219,11 @@ class AppDocs
 
       case production_hosted_on
       when "aws"
-        "https://deploy.blue.#{environment}.govuk.digital/job/run-rake-task/parambuild/#{query_params}"
+        if environment == "integration"
+          "https://deploy.#{environment}.publishing.service.gov.uk/job/run-rake-task/parambuild/#{query_params}"
+        else
+          "https://deploy.blue.#{environment}.govuk.digital/job/run-rake-task/parambuild/#{query_params}"
+        end
       when "carrenza"
         environment_prefix = environment == "production" ? "" : ".#{environment}"
         "https://deploy#{environment_prefix}.publishing.service.gov.uk/job/run-rake-task/parambuild/#{query_params}"

--- a/spec/app/app_docs_spec.rb
+++ b/spec/app/app_docs_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe AppDocs::App do
       let(:production_hosted_on) { "aws" }
       let(:environment) { "integration" }
 
-      it { is_expected.to eql("https://deploy.blue.integration.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=") }
+      it { is_expected.to eql("https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=") }
 
       describe "with a Rake task" do
         let(:rake_task) { "task" }
-        it { is_expected.to eql("https://deploy.blue.integration.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=task") }
+        it { is_expected.to eql("https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=task") }
       end
     end
 

--- a/spec/app/run_rake_task_spec.rb
+++ b/spec/app/run_rake_task_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RunRakeTask do
       end
 
       it "has three links" do
-        expect(html).to have_link("Run publishing_api:republish on Integration", href: "https://deploy.blue.integration.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
+        expect(html).to have_link("Run publishing_api:republish on Integration", href: "https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
         expect(html).to have_link("Run publishing_api:republish on Staging", href: "https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
         expect(html).to have_link("Run publishing_api:republish on Production", href: "https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
       end


### PR DESCRIPTION
Rake task links in the  method no longer take you to the correct url.  Staging and Production are correct.  Add test for the integration environment and change as appropriate.