### PR TITLE
Set the dependencies team for ckanext-datagovuk

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -614,6 +614,7 @@
   puppet_name: ckan
   type: data.gov.uk apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-datagovuk"
   production_hosted_on: aws
   sentry_url: false
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1


### PR DESCRIPTION
It's more helpful that #govuk-datagovuk gets to see information about these Dependabot PRs. This is already the case for Find and Publisher.