### PR TITLE
Convert GitHub API calls to HTTP requests

### DIFF
--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -23,7 +23,7 @@ class GitHubRepoFetcher
   # Note that it is cached as pure markdown and requires further processing.
   def readme(app_name)
     CACHE.fetch("alphagov/#{app_name} README", expires_in: 1.hour) do
-      Base64.decode64(client.readme("alphagov/#{app_name}").content)
+      HTTP.get("https://raw.githubusercontent.com/alphagov/#{app_name}/master/README.md")
     rescue Octokit::NotFound
       nil
     end

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -3,20 +3,9 @@ require "octokit"
 class GitHubRepoFetcher
   include Singleton
 
-  # Fetch a repo from GitHub.
-  #
-  # If the app_name is just a repo name we'll assume that it's in the alphagov
-  # org. Because 99% of the repos will be from that org, we can download and
-  # cache all alphagov-repos and save on API calls.
+  # Fetch a repo from GitHub
   def repo(app_name)
-    if app_name =~ %r{/}
-      # Not on alphagov, make a separate call to the API. Cache it for
-      # development speed.
-      @cache ||= {}
-      @cache[app_name] ||= client.repo(app_name)
-    else
-      all_alphagov_repos.find { |repo| repo.name == app_name } || raise("alphagov/#{app_name} not found")
-    end
+    all_alphagov_repos.find { |repo| repo.name == app_name } || raise("alphagov/#{app_name} not found")
   end
 
   # Fetch a README for an alphagov application and cache it.

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -12,7 +12,8 @@ class GitHubRepoFetcher
   # Note that it is cached as pure markdown and requires further processing.
   def readme(app_name)
     CACHE.fetch("alphagov/#{app_name} README", expires_in: 1.hour) do
-      HTTP.get("https://raw.githubusercontent.com/alphagov/#{app_name}/master/README.md")
+      default_branch = repo(app_name).default_branch
+      HTTP.get("https://raw.githubusercontent.com/alphagov/#{app_name}/#{default_branch}/README.md")
     rescue Octokit::NotFound
       nil
     end

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -110,7 +110,6 @@
     - name: Misc
       repos:
         - seal
-        - dsingleton/deploy-lag-radiator
         - govuk-browser-extension
         - govuk-dependencies
         - govuk-deploy-lag-badger

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -21,26 +21,24 @@ RSpec.describe GitHubRepoFetcher do
 
   describe "#readme" do
     def readme_url(repo_name)
-      "https://api.github.com/repos/alphagov/#{repo_name}/readme"
+      "https://raw.githubusercontent.com/alphagov/#{repo_name}/master/README.md"
     end
 
     it "caches the first response" do
       repo_name = SecureRandom.uuid
       stubbed_request = stub_request(:get, readme_url(repo_name))
-        .to_return(status: 200, body: '{ "content": {} }', headers: { content_type: "application/json" })
+        .to_return(status: 200, body: "Foo")
 
       GitHubRepoFetcher.instance.readme(repo_name)
       GitHubRepoFetcher.instance.readme(repo_name)
       expect(stubbed_request).to have_been_requested.once
     end
 
-    it "retrieves the README content from the GitHub API response" do
+    it "retrieves the README content from the GitHub CDN" do
       repo_name = SecureRandom.uuid
       readme_contents = "# temporary-test"
-      base64_readme_contents = "IyB0ZW1wb3JhcnktdGVzdA=="
-      response = { "content": base64_readme_contents }
       stub_request(:get, readme_url(repo_name))
-        .to_return(status: 200, body: response.to_json, headers: { content_type: "application/json" })
+        .to_return(status: 200, body: readme_contents)
 
       expect(GitHubRepoFetcher.instance.readme(repo_name)).to eq(readme_contents)
     end
@@ -48,7 +46,7 @@ RSpec.describe GitHubRepoFetcher do
     it "returns nil if no README exists" do
       repo_name = SecureRandom.uuid
       stub_request(:get, readme_url(repo_name))
-        .to_return(status: 404, body: "{}", headers: { content_type: "application/json" })
+        .to_return(status: 404)
 
       expect(GitHubRepoFetcher.instance.readme(repo_name)).to eq(nil)
     end


### PR DESCRIPTION
We save around 70 API calls by curling the URL of each
app README directly. This helps prevent hitting API resource
limits locally, as well as making the code easier to read
since there is no base64 conversion required any more.

It also ensures that we don't accidentally expose any
private repo information. If we use the API and the relevant
access token, we could potentially download private repo content
which we wouldn't want to expose on the Dev Docs. By fetching
the public GitHub URL directly, if it's private we'll run
into a 404.

Finally, this PR removes deprecated logic around organisation names
on GitHub, which is no longer needed now that everything is under
@alphagov. Other parts of the code (README and docs/ ingestion)
make this assumption, so `repo` should too.

Trello: https://trello.com/c/of45ytdG/182-reduce-unnecessary-github-api-requests