### PR TITLE
Add missing link to security incidents

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -156,4 +156,6 @@ There are ongoing plans to move this responsibility to a different part of GDS.
 If you receive a request to change any other DNS that hasn't come from the GOV.UK
 Proposition team, send it to them using the Zendesk group "3rd Line--GOV.UK Proposition".
 
+[security-incidents]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/security/security-incidents
 [gds-cli]: https://github.com/alphagov/gds-cli
+


### PR DESCRIPTION
I noticed this was missing a link when viewing this doc and as this was the link used elsewhere I assume it's the link intended when introduced in 40fe29c4