### PR TITLE
Remove deprecated Puppet dev VM link

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -15,10 +15,6 @@
     - name: Development environment
       repos:
         - govuk-docker
-      sites:
-        - name: GOV.UK Development VM (deprecated)
-          url: https://github.com/alphagov/govuk-puppet/tree/master/development-vm
-          description: Tools and guide for running GOV.UK apps in the VM
 
     - name: Schemas
       repos:


### PR DESCRIPTION
The link now 404s