### PR TITLE
Improve ProxyPages spec tests

### DIFF
--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -9,26 +9,41 @@ RSpec.describe ProxyPages do
   end
 
   describe ".publishing_api_docs" do
-    it "is indexed in search" do
-      expect(described_class.publishing_api_docs).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by its default contents" do
+      expect(described_class.publishing_api_docs).to all(
+        include(frontmatter: hash_including(:title))
+        .and(include(frontmatter: hash_excluding(:content))),
+      )
+    end
+  end
+
+  describe ".email_alert_api_docs" do
+    it "is indexed in search by its default contents" do
+      expect(described_class.email_alert_api_docs).to all(
+        include(frontmatter: hash_including(:title))
+        .and(include(frontmatter: hash_excluding(:content))),
+      )
     end
   end
 
   describe ".app_docs" do
-    it "is indexed in search" do
-      expect(described_class.app_docs).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by its default contents" do
+      expect(described_class.app_docs).to all(
+        include(frontmatter: hash_including(:title))
+        .and(include(frontmatter: hash_excluding(:content))),
+      )
     end
   end
 
   describe ".document_types" do
-    it "is indexed in search" do
-      expect(described_class.document_types).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by title only" do
+      expect(described_class.document_types).to all(include(frontmatter: hash_including(:title, content: "")))
     end
   end
 
   describe ".supertypes" do
-    it "is indexed in search" do
-      expect(described_class.supertypes).to all(include(frontmatter: hash_including(:title)))
+    it "is indexed in search by title only" do
+      expect(described_class.supertypes).to all(include(frontmatter: hash_including(:title, content: "")))
     end
   end
 end


### PR DESCRIPTION
Rather than indexing the contents of application_template.html.md.erb,
which is more of a 'dashboard' and has little indexable value,
we pass an override of `content: ""` to only index by title,
which keeps the search light and fast.

I've now tweaked the tests to document this properly in code,
and also added a missing test for email_alert_api_docs.

Tangentially related Trello: https://trello.com/c/rzunnimb/143-automatically-consume-all-govuk-repo-readmes