### PR TITLE
Replace `ssh -A` commands on app pages with `gds govuk connect ssh`

### DIFF
--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -90,32 +90,28 @@ The production version of this application is hosted on **<%= application.hostin
 
 <% case application.production_hosted_on %>
 <% when  "carrenza" %>
-
 ### SSH Access (Carrenza & AWS)
 
 This application lives on `<%= application.carrenza_machine %>` machines in Carrenza.
 
-To SSH to one of these machines:
-
-```
-ssh -A -t jumpbox.staging.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
-ssh -A -t jumpbox.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.carrenza_machine %> --single-node`'
+```bash
+gds govuk connect ssh -e staging carrenza/<%= application.carrenza_machine %>
+gds govuk connect ssh -e production carrenza/<%= application.carrenza_machine %>
 ```
 
 This application lives on `<%= application.aws_puppet_class %>` machines on the integration environment in AWS.
 
-To SSH to one of these machines [via the jumpbox](/manual/howto-ssh-to-machines-in-aws.html), use this command:
+```bash
+gds govuk connect ssh -e integration <%= application.aws_puppet_class %>
+```
 
-```
-ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
-```
 <% when  "aws" %>
 ### SSH Access (AWS)
 
-```
-ssh -A -t jumpbox.integration.publishing.service.gov.uk 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
-ssh -A -t jumpbox.staging.govuk.digital 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
-ssh -A -t jumpbox.production.govuk.digital 'ssh `govuk_node_list -c <%= application.aws_puppet_class %> --single-node`'
+```bash
+gds govuk connect ssh -e integration <%= application.aws_puppet_class %>
+gds govuk connect ssh -e staging aws/<%= application.aws_puppet_class %>
+gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
 ```
 <% end %>
 


### PR DESCRIPTION
- This is to be consistent with the rest of the docs about SSHing that
  now say `gds govuk connect ssh` is the thing one should use.
- When we [delete the dev VM directory from
  Puppet](https://trello.com/c/1xBp5GeI/137-delete-the-development-vm-code-in-govuk-puppet),
  people won't have the SSH config any more, so these commands won't work.
- And by removing this, we get rid of a lot of instances of SSH agent
  forwarding, which is insecure.

https://trello.com/c/7T1NB3ym/135-update-dev-docs-for-govuk-connect

Before:

<img width="866" alt="Screenshot 2020-04-16 at 15 15 47" src="https://user-images.githubusercontent.com/355033/79467491-ba727600-7ff5-11ea-9821-a4ca9ff48c3b.png">

After:

<img width="821" alt="Screenshot 2020-04-16 at 15 12 46" src="https://user-images.githubusercontent.com/355033/79467485-b9d9df80-7ff5-11ea-83d5-4206af659240.png">
