### PR TITLE
Update instructions for publishing emergency banner

### DIFF
--- a/markdown_lint.rb
+++ b/markdown_lint.rb
@@ -109,3 +109,9 @@ exclude_rule "no-bare-urls"
 # If that is implemented, we'll be able to override the rule only
 # in the places we want to allow inline HTML.
 exclude_rule "no-inline-html"
+
+# This rule stops us from having correctly rendered nested unordered
+# lists within an ordered list.
+# It is a known issue with this gem:
+# https://github.com/markdownlint/markdownlint/issues/296
+exclude_rule "ul-indent"

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 important: true
-last_reviewed_on: 2020-04-20
+last_reviewed_on: 2020-08-07
 review_in: 6 months
 ---
 
@@ -42,13 +42,13 @@ The GOV.UK on-call escalations contact will supply you with:
 The data for the emergency banner is stored in Redis. Jenkins is used to set the variables.
 
 1. Go to the Jenkins task:
-  - [Deploy the emergency banner on Integration](https://deploy.integration.publishing.service.gov.uk/job/deploy-emergency-banner/)
-  - [Deploy the emergency banner on Staging](https://deploy.blue.staging.govuk.digital/job/deploy-emergency-banner/)
-  - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.blue.production.govuk.digital/job/deploy-emergency-banner/)
+   - [Deploy the emergency banner on Integration](https://deploy.integration.publishing.service.gov.uk/job/deploy-emergency-banner/)
+   - [Deploy the emergency banner on Staging](https://deploy.blue.staging.govuk.digital/job/deploy-emergency-banner/)
+   - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.blue.production.govuk.digital/job/deploy-emergency-banner/)
 
-2. Fill in the appropriate variables using the form presented by Jenkins
+1. Fill in the appropriate variables using the form presented by Jenkins
 
-3. Click `Build`.
+1. Click `Build`.
 
 ![Jenkins Deploy Emergency Banner](images/emergency_publishing/deploy_emergency_banner_job.png)
 
@@ -92,12 +92,11 @@ Once all caches have had time to clear, check that the emergency banner is visib
 ### Remove the banner using Jenkins
 
 1. Navigate to the appropriate deploy Jenkins environment (integration, staging or production):
+  - [Remove the emergency banner from Integration](https://deploy.integration.publishing.service.gov.uk/job/remove-emergency-banner/)
+  - [Remove the emergency banner from Staging](https://deploy.blue.staging.govuk.digital/job/remove-emergency-banner/)
+  - [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.blue.production.govuk.digital/job/remove-emergency-banner/)
 
-- [Remove the emergency banner from Integration](https://deploy.integration.publishing.service.gov.uk/job/remove-emergency-banner/)
-- [Remove the emergency banner from Staging](https://deploy.blue.staging.govuk.digital/job/remove-emergency-banner/)
-- [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.blue.production.govuk.digital/job/remove-emergency-banner/)
-
-2. Click `Build now` in the left hand menu.
+1. Click `Build now` in the left hand menu.
 
 ![Jenkins Remove Emergency Banner](images/emergency_publishing/remove_emergency_banner_job.png)
 
@@ -132,22 +131,22 @@ You can manually check whether the data has been stored in Redis by the Jenkins 
 
 1. From your development machine, SSH into a frontend machine appropriate to the environment you want to check.
 
-```bash
-$ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
-```
+   ```bash
+   $ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+   ```
 
-2. Load a Rails console for static:
+1. Load a Rails console for static:
 
-```bash
-$ govuk_app_console static
-```
+   ```bash
+   $ govuk_app_console static
+   ```
 
-3. Check the Redis key exists:
+1. Check the Redis key exists:
 
-```rb
-irb(main):001:0> Redis.new.hgetall("emergency_banner")
-#> {}
-```
+   ```rb
+   irb(main):001:0> Redis.new.hgetall("emergency_banner")
+   #> {}
+   ```
 
 In the above example, the key has not been set. A successfully set key would return a result similar to the following:
 
@@ -163,22 +162,22 @@ If you need to manually run the rake tasks to set the Redis keys, you can do so 
 1. SSH into a `frontend` machine appropriate to the environment you are
    deploying the banner on. For example:
 
-```bash
-$ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
-```
+   ```bash
+   $ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+   ```
 
-2. Change into the directory for `static`:
+1. Change into the directory for `static`:
 
-```bash
-$ cd /var/apps/static
-```
+   ```bash
+   $ cd /var/apps/static
+   ```
 
-3. Run the rake task to create the emergency banner hash in Redis, substituting
+1. Run the rake task to create the emergency banner hash in Redis, substituting
    the quoted data for the parameters:
 
-```bash
-$ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:deploy[campaign_class,heading,short_description,link,link_text]
-```
+   ```bash
+   $ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:deploy[campaign_class,heading,short_description,link,link_text]
+   ```
 
 The `campaign_class` is directly injected into the HTML as a `class` and must be one of
 
@@ -213,27 +212,27 @@ $ exit
 
 1. SSH into a frontend machine:
 
-```bash
-$ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
-```
+   ```bash
+   $ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+   ```
 
-2. Change into the directory for `static`:
+1. Change into the directory for `static`:
 
-```bash
-$ cd /var/apps/static
-```
+   ```bash
+   $ cd /var/apps/static
+   ```
 
-3. Run the rake task to remove the emergency banner hash from Redis:
+1. Run the rake task to remove the emergency banner hash from Redis:
 
-```bash
-$ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:remove
-```
+   ```bash
+   $ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:remove
+   ```
 
-4. Quit your SSH session
+1. Quit your SSH session
 
-```bash
-$ exit
-```
+   ```bash
+   $ exit
+   ```
 
 ---
 

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -131,16 +131,10 @@ various points in our stack as well as locally in your browser. Things to try:
 
 You can manually check whether the data has been stored in Redis by the Jenkins job on one of the frontend machines.
 
-1. From your development machine, SSH into a frontend machine appropriate to the environment you want to check.
+1. Load a Rails console for the static application on the frontend machine in the relevant environment.
 
    ```bash
-   $ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
-   ```
-
-1. Load a Rails console for static:
-
-   ```bash
-   $ govuk_app_console static
+   $ gds govuk connect -e staging app-console frontend/static
    ```
 
 1. Check the Redis key exists:
@@ -165,7 +159,7 @@ If you need to manually run the rake tasks to set the Redis keys, you can do so 
    deploying the banner on. For example:
 
    ```bash
-   $ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+   $ gds govuk connect -e staging ssh frontend
    ```
 
 1. Change into the directory for `static`:
@@ -215,7 +209,7 @@ $ exit
 1. SSH into a frontend machine:
 
    ```bash
-   $ ssh $(ssh staging-aws "govuk_node_list --single-node -c frontend").staging-aws
+   $ gds govuk connect -e staging ssh frontend
    ```
 
 1. Change into the directory for `static`:

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -46,7 +46,9 @@ The data for the emergency banner is stored in Redis. Jenkins is used to set the
    - [Deploy the emergency banner on Staging](https://deploy.blue.staging.govuk.digital/job/deploy-emergency-banner/)
    - [⚠️ Deploy the emergency banner on Production ⚠️](https://deploy.blue.production.govuk.digital/job/deploy-emergency-banner/)
 
-1. Fill in the appropriate variables using the form presented by Jenkins
+1. Click `Build with Parameters`.
+
+1. Fill in the appropriate variables using the form presented by Jenkins.
 
 1. Click `Build`.
 
@@ -92,9 +94,9 @@ Once all caches have had time to clear, check that the emergency banner is visib
 ### Remove the banner using Jenkins
 
 1. Navigate to the appropriate deploy Jenkins environment (integration, staging or production):
-  - [Remove the emergency banner from Integration](https://deploy.integration.publishing.service.gov.uk/job/remove-emergency-banner/)
-  - [Remove the emergency banner from Staging](https://deploy.blue.staging.govuk.digital/job/remove-emergency-banner/)
-  - [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.blue.production.govuk.digital/job/remove-emergency-banner/)
+   - [Remove the emergency banner from Integration](https://deploy.integration.publishing.service.gov.uk/job/remove-emergency-banner/)
+   - [Remove the emergency banner from Staging](https://deploy.blue.staging.govuk.digital/job/remove-emergency-banner/)
+   - [⚠️ Remove the emergency banner from Production ⚠️](https://deploy.blue.production.govuk.digital/job/remove-emergency-banner/)
 
 1. Click `Build now` in the left hand menu.
 


### PR DESCRIPTION
Adds a missing step to the emergency banner publishing instructions.

Also removed the hardcoded numbering of lists and replaced all items with `1.`.  This gets parsed by Github (or any other markdown renderer) as a numbered list with the numbers added automatically.  This reduces the number of lines included in a diff when items are added or removed from the list.

Trello card: https://trello.com/c/A96YxL0F