### PR TITLE
Add new doc to describe auto security updates

### DIFF
--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -105,45 +105,6 @@ not boot when the affected VM is restarted. See the
 manual entry on [adding disks](/manual/adding-disks-in-vcloud.html) for
 more info.
 
-## Rebooting to apply unattended upgrades
-
-Machines are configured with [automatic security updates](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package)
-which install security updates overnight. Sometimes these require a reboot
-in order to become active.
-
-You can review the list of packages on machines (or classes of machines)
-by running:
-
-```
-fab $environment all apt.packages_with_reboots
-```
-
-NB, logs of the previous runs can be found in `/var/log/unattended-upgrades`.
-
-You will then need to decide whether to:
-
-- Reboot the machine, or
-- Silence the check until the next package requires update
-  (`fab $environment all apt.reset_reboot_needed`)
-
-### Deciding whether to reboot or silence
-
-This can be quite nuanced. Before you go ahead with any course of action,
-gather evidence and then ask in the \#re-govuk Slack channel.
-
-Find details of the update from the [Ubuntu Security
-Notices](http://www.ubuntu.com/usn/).
-
-- Is it a remote or local exploit?
-- Is it a kernel update?
-- If it's a shared library, are we using it (see below)?
-
-There is a Fabric task to find all processes using a deprecated library:
-
-```
-fab $environment all vm.deprecated_library:dbus
-```
-
 ## Special cases
 
 ### Rebooting Cache machines in AWS

--- a/source/manual/alerts/security-updates.html.md
+++ b/source/manual/alerts/security-updates.html.md
@@ -1,0 +1,25 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Security updates
+section: Infrastructure
+layout: manual_layout
+parent: "/manual.html"
+important: true
+last_reviewed_on: 2020-07-24
+review_in: 6 months
+---
+
+Machines are configured to [automatically install security updates](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package) on a daily basis.
+
+- This is triggered by the `/etc/cron.daily/apt` script.
+- Relevant config can be found in `/etc/apt/apt.conf.d`.
+
+This alert indicates automatic updates have stopped working. While this is not normally a critical issue, it becomes so if we start missing out on security patches. Some commands to start debugging with:
+
+```bash
+# check the output of the last automatic upgrade
+less /var/log/unattended-upgrades/unattended-upgrades.log
+
+# try running the upgrade manually
+sudo unattended-upgrade -d --dry-run
+```


### PR DESCRIPTION
https://trello.com/c/5JpkmLwB/940-fix-not-alerting-about-outstanding-security-updates

Previously this was mixed up with rebooting guidance. Although
the original doc had guidance about choosing when to reboot, this
came from a legacy import [1] and it's unclear if we really need
to check the details of updates that have already been applied.

Note: the original "/var/log/unattended-upgrades" path suggestion
was wrong; the new doc has a corrected version.

[1]: https://github.com/alphagov/govuk-developer-docs/commit/5547bb99c17bbf9acc5841272596d585a61018e6