### PR TITLE
Update travel advice & medical safety alert docs

### DIFF
--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -5,35 +5,39 @@ section: Icinga alerts
 subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-07-16
+last_reviewed_on: 2020-08-18
 review_in: 6 months
 ---
 
-There is [a check][email-check] to verify that emails are sent for
-[drug and medical device alerts][] and [travel advice updates][]. These checks
-are run via Jenkins: [Drug and medical device alerts check][drug-alerts-check]
-and [Travel advice alerts check][travel-advice-check].
+We expect that when new GOV.UK content is published, or when existing content
+is updated in a significant way, emails will be sent to any subscribers to
+notify them of the change.
+
+We actively monitor this for [medical safety alerts][] and [travel advice
+updates][] with the [Medical safety alerts check][medical safety check] and
+[Travel advice alerts check][travel advice check], these are configured in
+[email-alert-monitoring][].
+
+These checks determine a list of content that we expect subscribers to have
+been emailed. We use a Gmail account which is subscribed to all travel advice
+and medical safety alerts to check whether an email has been received within a
+sufficient time period, if not the checks will fail.
 
 ## Troubleshooting failed checks
 
 First inspect the console logs for the Jenkins job to confirm the reason for the
-failure. The email check looks in two different mailboxes and the failure message
-should describe which mailbox is seeing an issue.
+failure.
 
-* Check the mailbox that is used for the check to rule out an issue searching
-  for the message: `govuk_email_check@digital.cabinet-office.gov.uk`
-  This email address is subscribed to travel advice alerts and drug and medical
-  device alerts. Its credentials can be found in the [2nd line password store][]
-  under `google-accounts/govuk_email_check@digital.cabinet-office.gov.uk`.
-
-* [Check the courtesy copy inbox]. Its presence here doesn't mean that the
-  email was sent to users, just that Email Alert API processed the content change.
+Check the mailbox that is used for the check to rule out an issue searching for
+the message: `govuk_email_check@digital.cabinet-office.gov.uk`. Its credentials
+can be found in the [2nd line password store][] under
+`google-accounts/govuk_email_check@digital.cabinet-office.gov.uk`.
 
 If the email has been received by the mailbox but the subject of the email
 doesn't match the title of the content item, this means that the title of the
 content was updated after it was first published and after the emails went out.
 To stop the check from constantly failing, add the updated content item title
-to the [acknowledged email list] and then re-run the Jenkins job.
+to the [acknowledged email list][] and then re-run the Jenkins job.
 
 ## Troubleshooting unsent emails
 
@@ -44,17 +48,16 @@ If the check is reporting correctly then emails are not being sent. Try the
 
 If you need to force the sending of a travel advice email alert, there
 is a rake task in Travel Advice Publisher, which you can run using
-[this Jenkins job][resend-travel-advice-job] where the edition ID of the
+[this Jenkins job][resend travel advice job] where the edition ID of the
 travel advice content item can be found in the URL of the country's edit
 page in Travel Advice Publisher and looks like `fedc13e231ccd7d63e1abf65`.
 
 [2nd line password store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline
 [acknowledged email list]: https://github.com/alphagov/email-alert-monitoring/blob/master/lib/email_verifier.rb#L6-L14
-[check the courtesy copy inbox]: /manual/email-troubleshooting.html#check-the-courtesy-copy-inbox
-[drug-alerts-check]: https://deploy.blue.production.govuk.digital/job/email-alert-check/
-[drug and medical device alerts]: https://www.gov.uk/drug-device-alerts
-[email-check]: https://github.com/alphagov/email-alert-monitoring
-[resend-travel-advice-job]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D
-[travel-advice-check]: https://deploy.blue.production.govuk.digital/job/travel-advice-email-alert-check/
+[medical safety check]: https://deploy.blue.production.govuk.digital/job/medical-safety-email-alert-check/
+[medical safety alerts]: https://www.gov.uk/drug-device-alerts
+[email-alert-monitoring]: https://github.com/alphagov/email-alert-monitoring
+[resend travel advice job]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D
+[travel advice check]: https://deploy.blue.production.govuk.digital/job/travel-advice-email-alert-check/
 [travel advice updates]: https://www.gov.uk/foreign-travel-advice
 [troubleshooting]: /manual/email-troubleshooting.html

--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -77,6 +77,6 @@ first. The integration and staging environments only allow email to be
 sent to a small number of email addresses so you cannot test using your
 own email address in these environments.
 
-[dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
+[dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_technical.json?refresh=1m&orgId=1&from=now-6h&to=now
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
 [password-store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/govuk-notify


### PR DESCRIPTION
This updates the docs to take into account work to remove the courtesy
copies email box from the checks.

Depends on:
https://github.com/alphagov/email-alert-monitoring/pull/67

Trello:
https://trello.com/c/kfZC9tes/455-improve-drug-and-travel-advice-checks