### PR TITLE
Switch responsibility for more apps to Platform Health

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -3,7 +3,7 @@
 - github_repo_name: collections-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pubworkflow-dev"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: carrenza
   dependencies:
     publishing-api:
@@ -53,7 +53,7 @@
   - Publisher
 - github_repo_name: content-publisher
   type: Publishing apps
-  team: "#govuk-pubworkflow-dev"
+  team: "#govuk-platform-health"
   production_hosted_on: carrenza
   dependencies:
     content-publisher:
@@ -82,7 +82,7 @@
 - github_repo_name: manuals-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: carrenza
   dependencies:
     router:
@@ -140,7 +140,7 @@
 - github_repo_name: service-manual-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: carrenza
   dependencies:
     service-manual-frontend:
@@ -156,12 +156,12 @@
 - github_repo_name: short-url-manager
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: carrenza
 - github_repo_name: specialist-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: carrenza
   dependencies:
     support:
@@ -199,7 +199,7 @@
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pubworkflow-dev"
+  dependencies_team: "#govuk-platform-health"
   api_docs_url: "/apis/whitehall.html"
   production_hosted_on: aws
   dependencies:
@@ -238,7 +238,7 @@
 - github_repo_name: content-store
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pubworkflow-dev"
+  dependencies_team: "#govuk-platform-health"
   api_docs_url: "/apis/content-store.html"
   production_hosted_on: aws
   dependencies:
@@ -274,7 +274,7 @@
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pubworkflow-dev"
+  dependencies_team: "#govuk-platform-health"
   api_docs_url: "/apis/publishing-api.html"
   production_hosted_on: aws
   dependencies:
@@ -284,7 +284,7 @@
       description: ''
 - github_repo_name: search-api
   type: APIs
-  team: "#govuk-searchandnav"
+  team: "#govuk-platform-health"
   api_docs_url: /apis/search-api.html
   production_hosted_on: aws
   dependencies:
@@ -295,7 +295,7 @@
 - github_repo_name: asset-manager
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pubworkflow-dev"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     signon:
@@ -305,7 +305,7 @@
 - github_repo_name: router-api
   type: APIs
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies: {}
 - github_repo_name: support-api
@@ -359,7 +359,7 @@
       description: ''
 - github_repo_name: search-analytics
   type: Services
-  team: "#govuk-searchandnav"
+  team: "#govuk-platform-health"
   production_hosted_on: carrenza
 
 # Support
@@ -381,7 +381,7 @@
       description: ''
 - github_repo_name: search-admin
   type: Supporting apps
-  team: "#govuk-searchandnav"
+  team: "#govuk-platform-health"
   production_hosted_on: carrenza
 - github_repo_name: signon
   type: Supporting apps
@@ -404,7 +404,7 @@
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-pubworkflow-dev"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: release
   type: Supporting apps
@@ -479,7 +479,7 @@
       description: ''
 - github_repo_name: finder-frontend
   type: Frontend apps
-  team: "#govuk-searchandnav"
+  team: "#govuk-platform-health"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
   dependencies:
@@ -494,7 +494,7 @@
 - github_repo_name: frontend
   type: Frontend apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     search-api:
@@ -514,7 +514,7 @@
 - github_repo_name: government-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
   dependencies:
@@ -525,7 +525,7 @@
 - github_repo_name: info-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     static:
@@ -534,7 +534,7 @@
   type: Frontend apps
   puppet_name: licencefinder
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     content-store:
@@ -546,7 +546,7 @@
 - github_repo_name: manuals-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     content-store:
@@ -571,7 +571,7 @@
       description: ''
 - github_repo_name: service-manual-frontend
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   type: Frontend apps
   production_hosted_on: aws
   dependencies:
@@ -582,7 +582,7 @@
 - github_repo_name: static
   type: Frontend apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-searchandnav"
+  dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     static:
@@ -748,7 +748,7 @@
   dashboard_url: false
 - github_repo_name: search-performance-explorer
   production_hosted_on: heroku
-  team: "#govuk-searchandnav"
+  team: "#govuk-platform-health"
   type: Utilities
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
This moves application ownership and responsibility for dependabot PRs to the Platform Health team, given changes to other teams.

[Trello card](https://trello.com/c/uQQqNanN/1906-change-dependabot-responsibility-for-some-apps)