### PR TITLE
Use seed to generate predictably random schema examples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "github-markdown"
 gem "html-pipeline"
 gem "redcarpet", "~> 3.5.0"
 
-gem "govuk_schemas", "~> 4.0.0"
+gem "govuk_schemas", "~> 4.1.0"
 
 # GitHub API
 gem "faraday-http-cache", "~> 2.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     fastimage (2.1.7)
     ffi (1.13.1)
     github-markdown (0.6.9)
-    govuk_schemas (4.0.0)
+    govuk_schemas (4.1.0)
       json-schema (~> 2.8.0)
     govuk_tech_docs (2.0.12)
       activesupport
@@ -278,7 +278,7 @@ DEPENDENCIES
   faraday_middleware (~> 1.0.0)
   ffi (= 1.13.1)
   github-markdown
-  govuk_schemas (~> 4.0.0)
+  govuk_schemas (~> 4.1.0)
   govuk_tech_docs
   html-pipeline
   middleman (~> 4.3.7)

--- a/app/content_schema.rb
+++ b/app/content_schema.rb
@@ -1,26 +1,27 @@
 require "govuk_schemas"
 
 class ContentSchema
-  attr_reader :schema_name
+  attr_reader :schema_name, :seed
 
-  def initialize(schema_name)
+  def initialize(schema_name, seed = 777)
     @schema_name = schema_name
+    @seed = seed
   end
 
   def frontend_schema
-    FrontendSchema.new(schema_name)
+    FrontendSchema.new(schema_name, seed)
   rescue Errno::ENOENT
     nil
   end
 
   def publisher_content_schema
-    PublisherContentSchema.new(schema_name)
+    PublisherContentSchema.new(schema_name, seed)
   rescue Errno::ENOENT
     nil
   end
 
   def publisher_links_schema
-    PublisherLinksSchema.new(schema_name)
+    PublisherLinksSchema.new(schema_name, seed)
   rescue Errno::ENOENT
     nil
   end
@@ -28,8 +29,9 @@ class ContentSchema
   class FrontendSchema
     attr_reader :schema_name
 
-    def initialize(schema_name)
+    def initialize(schema_name, seed)
       @schema_name = schema_name
+      @seed = seed
       raw_schema
     end
 
@@ -38,7 +40,7 @@ class ContentSchema
     end
 
     def random_example
-      GovukSchemas::RandomExample.new(schema: raw_schema).payload
+      GovukSchemas::RandomExample.new(schema: raw_schema, seed: @seed).payload
     end
 
     def properties
@@ -55,8 +57,9 @@ class ContentSchema
   class PublisherContentSchema
     attr_reader :schema_name
 
-    def initialize(schema_name)
+    def initialize(schema_name, seed)
       @schema_name = schema_name
+      @seed = seed
       raw_schema
     end
 
@@ -65,7 +68,7 @@ class ContentSchema
     end
 
     def random_example
-      GovukSchemas::RandomExample.new(schema: raw_schema).payload
+      GovukSchemas::RandomExample.new(schema: raw_schema, seed: @seed).payload
     end
 
     def properties
@@ -82,8 +85,9 @@ class ContentSchema
   class PublisherLinksSchema
     attr_reader :schema_name
 
-    def initialize(schema_name)
+    def initialize(schema_name, seed)
       @schema_name = schema_name
+      @seed = seed
       raw_schema
     end
 
@@ -92,7 +96,7 @@ class ContentSchema
     end
 
     def random_example
-      GovukSchemas::RandomExample.new(schema: raw_schema).payload
+      GovukSchemas::RandomExample.new(schema: raw_schema, seed: @seed).payload
     end
 
     def properties


### PR DESCRIPTION
We rebuild gh-pages every hour, and without the seed this means
regenerating entire schema examples for every content schema
type. This leads to ~50,000 line changes per commit, which
quickly makes govuk-developer-docs a very heavy repo to work
with.

We don't care about producing a different random schema on
every run; only that the example itself is easy to generate.
Applying a simple seed (here arbitrarily assigned '777') makes
govuk_schemas generate the same schema example every time we
call it (from v4.1.0 onwards).

Trello: https://trello.com/c/nEP3URQF/171-host-the-dev-docs-on-github-pages