### PR TITLE
Add note about loadbalancing

### DIFF
--- a/source/manual/uptime-metrics.html.md
+++ b/source/manual/uptime-metrics.html.md
@@ -31,6 +31,10 @@ They are available broken down into a day by day view, highlighted in different
 colours representing the level of uptime. Green means 100%, orange means above
 99.31% (equivalent to 10 minutes of downtime) and red for everything else.
 
+>**Note** These metrics aren't a true reflection of availability. Loadbalancing means that 
+>even if a particular healthcheck fails, and the metrics change as a result, publishing is
+> unlikely to be affected.
+
 ## Further Reading
 
 The service which collects the uptime data runs on the monitoring machines and

--- a/source/manual/uptime-metrics.html.md
+++ b/source/manual/uptime-metrics.html.md
@@ -31,9 +31,9 @@ They are available broken down into a day by day view, highlighted in different
 colours representing the level of uptime. Green means 100%, orange means above
 99.31% (equivalent to 10 minutes of downtime) and red for everything else.
 
->**Note** These metrics aren't a true reflection of availability. Loadbalancing means that 
+>**Note** These metrics aren't a true reflection of availability. Loadbalancing means that
 >even if a particular healthcheck fails, and the metrics change as a result, publishing is
-> unlikely to be affected.
+>unlikely to be affected.
 
 ## Further Reading
 


### PR DESCRIPTION
Loadbalancing means that even if a healthcheck fails, the application itself should still be available. We should explain this. 

[Trello card](https://trello.com/c/H51Pcoip/1997-add-note-about-loadbalancing-to-uptime-metrics-docs)