### PR TITLE
Remove forward slash prefixing path

### DIFF
--- a/app/publishing_api_docs.rb
+++ b/app/publishing_api_docs.rb
@@ -23,7 +23,7 @@ class PublishingApiDocs
     end
 
     def path
-      "/doc/#{filename}.md"
+      "doc/#{filename}.md"
     end
 
     def repository


### PR DESCRIPTION
The forward slash prefixing the path in the PublishingApiDocs class is
superfluous as when it's resolved to a url there are two forward slashes
prefixing the path. This was causing a 301 moved permanently to be
returned and not the actual page for the document.

An example of the two requests are below:

```
[11] pry(ExternalDoc)> HTTP.get("https://raw.githubusercontent.com/alphagov/publishing-api/master//doc/api.md")
=> "<a href=\"/alphagov/publishing-api/master/doc/api.md\">Moved Permanently</a>.\n\n"
[12] pry(ExternalDoc)> HTTP.get("https://raw.githubusercontent.com/alphagov/publishing-api/master/doc/api.md")
=> "# Publishing API's API\n\nThis is the primary interface from publishing apps to the publishing pipeline....
```

We're unsure as to what caused the issue to surface as there has been
multiple slashes in the url for the last 3 years. Another weirdity on
top of that is the redirect HTTP.get returns isn't even the correct
redirect as to what an actual browser follows...

This issue was causing all deploy builds to fail for the last 7 days for
govuk-developer-docs through a cryptic error message of `undefined
method 'unlink' for nil:NilClass.`. This was because unlink was being
called on the first HTML header of the response which previously
didn't include a header so resolved to nil ->
https://deploy.publishing.service.gov.uk/job/deploy-developer-docs/1791/

co-authored: @beccapearce 

Trello:
https://trello.com/c/YJqZN7mM/1893-fix-error-in-adding-heading-in-developer-docs