### PR TITLE
Remove install yarn from GitHub Action example

### DIFF
--- a/source/manual/test-and-build-a-project-with-github-actions.html.md
+++ b/source/manual/test-and-build-a-project-with-github-actions.html.md
@@ -213,7 +213,6 @@ jobs:
           restore-keys: bundle
       - run: bundle install --jobs 4 --retry 3 --deployment
       - uses: actions/setup-node@v1
-      - run: npm install -g yarn
       - name: Check for cached node modules
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
This removes the step to install yarn, as it appears that's already installed with `actions/setup-node@v1`. See the section about ]publishing with yarn in the README](https://github.com/actions/setup-node#usage).