### PR TITLE
Update unprocessed email docs

### DIFF
--- a/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
@@ -5,7 +5,7 @@ section: Icinga alerts
 subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-06-04
+last_reviewed_on: 2020-07-09
 review_in: 6 months
 ---
 
@@ -15,8 +15,8 @@ This may be fine and the emails will eventually go out, but it's worth some inve
 
 ### Icinga checks
 
-* `warning` - `content_changes` unprocessed for over 5 minutes
-* `critical` - `content_changes` unprocessed for over 10 minutes
+* `warning` - `content_changes` unprocessed for over 90 minutes
+* `critical` - `content_changes` unprocessed for over 120 minutes
 
 See the [ProcessContentChangeAndGenerateEmailsWorker][content-change-worker] for
 more information.
@@ -32,7 +32,7 @@ $ gds govuk connect app-console -e production email-alert-api
 #### Check which content changes are affected
 
 ```ruby
-ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil)
+ContentChange.where("created_at < ?", 120.minutes.ago).where(processed_at: nil)
 ```
 
 #### Check number of subscription contents built for a content change (you would expect this number to keep going up)
@@ -50,7 +50,7 @@ ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)
 #### Resend the emails for a content change in bulk (ignore ones that have already gone out)
 
 ```ruby
-ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).map { |content_change| ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)  }
+ContentChange.where("created_at < ?", 120.minutes.ago).where(processed_at: nil).map { |content_change| ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)  }
 ```
 
 ### Useful rake tasks
@@ -63,6 +63,14 @@ ContentChange.where("created_at < ?", 10.minutes.ago).where(processed_at: nil).m
 
 - [content_change_failed_emails][]
 
+#### Resend failed emails by email ids
+
+- [resend_failed_emails:by_id][]
+
+#### Resend failed emails by date range
+
+- [resend_failed_emails:by_date][]
+
 ### Still stuck?
 
 Read [email troubleshooting].
@@ -71,3 +79,5 @@ Read [email troubleshooting].
 [email troubleshooting]: /manual/email-troubleshooting.html
 [content_change_email_status_count]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:content_change_email_status_count['one_required_content_change_id','optional_second_content_change_id','and_so_on']
 [content_change_failed_emails]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:content_change_failed_emails['one_required_content_change_id','optional_second_content_change_id','and_so_on']
+[resend_failed_emails:by_id]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:resend_failed_emails:by_id['some-id,%20another-id']
+[resend_failed_emails:by_date]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:resend_failed_emails:by_date[%272020-01-01T10:00:00Z,%202020-01-01T11:00:00Z%27]

--- a/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
@@ -5,79 +5,40 @@ section: Icinga alerts
 subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-07-09
+last_reviewed_on: 2020-07-14
 review_in: 6 months
 ---
 
-This means that there are some emails informing users of content changes
-which haven't been processed within the time we would expect.
-This may be fine and the emails will eventually go out, but it's worth some investigation.
-
-### Icinga checks
+This alert is triggered when content changes are not processed within the time we would expect.
 
 * `warning` - `content_changes` unprocessed for over 90 minutes
 * `critical` - `content_changes` unprocessed for over 120 minutes
 
-See the [ProcessContentChangeAndGenerateEmailsWorker][content-change-worker] for
-more information.
+Every 30 minutes, [RecoverLostJobsWorker] automatically requeues jobs for any
+unprocessed content changes and messages that are over 1-hour old.
 
-### Useful queries
+If you see this alert it is likely that something has broken in Email Alert API
+that is either blocking one or all recovery attempts.
 
