### PR TITLE
reboots-required: Slightly better docs

### DIFF
--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -47,12 +47,10 @@ time.
 
 ### Rules of manual rebooting
 
-* Do not reboot more than one machine of the same class at the
-  same time.
-* Most machines in Production should be rebooted out of hours, and this
-  is handled by those who are on call out of hours.
-  * In emergencies, machines in Production may need to be rebooted in-hours.
-  * Machines in other environments can be rebooted in hours.
+* Do not reboot more than one machine of the same class at the same time.
+* There are Icinga alerts that warn if machines need rebooting. Those
+  alerts will tell you if it's a manual reboot, and whether it's in-
+  or out-of-hours.
 * There is [extra guidance if the machine you are rebooting is in AWS](#rebooting-guidance-for-aws).
   You may wish to pair with the RE interruptible/on call person.
 * There are also [things to consider when rebooting Carrenza machines](#rebooting-guidance-for-carrenza).

--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -298,12 +298,4 @@ by On Call staff.
 They may be rebooted in working hours in the staging environment, however you
 should notify colleagues before doing so.
 
-### Rebooting Docker Management machines
-
-These currently just run etcd which is used to coorindate automatic
-out of hours reboots.
-
-Reboots of these machines should be organised by 2nd line and happen
-in hours.
-
 [vcloud]: /manual/connect-to-vcloud-director.html


### PR DESCRIPTION
- rebooting-machines: Remove special instructions for `docker-management-1`
  - These don't add anything more than we were getting from the Icinga
  alert to reboot this machine in-hours. And it was right at the bottom of
  all the things about rebooting Carrenza machines which are becoming
  increasingly irrelevant.
- reboots-required: De-emphasize "most things are out-of-hours"
  - This is apparently untrue, now. A lot of things have been changed to
  'careful' which means 'in-hours', including `cache` boxes which
  doesn't at all surprise me given how careful we are with them.
  - Woohoo, less manual work for on-call to do.
  - Source: Pete and I went to do some manual out-of-hours reboots to find
  that the alert was only saying about in-hours ones. So we needn't have
  both woken up early.
