### PR TITLE
Add 'docs.publishing.service.gov.uk' CNAME for GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.publishing.service.gov.uk


### PR DESCRIPTION
This is required to enable GitHub Pages with a custom domain.
Details on the file formatting:
https://docs.github.com/en/github/working-with-github-pages/troubleshooting-custom-domains-and-github-pages\#cname-errors