### PR TITLE
Use GitHub Actions, not Jenkins, for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Clone govuk-content-schemas
+        uses: actions/checkout@v2
+        with:
+          repository: alphagov/govuk-content-schemas
+          ref: deployed-to-production
+          path: ./govuk-content-schemas
       - uses: ruby/setup-ruby@v1
       - uses: actions/cache@v1
         with:
@@ -22,4 +29,6 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - run: bundle exec rake
+        env:
+          GOVUK_CONTENT_SCHEMAS_PATH: ./govuk-content-schemas
       - run: bundle exec rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+
+      - run: bundle install --jobs 4 --retry 3
+      - run: bundle exec rake
+      - run: bundle exec rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,20 +15,20 @@ jobs:
         with:
           repository: alphagov/govuk-content-schemas
           ref: deployed-to-production
-          path: ./govuk-content-schemas
+          path: tmp/govuk-content-schemas
       - uses: ruby/setup-ruby@v1
       - uses: actions/cache@v1
         with:
-          path: actions-gem-cache/bundle
+          path: tmp/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
 
       - run: |
-          bundle config path actions-gem-cache/bundle
+          bundle config path tmp/bundle
           bundle install --jobs 4 --retry 3
 
       - run: bundle exec rake
         env:
-          GOVUK_CONTENT_SCHEMAS_PATH: ./govuk-content-schemas
+          GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
       - run: bundle exec rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+      - uses: actions/cache@v1
+        with:
+          path: actions-gem-cache/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
-      - run: bundle install --jobs 4 --retry 3
+      - run: |
+          bundle config path actions-gem-cache/bundle
+          bundle install --jobs 4 --retry 3
+
       - run: bundle exec rake
       - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,5 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  Exclude:
-    - "actions-gem-cache/**/*"
-    - "govuk-content-schemas/**/*"
-
 Style/ClassVars:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_mode:
 AllCops:
   Exclude:
     - "actions-gem-cache/**/*"
+    - "govuk-content-schemas/**/*"
 
 Style/ClassVars:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,13 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
+AllCops:
+  Exclude:
+    - "actions-gem-cache/**/*"
+
 Style/ClassVars:
   Enabled: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  govuk.buildProject(skipDeployToIntegration: true)
-}


### PR DESCRIPTION
- This runs Rake and RuboCop checks with the Ruby version defined in
  `.ruby-version`, for ease of updating later.
- The deployment of this app is done on the deploy Jenkins, once an hour
  on a timer, and the job `bin/deploy-to-s3` builds the site and pushes
  the files to S3. The CI Jenkins is not involved in the deployment
  process at all, and we don't seem to use the release tags generated in
  the master build process for anything.
- This reduces the amount of load on our Jenkins CI servers, and gets us
  further towards RFC-123.
