### PR TITLE
Add some docs on how we use GOV.UK Notify

### DIFF
--- a/source/manual/alerts/email-alerts.html.md
+++ b/source/manual/alerts/email-alerts.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Email alerts not sent
+title: Travel Advice or Drug and Medical Device email alerts not sent
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -1,0 +1,71 @@
+---
+owner_slack: "#govuk-developers"
+title: How we use GOV.UK Notify
+section: Emails
+type: learn
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-04-29
+review_in: 6 months
+---
+
+[GOV.UK Notify][notify] is a Government-as-a-Platform service that allows
+clients of their API to send emails, text messages and letters. We use GOV.UK
+Notify to send emails to users - both citizens and publishers. Historically
+we've also used AWS SES to send emails, but that's being phased out in favour
+of GOV.UK Notify.
+
+[notify]: https://www.notifications.service.gov.uk/
+
+We have two main services on GOV.UK Notify (six in total as we have a service
+for each environment):
+
+- **GOV.UK Emails**
+
+  This service is used by Email Alert API only. It's used to send citizen-facing
+  email updates about pieces of content on GOV.UK. It's our biggest sender of
+  emails and regularly exceeds one million emails per day.
+
+- **GOV.UK Publishing**
+
+  This service is used by our publishing applications. It's used to send
+  publisher-facing emails. The type of email can vary a lot, but a typical
+  example might be to receive an email when a scheduled document on GOV.UK has
+  been automatically published.
+
+_In the future we may set up a new 'GOV.UK Public' service which is used to
+send citizen-facing emails which haven't gone through Email Alert API._
+
+## Accessing the dashboard
+
+**[👉 Sign in to the GOV.UK Notify dashboard](https://www.notifications.service.gov.uk/sign-in)**
+
+You can either use your own credentials (if you have them) or you can use the
+credentials in [govuk-secrets] (found in the `govuk-notify/2nd-line-support`
+entry).
+
+[govuk-secrets]: https://github.com/alphagov/govuk-secrets
+
+## Receiving emails from GOV.UK Notify
+
+GOV.UK Notify services have two modes: live and [trial][trial-mode]. Only our
+production services are in live mode, the others are in trial mode. In this
+mode emails will only be sent to members of the service or email address in the
+allow-list, any request to send an email to another email address will fail.
+
+[trial-mode]: https://www.notifications.service.gov.uk/using-notify/trial-mode
+
+To receive emails in integration and staging through GOV.UK Notify, you should
+add yourself to the service:
+
+1. Choose the service in the appropriate environment and navigate to
+   "Team members".
+
+2. The members with the permission `Manage settings, team and usage` will be
+   able to add you to this team.
+
+**Note:** some of our applications, notably Email Alert API, has an extra level
+of protection and [there is an extra step][email-alert-api-receive-emails]
+before you can receive emails through Email Alert API.
+
+[email-alert-api-receive-emails]: /manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -4,7 +4,7 @@ title: Receive emails from Email Alert API in integration and staging
 section: Emails
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-02-28
+last_reviewed_on: 2020-04-29
 review_in: 6 months
 ---
 
@@ -13,20 +13,11 @@ to a single test address: `success@simulator.amazonses.com`. This is used to
 simulate a successful email sending.
 
 However, you can override this for specific email addresses for testing
-purposes. To do this, you will need to be added as a team member to
-the GOV.UK Email Integration or Staging service in Notify and make
-changes to govuk-puppet.
+purposes. To do this, [you will need to be added as a team member to
+the GOV.UK Email Integration or Staging service in Notify][add-in-notify] and
+make changes to govuk-puppet.
 
-In [Notify][]:
-
-1. Log in using the 2nd-line-support account which is stored in
-   [govuk-secrets][] under `govuk-notify/2nd-line-support`. You should
-   then receive an email via 2nd Line Support containing a link to
-   sign in to Notify.
-2. Choose the service (GOV.UK Email) in the appropriate environment
-   and navigate to "Team members".  The members with the permission
-   `Manage settings, team and usage` will be able to add you to this
-   team.
+[add-in-notify]: /manual/govuk-notify.html#receiving-emails-from-govuk-notify
 
 In [govuk-puppet][]:
 

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -15,11 +15,9 @@ simulate a successful email sending.
 However, you can override this for specific email addresses for testing
 purposes. To do this, [you will need to be added as a team member to
 the GOV.UK Email Integration or Staging service in Notify][add-in-notify] and
-make changes to govuk-puppet.
+make changes to [govuk-puppet].
 
 [add-in-notify]: /manual/govuk-notify.html#receiving-emails-from-govuk-notify
-
-In [govuk-puppet][]:
 
 1. Add your email address to the common.yml for [hieradata](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml#L442) and [hieradata_aws](https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml#L488) (these lists need to be kept in sync with the team members list in Notify)
 2. Add your email address to the override whitelist in the YAML file for the environment you're testing on. This is set as an


### PR DESCRIPTION
We're starting to use GOV.UK Notify in lots of places (not just Email Alert API), so this updates the docs to make this clearer and start to introduce separation between GOV.UK Notify and Email Alert API in peoples minds.