### PR TITLE
Update find-support app info

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -683,7 +683,7 @@
   private_repo: false
   type: Specialist apps
   production_hosted_on: paas
-  team: "#govuk-corona-services-tech"
+  team: "#govuk-smart-answers-devs"
   sentry_url: https://sentry.io/organizations/govuk/issues/?project=5192076
   deploy_url: 'https://github.com/alphagov/govuk-coronavirus-find-support/blob/master/concourse/pipeline.yml'
   dashboard_url: false


### PR DESCRIPTION
The find support app has been handed over the the coronavirus smartanswers team,
so the dependapanda slack alerts should be moved too.