### PR TITLE
Improve ProxyPages tests and make robust to non-UTF-8 content

### DIFF
--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -21,7 +21,7 @@ class GitHubRepoFetcher
   # Note that it is cached as pure markdown and requires further processing.
   def readme(app_name)
     CACHE.fetch("alphagov/#{app_name} README", expires_in: 1.hour) do
-      Base64.decode64(client.readme("alphagov/#{app_name}").content)
+      Base64.decode64(client.readme("alphagov/#{app_name}").content).force_encoding("UTF-8")
     rescue Octokit::NotFound
       nil
     end

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -9,26 +9,41 @@ RSpec.describe ProxyPages do
   end
 
   describe ".publishing_api_docs" do
-    it "is indexed in search" do
-      expect(described_class.publishing_api_docs).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by its default contents" do
+      expect(described_class.publishing_api_docs).to all(
+        include(frontmatter: hash_including(:title))
+        .and(include(frontmatter: hash_excluding(:content))),
+      )
+    end
+  end
+
+  describe ".email_alert_api_docs" do
+    it "is indexed in search by its default contents" do
+      expect(described_class.email_alert_api_docs).to all(
+        include(frontmatter: hash_including(:title))
+        .and(include(frontmatter: hash_excluding(:content))),
+      )
     end
   end
 
   describe ".app_docs" do
-    it "is indexed in search" do
-      expect(described_class.app_docs).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by its default contents" do
+      expect(described_class.app_docs).to all(
+        include(frontmatter: hash_including(:title))
+        .and(include(frontmatter: hash_excluding(:content))),
+      )
     end
   end
 
   describe ".document_types" do
-    it "is indexed in search" do
-      expect(described_class.document_types).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by title only" do
+      expect(described_class.document_types).to all(include(frontmatter: hash_including(:title, content: "")))
     end
   end
 
   describe ".supertypes" do
-    it "is indexed in search" do
-      expect(described_class.supertypes).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by title only" do
+      expect(described_class.supertypes).to all(include(frontmatter: hash_including(:title, content: "")))
     end
   end
 end


### PR DESCRIPTION
This PR was originally to do with fixing search indexing of README content (hence the branch name), but on further investigation the search indexing was already working.

However, by that point I'd already made some good improvements to the code, so have now refactored this PR to contain only the improvements:

1) Improved ProxyPages tests (helps document the 'why' behind the `content: ""` decision)
2) Force convert README content to UTF-8

Trello: https://trello.com/c/rzunnimb/143-automatically-consume-all-govuk-repo-readmes