### PR TITLE
Fix get started

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -81,7 +81,7 @@ class ExternalDoc
   # contain links to other pages of documentation also formatted with Markdown.
   # When the documentation is rendered as part of GOV.UK Developer Docs we
   # render it as HTML so we need to rewrite the links so that they have a .html
-  # extension to match out routing.
+  # extension to match our routing.
   #
   # For example a link to `link-expansion.md` would be rewritten to
   # `link-expansion.html`

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -115,7 +115,7 @@ Ask somebody with access to add your SSH username (`firstnamelastname`) to the [
 
 User accounts in our integration environments are managed in the [govuk-puppet][] repository.
 
-``bash
+```bash
 mkdir ~/govuk
 cd ~/govuk
 git clone git@github.com:alphagov/govuk-puppet.git
@@ -303,10 +303,11 @@ consult the [gds-cli README](https://github.com/alphagov/gds-cli).
 
 You can also chain commands, like this one to list S3 buckets in integration:
 
-        gds aws govuk-integration-poweruser aws s3 ls
+```bash
+gds aws govuk-integration-poweruser aws s3 ls
+```
 
 [govuk-aws-data-users-group]: /manual/set-up-aws-account.html#4-get-the-appropriate-access
-
 [infra-terra]: https://github.com/alphagov/govuk-aws-data/tree/master/data/infra-security
 [MFA]: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#multi-factor-authentication
 [iam]: https://console.aws.amazon.com/iam/home?region=eu-west-1#/users


### PR DESCRIPTION
A missing ` caused this issue on the Get Started page:

> ![Screenshot 2020-04-15 at 09 08 39](https://user-images.githubusercontent.com/5111927/79313827-d80de580-7ef8-11ea-98cf-6fc53117561e.png)
