### PR TITLE
Update process for unprocessed fact check emails

### DIFF
--- a/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
+++ b/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
@@ -76,9 +76,9 @@ Once you've found the edition, you can check in the "History and notes" tab
 to see if the fact check was eventually re-sent with the correct subject line.
 If this is the case, **the duplicate email can be deleted**.
 
-If the fact check email never made it, you can let the content team know. In
-general this means the contents of the email can be manually copied into the
-edition as an "Edition note". Once this is done, **the original email can then
-be deleted**.
+If the fact check email never made it, you should forward the email to
+govuk-fact-check@digital.cabinet-office.gov.uk with the edtion ID added to the
+subject line in square brackets. Check this appears in publisher (usually within
+10 minutes) then delete the original unprocessed email from the inbox.
 
 [publisher]: https://publisher.publishing.service.gov.uk/


### PR DESCRIPTION
By forwarding the message rather than copying it into Publisher, it retains the status of a fact check response (rather than an internal note)  and updates the edition's status in Publisher to "Fact check received" which alerts the content designer to the response having been received.