### PR TITLE
Add new CNAME to consider AKA domains step

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -61,7 +61,10 @@ preview according to the following pattern:
 There are lots of examples of these in [hosts currently configured in
 Transition][transition-hosts].
 
-These AKA domains should be CNAMEd to: `redirector-cdn.production.govuk.service.gov.uk`
+These AKA domains should be CNAMEd to: `bouncer-cdn.production.govuk.service.gov.uk`
+
+Previously we used a `redirector-cdn` address which reached its capacity and will now fail if added as the
+CNAME record for any new domains.
 
 [transition-hosts]: https://transition.publishing.service.gov.uk/hosts
 


### PR DESCRIPTION
Relates to commit b4e5e77b, forgot to change this CNAME record for the AKA step too, also added a line of context in case a reader is confused to find a different CNAME compared to previously migrated domains, or if there's any potential for a clash with older docs (Google Docs from 2017 are still doing the rounds for example)