### PR TITLE
Replace raw SSH commands with `gds govuk connect` equivalents

### DIFF
--- a/source/manual/alerts/onsite-backups.html.md
+++ b/source/manual/alerts/onsite-backups.html.md
@@ -17,7 +17,7 @@ It's likely that this is failing because one of the backups it's trying to colle
 To rerun an individual backup:
 
 ```
-ssh backup-1.management.production
+gds govuk connect ssh -e production <backup-hostname-from-alert>
 sudo su - govuk-backup
 cd /etc/backup/
 ./001_directory_backup_postgresql_backups_postgresql_primary_1 # Or whichever script is relevant

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -59,12 +59,9 @@ to the mirrors, but it will not stop the mirrors from working.
 To inspect the contents of the mirror:
 
 ```bash
-ssh <mirrorer_machine_name>
+gds govuk connect -e production ssh mirrorer
 cd /mnt/crawler_worker/www.gov.uk
 ```
-
-where `<mirrorer_machine_name>` can be obtained from the `govuk_node_list -c mirrorer` command
-on the jumpbox.
 
 ## Forcing failover to the static mirrors
 
@@ -93,14 +90,11 @@ You'll be notified by the escalation on-call contact that you need to edit the s
 
 1. If you're at home, connect to the [VPN][gds-vpn].
 
-1. ssh to the Mirrorer machine by running:
+1. SSH to the mirrorer machine:
 
     ```bash
-    ssh <mirrorer_machine_name>
+    gds govuk connect -e production ssh mirrorer
     ```
-
-    where `<mirrorer_machine_name>` can be obtained from the `govuk_node_list -c mirrorer` command
-    on the jumpbox.
 
 1. Disable puppet on the machine by running:
 

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -47,16 +47,9 @@ and proxies requests to Jenkins. It is also running on port 80 to serve a monito
 
 ## Access
 
-Ensure your SSH configuration (`~/.ssh/config`) includes the CI section.
-It should if you've followed the [SSH setup instructions](/manual/get-ssh-access.html).
-
-SSH to parts of the CI stack:
-
-`ssh ci-agent-1.ci`
-
-To view available nodes:
-
-`ssh ci "govuk_node_list"`
+SSH to a random CI machine with `gds govuk connect ssh -e ci ci-agent`.
+If you know the agent you want, append `:number` to the end of
+`ci_agent` to go straight to that machine.
 
 ## Configuration
 

--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -50,15 +50,11 @@ the indices sequentially.
 
 You can also run this task from Jenkins.
 
-To monitor progress, SSH to a search box:
+To monitor progress, SSH to a search box and check how many documents
+have been copied to the new index:
 
-```
-ssh $(ssh integration "govuk_node_list --single-node -c search").integration
-```
-
-Then check how many documents have been copied to the new index:
-
-```
+```bash
+gds govuk connect ssh -e integration search
 govuk_setenv search-api \
 bash -c 'curl "$ELASTICSEARCH_URI/_cat/indices?v"'
 ```

--- a/source/manual/sidekiq.html.md
+++ b/source/manual/sidekiq.html.md
@@ -29,31 +29,14 @@ that can display the current state of a [Sidekiq] installation. We have
 multiple [Sidekiq] configurations used throughout [GOV.UK].
 
 We have restricted public access as the Web UI allows modifying the state of
-[Sidekiq] queues.
-
-To gain access you should setup SSH port forwarding to a backend box belonging
-to the environment you wish to monitor when connected to the office wireless
-network or the VPN:
+[Sidekiq] queues. To access the Sidekiq monitoring UI for Production AWS,
+run:
 
 ```bash
-$ ssh backend-1.backend.staging -CNL 9000:127.0.0.1:3211
-```
-
-Or on AWS:
-
-```bash
-$ ssh $(ssh integration "govuk_node_list --single-node -c backend").integration -CNL 9000:127.0.0.1:3211
-```
-
-or using `govuk-connect`:
-
-```bash
-$ brew install alphagov/gds/govuk-connect
 $ gds govuk connect sidekiq-monitoring -e production aws/backend 
 ```
 
-Then visit [http://127.0.0.1:9000](http://127.0.0.1:9000) to see a list of
-[Sidekiq] configurations you can monitor.
+Go to the `127.0.0.1:port` URL in the command output to see the UI.
 
 ### Sidekiq Grafana Dashboard
 


### PR DESCRIPTION
- Further to #2462.

https://trello.com/c/ZBGHVlTr/132-deprecate-and-delete-govukcli