### PR TITLE
Update security-updates.html.md

### DIFF
--- a/source/manual/alerts/security-updates.html.md
+++ b/source/manual/alerts/security-updates.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline"
 title: Outstanding security updates
-section: Infrastructure
+section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 important: true

--- a/source/manual/alerts/security-updates.html.md
+++ b/source/manual/alerts/security-updates.html.md
@@ -1,11 +1,11 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Security updates
+title: Outstanding security updates
 section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2020-07-24
+last_reviewed_on: 2020-07-27
 review_in: 6 months
 ---
 
@@ -23,3 +23,12 @@ less /var/log/unattended-upgrades/unattended-upgrades.log
 # try running the upgrade manually
 sudo unattended-upgrade -d --dry-run
 ```
+
+If the unattended upgrades log looks okay, check which security updates are outstanding:
+
+```bash
+apt-get upgrade -s | grep -i security
+```
+
+You may find that the upgrades are on a [deny list in govuk-puppet](https://github.com/alphagov/govuk-puppet/commit/a0872cb1c9e6e7981863660b1500f3a2ede631fe)
+(for example, `mysql-server-5.5` which [needs upgrading manually](/manual/upgrading-mysql.html)).


### PR DESCRIPTION
Rename title to match the Icinga alert.

Add a debug step to find out which upgrades are required.

Link to MySQL upgrade documentation - it may be useful for a dev coming to this page.

https://trello.com/c/5JpkmLwB/940-fix-not-alerting-about-outstanding-security-updates