### PR TITLE
Fix issue where 'markdown' is nil and docs don't deploy

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -50,7 +50,7 @@ class ExternalDoc
 
     HTML::Pipeline
       .new(filters)
-      .to_html(markdown.force_encoding("UTF-8"))
+      .to_html(markdown.to_s.force_encoding("UTF-8"))
   end
 
   def self.title(markdown)


### PR DESCRIPTION
```
Error processing resource for index: apps/licensify.html
undefined method `force_encoding' for nil:NilClass
 /var/lib/jenkins/workspace/deploy-developer-docs/app/external_doc.rb:53:in `parse'
```

Not sure why this wasn't caught in the PR checks, as we
simulate a full build. However, in the interests of fixing
the issue quickly, we can force `markdown` to be a string if
it is a `nil`.