### PR TITLE
Review docs about our use of GitHub

### DIFF
--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -4,13 +4,13 @@ title: Configure a GitHub repo
 parent: /manual.html
 layout: manual_layout
 section: GitHub
-last_reviewed_on: 2019-10-21
+last_reviewed_on: 2020-04-21
 review_in: 6 months
 ---
 
 Repositories in GOV.UK must:
 
-- Have the [GOV.UK team][team] as `Admin`
+- Have the [GOV.UK CI Bots][govuk-ci-bots-team] and [GOV.UK Production][govuk-production-team] teams as `Admin`
 - Have a good description
 - Link to relevant documentation
 - Be tagged with [`govuk`](https://github.com/search?q=topic:govuk)
@@ -19,10 +19,11 @@ Repositories in GOV.UK must:
 Almost all repos should:
 
 - Have [branch protection](https://help.github.com/articles/about-protected-branches) on master
-- Have [Jenkins CI](/manual/testing-projects.html) configured
+- Have [Jenkins CI](/manual/testing-projects.html) configured, if a Jenkinsfile exists in the repo
 - Have [GitHub Trello Poster](/manual/github-trello-poster.html) enabled
 
-[team]: https://github.com/orgs/alphagov/teams/gov-uk/members
+[govuk-ci-bots]: https://github.com/orgs/alphagov/teams/gov-uk-ci-bots
+[govuk-production-team]: https://github.com/orgs/alphagov/teams/gov-uk-production
 
 ## Auto configuration
 

--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -19,7 +19,7 @@ Repositories in GOV.UK must:
 Almost all repos should:
 
 - Have [branch protection](https://help.github.com/articles/about-protected-branches) on master
-- Have [Jenkins CI](/manual/testing-projects.html) configured, if a Jenkinsfile exists in the repo
+- Have [Jenkins CI](/manual/testing-projects.html) configured, if the repo uses Jenkins
 - Have [GitHub Trello Poster](/manual/github-trello-poster.html) enabled
 
 [govuk-ci-bots]: https://github.com/orgs/alphagov/teams/gov-uk-ci-bots

--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -5,12 +5,13 @@ parent: /manual.html
 layout: manual_layout
 section: GitHub
 type: learn
-last_reviewed_on: 2019-10-21
+last_reviewed_on: 2020-04-21
 review_in: 6 months
 ---
 
 We share the [alphagov GitHub organisation][alphagov] with the other teams in the
-Government Digital Service (GDS).
+Government Digital Service (GDS). Our GitHub organisation is on the
+Enterprise Cloud plan.
 
 This can sometimes make it hard to find repositories that belong to our team. We use
 GitHub "topics" to organise the repos. All repos owned by us should be tagged with


### PR DESCRIPTION
See commits for more details.

Turns out that Jenkins can't handle `#` characters in branch names, so #2482 didn't work.
