### PR TITLE
Add coronavirus apps to the dev docs

### DIFF
--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -150,9 +150,13 @@ class AppDocs
     end
 
     def deploy_url
-      return if app_data["deploy_url"] == false || production_hosted_on.in?(%w[paas heroku])
+      return if app_data["deploy_url"] == false || production_hosted_on == "heroku"
 
-      "https://github.com/alphagov/govuk-app-deployment/blob/master/#{github_repo_name}/config/deploy.rb"
+      if production_hosted_on == "paas"
+        app_data["deploy_url"]
+      else
+        "https://github.com/alphagov/govuk-app-deployment/blob/master/#{github_repo_name}/config/deploy.rb"
+      end
     end
 
     def dashboard_url

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -659,6 +659,28 @@
   dashboard_url: false
   description: 'GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)'
 
+# Coronavirus
+
+- github_repo_name: govuk-coronavirus-vulnerable-people-form
+  private_repo: false
+  type: Specialist apps
+  production_hosted_on: paas
+  team: "#govuk-vulnerable-people-tech"
+  sentry_url: false # TODO - can the reviewer let me know what this should be?
+  deploy_url: 'https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/blob/master/concourse/pipeline.yml'
+  dashboard_url: 'https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/d006_coronavirus?form.main.earliest=-7d%40h&form.main.latest=now&form.xhost=coronavirus-vulnerable-people.service.gov.uk'
+  description: 'Helps citizens get support during the Covid-19 pandemic'
+
+- github_repo_name: govuk-coronavirus-business-volunteer-form
+  private_repo: false
+  type: Specialist apps
+  production_hosted_on: paas
+  team: "#govuk-corona-forms-tech"
+  sentry_url: false # TODO - can the reviewer let me know what this should be?
+  deploy_url: 'https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/blob/master/concourse/pipeline.yml'
+  dashboard_url: false
+  description: 'Lets businesses volunteer with the response to the Covid-19 pandemic'
+
 # Utility Heroku apps (don't add apps that are only for review here)
 
 - github_repo_name: seal

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -676,7 +676,7 @@
   type: Specialist apps
   production_hosted_on: paas
   team: "#govuk-corona-forms-tech"
-  sentry_url: false https://sentry.io/organizations/govuk/issues/?project=5170680
+  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5172100
   deploy_url: 'https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/blob/master/concourse/pipeline.yml'
   dashboard_url: false
   description: 'Lets businesses volunteer with the response to the Covid-19 pandemic'

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -666,7 +666,7 @@
   type: Specialist apps
   production_hosted_on: paas
   team: "#govuk-vulnerable-people-tech"
-  sentry_url: false # TODO - can the reviewer let me know what this should be?
+  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5170680
   deploy_url: 'https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/blob/master/concourse/pipeline.yml'
   dashboard_url: 'https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/d006_coronavirus?form.main.earliest=-7d%40h&form.main.latest=now&form.xhost=coronavirus-vulnerable-people.service.gov.uk'
   description: 'Helps citizens get support during the Covid-19 pandemic'
@@ -676,7 +676,7 @@
   type: Specialist apps
   production_hosted_on: paas
   team: "#govuk-corona-forms-tech"
-  sentry_url: false # TODO - can the reviewer let me know what this should be?
+  sentry_url: false https://sentry.io/organizations/govuk/issues/?project=5170680
   deploy_url: 'https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/blob/master/concourse/pipeline.yml'
   dashboard_url: false
   description: 'Lets businesses volunteer with the response to the Covid-19 pandemic'

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -8,6 +8,7 @@
     - name: Frontend apps
     - name: data.gov.uk apps
     - name: Licensing apps
+    - name: Specialist apps
 
 - name: Developing
   sections:


### PR DESCRIPTION
Apparently nothing else that's deployed to paas has a deployment script,
but these apps do (well, a concourse pipeline) so I had to patch the
code to work for them.