### PR TITLE
Redirect previous paths for our AWS docs to Get Started

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -26,6 +26,7 @@ redirects:
   /dictionary.html: /manual/dictionary.html
   /getting-started.html: /manual/get-started.html
   /guides.html: /manual.html
+  /manual/access-aws-console.html: /manual/get-started.html
   /manual/alerts/applications/sidekiq-monitoring.html: /manual/setting-up-new-sidekiq-monitoring-app.html
   /manual/alerts/publisher-app-health-check-not-ok.html: /manual/alerts/publisher-app-healthcheck-not-ok.html
   /manual/alerts/data-sources-for-transition.html: /manual/transition-architecture.html
@@ -65,6 +66,7 @@ redirects:
   /manual/troubleshooting-vagrant.html: /manual/fix-problems-with-vagrant.html
   /manual/upgrade-to-sentry.html: /manual/sentry.html
   /manual/use-terraboard-to-monitor-terraform-state.html: /manual.html
+  /manual/user-management-in-aws.html: /manual/get-started.html
   /manual/virus-scanning.html: /manual/alerts/virus-scanning.html
   /opsmanual.html: /manual.html
   /opsmanual/ab_testing.html: /manual/ab-testing.html


### PR DESCRIPTION
- Turns out that the `gds-users` "request an account" service, managed
  by RE, links to `manual/user-management-in-aws`. A new user complained
  the link was broken.
