### PR TITLE
Fix links leading to 404 pages

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -92,8 +92,7 @@ class ExternalDoc
 
         href = element["href"].strip
         uri = URI.parse(href)
-
-        if uri.path.end_with?(".md")
+        if uri.path.end_with?(".md") && uri.host == nil
           uri.path.sub!(/.md$/, ".html")
           element["href"] = uri.to_s
         end

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe ExternalDoc do
       expect(html).to have_link("turpis ultrices", href: "/ultrices.html")
     end
 
+    it "does not rewrite links to markdown pages with a host" do
+      expect(html).to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.md")
+      expect(html).not_to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.html")
+    end
+
     it "rewrites relative images" do
       expect(html).to have_css('img[src="https://raw.githubusercontent.com/example/lipsum/master/suspendisse_iaculis.png"]')
     end

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -5,6 +5,7 @@
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam efficitur lacus in
 neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
 [turpis ultrices](/ultrices.md), imperdiet eros ut, [tincidunt leo].
+[Nam eget dui](https://nam.com/eget/dui/uploading.md)
 
 ## Suspendisse iaculis
 


### PR DESCRIPTION
When linking to documentation written in markdown on github we were replacing the `.md` extension with `.html`, however this was linking incorrectly and returning 404 errors. Here we change the behaviour to only modify links pointing internally and not to modify links pointing to external github repos.