### PR TITLE
Review Re-create an AWS mongo instance

### DIFF
--- a/source/manual/alerts/recreate-a-mongo-instance-in-aws.html.md
+++ b/source/manual/alerts/recreate-a-mongo-instance-in-aws.html.md
@@ -4,12 +4,9 @@ title: Re-create an AWS mongo instance
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-05-04
-review_in: 3 months
+last_reviewed_on: 2020-08-12
+review_in: 6 months
 ---
-> Deprecation note:
-> We expect this to be fixed by <https://github.com/alphagov/govuk-aws/pull/1097>
-> If you see a similar issue, please let RE know in Slack #re-govuk.
 
 ## Symptom
 


### PR DESCRIPTION
Although the original cause of this issue is now fixed, it may still be
useful to have this documentation in case a similar problem occurs. With that in
mind the deprecation notice has been removed and the review time lengthened.