### PR TITLE
Notifications team look after email apps

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -245,7 +245,7 @@
       description: ''
 - github_repo_name: email-alert-api
   type: APIs
-  team: "#govuk-platform-health"
+  team: "#govuk-notifications-dev"
   metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: aws
   consume_docs_folder: true
@@ -352,7 +352,7 @@
   dependencies: {}
 - github_repo_name: email-alert-service
   type: Services
-  team: "#govuk-platform-health"
+  team: "#govuk-notifications-dev"
   production_hosted_on: aws
   dependencies:
     email-alert-api:
@@ -447,7 +447,7 @@
       description: ''
 - github_repo_name: email-alert-frontend
   type: Frontend apps
-  team: "#govuk-platform-health"
+  team: "#govuk-notifications-dev"
   production_hosted_on: aws
   dependencies:
     static:


### PR DESCRIPTION
This is to switch ownership and dependabot notifications for these apps to the notifications team that has been running for a few months now.