### PR TITLE
Set source_url for external docs

### DIFF
--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -39,6 +39,7 @@ class GitHubRepoFetcher
           path: "/apis/#{app_name}/#{filename}.html",
           title: title,
           markdown: contents,
+          source_url: doc.html_url,
         }
       end
     rescue Octokit::NotFound

--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -23,6 +23,9 @@ class ProxyPages
               title: "#{app.app_name}: #{page[:title]}",
               markdown: page[:markdown],
             },
+            data: {
+              source_url: page[:source_url],
+            },
           },
         }
       end

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe GitHubRepoFetcher do
         {
           name: "analytics.md",
           download_url: "https://raw.githubusercontent.com/alphagov/#{repo_name}/master/docs/analytics.md",
+          html_url: "https://github.com/alphagov/#{repo_name}/blob/master/docs/analytics.md",
         },
       ]
       expected_output = [
@@ -66,6 +67,7 @@ RSpec.describe GitHubRepoFetcher do
           title: "Analytics",
           path: "/apis/#{repo_name}/analytics.html",
           markdown: markdown_fixture,
+          source_url: "https://github.com/alphagov/#{repo_name}/blob/master/docs/analytics.md",
         },
       ]
       stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/contents/docs")

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe ProxyPages do
         .and(include(frontmatter: hash_excluding(:content))),
       )
     end
+
+    it "sets the correct source_url for the doc" do
+      expect(described_class.api_docs).to all(
+        include(frontmatter: hash_including(data: hash_including(:source_url))),
+      )
+    end
   end
 
   describe ".app_docs" do


### PR DESCRIPTION
When we click 'View source', we expect it to take us to the main
document representing the page, so that we can easily edit the
information.
Until now, external docs' 'View source' link simply took you to
external_doc_template.html.erb, which is not a very useful
workflow.
We now bubble up the original source URL from the GitHub API
response so that we link to the right place.

Trello: https://trello.com/c/z3wOzJZS/165-create-one-way-to-import-api-docs