### PR TITLE
Remove overly generic email troubleshooting steps

### DIFF
--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -43,27 +43,6 @@ environment name.
 > are being sent to subscribers, and instead a better test is to
 > subscribe yourself and check that emails arrive.
 
-## Check the email alert API
-
-A useful debug step if you're not sure if an email has been sent is to
-check Email Alert API to see if it has created records in its database.
-
-```
-$ govuk_app_console email-alert-api
-
-# Note that we are not using `Email.last` because its primary key is `id`,
-# which is a string and alphabetically ordered rather than by create date
-
-> ContentChange.where(created_at: DateTime.now - 15.minutes...DateTime.now)
-> Email.where(created_at: DateTime.now - 15.minutes...DateTime.now)
-> DeliveryAttempt.where(created_at: DateTime.now - 15.minutes...DateTime.now)
-```
-
-Emails won't be sent if no one is subscribed, so you'll need to do that
-first. The integration and staging environments only allow email to be
-sent to a small number of email addresses so you cannot test using your
-own email address in these environments.
-
 [dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_technical.json?refresh=10s&orgId=1
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
 [password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify

--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -36,22 +36,9 @@ is available in the ['govuk-email-courtesy-copies' Google Group][google-group].
 Integration and staging emails have a subject prefixed by the
 environment name.
 
-If you need to test the process of subscribing to an email alert, you
-can subscribe with `govuk-email-courtesy-copies@digital.cabinet-office.gov.uk`.
-You should then see two copies of the email at that address when you
-perform an action that triggers an email alert (the courtesy copy and
-the subscriber one).
-
-The process for triggering an alert varies by publishing application,
-but it usually involves creating a new edition of some content, then
-publishing it with a 'major' update type. The change note you enter
-will appear in the email that gets sent.
-
 > **Note**
 >
-> Due to the way that we send the courtesy copy emails and the
-> anonymisation integration data sync, we can't fully exercise the code
-> that matches content changes with subscriptions. Therefore, it is not
+> Courtesy copies are sent separately to normal emails. Therefore, it is not
 > safe to rely on the courtesy copy Google Group to guarantee that emails
 > are being sent to subscribers, and instead a better test is to
 > subscribe yourself and check that emails arrive.

--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -5,7 +5,7 @@ section: Emails
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-05-14
+last_reviewed_on: 2020-08-14
 review_in: 6 months
 ---
 

--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -16,7 +16,7 @@ email architecture, read [Email notifications: how they work](/manual/email-noti
 
 ### Check the current health of the ecosystem
 
-You can check the [Email Alert API Metrics dashboard][dashboard] to monitor
+You can check the [Email Alert API Technical dashboard][dashboard] to monitor
 if emails are going out.
 
 ### Check that Notify sent the email
@@ -77,6 +77,6 @@ first. The integration and staging environments only allow email to be
 sent to a small number of email addresses so you cannot test using your
 own email address in these environments.
 
-[dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_technical.json?refresh=1m&orgId=1&from=now-6h&to=now
+[dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_technical.json?refresh=10s&orgId=1
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
 [password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify


### PR DESCRIPTION
https://trello.com/c/Xd47oJKZ/415-remove-the-deliveryattempt-model

Please see the commits for more details.