### PR TITLE
Update Release app hosting provider

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -409,7 +409,7 @@
 - github_repo_name: release
   type: Supporting apps
   team: "#govuk-platform-health"
-  production_hosted_on: carrenza
+  production_hosted_on: aws
 - github_repo_name: router
   type: Supporting apps
   team: "#govuk-platform-health"


### PR DESCRIPTION
Release app in production is now in AWS as of a few months ago.