### PR TITLE
Update zendesk.html.md

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -15,9 +15,9 @@ and general queries from users of data.gov.uk ("DGU"), for whom 2nd line provide
 ## Get started
 
 [Create an account][zendesk-create-account], then ask a fellow 2nd liner to assign a new ticket to
-"2nd/3rd Line\--Zendesk Administration" asking to give you access to "2nd Line - GOV.UK Alerts and Issues".
+`2nd/3rd Line--Zendesk Administration` asking to give you access to `2nd Line--GOV.UK Alerts and Issues`.
 
-When you're logged in, you should be looking at the ['2nd Line\--GOV.UK Alerts and Issues' queue][zendesk-queue].
+When you're logged in, you should be looking at the [`2nd Line--GOV.UK Alerts and Issues` queue][zendesk-queue].
 
 ## Priorities
 
@@ -74,10 +74,10 @@ Once you've resolved a ticket, click "Submit as Solved".
 
 ## Tickets left pending without a response
 
-Note that if a ticket has been resolved and pending a response for 4 or more days with no response from the
+Note that if a ticket has been resolved and pending a response for 5 or more days with no response from the
 requester, you can submit it as solved with a message telling them why and that if they still need help they
-can get in touch. Do this by clicking the "Apply macro" button at the bottom of the tickert screen, and
-choosing the "GOV.UK 2nd line tech: pending for 4+ days" option.
+can get in touch. Do this by clicking the "Apply macro" button at the bottom of the ticket screen, and
+choosing the "GOV.UK 2nd line tech: pending for 5+ days" option.
 
 [zendesk-create-account]: https://govuk.zendesk.com/auth/v2/login/registration?auth_origin=3194076%2Cfalse%2Ctrue&amp;brand_id=3194076&amp;return_to=https%3A%2F%2Fgovuk.zendesk.com%2Fhc%2Fen-us&amp;theme=hc
 [zendesk-queue]: https://govuk.zendesk.com/agent/filters/360000051009


### PR DESCRIPTION
In 197ff4b655be363c1833bfaa878f8397aff28776 I changed this from 5 days to 4 days as
this was the macro that I saw in Zendesk. However, that turns out to be a separate macro
and GOV.UK is still expected to follow the 5 day rule.

Also the markdown escaping from that commit did not work, so I've wrapped inside
backticks to preserve the `--`.