### PR TITLE
Stop generating 'Icinga alerts' breadcrumb for non-existing anchor

### DIFF
--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -1,4 +1,10 @@
-<% breadcrumb = "<p><a href='/manual.html##{section_url}'>#{current_page.data.section}</a></p>" %>
+<%
+  breadcrumb = if current_page.data.section == "Icinga alerts"
+                 ""
+               else
+                 "<p><a href='/manual.html##{section_url}'>#{current_page.data.section}</a></p>"
+               end
+%>
 <% html = "#{breadcrumb} <h1 id='header'>#{current_page.data.title}</h1>#{yield}" %>
 
 <% content_for :page_description, Snippet.generate(html) %>


### PR DESCRIPTION
There is no 'Icinga alerts' section on manual.html, as alerts are
their own special thing. We already have logic in the manual_layout
template to do something different with Icinga Alerts, so it doesn't
seem controversial to add another conditional.

I did consider removing all 'section: Icinga alerts' lines from the
docs under /alerts, as they are ALL the same and we can infer it
from the path. But that feels like a future optimisation. In the
meantime I just want to stop linking to an anchor point that
doesn't exist.

Before:
![Screenshot 2020-05-13 at 16 19 14](https://user-images.githubusercontent.com/5111927/81832237-2c2ada80-9536-11ea-867c-83b9ba77db26.png)

After:

![Screenshot 2020-05-13 at 16 21 15](https://user-images.githubusercontent.com/5111927/81832253-30ef8e80-9536-11ea-8a36-5ecd29d18a07.png)

Trello: https://trello.com/c/KNesH0LZ/1939-3-improve-documentation-for-email-alert-api