### PR TITLE
Sync task names with Email Alert API

### DIFF
--- a/source/manual/email-alert-api-callback-from-notify-fails.html.md
+++ b/source/manual/email-alert-api-callback-from-notify-fails.html.md
@@ -17,7 +17,7 @@ There are two rake tasks that can do this using either the `reference` or the
 ## Query the Notify API for email(s) by reference
 
 ```
-report:get_notifications_from_notify[reference]
+troubleshoot:get_notifications_from_notify[reference]
 ```
 
 [⚙ Run rake task on production][reference]
@@ -25,7 +25,7 @@ report:get_notifications_from_notify[reference]
 ## Query the Notify API for email(s) by email ID
 
 ```
-report:get_notifications_from_notify_by_email_id[id]
+troubleshoot:get_notifications_from_notify_by_email_id[id]
 ```
 
 [⚙ Run rake task on production][email_id]
@@ -64,5 +64,5 @@ permanent-failure, accepted, received]"}]
 Read [email troubleshooting].
 
 [email troubleshooting]: /manual/email-troubleshooting.html
-[email_id]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:get_notifications_from_notify_by_email_id[id]
-[reference]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:get_notifications_from_notify[reference]
+[email_id]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:get_notifications_from_notify_by_email_id[id]
+[reference]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:get_notifications_from_notify[reference]

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -32,7 +32,7 @@ make changes to [govuk-puppet].
 
 Once these changes have been deployed and the environment variable
 `EMAIL_ADDRESS_OVERRIDE_WHITELIST` is populated with your address you can test
-that you can receive emails by running the [deliver:to_test_email[name@example.com]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=deliver:to_test_email[name@example.com]) [rake task].
+that you can receive emails by running the [troubleshoot:to_test_email[name@example.com]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=deliver:to_test_email[name@example.com]) [rake task].
 
 ## Testing digest emails
 


### PR DESCRIPTION
https://trello.com/c/IAj6XWFo/309-create-a-report-to-show-the-content-changes-that-have-triggered-notifications

Depends on: https://github.com/alphagov/email-alert-api/pull/1281

These were changed in the recent rake task reshuffle [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1281