### PR TITLE
Update rake task references for Email Alert API

### DIFF
--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -33,7 +33,7 @@ make changes to [govuk-puppet].
 
 Once these changes have been deployed and the environment variable
 `EMAIL_ADDRESS_OVERRIDE_WHITELIST` is populated with your address you can test
-that you can receive emails by running the [troubleshoot:deliver_to_test_email[name@example.com]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=troubleshoot:deliver_to_test_email[name@example.com]) [rake task].
+that you can receive emails by running the [support:deliver_to_test_email[name@example.com]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=support:deliver_to_test_email[name@example.com]) [rake task].
 
 ## Testing digest emails
 

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -107,9 +107,9 @@ The country's subscription list(s) `title` and `slug` needs to be updated, such 
 * "`<country_name>` - travel advice"
 * "`<country_name>`"
 
-1. Run the rake task [manage:find_subscriber_list_by_title[title]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:find_subscriber_list_by_title[country_name])
+1. Run the rake task [data_migration:find_subscriber_list_by_title[title]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=data_migration:find_subscriber_list_by_title[country_name])
   with the country name to see which subscription lists need to be updated
-2. Run the rake task [manage:update_subscriber_list[slug,new_title,new_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:update_subscriber_list[country_slug,new_title,new_country_slug])
+2. Run the rake task [data_migration:update_subscriber_list[slug,new_title,new_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=data_migration:update_subscriber_list[country_slug,new_title,new_country_slug])
   to update the subscription lists
 
   > **Note**


### PR DESCRIPTION
https://github.com/alphagov/email-alert-api/pull/1352#discussion_r465690000

Relates to: https://github.com/alphagov/email-alert-api/pull/1371