### PR TITLE
Use more inclusive terminology (public vs citizen)

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -671,7 +671,7 @@
   sentry_url: https://sentry.io/organizations/govuk/issues/?project=5170680
   deploy_url: 'https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/blob/master/concourse/pipeline.yml'
   dashboard_url: 'https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/d006_coronavirus?form.main.earliest=-7d%40h&form.main.latest=now&form.xhost=coronavirus-vulnerable-people.service.gov.uk'
-  description: 'Helps citizens get support during the Covid-19 pandemic'
+  description: 'Helps the public get support during the Covid-19 pandemic'
 
 - github_repo_name: govuk-coronavirus-business-volunteer-form
   private_repo: false

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -9,7 +9,7 @@ last_reviewed_on: 2020-02-11
 review_in: 6 months
 ---
 
-GOV.UK uses Fastly as a CDN. Citizen users aren't accessing GOV.UK servers directly, they connect via the CDN. This is better because:
+GOV.UK uses Fastly as a CDN. Public users aren't accessing GOV.UK servers directly, they connect via the CDN. This is better because:
 
 - The CDN "edge nodes" (webservers) are closer to end users. Fastly has servers all around the world but our "origin" servers are only in the UK.
 - It reduces load on our origin. Fastly uses Varnish to cache responses.

--- a/source/manual/covid-19-services.html.md
+++ b/source/manual/covid-19-services.html.md
@@ -26,7 +26,7 @@ services such as medical equipment, hotel rooms or childcare.
 
 ## Get coronavirus support as an extremely vulnerable person
 
-This service allows citizens identified as vulnerable by the NHS to
+This service allows people identified as vulnerable by the NHS to
 tell us if they need help accessing essential supplies and support.
 Users will have received a link to the service in a letter or a text
 message from the NHS, or been advised by their GP to fill in the form.
@@ -46,7 +46,7 @@ SV.
 
 ## Find support if you're affected by coronavirus
 
-This service allows all citizens - who may not have been eligible for
+This service allows the public - who may not have been eligible for
 the extremely vulnerable service - to find information about what help
 is available if they're struggling with unemployment, an inability to
 get food, having somewhere to live, or their general wellbeing as a

--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -11,9 +11,9 @@ review_in: 6 months
 
 [GOV.UK Notify][notify] is a Government-as-a-Platform service that allows
 clients of their API to send emails, text messages and letters. We use GOV.UK
-Notify to send emails to users - both citizens and publishers. Historically
-we've also used AWS SES to send emails, but that's being phased out in favour
-of GOV.UK Notify.
+Notify to send emails to users - both members of the public and publishers.
+Historically, we've also used AWS SES to send emails, but that's being phased
+out in favour of GOV.UK Notify.
 
 [notify]: https://www.notifications.service.gov.uk/
 
@@ -22,7 +22,7 @@ for each environment):
 
 - **GOV.UK Emails**
 
-  This service is used by Email Alert API only. It's used to send citizen-facing
+  This service is used by Email Alert API only. It's used to send public-facing
   email updates about pieces of content on GOV.UK. It's our biggest sender of
   emails and regularly exceeds one million emails per day.
 
@@ -34,7 +34,7 @@ for each environment):
   been automatically published.
 
 _In the future we may set up a new 'GOV.UK Public' service which is used to
-send citizen-facing emails which haven't gone through Email Alert API._
+send public-facing emails which haven't gone through Email Alert API._
 
 ## Accessing the dashboard
 


### PR DESCRIPTION
"Citizen" is a very specific term and should only be used when we
specifically mean someone with a particular citizenship. Users of GOV.UK
services are generally not only British citizens but the broader public.
Using more general terms ("people", "public", "members of the public")
instead of "citizen" makes this clear and our docs more inclusive.
