### PR TITLE
Monitor dependencies for Ruby DGU apps

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -604,12 +604,14 @@
 - github_repo_name: datagovuk_find
   type: data.gov.uk apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-datagovuk"
   production_hosted_on: paas
   sentry_url: https://sentry.io/govuk/find-data
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
 - github_repo_name: datagovuk_publish
   type: data.gov.uk apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-datagovuk"
   production_hosted_on: paas
   sentry_url: https://sentry.io/govuk/publish-data
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1


### PR DESCRIPTION
DGU apps have dependencies too! While 'Publish' is relatively well
maintained, DGU Find has lots of outdated dependencies.