### PR TITLE
aws migration publishers

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -4,7 +4,7 @@
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     publishing-api:
       description: ''
@@ -22,7 +22,7 @@
   type: Publishing apps
   puppet_name: contacts
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     whitehall:
       description: ''
@@ -33,7 +33,7 @@
 - github_repo_name: content-tagger
   type: Publishing apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     publishing-api:
       description: ''
@@ -54,7 +54,7 @@
 - github_repo_name: content-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     content-publisher:
       description: ''
@@ -83,7 +83,7 @@
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     router:
       description: ''
@@ -104,7 +104,7 @@
 - github_repo_name: maslow
   type: Publishing apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     publishing-api:
       description: ''
@@ -115,7 +115,7 @@
 - github_repo_name: publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     publishing-api:
       description: ''
@@ -141,7 +141,7 @@
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     service-manual-frontend:
       description: ''
@@ -157,12 +157,12 @@
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 - github_repo_name: specialist-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     support:
       description: ''
@@ -179,7 +179,7 @@
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     router:
       description: ''
@@ -324,7 +324,7 @@
 - github_repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
   dependencies:
     manuals-frontend:
       description: ''
@@ -382,7 +382,7 @@
 - github_repo_name: search-admin
   type: Supporting apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 - github_repo_name: signon
   type: Supporting apps
   team: "#govuk-platform-health"

--- a/spec/app/run_rake_task_spec.rb
+++ b/spec/app/run_rake_task_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RunRakeTask do
 
     describe "given an application name" do
       before do
-        stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml")
+        stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml")
           .to_return(body: File.read("spec/fixtures/puppet-hieradata-common.yaml"))
       end
 
@@ -34,8 +34,8 @@ RSpec.describe RunRakeTask do
 
       it "has three links" do
         expect(html).to have_link("Run publishing_api:republish on Integration", href: "https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
-        expect(html).to have_link("Run publishing_api:republish on Staging", href: "https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
-        expect(html).to have_link("Run publishing_api:republish on Production", href: "https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
+        expect(html).to have_link("Run publishing_api:republish on Staging", href: "https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
+        expect(html).to have_link("Run publishing_api:republish on Production", href: "https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish")
       end
     end
   end


### PR DESCRIPTION
With the AWS migration of publishers, we need to change the location of the publishers to AWS in the developer docs.