### PR TITLE
Change CNAME value for transitioning sites.

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -167,7 +167,7 @@ the day after.
 
 Once the site has been imported successfully, the domain can be pointed
 at us by the organisation. For hostnames which can have a `CNAME`
-record, this is `redirector-cdn.production.govuk.service.gov.uk`.
+record, this is `bouncer-cdn.production.govuk.service.gov.uk`.
 Domains at the root of their zone can't use `CNAME` records, so must use
 an `A` record and point at one of the [Fastly GOV.UK IP
 addresses](https://github.com/alphagov/transition/blob/016c3d30e190c41eaa912ed554384a49f3418a91/app/models/host.rb#L22).


### PR DESCRIPTION
This was discovered as part of a piece of 2ndline work to allow a
department to register geography.gov.uk and then redirect it to their
organistaion page.

The old CNAME appears to have been used when transitions onto GOV.UK
were a frequent occurange. If used now the Department's URL will just
redirect to a fastly error page.

However at some point we've switched over to this bounder-cdn. This PR
updates that in the docs so we won't use the old value again in future!