### PR TITLE
Fix gh-pages CNAME configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          cname: docs.publishing.service.gov.uk
           commit_message: ${{steps.commit_message_writer.outputs.commit_message}}

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.publishing.service.gov.uk


### PR DESCRIPTION
1) CNAME should be on gh-pages, not master.
2) the hourly build overwrite the CNAME on gh-pages, so we
   need to add it to the actions-gh-pages config. See:
   https://github.com/peaceiris/actions-gh-pages\#%EF%B8%8F-add-cname-file-cname

Trello: https://trello.com/c/nEP3URQF/171-host-the-dev-docs-on-github-pages