### PR TITLE
Adds tests for the 'aws_puppet_class' method and fixes missing alias

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -611,6 +611,7 @@
   sentry_url: https://sentry.io/govuk/publish-data
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
 - github_repo_name: ckanext-datagovuk
+  puppet_name: ckan
   type: data.gov.uk apps
   team: "#govuk-platform-health"
   production_hosted_on: aws

--- a/spec/app/app_docs_spec.rb
+++ b/spec/app/app_docs_spec.rb
@@ -70,6 +70,39 @@ RSpec.describe AppDocs::App do
     end
   end
 
+  describe "aws_puppet_class" do
+    before do
+      app_data = {
+        "calculators_frontend" => {
+          "apps" => %w[
+            calculators
+            finder-frontend
+            licencefinder
+            smartanswers
+          ],
+        },
+      }
+      allow(AppDocs).to receive(:aws_machines).and_return(app_data)
+    end
+
+    it "should find puppet class via github repo name if neither app name nor puppet name provided" do
+      expect(AppDocs::App.new("github_repo_name" => "calculators").aws_puppet_class).to eq("calculators_frontend")
+    end
+
+    it "should find puppet class via app name" do
+      expect(AppDocs::App.new("app_name" => "calculators").aws_puppet_class).to eq("calculators_frontend")
+    end
+
+    it "should find puppet class via puppet name" do
+      expect(AppDocs::App.new("puppet_name" => "smartanswers", "github_repo_name" => "foo").aws_puppet_class).to eq("calculators_frontend")
+    end
+
+    it "should return error message if no puppet class found" do
+      expect(AppDocs::App.new("github_repo_name" => "foo").aws_puppet_class)
+        .to eq("Unknown - have you configured and merged your app in govuk-puppet/hieradata_aws/common.yaml")
+    end
+  end
+
   describe "apps_with_docs" do
     it "should return apps that have specified we can consume their docs folder, alphabetically" do
       expect(AppDocs.apps_with_docs.map(&:app_name)).to eq(%w[app-on-paas whitehall])


### PR DESCRIPTION
See https://docs.publishing.service.gov.uk/apps/ckanext-datagovuk.html:

<img width="800" alt="Screenshot 2020-06-15 at 16 09 14" src="https://user-images.githubusercontent.com/5111927/84674219-96aeac00-af22-11ea-95ca-e44dd56ccca5.png">

This adds the missing alias.