### PR TITLE
[DO NOT MERGE] Remove priorities from Smokey alert manual

### DIFF
--- a/source/manual/alerts/high-priority-tests.html.md
+++ b/source/manual/alerts/high-priority-tests.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Run high priority tests
+title: Smokey loop tests
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
@@ -8,8 +8,12 @@ last_reviewed_on: 2020-06-15
 review_in: 6 months
 ---
 
-The high priority tests [come from Smokey][smokey] and [the Icinga check is defined in Puppet][icinga].
-Smokey can fail with an error message "Run high priority tests", or simply with "Smokey failed".
+[Smokey][smokey] runs in a continuous loop in each environment.
+We have [Icinga checks] for [most Smokey features], so that
+we are alerted when some aspect of GOV.UK may be in trouble.
+
+Smokey can fail with an error message "Smokey loop for \<feature\>",
+or simply with "Smokey failed".
 
 ## Tests failing
 
@@ -88,4 +92,5 @@ irb(main):002:0> smokey.update_attribute(:password_changed_at, Time.now)
 
 [signon]: https://github.com/alphagov/signon
 [smokey]: https://github.com/alphagov/smokey
-[icinga]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/checks/smokey.pp
+[most Smokey features]: https://github.com/alphagov/smokey/blob/master/docs/writing-tests.md#alerting-in-icinga
+[Icinga checks]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/checks/smokey.pp

--- a/source/manual/alerts/smokey-loop-tests.html.md
+++ b/source/manual/alerts/smokey-loop-tests.html.md
@@ -4,7 +4,7 @@ title: Smokey loop tests
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-06-15
+last_reviewed_on: 2020-07-08
 review_in: 6 months
 ---
 
@@ -67,15 +67,6 @@ their passphrase expire periodically. This will cause the tests to fail.
 
 You should change the passphrase of the account and rotate it in encrypted
 hieradata. Here's an [example PR in govuk-secrets](https://github.com/alphagov/govuk-secrets/pull/307).
-
-Alternatively, you can fake a passphrase change in the Signon Rails console,
-though this will only fix the alert temporarily.
-
-```
-$ govuk_app_console signon
-irb(main):001:0> smokey = User.find_by(name: "Smokey (test user)")
-irb(main):002:0> smokey.update_attribute(:password_changed_at, Time.now)
-```
 
 [signon]: https://github.com/alphagov/signon
 [smokey]: https://github.com/alphagov/smokey


### PR DESCRIPTION
Related to: https://github.com/alphagov/govuk-puppet/pull/10499

Previously we deprecated priorities in Smokey [1]. This manual was never
specific to high priority tests in the first place. I've also done a
general review of this manual, which was confusing because it conflated
alerts for the manual Smokey job, and the Smokey loop.

Please see the commits for more details.

[1]: https://github.com/alphagov/smokey/pull/693