### PR TITLE
Update guidance for related links

### DIFF
--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Publishing
-last_reviewed_on: 2020-01-07
+last_reviewed_on: 2020-07-24
 review_in: 6 months
 ---
 
@@ -14,11 +14,18 @@ review_in: 6 months
 Related links can be added or removed manually through [Content Tagger][].
 To do this, you can click on the **Edit a page** link at the top and enter the
 base path of the content item you need to edit. You will then see a section
-titled **Related content items** where you can edit the links.
+titled **Related content items** where you can add, edit or remove related links.
+
+It's important to note that the automatically generated related links are 
+contained in the section titled **Suggested related content items**. Related 
+links in this section can be re-ordered or removed, but no new links can be 
+added here. The links in this section (if any) will only be shown if there are no 
+manually-curated links in the **Related content items** section.
 
 If a request comes in a from a content designer to edit the related links of a
 page, you can send them to Content Tagger so they can edit the links
-themselves.
+themselves. You may also wish to point them to this guidance for managing related 
+links using Content Tagger.
 
 [Content Tagger]: https://content-tagger.publishing.service.gov.uk
 
@@ -39,7 +46,7 @@ Machine learning generated related links are created exclusively for Whitehall c
 - Related links are only generated for a number of content types, with exclusions in place for content that should not be linked _from_, linked _to_, or both. These exclusions can be found at https://github.com/alphagov/govuk-related-links-recommender/tree/master/src/config.
 - Generated related links are stored within the `suggested_ordered_related_items` property of a content item, while all existing and manually curated links continue to be stored within the `ordered_related_items` property.
 - If links exist with `ordered_related_items` for a content item, we do not show generated related links.
-- Requests need to have the header `Govuk-Use-Recommended-Related-Links` header set to `True` in order to show suggested related links - [this is set by the CDN for all requests](https://github.com/alphagov/govuk-cdn-config/blob/master/vcl_templates/www.vcl.erb#L238).
+- Requests need to have the header `Govuk-Use-Recommended-Related-Links` header set to `True` in order to show suggested related links - [this is set by the CDN for all requests](https://github.com/alphagov/govuk-cdn-config/blob/master/vcl_templates/www.vcl.erb#L242).
 
 
 ### Concourse pipeline details
@@ -52,7 +59,7 @@ This job runs the process to generate new related links for a subset of pages on
 
 The related links generated from this process are stored in an S3 environment-specific `govuk-related-links` bucket.
 
-Currently, this job is scheduled to run once every three weeks via a `time` resource attached to the production `run-generation-production` step.
+This job runs once every two weeks via a `time` resource attached to the production `run-generation-production` step.
 
 #### `link-ingestion`
 
@@ -60,11 +67,11 @@ This job runs the process of ingesting related links via the Publishing API.
 
 Links are retrieved from the environment-specific S3 bucket mentioned previously and then fed (in batches) to the Publishing API. There is a 20 minute delay between batches. Exclusions are applied during this stage from a `related_link_exclusions.json` file which is available in S3; for these links, we obtain the respective content ids and use them to remove any suggested links that may exist for the current batch of links being ingested.
 
-Currently, this job is triggered manually after reviewing a spreadsheet of the generated related links; it will be scheduled to run automatically by the end of September 2019.
+This job runs once every two weeks via a `time` resource attached to the production `run-generation-production` step, and specifically runs a few days after the generation of new related links takes place.
 
 ### Rolling back Links
 
-Should we ever need to roll back any suggested related links, there are a number of ways we can do this.
+Should we ever need to roll back any suggested related links, there are a number of ways we can do this, which are described below. If the request to roll back links is coming from a content designer, the process at the top of this document should be applied unless the request is to roll back links for more than a few pages.
 
 #### Links for individual pages
 
@@ -82,3 +89,5 @@ To exclude a document type or page from having links generated _to_ it, _from_ i
 To immediately and temporarily stop showing all suggested related links (for example, if a problem has led to bad links being generated for a large percentage of content / high traffic content), you will need to update the CDN to set the `Govuk-Use-Recommended-Related-Links` header to `False` and then [deploy the CDN](https://deploy.publishing.service.gov.uk/job/Deploy_CDN/) for `vhost: www`.
 
 The root cause of the problem should be investigated and a new set of related links generated and ingested through the pipeline, if possible. Should the fix not be immediate, we might consider re-ingesting an older batch of related links from S3.
+
+If you need to suspend all suggested related links, please reach out to the Data Labs team first so that we can help you assess the situation and take steps to address the root problem(s).


### PR DESCRIPTION
This PR updates the guidance for related links, adding further detail surrounding managing related links within Content Tagger and what to do should related links need to be rolled back.