### PR TITLE
Rewrite errors manual to give the big picture

### DIFF
--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -1,109 +1,50 @@
 ---
 owner_slack: "#govuk-developers"
-title: Triage and handle errors
+title: How we handle errors
 section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-11-11
+last_reviewed_on: 2020-05-18
 review_in: 6 months
 ---
 
+## How we categorise errors
+
 Sometimes applications will encounter exceptions. This policy describes what we should do for different types of errors. It was first proposed in [RFC 87](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-087-dealing-with-errors.md).
 
-## Principles
+### High priority errors
 
-### 1. When something goes wrong, we should be notified
+1. **When something goes wrong, we should be notified**. Applications should report exceptions to Sentry. Applications must not swallow errors.
 
-Applications should report exceptions to Sentry. Applications must not swallow errors.
+1. **Notifications should be actionable**. Sentry notifications should be something that requires a developer of the app to do something about it. Not just a piece of information.
 
-### 2. Notifications should be actionable
+1. **Applications should not continue to have these errors**. The goal of GOV.UK is that applications should not error. When something goes wrong it should be fixed.
 
-Sentry notifications should be something that requires a developer of the app to do something about it. Not just a piece of information.
+Example of high-priority errors:
 
-### 3. Applications should not error
+- **Bugs**, where the application crashes unexpectedly
 
-The goal of GOV.UK is that applications should not error. When something goes wrong it should be fixed.
+- **Sidekiq non-retryable errors** (or retries exhausted)
 
-## Classifying errors
+### Low priority errors
 
-### Bug
+1. **When something goes wrong, the error should be recorded in Kibana logs and/or application metrics.** A team can then monitor these errors over time, and prioritise ones to fix.
 
-A code change makes the application crash.
+Examples of low-priority errors:
 
-Desired behaviour: error is sent to Sentry, developers are notified and fix the error. Developers mark the error in Sentry as `Resolved`. This means a recurrence of the error will alert developers again.
+- **Intermittent errors without user impact** e.g. user sees a cached version of a page, due to an upstream API timeout, such as a request to the Content Store.
 
-### Intermittent errors without user impact
+- **Intermittent errors with user impact** e.g. an API request timeout occurs when a publisher tries to publish a document in one of our publishing apps.
 
-Frontend applications often see timeouts when talking to the content-store.
+  - When such errors are expected, we should show the user an error page that gives instructions for how to correct the issue, whether by taking action themselves, or submitting a request for support.
 
-There's no or little user impact because the request will be answered by the caching layer.
+- **User input errors** e.g. user submits a form with invalid data.
 
-Example: <https://sentry.io/govuk/app-finder-frontend/issues/352985400>
+  - For all 422 "unprocessable entity" errors, we should show the user an error page that gives instructions for how to correct the issue, whether by taking action themselves, or submitting a request for support.
 
-Desired behaviour: error is not sent to Sentry. Instead, we rely on Smokey and Icinga checks to make sure we the site functions.
+  - For all 404 "not found" errors, we should show the user an error page that gives instructions for how to proceed. Note that 404 responses are returned by default if using [Rails' ActiveRecord #find or similar](https://stackoverflow.com/questions/27925282/activerecordrecordnotfound-raises-404-instead-of-500).
 
-### Intermittent errors with user impact
+- **IP spoof errors (HTTP 400)**. Rails reports `ActionDispatch::RemoteIp::IpSpoofAttackError`.
 
-Publishing applications sometimes see timeouts when talking to publishing-api. This results in the publisher seeing an error page and possibly losing data.
+- **Environmental errors** e.g. errors due to data sync.
 
-Example: <https://sentry.io/govuk/app-content-tagger/issues/367277928>
-
-Desired behaviour: apps handle these errors better, for example by offloading the work to a Sidekiq worker. Since these errors aren't actionable, they should not be reported to Sentry. They should be tracked in Graphite.
-
-### Intermittent retryable errors
-
-Sidekiq worker sends something to the publishing-api, which times out. Sidekiq retries, the next time it works.
-
-Desired behaviour: errors are not reported to Sentry until retries are exhausted. See [this PR for an example](https://github.com/alphagov/content-data-api/pull/353).
-
-Relevant: https://github.com/getsentry/raven-ruby/pull/784
-
-### Expected environment-based errors
-
-MySQL errors on staging while data sync happens.
-
-Example: <https://sentry.io/govuk/app-whitehall/issues/343619055>
-
-Desired behaviour: our environment is set up such that these errors do not occur.
-
-### Bad request errors
-
-User makes a request the application can't handle ([example][bad-request]).
-
-Often happens in [security checks](https://sentry.io/govuk/app-frontend/issues/400074979).
-
-Example: <https://sentry.io/govuk/app-frontend/issues/400074979>
-
-Desired behaviour: user gets feedback, error is not reported to Sentry
-
-[bad-request]: https://sentry.io/govuk/app-service-manual-frontend/issues/400074003
-
-### Incorrect bubbling up of errors
-
-Search API crashes on date parsing, returns `422`, which raises an error in finder-frontend.
-
-Example: <https://sentry.io/govuk/app-finder-frontend/issues/400074507>
-
-Desired behaviour: a 4XX reponse is returned to the browser, including an error message. Nothing is ever sent to Sentry.
-
-### Manually logged errors
-
-Something goes wrong and we need to let developers know.
-
-Example: [Slimmer's old behaviour](https://github.com/alphagov/slimmer/pull/203/files#diff-e5615a250f587cf4e2147f6163616a1a)
-
-Desired behaviour: developers do not use Sentry for logging. The app either raises the actual error (which causes the user to see the error) or logs the error to Kibana.
-
-### IP spoof errors
-
-Rails reports `ActionDispatch::RemoteIp::IpSpoofAttackError`.
-
-Example: <https://sentry.io/govuk/app-service-manual-frontend/issues/365951370>
-
-Desired behaviour: HTTP 400 is returned, error is not reported to Sentry.
-
-### Database entry not found
-
-Often a controller will do something like `Thing.find(params[:id])` and rely on Rails to show a 404 page for the `ActiveRecord::RecordNotFound` it raises ([context](https://stackoverflow.com/questions/27925282/activerecordrecordnotfound-raises-404-instead-of-500)).
-
-Desired behaviour: errors are not reported to Sentry


### PR DESCRIPTION
https://trello.com/c/Uzpw1bDA/243-document-how-error-pages-work-on-govuk

Previously I found this manual hard to read, because the policy at
the top only applied to two of the subsequent sections: most errors
are *not* reported to Sentry. Most of the linked URLs also did not
work for me, and seem largely unnecessary/verbose.

This rewrites the manual to surface the two approaches we have for
errors more concisely, while maintaining the original policy of the
associated RFC. Shortening this general manual about 'errors' will
also allow for a planned addition that describes what happens when
an application errors on GOV.UK (this will be in a future PR).