### PR TITLE
WIP: standardise pipeline

### DIFF
--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -22,6 +22,9 @@ class ProxyPages
             locals: {
               title: "#{app.app_name}: #{page[:title]}",
               markdown: page[:markdown],
+              context: {
+                repository: "alphagov/#{app.app_name}",
+              },
             },
             data: {
               source_url: page[:source_url],

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -167,7 +167,7 @@ gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
 
 <% if ENV["GITHUB_TOKEN"] %>
 <div class="embedded-readme">
-  <%= ExternalDoc.parse(application.readme) %>
+  <%= ExternalDoc.parse(application.readme, context: { repository: "alphagov/#{application.app_name}" }) %>
 </div>
 <% else %>
 <span class="govuk-error-message">

--- a/source/templates/external_doc_template.html.erb
+++ b/source/templates/external_doc_template.html.erb
@@ -4,4 +4,4 @@ parent: /apis.html
 hide_from_sitemap: true
 ---
 
-<%= ExternalDoc.parse(markdown) %>
+<%= ExternalDoc.parse(markdown, context: { repository: repository }) %>


### PR DESCRIPTION
It makes no sense to have different pipelines depending on
whether code is fetched or passed directly as markdown.
Fixing this properly also means fixing links on content
passed to the 'parse' method.
