### PR TITLE
Add Publishing API docs, App docs, DocumentTypes/Supertypes to search

### DIFF
--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -1,0 +1,110 @@
+class ProxyPages
+  def self.resources
+    publishing_api_docs +
+      govuk_schema_names +
+      app_docs +
+      app_docs_json +
+      document_types +
+      supertypes
+  end
+
+  def self.publishing_api_docs
+    PublishingApiDocs.pages.map do |page|
+      {
+        path: "/apis/publishing-api/#{page.filename}.html",
+        template: "templates/publishing_api_template.html",
+        frontmatter: {
+          title: "Publishing API: #{page.title}",
+          locals: {
+            title: "Publishing API: #{page.title}",
+            page: page,
+          },
+        },
+      }
+    end
+  end
+
+  def self.govuk_schema_names
+    GovukSchemas::Schema.schema_names.map do |schema_name|
+      schema = ContentSchema.new(schema_name)
+
+      {
+        path: "/content-schemas/#{schema_name}.html",
+        template: "templates/schema_template.html",
+        frontmatter: {
+          # title: "Schema: #{schema.schema_name}", # FIXME - this slows down the search index too much
+          locals: {
+            title: "Schema: #{schema.schema_name}",
+            description: "Everything about the '#{schema.schema_name}' schema",
+            schema: schema,
+          },
+        },
+      }
+    end
+  end
+
+  def self.app_docs
+    AppDocs.pages.map do |application|
+      {
+        path: "/apps/#{application.app_name}.html",
+        template: "templates/application_template.html",
+        frontmatter: {
+          title: application.page_title,
+          locals: {
+            title: application.page_title,
+            description: "Everything about the #{application.app_name} application (#{application.description})",
+            application: application,
+          },
+        },
+      }
+    end
+  end
+
+  def self.app_docs_json
+    AppDocs.pages.map do |application|
+      {
+        path: "/apps/#{application.app_name}.json",
+        template: "templates/json_response.json",
+        frontmatter: {
+          locals: {
+            payload: application.api_payload,
+          },
+        },
+      }
+    end
+  end
+
+  def self.document_types
+    DocumentTypes.pages.map do |document_type|
+      {
+        path: "/document-types/#{document_type.name}.html",
+        template: "templates/document_type_template.html",
+        frontmatter: {
+          title: "Document type: #{document_type.name}",
+          locals: {
+            title: "Document type: #{document_type.name}",
+            description: "Everything about the '#{document_type.name}' document type",
+            page: document_type,
+          },
+        },
+      }
+    end
+  end
+
+  def self.supertypes
+    Supertypes.all.map do |supertype|
+      {
+        path: "/document-types/#{supertype.id}.html",
+        template: "templates/supertype_template.html",
+        frontmatter: {
+          title: "#{supertype.name} supertype",
+          locals: {
+            title: "#{supertype.name} supertype",
+            description: supertype.description,
+            supertype: supertype,
+          },
+        },
+      }
+    end
+  end
+end

--- a/config.rb
+++ b/config.rb
@@ -59,47 +59,6 @@ end
 
 ignore "templates/*"
 
-PublishingApiDocs.pages.each do |page|
-  proxy "/apis/publishing-api/#{page.filename}.html", "templates/publishing_api_template.html", locals: {
-    title: "Publishing API: #{page.title}",
-    page: page,
-  }
-end
-
-GovukSchemas::Schema.schema_names.each do |schema_name|
-  schema = ContentSchema.new(schema_name)
-
-  proxy "/content-schemas/#{schema_name}.html", "templates/schema_template.html", locals: {
-    title: "Schema: #{schema.schema_name}",
-    description: "Everything about the '#{schema.schema_name}' schema",
-    schema: schema,
-  }
-end
-
-AppDocs.pages.each do |application|
-  proxy "/apps/#{application.app_name}.html", "templates/application_template.html", locals: {
-    title: application.page_title,
-    description: "Everything about the #{application.app_name} application (#{application.description})",
-    application: application,
-  }
-
-  proxy "/apps/#{application.app_name}.json", "templates/json_response.json", locals: {
-    payload: application.api_payload,
-  }
-end
-
-DocumentTypes.pages.each do |document_type|
-  proxy "/document-types/#{document_type.name}.html", "templates/document_type_template.html", locals: {
-    title: "Document type: #{document_type.name}",
-    description: "Everything about the '#{document_type.name}' document type",
-    page: document_type,
-  }
-end
-
-Supertypes.all.each do |supertype|
-  proxy "/document-types/#{supertype.id}.html", "templates/supertype_template.html", locals: {
-    title: "#{supertype.name} supertype",
-    description: supertype.description,
-    supertype: supertype,
-  }
+ProxyPages.resources.each do |resource|
+  proxy resource[:path], resource[:template], resource[:frontmatter]
 end

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe ProxyPages do
+  before :each do
+    allow(AppDocs).to receive(:pages)
+      .and_return([double("App", app_name: "", page_title: "", description: "")])
+    allow(DocumentTypes).to receive(:pages)
+      .and_return([double("Page", name: "")])
+    allow(Supertypes).to receive(:all)
+      .and_return([double("Supertype", name: "", description: "", id: "")])
+  end
+
+  describe ".publishing_api_docs" do
+    it "is indexed in search" do
+      expect(described_class.publishing_api_docs).to all(include(frontmatter: hash_including(:title)))
+    end
+  end
+
+  describe ".app_docs" do
+    it "is indexed in search" do
+      expect(described_class.app_docs).to all(include(frontmatter: hash_including(:title)))
+    end
+  end
+
+  describe ".document_types" do
+    it "is indexed in search" do
+      expect(described_class.document_types).to all(include(frontmatter: hash_including(:title)))
+    end
+  end
+
+  describe ".supertypes" do
+    it "is indexed in search" do
+      expect(described_class.supertypes).to all(include(frontmatter: hash_including(:title)))
+    end
+  end
+end


### PR DESCRIPTION
Add Publishing API docs, App docs, DocumentTypes/Supertypes to search
  
- Moves this config into a new class 'ProxyPages' so that it can be tested
- Adds a 'title' frontmatter property so that it is indexed by middleman-search

This makes the search far more comprehensive and useful, although it does
slow the initial indexing down a bit, so the 'Loading search index'
message will stick around slightly longer. I think this is worth it for
the improved relevancy of search results, and if it becomes a problem we
can investigate a server-side search/index solution, or make better use
of caching. It should also only be a short term decrease in search speed;
when the latest version of middleman-search-gds is published, we'll
benefit by only indexing the titles of these external pages, not their
contents: https://github.com/alphagov/middleman-search/pull/5

Unfortunately, until that gem is released, I can't add the
govuk_schema_names pages as they break the indexing altogether.
It will be possible to add them in once the gem is updated.

Trello: https://trello.com/c/lVTGSjCA/142-imported-dev-docs-dont-appear-in-search

## Before
![Screenshot 2020-05-01 at 16 40 02](https://user-images.githubusercontent.com/5111927/80818068-7a50ed00-8bca-11ea-8878-ce507695a959.png)

## After
![Screenshot 2020-05-01 at 16 39 28](https://user-images.githubusercontent.com/5111927/80818053-745b0c00-8bca-11ea-8f3f-8757370566e6.png)
