### PR TITLE
Import Email Alert API docs

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -248,6 +248,7 @@
   team: "#govuk-platform-health"
   metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: aws
+  consume_docs_folder: true
   dependencies:
     signon:
       description: ''


### PR DESCRIPTION
External doc importing was refactored in https://github.com/alphagov/govuk-developer-docs/pull/2595

But Email Alert API got missed when adding the 'consume_docs_folder'
property.