### PR TITLE
Link to Frontend architecture

### DIFF
--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -195,6 +195,7 @@ then content items are retrieved via the [search-api].
 Whilst views can be any arbitrary HTML, GOV.UK pages are typically constructed
 from components defined in [govuk_publishing_components], set in a standard
 page template (header, footer, JavaScript and CSS) defined in [static].
+For more details, read about the GOV.UK [Frontend architecture].
 
 Static JS/CSS is delivered over <https://assets.publishing.service.gov.uk>.
 Custom assets, such as images, are delivered over the same domain and uploaded
@@ -204,6 +205,7 @@ live in an [AWS S3 bucket] (read ["Assets: how they work"]).
 [asset-manager]: https://github.com/alphagov/asset-manager
 ["Assets: how they work"]: /manual/assets.html
 [AWS S3 bucket]: https://aws.amazon.com/free/storage/
+[Frontend architecture]: /manual/frontend-architecture.html
 [govuk_publishing_components]: https://components.publishing.service.gov.uk/component-guide
 [static]: https://github.com/alphagov/static
 


### PR DESCRIPTION
The deep-dive somewhat simplifies just how complicated the frontend of GOV.UK is.
We should link off to this other resource which explains it in more detail:
https://docs.publishing.service.gov.uk/manual/frontend-architecture.html