-First, enter an Email Alert Api Rails console:
+To diagnose this problem, consult [Sentry](https://sentry.io/organizations/govuk/issues/?project=202220)
+to see if there are errors reported.
 
-```bash
-$ gds govuk connect app-console -e production email-alert-api
-```
+If you find nothing conclusive in Sentry, go to [Email Alert API sidekiq logs] and check the jobs are running correctly.
 
-#### Check which content changes are affected
-
-```ruby
-ContentChange.where("created_at < ?", 120.minutes.ago).where(processed_at: nil)
-```
-
-#### Check number of subscription contents built for a content change (you would expect this number to keep going up)
-
-```ruby
-SubscriptionContent.where(content_change: content_change).count
-```
-
-#### Resend the emails for a content change (ignore ones that have already gone out)
-
-```ruby
-ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)
-```
-
-#### Resend the emails for a content change in bulk (ignore ones that have already gone out)
-
-```ruby
-ContentChange.where("created_at < ?", 120.minutes.ago).where(processed_at: nil).map { |content_change| ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)  }
-```
-
-### Useful rake tasks
-
-#### Check sent, pending and failed email counts for a content change
-
-- [content_change_email_status_count][]
-
-#### Check failed email ids and failure reasons for a content change
-
-- [content_change_failed_emails][]
-
-#### Resend failed emails by email ids
-
-- [resend_failed_emails:by_id][]
-
-#### Resend failed emails by date range
-
-- [resend_failed_emails:by_date][]
+If the problem persists, run the [RecoverLostJobsWorker] and/or [ProcessContentChangeWorker] [directly](https://stackoverflow.com/a/48543738)
+to see if any problems occur.
 
 ### Still stuck?
 
-Read [email troubleshooting].
+* [General troubleshooting tips]
+* [Email Alert API troubleshooting] for more information
+* [Email Alert API Metrics dashboard] to check if emails are going out
 
-[content-change-worker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_content_change_and_generate_emails_worker.rb
-[email troubleshooting]: /manual/email-troubleshooting.html
-[content_change_email_status_count]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:content_change_email_status_count['one_required_content_change_id','optional_second_content_change_id','and_so_on']
-[content_change_failed_emails]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:content_change_failed_emails['one_required_content_change_id','optional_second_content_change_id','and_so_on']
-[resend_failed_emails:by_id]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:resend_failed_emails:by_id['some-id,%20another-id']
-[resend_failed_emails:by_date]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:resend_failed_emails:by_date[%272020-01-01T10:00:00Z,%202020-01-01T11:00:00Z%27]
+
+[Email Alert API sidekiq logs]: https://docs.publishing.service.gov.uk/manual/logging.html#kibana
+[RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/recover_lost_jobs_worker.rb
+[ProcessContentChangeWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_content_change_worker.rb
+
+[General troubleshooting tips]: /manual/email-troubleshooting.html
+[Email Alert API troubleshooting]: /apis/email-alert-api/troubleshooting.html
+[Email Alert API Metrics dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1

--- a/source/manual/alerts/email-alert-api-unprocessed-messages.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-messages.html.md
@@ -5,76 +5,49 @@ section: Icinga alerts
 subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-07-09
+last_reviewed_on: 2020-07-14
 review_in: 6 months
 ---
 
-`Messages` are similar to [content changes][content-changes], introduced in
-September 2019 to support the [GOV.UK Get ready for Brexit checker][brexit-checker].
+`Messages` are similar to [content changes], introduced in September 2019 to support the [Brexit checker].
 It is intended to provide a means for applications to alert subscribers to ad hoc
 events that may not be represented by a content change. See the [ADR for Messages][adr-messages] for more information.
 
-This alert is triggered when these messages are not processed within the time we
-would expect. This may be fine and the emails will eventually go out, but it's worth some investigation.
+This alert is triggered when these messages are not processed within the time we would expect. This
+may be fine and the emails will eventually go out, but it's worth investigating.
 
 * `warning` - unprocessed `messages` created more than 90 minutes ago
 * `critical` - unprocessed `messages` created more than 120 minutes ago
 
-See the [ProcessMessageWorker][process-message-worker] for more information.
+Every 30 minutes, [RecoverLostJobsWorker] automatically requeues jobs for any
+unprocessed content changes and messages that are over 1-hour old.
 
-## Useful queries
+If you see this alert it is likely that something has broken in Email Alert API
+that is either blocking one or all recovery attempts.
 
-### Check which messages this affects
+To diagnose this problem, consult [Sentry](https://sentry.io/organizations/govuk/issues/?project=202220)
+to see if there are errors reported.
 
-```ruby
-Message.where("created_at < ?", 120.minutes.ago).where(processed_at: nil)
-```
+If you find nothing conclusive in Sentry, go to [Email Alert API sidekiq logs] and check the jobs are running correctly.
 
-Check the count, then run the above query again to see if the count has
-decreased. If it's decreasing, then it means that emails are going out and
-there's probably a lot being processed.
-If it's not decreasing the Sidekiq worker might be stuck, see the [sidekiq][sidekiq]
-section on how to view the Sidekiq queues.
+If the problem persists, run the [RecoverLostJobsWorker] and/or [ProcessMessageWorker] [directly](https://stackoverflow.com/a/48543738)
+to see if any problems occur.
 
-### Check number of subscription contents built for a message (you would expect this number to keep going up)
+### Still stuck?
 
-```ruby
-SubscriptionContent.where(message: message).count
-```
-
-### Resend the emails for a message (ignore ones that have already gone out)
-
-```ruby
-ProcessMessageWorker.new.perform(message.id)
-```
-
-### Resend the emails for a message in bulk (ignore ones that have already gone out)
-
-```ruby
-Message.where("created_at < ?", 120.minutes.ago).where(processed_at: nil).map { |message| ProcessMessageWorker.new.perform(message.id)  }
-```
-
-### Useful rake tasks
-
-#### Resend failed emails by email ids
-
-- [resend_failed_emails:by_id][]
-
-#### Resend failed emails by date range
-
-- [resend_failed_emails:by_date][]
+* [General troubleshooting tips]
+* [Email Alert API troubleshooting] for more information
+* [Email Alert API Metrics dashboard] to check if emails are going out
 
 
-You can also check the [Email Alert API Metrics dashboard][dashboard] to monitor
-if emails are going out and see the [general troubleshooting tips][troubleshooting]
-section for more information.
-
-[sidekiq]: /manual/sidekiq.html#sidekiq-web
-[content-changes]: https://docs.publishing.service.gov.uk/manual/alerts/email-alert-api-unprocessed-content-changes.html
-[brexit-checker]: https://www.gov.uk/get-ready-brexit-check
+[content changes]: https://docs.publishing.service.gov.uk/manual/alerts/email-alert-api-unprocessed-content-changes.html
+[Brexit checker]: https://www.gov.uk/get-ready-brexit-check
 [adr-messages]: https://github.com/alphagov/email-alert-api/blob/master/docs/arch/adr-004-message-concept.md
-[process-message-worker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_message_worker.rb
-[dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
-[troubleshooting]: /manual/email-troubleshooting.html
-[resend_failed_emails:by_id]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:resend_failed_emails:by_id['some-id,%20another-id']
-[resend_failed_emails:by_date]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:resend_failed_emails:by_date[%272020-01-01T10:00:00Z,%202020-01-01T11:00:00Z%27]
+
+[Email Alert API sidekiq logs]: https://docs.publishing.service.gov.uk/manual/logging.html#kibana
+[RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/recover_lost_jobs_worker.rb
+[ProcessMessageWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_message_worker.rb
+
+[General troubleshooting tips]: /manual/email-troubleshooting.html
+[Email Alert API troubleshooting]: /apis/email-alert-api/troubleshooting.html
+[Email Alert API Metrics dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -5,7 +5,7 @@ section: Emails
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-12-03
+last_reviewed_on: 2019-07-13
 review_in: 6 months
 ---
 
@@ -14,7 +14,7 @@ review_in: 6 months
 The purpose of the email notifications system is to inform users when
 content they are interested in is added to or changed on GOV.UK. Users
 indicate their interest by subscribing to receive updates for an area of
-interest (such as topic or government department).
+interest, such as topic or government department.
 
 The applications that comprise the email notifications system are:
 
@@ -37,7 +37,8 @@ communicate directly with the Email Alert API.
 To have a near real-time overview of the status of data passing through
 the Email Alert API, view the [metrics dashboard][dashboard].
 
-There is more detail about how this works in the [Email Alert API docs].
+For more information about how content changes trigger emails, as well as
+common issues and troubleshooting, view [Email Alert API docs].
 
 ### Email Alert Frontend
 


### PR DESCRIPTION
Adds new latency thresholds and updates the doc with some useful rake
tasks that were recently added.

Previews:

* https://github.com/alphagov/govuk-developer-docs/blob/update-unprocessed-alerts-docs/source/manual/alerts/email-alert-api-unprocessed-messages.html.md
* https://github.com/alphagov/govuk-developer-docs/blob/update-unprocessed-alerts-docs/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md

---

Depends on:
https://github.com/alphagov/email-alert-api/compare/increase-latency-thresholds?expand=1

Trello:
https://trello.com/c/Li8Zo03f/381-relax-the-thresholds-for-content-change-and-message-alerts