### PR TITLE
Make verify_deployable_apps and check_puppet_names abort on error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,4 +73,4 @@ task :check_puppet_names do
   end
 end
 
-task default: %i[lint spec cache:clear assets:precompile]
+task default: %i[verify_deployable_apps check_puppet_names lint spec cache:clear assets:precompile]

--- a/app/app_docs.rb
+++ b/app/app_docs.rb
@@ -161,6 +161,8 @@ class AppDocs
     def puppet_url
       return unless production_hosted_on.in?(%w[aws carrenza])
 
+      return app_data["puppet_url"] if app_data["puppet_url"]
+
       "https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/#{puppet_name}.pp"
     end
 

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -724,6 +724,12 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+- github_repo_name: govuk-puppet
+  team: "#govuk-developers"
+  production_hosted_on: none
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 - github_repo_name: govuk-zendesk-display-screen
   management_url: https://dashboard.heroku.com/apps/govuk-zendesk-display-screen
   production_hosted_on: heroku

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -652,6 +652,7 @@
   type: Licensing apps
   production_hosted_on: aws
   team: "#govuk-licensing"
+  puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify.pp
   sentry_url: false
   deploy_url: false
   dashboard_url: false

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -360,7 +360,7 @@
 - github_repo_name: search-analytics
   type: Services
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: none
 
 # Support
 
@@ -630,7 +630,7 @@
   team: "#govuk-data-labs"
   type: Data science
   description: "Machine learning model to recommend related content"
-  production_hosted_on: aws
+  production_hosted_on: none
   dashboard_url: false
   deploy_url: false
   sentry_url: false


### PR DESCRIPTION
This PR fixes the errors found by the `verify_deployable_apps` and `check_puppet_names` rake tasks, and adds these tasks to the `default` task so that they can catch configuration errors as soon as they're introduced.

See commits for details.