### PR TITLE
Fix build issues introduced in README-ingestion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,6 @@ task :lint, :environment do
   sh "bundle exec rubocop --format clang"
 end
 
-task default: %i[lint spec]
-
 namespace :cache do
   desc "Clear the cache of external content"
   task :clear do
@@ -63,3 +61,5 @@ task :check_puppet_names do
     HTTP.get(app.puppet_url)
   end
 end
+
+task default: %i[lint spec cache:clear assets:precompile]

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -115,7 +115,8 @@ class ExternalDoc
   # Removes the H1 from the page so that we can choose our own title
   class PrimaryHeadingFilter < HTML::Pipeline::Filter
     def call
-      doc.at("h1:first-of-type").unlink
+      h1 = doc.at("h1:first-of-type")
+      h1.unlink if h1.present?
       doc
     end
   end

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -47,7 +47,6 @@ class ExternalDoc
       HTML::Pipeline::MarkdownFilter,
       PrimaryHeadingFilter,
       HeadingFilter,
-      MarkdownLinkFilter,
     ]
 
     HTML::Pipeline.new(filters).call(markdown)[:output]

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -45,7 +45,6 @@ class ExternalDoc
   def self.parse(markdown)
     filters = [
       HTML::Pipeline::MarkdownFilter,
-      HTML::Pipeline::AbsoluteSourceFilter,
       PrimaryHeadingFilter,
       HeadingFilter,
       MarkdownLinkFilter,

--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -19,11 +19,5 @@ GitHub "topics" to organise the repos. All repos owned by us should be tagged wi
 
 We use [govuk-saas-config][] to configure our repositories.
 
-## Topics on GitHub
-
-<% AppDocs.topics_on_github.each do |topic| %>
-- <%= link_to topic, "https://github.com/search?q=topic:#{topic}+org:alphagov" %>
-<% end %>
-
 [alphagov]: https://github.com/alphagov
 [govuk-saas-config]: https://github.com/alphagov/govuk-saas-config/tree/master/github


### PR DESCRIPTION
https://github.com/alphagov/govuk-developer-docs/pull/2519 tests passed but the subsequent [building of the docs in Jenkins](https://deploy.publishing.service.gov.uk/job/deploy-developer-docs) broke.

I've fixed each issue one-by-one, and then added a build instruction to the GitHub Action config to prevent this sort of thing from happening again. This will slow down future PRs slightly, as now we're testing _and_ building, but we can be confident we haven't broken anything (and this also paves the way for post-processing, e.g. checking that all markdown has successfully been parsed into HTML).

I was a little worried we might hit our GitHub API limit with this but [GitHub Actions create a new token on every run](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) (at least that's how I understand it), so we're good to go.