### PR TITLE
Review page on receiving emails from staging

### DIFF
--- a/source/manual/receive-public-facing-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receive-public-facing-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -1,0 +1,88 @@
+---
+owner_slack: "#govuk-developers"
+title: Receive public facing emails from Email Alert API in integration and staging
+section: Emails
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-04-21
+review_in: 6 months
+---
+
+> **Note**
+>
+> This only relates to public facing emails, not to [publisher emails][].
+
+In `integration` and `staging` Email Alert API defaults to sending emails
+to a single test address: `success@simulator.amazonses.com`. This is used to
+simulate a successful email sending.
+
+However, you can override this for specific email addresses for testing
+purposes. To do this, you will need to be added as a team member to
+the GOV.UK Email Integration or Staging service in Notify and make
+changes to govuk-puppet.
+
+In [Notify][]:
+
+1. Log in using the 2nd-line-support account which is stored in
+   [govuk-secrets][] under `govuk-notify/2nd-line-support`. You should
+   then receive an email via 2nd Line Support containing a link to
+   sign in to Notify.
+1. Choose the service (GOV.UK Email) in the appropriate environment
+   and navigate to "Team members".  The members with the permission
+   `Manage settings, team and usage` will be able to add you to this
+   team.
+
+In [govuk-puppet][]:
+
+1. Add your email address to the override whitelist in
+[hieradata_aws/common.yaml][] as shown in [this PR][].
+This is set as an environment variable via hieradata under the key of
+`govuk::apps::email_alert_api::email_address_override_whitelist`. It should look
+something like this:
+```
+govuk::apps::email_alert_api::email_address_override_whitelist:
+  - your.name@digital.cabinet-office.gov.uk
+```
+This list of email addresses needs to be kept in sync with the team members list
+in Notify.
+1. Create a branch with these changes and push them to GitHub. Deploy these
+changes by running [integration-puppet-deploy][], providing your branch name
+instead of a release tag.
+
+Once these changes have been deployed and the environment variable
+`EMAIL_ADDRESS_OVERRIDE_WHITELIST` is populated with your address you can test
+that you can receive emails by running the
+[deliver:to_test_email[name@example.com]][deliver-task] [rake task].
+
+## Testing digest emails
+
+It is possible to re-send an entire digest run (e.g. to test changes that have
+been made to the email template) in integration.  You will need to have added
+yourself to the whitelist and have a digest subscription (daily or weekly) to
+something that had a significant update during the time period the digest covers
+(e.g. daily would be 07:00 the previous day to 07:00 today).
+
+Using a Rails console for email-alert-api, retrieve the digest run that you wish
+to resend, then delete it, e.g.
+
+```
+digest = DigestRun.where(range: 'daily').last
+DigestRun.delete(digest)
+```
+
+Then rerun the relevant digest initiator worker (either daily or weekly):
+
+```
+DailyDigestInitiatorWorker.perform_async
+WeeklyDigestInitiatorWorker.perform_async
+```
+
+[publisher emails]: /receive-publisher-emails-from-email-alert-api-in-integration-and-staging.html
+[Notify]: https://www.notifications.service.gov.uk
+[govuk-secrets]: https://github.com/alphagov/govuk-secrets
+[govuk-puppet]: https://github.com/alphagov/govuk-puppet
+[hieradata_aws/common.yaml]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml
+[this PR]: https://github.com/alphagov/govuk-puppet/pull/10307
+[integration-puppet-deploy]: https://ci.integration.publishing.service.gov.uk/job/integration-puppet-deploy/build?delay=0sec
+[deliver-task]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=deliver:to_test_email[name@example.com]
+[rake task]: https://github.com/alphagov/email-alert-api/blob/master/lib/tasks/deliver.rake#L19

