### PR TITLE
Add a section about rotating SES SMTP credentials

### DIFF
--- a/source/manual/aws-iam-key-rotation.html.md
+++ b/source/manual/aws-iam-key-rotation.html.md
@@ -109,6 +109,25 @@ you can safely [remove the key](#6-remove-the-old-key).
   - Either wait up to 30 minutes for this to take effect or run
   `govuk_puppet --verbose` in the machine that uses that key.
 
+#### Rotating SES SMTP credentials
+
+The SMTP credentials for SES are connected to a user in IAM, but they are
+separate to the security credentials. As of August 2020, to rotate SMTP
+credentials, the user needs to be re-created and the new credentials will
+be displayed. They cannot be rotated after that point.
+
+When creating the new user, it's sensible to append the current date
+(such as `.YYYYMMDD`) to the username so it's easy to see when the user
+was created and the username won't conflict with the existing user. This
+allows both credentials to be available at the same time while switching over.
+The old user can be deleted once the app is using the new credentials.
+
+See [this PR][smtp-rotation-pr] for an example and the relevant [AWS documentation
+on obtaining SES credentials][aws-ses-credentials].
+
+[smtp-rotation-pr]: https://github.com/alphagov/govuk-secrets/pull/1032
+[aws-ses-credentials]: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html
+
 ### 5. Ensure new key is being used
 
 Ensure that the `Last used` values change to show that the new key is being


### PR DESCRIPTION
It turns out it's not as simple as rotating security credentials when rotating SMTP credentials.

See https://github.com/alphagov/govuk-secrets/pull/1032 for an example.