### PR TITLE
Fix links on unprocessed content changes and messages pages

### DIFF
--- a/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-content-changes.html.md
@@ -5,7 +5,7 @@ section: Icinga alerts
 subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-07-14
+last_reviewed_on: 2020-07-16
 review_in: 6 months
 ---
 
@@ -25,7 +25,7 @@ to see if there are errors reported.
 
 If you find nothing conclusive in Sentry, go to [Email Alert API sidekiq logs] and check the jobs are running correctly.
 
-If the problem persists, run the [RecoverLostJobsWorker] and/or [ProcessContentChangeWorker] [directly](https://stackoverflow.com/a/48543738)
+If the problem persists, run the [RecoverLostJobsWorker] and/or [ProcessContentChangeWorker][process-content-change-worker] [directly](https://stackoverflow.com/a/48543738)
 to see if any problems occur.
 
 ### Still stuck?
@@ -37,7 +37,7 @@ to see if any problems occur.
 
 [Email Alert API sidekiq logs]: https://docs.publishing.service.gov.uk/manual/logging.html#kibana
 [RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/recover_lost_jobs_worker.rb
-[ProcessContentChangeWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_content_change_worker.rb
+[process-content-change-worker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_content_change_worker.rb
 
 [General troubleshooting tips]: /manual/email-troubleshooting.html
 [Email Alert API troubleshooting]: /apis/email-alert-api/troubleshooting.html

--- a/source/manual/alerts/email-alert-api-unprocessed-messages.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-messages.html.md
@@ -5,7 +5,7 @@ section: Icinga alerts
 subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-07-14
+last_reviewed_on: 2020-07-16
 review_in: 6 months
 ---
 
@@ -30,7 +30,7 @@ to see if there are errors reported.
 
 If you find nothing conclusive in Sentry, go to [Email Alert API sidekiq logs] and check the jobs are running correctly.
 
-If the problem persists, run the [RecoverLostJobsWorker] and/or [ProcessMessageWorker] [directly](https://stackoverflow.com/a/48543738)
+If the problem persists, run the [RecoverLostJobsWorker] and/or [ProcessMessageWorker][process-message-worker] [directly](https://stackoverflow.com/a/48543738)
 to see if any problems occur.
 
 ### Still stuck?
@@ -46,7 +46,7 @@ to see if any problems occur.
 
 [Email Alert API sidekiq logs]: https://docs.publishing.service.gov.uk/manual/logging.html#kibana
 [RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/recover_lost_jobs_worker.rb
-[ProcessMessageWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_message_worker.rb
+[process-message-worker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_message_worker.rb
 
 [General troubleshooting tips]: /manual/email-troubleshooting.html
 [Email Alert API troubleshooting]: /apis/email-alert-api/troubleshooting.html


### PR DESCRIPTION
Fixes mis-parsed links on:

* https://docs.publishing.service.gov.uk/manual/alerts/email-alert-api-unprocessed-content-changes.html
* https://docs.publishing.service.gov.uk/manual/alerts/email-alert-api-unprocessed-messages.html