### PR TITLE
Expose GITHUB_TOKEN as ENV variable when deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -156,15 +156,6 @@ gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
 
 ## README
 
-<div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-    The content below is pulled in directly from the repository.<br />
-    Links might not function properly.
-  </strong>
-</div>
-
 <% if application.private_repo? %>
   <span class="govuk-error-message">
     Cannot fetch README of private repo.
@@ -174,6 +165,15 @@ gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
     Cannot fetch README without `GITHUB_TOKEN`.
   </span>
 <% else %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      The content below is pulled in directly from the repository.<br />
+      Links might not function properly.
+    </strong>
+  </div>
+
   <div class="embedded-readme">
     <%= ExternalDoc.parse(application.readme) %>
   </div>

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -165,14 +165,18 @@ gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
   </strong>
 </div>
 
-<% if ENV["GITHUB_TOKEN"] %>
-<div class="embedded-readme">
-  <%= ExternalDoc.parse(application.readme) %>
-</div>
+<% if application.private_repo? %>
+  <span class="govuk-error-message">
+    Cannot fetch README of private repo.
+  </span>
+<% elsif ENV["GITHUB_TOKEN"].nil? %>
+  <span class="govuk-error-message">
+    Cannot fetch README without `GITHUB_TOKEN`.
+  </span>
 <% else %>
-<span class="govuk-error-message">
-  Error: cannot fetch README without `GITHUB_TOKEN`.
-</span>
+  <div class="embedded-readme">
+    <%= ExternalDoc.parse(application.readme) %>
+  </div>
 <% end %>
 
 <% end %>


### PR DESCRIPTION
We have some [build-time logic](https://github.com/alphagov/govuk-developer-docs/blob/130c6ac6f87f1fe5e6402a534a73ed0128b16a52/source/templates/application_template.html.md.erb#L168-L176) which checks for the presence of a GITHUB_TOKEN ENV variable
before attempting to call `application.readme`. This is so that
devs working on their local machine can compile the dev docs
without having to specify a token, and without hitting the GitHub
API limit.

This commit should fix issues like we're seeing on https://docs.publishing.service.gov.uk/apps/imminence.html:

> <img width="594" alt="Screenshot showing error message 'Error: cannot fetch README without `GITHUB_TOKEN`.'" src="https://user-images.githubusercontent.com/5111927/89397591-f1d17380-d707-11ea-8edb-938da8f001ec.png">

Running `GITHUB_TOKEN=$(cat ~/github_token.txt) ./startup.sh`
locally builds the pages as expected.

It also explicitly explains that private repos shouldn't have README content pulled in:

> <img width="360" alt="Screenshot 2020-09-04 at 09 31 26" src="https://user-images.githubusercontent.com/5111927/92218945-c9b56b80-ee91-11ea-9b3a-c3092e7b077b.png">
