### PR TITLE
Update "Write an incident report" page

### DIFF
--- a/source/manual/incident-reports.html.md
+++ b/source/manual/incident-reports.html.md
@@ -4,13 +4,13 @@ title: Write an incident report
 parent: "/manual.html"
 layout: manual_layout
 section: Incidents
-last_reviewed_on: 2019-11-11
+last_reviewed_on: 2020-07-06
 review_in: 3 months
 ---
 
 This page is for reference only. Use the [incident report template][tpl] on Google Drive when drafting the report.
 
-[tpl]: https://docs.google.com/document/d/1cMJP2p_PlDalJEcpS6TbXjZgUwdm9gd1rFrhUXa6uh4/edit
+[tpl]: https://docs.google.com/document/d/1YDA13RU6wicXoKgDv5VucJe3o_Z0k_Qhug9EJC_XdSE/edit
 
 ## Incident report checklist:
 
@@ -29,7 +29,7 @@ End Date|YYYY-MM-DD
 Start Time|HH:MM (local time)
 End Time|HH:MM (local time)
 Application / process|
-Priority|Was it a P1, P2, or P3 incident? 
+Priority|Was it a P1, P2, P3, or P4 incident? 
 Incident lead| 2nd line primary engineer or a senior developer
 Comms lead|2nd line secondary engineer
 
@@ -37,16 +37,16 @@ Overview
 
 _[Provide a summary here]_
 
-User impact
+User impact (external/internal)
 
 _[Detail of the specific front-end user impact]_
 
-Departmental impact
+Services affected and/or Departmental impact
 
 _[Detail of the specific departmental/publisher impact]_
 
 Timeline
-All times in local time, unless otherwise stated.
+All times in 24-hour (e.g. 16:12) local time, unless otherwise stated.
 
 Time|Description
 ----|-----------  
@@ -60,30 +60,51 @@ Time to fix (time from when incident declared to marked as resolved)|
 ### Time:
 ### Attendance:
 
-### Root cause
+### Root cause analysis
 
-Use this section to summarise the root cause of the incident. A draft root cause should be included, and discussed and agreed upon during the incident review. This root cause should be written for a non-technical audience.
- 
-Please also include the root cause category:
+A root cause is an underlying factor why an incident occurred, which when fixed would prevent a recurrence. Identify and summarise all of the root causes that led to the incident in a short paragraph, aimed at a non-technical audience.
 
+Reference all root cause categories that apply, for instance;
 * Unexpected effect of code change
-* Infrastructure failure (disk space, logging etc)
-* Provider failure (hardware, network failure etc
-* Security
+* Configuration fault (configuration change, pre-existing fault, etc)
+* Capacity issue (insufficient capacity to meet demand, implementation issue, etc)
+* Provider / third-party infrastructure failure (hardware, network failure, etc)
+* Workflow issue (usability issue, misoperation, etc)
+* Software design / architecture problem (i.e. worked as designed but led to a problem)
+* Other (please specify)
 
 ...
 ### Actions
 
-Use this section to assign actions to individuals (not teams). These are actions to be taken to fix the root cause of the issue or for preventative measures.
+Use this section to assign actions to individuals (not teams). These are actions to be taken to fix the root cause of the issue, for preventative measures and for any other improvements.
 
 * ...
+
 ### Standing actions
 
-* Does it need a blogpost? (P1 or P2; P3 if interesting).
-* Present a summary of the incident at GOV.UK technologists fortnightly to share learning.
-Recommendations
+* Update your incident log with incident title, priority, dates/times and a link to this report.
+* Present a summary of this incident to your team to share learning.
+* Coordinate a blogpost - if applicable
 
-* ...
 ### Recommendations
 
 * ...
+
+### Considerations
+
+Some questions to consider when writing the Incident Report and whilst working on RCA.
+
+* What caused the original issue to occur?
+* Why was this not caught before it reached production, if applicable?
+* Were we alerted quickly?
+* Were we able to diagnose and fix the immediate issue quickly?
+* Has the underlying issue been fixed?, if not how do we prevent a recurrence?
+* What other fixes/changes have been taken or need to take place as a result, if any?
+* What things helped during the incident?
+* What things hindered during the incident?
+* Was the process followed well and were comms effective?
+* What could we do to improve our response and comms process?
+
+### Notes
+
+Use this section to add notes during the incident management process.


### PR DESCRIPTION
The incident report template has changed to be GDS-wide, rather than GOV.UK specific.

I'm not convinced there is a user need to have the template duplicated in the developer docs, but since it is already there, I assume someone has decided there was, so I've updated it accordingly.

Trello card: https://trello.com/c/o9lLuXK1