--- a/source/manual/receive-publisher-and-public-facing-emails-from-integration-and-staging.html.md
+++ b/source/manual/receive-publisher-and-public-facing-emails-from-integration-and-staging.html.md
@@ -1,0 +1,83 @@
+---
+owner_slack: "#govuk-developers"
+title: Receive publisher and public facing emails from integration and staging
+section: Emails
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-04-21
+review_in: 6 months
+---
+
+In `integration` and `staging`, Email Alert API defaults to sending
+public-facing emails to `success@simulator.amazonses.com` only. This is used to
+simulate a successful email sending.
+
+However, you can override this for specific email addresses for testing
+purposes. To do this, you will need to be added as a team member to
+the GOV.UK Email Integration or Staging service in Notify and make
+changes to govuk-puppet.
+
+In [Notify][]:
+
+1. Log in using the 2nd-line-support account which is stored in
+   [govuk-secrets][] under `govuk-notify/2nd-line-support`. You should
+   then receive an email via 2nd Line Support containing a link to
+   sign in to Notify.
+1. Choose the service (GOV.UK Email) in the appropriate environment
+   and navigate to "Team members".  The members with the permission
+   `Manage settings, team and usage` will be able to add you to this
+   team.
+
+In [govuk-puppet][]:
+
+1. Add your email address to the override whitelist in
+[hieradata_aws/common.yaml][] as shown in [this PR][].
+This is set as an environment variable via hieradata under the key of
+`govuk::apps::email_alert_api::email_address_override_whitelist`. It should look
+something like this:
+```
+govuk::apps::email_alert_api::email_address_override_whitelist:
+  - your.name@digital.cabinet-office.gov.uk
+```
+This list of email addresses needs to be kept in sync with the team members list
+in Notify.
+1. Create a branch with these changes and push them to GitHub. Deploy these
+changes by running [integration-puppet-deploy][], providing your branch name
+instead of a release tag.
+
+Once these changes have been deployed and the environment variable
+`EMAIL_ADDRESS_OVERRIDE_WHITELIST` is populated with your address you can test
+that you can receive emails by running the
+[deliver:to_test_email[name@example.com]][deliver-task] [rake task].
+
+## Testing digest emails
+
+It is possible to re-send an entire digest run (e.g. to test changes that have
+been made to the email template) in integration.  You will need to have added
+yourself to the whitelist and have a digest subscription (daily or weekly) to
+something that had a significant update during the time period the digest covers
+(e.g. daily would be 07:00 the previous day to 07:00 today).
+
+Using a Rails console for email-alert-api, retrieve the digest run that you wish
+to resend, then delete it, e.g.
+
+```
+digest = DigestRun.where(range: 'daily').last
+DigestRun.delete(digest)
+```
+
+Then rerun the relevant digest initiator worker (either daily or weekly):
+
+```
+DailyDigestInitiatorWorker.perform_async
+WeeklyDigestInitiatorWorker.perform_async
+```
+
+[Notify]: https://www.notifications.service.gov.uk
+[govuk-secrets]: https://github.com/alphagov/govuk-secrets
+[govuk-puppet]: https://github.com/alphagov/govuk-puppet
+[hieradata_aws/common.yaml]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml
+[this PR]: https://github.com/alphagov/govuk-puppet/pull/10307
+[integration-puppet-deploy]: https://ci.integration.publishing.service.gov.uk/job/integration-puppet-deploy/build?delay=0sec
+[deliver-task]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=deliver:to_test_email[name@example.com]
+[rake task]: https://github.com/alphagov/email-alert-api/blob/master/lib/tasks/deliver.rake#L19

--- a/source/manual/receive-publisher-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receive-publisher-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -1,0 +1,15 @@
+---
+owner_slack: "#govuk-developers"
+title: Receive publisher emails from Email Alert API in integration and staging
+section: Emails
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-04-21
+review_in: 6 months
+---
+
+> **Note**
+>
+> This only relates to publisher emails, not to [public facing emails].
+
+[public facing emails]: /receive-public-facing-emails-from-email-alert-api-in-integration-and-staging.html


### PR DESCRIPTION
This edits this doc page to reflect the fact that it relates only to
public facing emails and not to publisher emails. In order to do so, I
changed the title and added a note at the top of the page.

I also:
 - changed the file name to reflect the new tile
 - created a new placeholder file that will (in a later PR) document the
   process to receive publisher emails from Email Alert API in
   integration and staging
 - added a link to the new file in the aforementioned note

All this should hopefully clarify the distinction between public facing
emails and publishers emails and the different processes to get them in
our non-production environments.

The part on what to change in puppet was still showing outdated
instructions that are not relevant anymore (since we migrated
email_alert_api to AWS), so I edited that part too.