### PR TITLE
get-started: Link from "set up gds-cli" back to "install gds-cli"

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -247,7 +247,7 @@ or `govuk-internal-administrators` group needs to deploy the
 
 ### First run
 
-Here, you will use the GDS CLI you installed and set up earlier. You'll be asked for AWS credentials on the first run:
+Here, you will use the GDS CLI you [installed and set up earlier](#3-install-gds-tooling). You'll be asked for AWS credentials on the first run:
 
 ```shell
 $ gds aws govuk-integration-poweruser -l


### PR DESCRIPTION
- These are quite far apart and now we just say "earlier". For people
  coming to these docs from other docs, this gives an entry point if
  they don't know what the GDS CLI is.