### PR TITLE
Fix broken link due to markdown parse error

### DIFF
--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -204,7 +204,7 @@ For more details, read about the GOV.UK [Frontend architecture].
 Static JS/CSS is delivered over <https://assets.publishing.service.gov.uk>.
 Custom assets, such as images, are delivered over the same domain and uploaded
 by content designers via [asset-manager]. Under the hood, all of these assets
-live in an [AWS S3 bucket] (read ["Assets: how they work"]).
+live in an [AWS S3 bucket]; read ["Assets: how they work"].
 
 [asset-manager]: https://github.com/alphagov/asset-manager
 ["Assets: how they work"]: /manual/assets.html


### PR DESCRIPTION
`[AWS S3 bucket] (read ["Assets: how they work"])`

Was being converted to:

`<a href="read [\"Assets: how they work\"]>AWS S3 bucket</a>`.

I.e. it was mistakingly treating the text following the first `]` as the URL.

We should look at why this parsing issue happens - whether it's down to
a bug in CommonMarker, or our markdown, or the dev docs.

> <img width="492" alt="screenshot demonstrating the issue" src="https://user-images.githubusercontent.com/5111927/85716447-5ac6d400-b6e4-11ea-8a89-087270c08180.png">
