### PR TITLE
Create script to update gh-pages branch via Jenkins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,4 +73,7 @@ task :check_puppet_names do
   end
 end
 
-task default: %i[verify_deployable_apps check_puppet_names lint spec cache:clear assets:precompile]
+desc "Clear out and rebuild the build/ folder"
+task build: %i[cache:clear assets:precompile]
+
+task default: %i[verify_deployable_apps check_puppet_names lint spec build]

--- a/bin/update-github-pages
+++ b/bin/update-github-pages
@@ -1,0 +1,27 @@
+#!/bin/bash -x
+
+# ensure a predictable starting point
+git checkout master
+
+# delete 'build' folder if it exists
+rm -rf build/
+
+# create a 'build' directory checked out to the gh-pages branch
+git worktree add -B gh-pages build origin/gh-pages
+
+# build the project
+bundle exec rake build
+
+# cd into 'build' folder, which is now on the gh-pages branch
+cd build
+
+# fail if for some reason this isn't the gh-pages branch
+current_branch=$(git symbolic-ref --short -q HEAD)
+if [ "$current_branch" != "gh-pages" ]; then
+  echo "Expected build folder to be on gh-pages branch."
+  exit 1
+fi
+
+# commit and push to gh-pages
+git add . && git commit -m "Update gh-pages"
+git push


### PR DESCRIPTION
Alternative to #2656.
  
This script can either be run locally or triggered in a
GitHub Action or inside the hourly Jenkins cron task.

Next we'll need to [update the Jenkins job][job] to call
`update-github-pages` in addition to `deploy-to-s3`. When
we're happy that `gh-pages` is deploying as regularly as
the S3 version, and happy that it works, we can work on
pointing https://docs.publishing.service.gov.uk/ to GitHub
Pages, and then remove the S3 bucket and associated code.

In the long term, we'll probably want to [use GitHub Actions
for deployment][action], which would let us kill off the
Jenkins job altogether. This is dependant on having use
of secrets signed off.

Trello: https://trello.com/c/nEP3URQF/171-host-the-dev-docs-on-github-pages

[action]: https://github.com/alphagov/govuk-developer-docs/pull/2656
[job]: https://github.com/alphagov/govuk-puppet/blob/7f8de3c9ea11697b054aa644d1dec8d8071bb8b1/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb#L29
