### PR TITLE
Replace all occurrences of `govukcli ssh` with `gds govuk connect ssh`

### DIFF
--- a/source/manual/change-base-path-in-specialist-publisher.html.md
+++ b/source/manual/change-base-path-in-specialist-publisher.html.md
@@ -21,8 +21,7 @@ if necessary). For the change to be permanent, you need to publish the draft, wh
 either do in the Specialist Publisher UI or by using the CLI:
 
 ```sh
-local$      govukcli set-context production
-local$      govukcli ssh backend
+local$      gds govuk connect -e production ssh backend
 
 production$ govuk_app_console specialist-publisher
 

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -14,7 +14,7 @@ is shown a 'Gone' page, follow these instructions:
 ## Connect to a router-backend machine
 
 ```bash
-$ govukcli ssh --context production router_backend
+gds govuk connect -e production ssh router_backend
 ```
 
 ## Check the router API for a `gone` route

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -332,7 +332,7 @@ ID and name of the harvest source.
 
 If the harvest job is hanging and the 'Stop' button is not responding, you will have to log on to the `ckan` machine to restart it:
 
-1. Log on to `ckan` machine using `govukcli`.
+1. SSH into the ckan machine with `gds govuk connect -e production ssh ckan`
 1. Assume the deploy user - `sudo su deploy`
 1. Activate the virtual environment - `. /var/apps/ckan/venv/bin/activate`
 1. Run the harvest job manually - `paster --plugin=ckanext-harvest harvester run_test <harvest source> -c /var/ckan/ckan.ini`
@@ -385,11 +385,7 @@ You can check whether the process is still running by checking if entries are
 still being written to the log file on the `ckan` machine:
 
 ```bash
-$ govukcli set-context production-aws
-$ govukcli ssh ckan
-```
-
-```bash
+$ gds govuk connect -e production ssh ckan
 $ sudo tail -f /var/log/ckan/procfile_harvester_fetch_consumer.err.log
 ```
 

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -20,8 +20,7 @@ If there's a need to edit a route in the database:
 1. Connect to a router-backend machine
 
 ```console
-govukcli set-context production-aws
-govukcli ssh router_backend
+gds govuk connect -e production ssh aws/router_backend
 ```
 
 2. Connect to router-api and get the route

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -118,14 +118,8 @@ In this scenario, Jenkins security should be disabled to enable deployment:
 1. SSH to the Jenkins deploy instance:
 
 ```console
-ssh jenkins-1.<environment>
-```
-
-in Carrenza, and
-
-```console
-govukcli set-context <environment>
-govukcli ssh jenkins
+gds govuk connect -e production ssh carrenza/jenkins
+gds govuk connect -e production ssh aws/jenkins
 ```
 
 in AWS.

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -57,8 +57,7 @@ the previous version of the software.
 1.  Upload the new files:
 
       ```shell
-      govukcli set-context production-aws
-      govukcli ssh backend
+      gds govuk connect -e production ssh aws/backend
       "mkdir -p /tmp/hmrc-paye && rm -rf /tmp/hmrc-paye/*"
       ```
 
@@ -70,8 +69,7 @@ the previous version of the software.
 1.  Load the files into the Asset Manager, with "test-" at the start of the manifest file's name:
 
       ```shell
-      govukcli set-context production-aws
-      govukcli ssh backend
+      gds govuk connect -e production ssh aws/backend
       cd /var/apps/asset-manager
       sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_zips[/tmp/hmrc-paye]
       sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_asset[/tmp/hmrc-paye/realtimepayetools-update-vXX.xml,test-realtimepayetools-update-vXX.xml]
@@ -94,8 +92,7 @@ the previous version of the software.
     ticket), re-load the test file to the production path:
 
       ```shell
-      govukcli set-context production-aws
-      govukcli ssh backend
+      gds govuk connect -e production ssh aws/backend
       cd /var/apps/asset-manager
       sudo -udeploy govuk_setenv asset-manager bundle exec rake govuk_assets:create_hmrc_paye_asset[/tmp/hmrc-paye/realtimepayetools-update-vXX.xml]
       ```

--- a/source/manual/make-github-repo-private.html.md
+++ b/source/manual/make-github-repo-private.html.md
@@ -43,9 +43,8 @@ Perform these actions on staging first, before rolling out to production.
 
 In the relevant environment, disable Puppet on the Jenkins machine, otherwise Puppet will overwrite your changes.  This can be done by SSHing into the Jenkins machine:
 
-
 ```
-$ govukcli ssh jenkins
+$ gds govuk connect -e <environment> ssh jenkins
 $ govuk_puppet --disable
 ```
 
@@ -68,7 +67,7 @@ The app can now be deployed as normal.
 After deployment is complete, Puppet can be re-enabled:
 
 ```
-$ govukcli ssh jenkins
+$ gds govuk connect -e <environment> ssh jenkins
 $ govuk_puppet --enable
 ```
 

--- a/source/manual/pagerduty.html.md
+++ b/source/manual/pagerduty.html.md
@@ -23,7 +23,7 @@ and that they're correctly scheduled in.
 When an alert that triggers PagerDuty goes off, someone on the escalation schedule must acknowledge
 them, otherwise they will be escalated further. NB, 2nd line shadowers are not required to be on PagerDuty.
 
-## PagerDuty drill
+## PagerDuty drill
 
 Every week we test PagerDuty to make sure it can phone to alert us to
 any issues. This happens every Wednesday morning at 10am UTC.
@@ -48,11 +48,10 @@ anyone else being phoned.
 
 To trigger the drill manually, follow these steps:
 
-1. Shell onto the monitoring box:
+1. SSH onto the monitoring box:
 
 ```shell
-$ govukcli set-context production
-$ govukcli ssh monitoring
+$ gds govuk connect -e production ssh aws/monitoring
 ```
 
 2. Generate the file that the Icinga monitor looks for which triggers the alert:

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -21,8 +21,7 @@ departments, usually for use with for campaign materials.
 To find if there is already a redirect for a particular path:
 
 ```console
-govukcli set-context production-aws
-govukcli ssh router_backend
+gds govuk connect -e production ssh aws/router_backend
 ```
 
 Then:

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -99,15 +99,14 @@ puppetmaster and then on the monitoring machine, which could be up to
 an hour.  You can force this by running Puppet on the puppetmaster:
 
 ```console
-$ govukcli set-context <environment>
-$ govukcli ssh puppetmaster
+$ gds govuk connect -e <environment> ssh puppetmaster
 $ govuk_puppet --verbose
 ```
 
 And then on the monitoring machine:
 
 ```console
-$ govukcli ssh monitoring
+$ gds govuk connect -e <environment> ssh monitoring
 $ govuk_puppet --verbose
 ```
 


### PR DESCRIPTION
- Now the rest of the docs match the Get Started guide, we will no
  longer confuse new people (or old people trying to decipher which tool
  they should use).
- Some of these could be replaced with `gds govuk connect -e production
  app_console <app>`, but that's an exercise for later.
- Relates to https://github.com/alphagov/govuk-aws/issues/1159. Come and talk to us in #govuk-dev-tools!