### PR TITLE
Replace use of scp with govuk-connect

### DIFF
--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -162,12 +162,12 @@ deb file to aptly.
 2. Upload the package to the aptly machine:
 
     ```
-      $ scp ~/Downloads/rbenv-ruby-2.6.1_1_amd64.deb username@<inet_addr>.<environment>:/home/username/
+      $ gds govuk connect scp-push -e <environment> aws/apt ~/Downloads/rbenv-ruby-2.6.1_1_amd64.deb /tmp
     ```
 3. In the machine, add the package to the repo:
 
     ```
-      $ sudo -i aptly repo add rbenv-ruby /home/username/rbenv-ruby-2.6.1_1_amd64.deb
+      $ sudo -i aptly repo add rbenv-ruby /tmp/rbenv-ruby-2.6.1_1_amd64.deb
         Loading packages...
         [+] rbenv-ruby-2.6.1_1_amd64 added
     ```

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -4,7 +4,7 @@ title: Upload HMRC PAYE files
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-05-06
+last_reviewed_on: 2020-07-17
 review_in: 6 months
 ---
 

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -54,25 +54,21 @@ the previous version of the software.
 1. Check that GOV.UK content teams are aware of the ticket. They may
    need to request further tickets to be raised to cover the content updates.
 1. Download all zip files and XML file in the ticket
-1. Log into a backend machine: `gds govuk connect ssh -e production aws/backend`.
+1. Log into a backend machine: `gds govuk connect ssh -e production aws/backend:1`.
    **Yes, production - don't use integration or staging to test. There's a test procedure on production.**
-1. Make a note of the IP address you just SSH'd into, e.g. `ip-10-13-4-77.eu-west-1.compute.internal`
-1. Create a directory for the files to go into: `mkdir hmrc-paye`
+1. Create a directory for the files to go into: `mkdir /tmp/hmrc-paye`
 1. Either `exit` to return to your dev machine, or open another shell
 1. Upload the new files:
 
    ```shell
-   $mac scp -oProxyJump=jumpbox.production.govuk.digital *.zip yourname@<aws_machine_ip_address>:/home/yourname/hmrc-paye
-   $mac scp -oProxyJump=jumpbox.production.govuk.digital *.xml yourname@<aws_machine_ip_address>:/home/yourname/hmrc-paye
+   $mac gds govuk connect scp-push -e production aws/backend:1 *.zip /tmp/hmrc-paye
+   $mac gds govuk connect scp-push -e production aws/backend:1 *.xml /tmp/hmrc-paye
    ```
 
 1. SSH back into the machine if you exited earlier:
-   `gds govuk connect ssh -e production <aws_machine_ip_address>`
+   `gds govuk connect ssh -e production aws/backend:1`
 
-1. Verify that the files copied over correctly: `ls ~/hmrc-paye`
-
-1. Move the files over to the `/tmp` directory: `sudo mv ~/hmrc-paye /tmp`
-   **(The deploy doesn't work if you try to do it directly from your home directory)**.
+1. Verify that the files copied over correctly: `ls /tmp/hmrc-paye`
 
 1. Upload the ZIP files into Asset Manager
 

--- a/source/manual/howto-copy-postgresql-between-machines.html.md
+++ b/source/manual/howto-copy-postgresql-between-machines.html.md
@@ -28,7 +28,7 @@ Find the name of the database you want to back up. Start the PostgreSQL console
 Then create a dump:
 
 ```sh
-pg_dump name_of_database > name_of_database.bak
+pg_dump name_of_database > /tmp/name_of_database.bak
 ```
 
 Return to being a normal user on the instance:
@@ -37,45 +37,36 @@ Return to being a normal user on the instance:
 exit
 ```
 
-Now move the backup into your home directory:
+Now fix the permissions so that you own it:
 
 ```sh
-sudo mv /var/lib/postgresql/name_of_database.bak .
-```
-
-And fix the permissions so that you own it:
-
-```sh
-sudo chown $(whoami):$(whoami) name_of_database.bak
+sudo chown $(whoami):$(whoami) /tmp/name_of_database.bak
 ```
 
 Now `exit` the instance and move on to the next step.
 
 ## Download the backup to your local machine
 
-Use `scp` to download the file - you'll need to proxy via the jumpbox
-to hit the internal IP address. For example:
+Use `govuk-connect` to download the file. For example:
 
 ```sh
-scp -oProxyJump=jumpbox.staging.govuk.digital \
-johnsmith@ip-10-12-4-80.eu-west-1.compute.internal:name_of_database.bak .
+gds govuk connect scp-pull -e <environment> <ip> /tmp/name_of_database.bak
 ```
 
 ## Upload your backup to the desired machine
 
-Use `scp` to upload the file. For example:
+Use `govuk-connect` to upload the file. For example:
 
 ```sh
-scp -oProxyJump=jumpbox.integration.publishing.service.gov.uk \
-name_of_database.bak johnsmith@ip-10-1-4-71.eu-west-1.compute.internal:/home/johnsmith/
+gds govuk connect scp-push -e <environment> <ip> name_of_database.bak /tmp
 ```
 
 ## Import the backup to overwrite your PostgreSQL database
 
-SSH into the machine, and then move the backup away from the user home:
+SSH into the machine, and then move the backup away from `/tmp`:
 
 ```sh
-sudo mv name_of_database.bak /var/lib/postgresql/
+sudo mv /tmp/name_of_database.bak /var/lib/postgresql/
 ```
 
 Pass ownership over to the PostgreSQL user:

--- a/source/manual/howto-replace-an-assets-file.html.md
+++ b/source/manual/howto-replace-an-assets-file.html.md
@@ -15,12 +15,15 @@ changing the URL, follow these steps:
 0. Copy the new file from your computer to a `backend` server:
 
     ```
-    scp filename.ext <hostname>:/tmp/filename.ext
+    gds govuk connect scp-push -e <environment> aws/backend:1 filename.ext /tmp
     ```
 
-0. `ssh <hostname>`
+0. Get an app console on that same server:
 
-0. `govuk_app_console asset-manager`
+    ```
+    gds govuk connect ssh -e <environment> aws/backend:1
+    govuk_app_console asset-manager
+    ```
 
 0. Find the asset:
 

--- a/source/manual/howto-upload-an-asset-to-asset-manager.html.md
+++ b/source/manual/howto-upload-an-asset-to-asset-manager.html.md
@@ -16,13 +16,13 @@ Production assets are replicated to staging and integration nightly, so it is be
 the upload directly in production. First, upload the asset to a backend machine:
 
 ```
-scp my_file.jpg backend-1.backend.production:/tmp/
+gds govuk connect scp-push -e production aws/backend:1 my_file.jpg /tmp
 ```
 
 Then SSH to the same machine and run the upload command:
 
 ```
-ssh backend-1.backend.production
+gds govuk connect ssh -e production aws/backend:1
 cd /var/apps/asset-manager
 sudo -u deploy govuk_setenv asset-manager bin/create_asset /tmp/my_file.jpg
 ```


### PR DESCRIPTION
I also tweaked the docs a bit:

- use machine `:1` for cases where you need to copy things to and then ssh into a consistent machine, rather than noting down IPs

- use `/tmp` instead of `/home/<username>`, because it's less typing

---

[Trello card](https://trello.com/c/QcGSCmcL/130-support-scp-with-govuk-connect)