### PR TITLE
Fix URL for Whitehall asset removal rake task

### DIFF
--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -24,6 +24,6 @@ follow these steps:
   - Go to the GOVUK Production project under the DIGITAL.CABINET-OFFICE.GOV.UK organisation
   - Select Storage -> Browser, manually delete the asset in the govuk-production-mirror bucket
 
-[whitehall-rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete[]
-[rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:whitehall_delete[]
+[whitehall-rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:whitehall_delete[]
+[rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete[]
 [clear-cache]: https://docs.publishing.service.gov.uk/manual/purge-cache.html#assets


### PR DESCRIPTION
The URL contained the wrong rake task name, so didn't work if you tried to run the task without checking the task name.