### PR TITLE
Redirect manual/alerts/email-alerts.html to its new location

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -28,6 +28,7 @@ redirects:
   /guides.html: /manual.html
   /manual/access-aws-console.html: /manual/get-started.html
   /manual/alerts/applications/sidekiq-monitoring.html: /manual/setting-up-new-sidekiq-monitoring-app.html
+  /manual/alerts/email-alerts.html: /manual/alerts/email-alerts-travel-medical.html
   /manual/alerts/publisher-app-health-check-not-ok.html: /manual/alerts/publisher-app-healthcheck-not-ok.html
   /manual/alerts/data-sources-for-transition.html: /manual/transition-architecture.html
   /manual/alerts/rummager-queue-latency.html: /manual/alerts/search-api-queue-latency.html


### PR DESCRIPTION
- This is good practice, for "no link left behind", and infinitely easier than deploying Puppet across all three environments to fix the alert link itself.
