### PR TITLE
Remove unused `dependencies` config

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -7,15 +7,10 @@
   production_hosted_on: aws
   dependencies:
     publishing-api:
-      description: ''
     content-store:
-      description: ''
     content-tagger:
-      description: ''
     router:
-      description: ''
     signon:
-      description: ''
   actors:
   - Publisher
 - github_repo_name: contacts-admin
@@ -25,30 +20,20 @@
   production_hosted_on: aws
   dependencies:
     whitehall:
-      description: ''
     publishing-api:
-      description: ''
     signon:
-      description: ''
 - github_repo_name: content-tagger
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     publishing-api:
-      description: ''
     content-store:
-      description: ''
     search-api:
-      description: ''
     email-alert-api:
-      description: ''
     router:
-      description: ''
     search-admin:
-      description: ''
     signon:
-      description: ''
   actors:
   - Publisher
 - github_repo_name: content-publisher
@@ -57,28 +42,19 @@
   production_hosted_on: aws
   dependencies:
     content-publisher:
-      description: ''
     router:
-      description: ''
     content-data-api:
-      description: ''
     signon:
-      description: ''
 - github_repo_name: local-links-manager
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     signon:
-      description: ''
     local-links-manager:
-      description: ''
     link-checker-api:
-      description: ''
     mapit:
-      description: ''
     publishing-api:
-      description: ''
 - github_repo_name: manuals-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
@@ -86,57 +62,36 @@
   production_hosted_on: aws
   dependencies:
     router:
-      description: ''
     manuals-publisher:
-      description: ''
     signon:
-      description: ''
     asset-manager:
-      description: ''
     content-store:
-      description: ''
     whitehall:
-      description: ''
     publishing-api:
-      description: ''
     link-checker-api:
-      description: ''
 - github_repo_name: maslow
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     publishing-api:
-      description: ''
     support:
-      description: ''
     signon:
-      description: ''
 - github_repo_name: publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     publishing-api:
-      description: ''
     frontend:
-      description: ''
     link-checker-api:
-      description: ''
     router:
-      description: ''
     content-tagger:
-      description: ''
     publisher:
-      description: ''
     mapit:
-      description: ''
     signon:
-      description: ''
     asset-manager:
-      description: ''
     router-api:
-      description: ''
 - github_repo_name: service-manual-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
@@ -144,15 +99,10 @@
   production_hosted_on: aws
   dependencies:
     service-manual-frontend:
-      description: ''
     service-manual-publisher:
-      description: ''
     signon:
-      description: ''
     asset-manager:
-      description: ''
     publishing-api:
-      description: ''
 - github_repo_name: short-url-manager
   type: Publishing apps
   team: "#govuk-platform-health"
@@ -165,36 +115,23 @@
   production_hosted_on: aws
   dependencies:
     support:
-      description: ''
     router:
-      description: ''
     signon:
-      description: ''
     publishing-api:
-      description: ''
     asset-manager:
-      description: ''
     email-alert-api:
-      description: ''
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     router:
-      description: ''
     travel-advice-publisher:
-      description: ''
     email-alert-api:
-      description: ''
     link-checker-api:
-      description: ''
     signon:
-      description: ''
     asset-manager:
-      description: ''
     publishing-api:
-      description: ''
 - github_repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
@@ -204,31 +141,18 @@
   production_hosted_on: aws
   dependencies:
     router:
-      description: ''
     whitehall:
-      description: ''
     static:
-      description: ''
     link-checker-api:
-      description: ''
     maslow:
-      description: ''
     search-api:
-      description: ''
     signon:
-      description: ''
     publishing-api:
-      description: ''
     content-store:
-      description: ''
     router-api:
-      description: ''
     asset-manager:
-      description: ''
     support:
-      description: ''
     email-alert-api:
-      description: ''
   actors:
     - Publisher
     - Public
@@ -242,7 +166,6 @@
   production_hosted_on: aws
   dependencies:
     router-api:
-      description: ''
 - github_repo_name: email-alert-api
   type: APIs
   team: "#govuk-notifications-dev"
@@ -251,18 +174,14 @@
   consume_docs_folder: true
   dependencies:
     signon:
-      description: ''
     content-store:
-      description: ''
 - github_repo_name: imminence
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     mapit:
-      description: ''
     signon:
-      description: ''
 - github_repo_name: link-checker-api
   type: APIs
   team: "#govuk-platform-health"
@@ -270,7 +189,6 @@
   production_hosted_on: aws
   dependencies:
     signon:
-      description: ''
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"
@@ -279,9 +197,7 @@
   production_hosted_on: aws
   dependencies:
     signon:
-      description: ''
     content-store:
-      description: ''
 - github_repo_name: search-api
   type: APIs
   team: "#govuk-platform-health"
@@ -289,9 +205,7 @@
   production_hosted_on: aws
   dependencies:
     signon:
-      description: ''
     publishing-api:
-      description: ''
 - github_repo_name: asset-manager
   type: APIs
   team: "#govuk-platform-health"
@@ -299,9 +213,7 @@
   production_hosted_on: aws
   dependencies:
     signon:
-      description: ''
     asset-manager:
-      description: ''
 - github_repo_name: router-api
   type: APIs
   team: "#govuk-platform-health"
@@ -314,28 +226,19 @@
   production_hosted_on: aws
   dependencies:
     support:
-      description: ''
     support-api:
-      description: ''
     content-store:
-      description: ''
     whitehall:
-      description: ''
 - github_repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     manuals-frontend:
-      description: ''
     signon:
-      description: ''
     publishing-api:
-      description: ''
     search-api:
-      description: ''
     content-store:
-      description: ''
 - github_repo_name: mapit
   type: APIs
   team: "#govuk-platform-health"
@@ -356,7 +259,6 @@
   production_hosted_on: aws
   dependencies:
     email-alert-api:
-      description: ''
 - github_repo_name: search-analytics
   type: Services
   team: "#govuk-platform-health"
@@ -374,11 +276,8 @@
   production_hosted_on: aws
   dependencies:
     content-data-api:
-      description: ''
     support:
-      description: ''
     signon:
-      description: ''
 - github_repo_name: search-admin
   type: Supporting apps
   team: "#govuk-platform-health"
@@ -389,16 +288,13 @@
   production_hosted_on: aws
   dependencies:
     whitehall:
-      description: ''
 - github_repo_name: support
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     support-api:
-      description: ''
     signon:
-      description: ''
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
@@ -425,11 +321,8 @@
   production_hosted_on: aws
   dependencies:
     static:
-      description: ''
     content-store:
-      description: ''
     publishing-api:
-      description: ''
 - github_repo_name: collections
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -438,35 +331,25 @@
   private_repo: false
   dependencies:
     static:
-      description: ''
     email-alert-api:
-      description: ''
     content-store:
-      description: ''
     search-api:
-      description: ''
 - github_repo_name: email-alert-frontend
   type: Frontend apps
   team: "#govuk-notifications-dev"
   production_hosted_on: aws
   dependencies:
     static:
-      description: ''
     email-alert-api:
-      description: ''
     content-store:
-      description: ''
 - github_repo_name: feedback
   type: Frontend apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
   dependencies:
     static:
-      description: ''
     support:
-      description: ''
     support-api:
-      description: ''
 - github_repo_name: finder-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -474,13 +357,9 @@
   production_hosted_on: aws
   dependencies:
     content-store:
-      description: ''
     search-api:
-      description: ''
     email-alert-api:
-      description: ''
     static:
-      description: ''
 - github_repo_name: frontend
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -488,17 +367,11 @@
   production_hosted_on: aws
   dependencies:
     search-api:
-      description: ''
     imminence:
-      description: ''
     mapit:
-      description: ''
     local-links-manager:
-      description: ''
     content-store:
-      description: ''
     licensify:
-      description: ''
   actors:
   - Public
 - github_repo_name: government-frontend
@@ -509,9 +382,7 @@
   production_hosted_on: aws
   dependencies:
     content-store:
-      description: ''
     static:
-      description: ''
 - github_repo_name: info-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -519,7 +390,6 @@
   production_hosted_on: aws
   dependencies:
     static:
-      description: ''
 - github_repo_name: licence-finder
   type: Frontend apps
   puppet_name: licencefinder
@@ -528,11 +398,8 @@
   production_hosted_on: aws
   dependencies:
     content-store:
-      description: ''
     publishing-api:
-      description: ''
     search-api:
-      description: ''
 - github_repo_name: manuals-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -540,9 +407,7 @@
   production_hosted_on: aws
   dependencies:
     content-store:
-      description: ''
     publishing-api:
-      description: ''
 - github_repo_name: smart-answers
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -550,15 +415,10 @@
   production_hosted_on: aws
   dependencies:
     publishing-api:
-      description: ''
     static:
-      description: ''
     imminence:
-      description: ''
     whitehall:
-      description: ''
     content-store:
-      description: ''
 - github_repo_name: service-manual-frontend
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -566,9 +426,7 @@
   production_hosted_on: aws
   dependencies:
     content-store:
-      description: ''
     static:
-      description: ''
 - github_repo_name: static
   type: Frontend apps
   team: "#govuk-platform-health"
@@ -576,7 +434,6 @@
   production_hosted_on: aws
   dependencies:
     static:
-      description: ''
 
 # Transition
 

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -5,12 +5,6 @@
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    publishing-api:
-    content-store:
-    content-tagger:
-    router:
-    signon:
   actors:
   - Publisher
 - github_repo_name: contacts-admin
@@ -18,91 +12,38 @@
   puppet_name: contacts
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    whitehall:
-    publishing-api:
-    signon:
 - github_repo_name: content-tagger
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    publishing-api:
-    content-store:
-    search-api:
-    email-alert-api:
-    router:
-    search-admin:
-    signon:
   actors:
   - Publisher
 - github_repo_name: content-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    content-publisher:
-    router:
-    content-data-api:
-    signon:
 - github_repo_name: local-links-manager
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    signon:
-    local-links-manager:
-    link-checker-api:
-    mapit:
-    publishing-api:
 - github_repo_name: manuals-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    router:
-    manuals-publisher:
-    signon:
-    asset-manager:
-    content-store:
-    whitehall:
-    publishing-api:
-    link-checker-api:
 - github_repo_name: maslow
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    publishing-api:
-    support:
-    signon:
 - github_repo_name: publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    publishing-api:
-    frontend:
-    link-checker-api:
-    router:
-    content-tagger:
-    publisher:
-    mapit:
-    signon:
-    asset-manager:
-    router-api:
 - github_repo_name: service-manual-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    service-manual-frontend:
-    service-manual-publisher:
-    signon:
-    asset-manager:
-    publishing-api:
 - github_repo_name: short-url-manager
   type: Publishing apps
   team: "#govuk-platform-health"
@@ -113,25 +54,10 @@
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    support:
-    router:
-    signon:
-    publishing-api:
-    asset-manager:
-    email-alert-api:
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    router:
-    travel-advice-publisher:
-    email-alert-api:
-    link-checker-api:
-    signon:
-    asset-manager:
-    publishing-api:
 - github_repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
@@ -139,20 +65,6 @@
   dependencies_team: "#govuk-platform-health"
   consume_docs_folder: true
   production_hosted_on: aws
-  dependencies:
-    router:
-    whitehall:
-    static:
-    link-checker-api:
-    maslow:
-    search-api:
-    signon:
-    publishing-api:
-    content-store:
-    router-api:
-    asset-manager:
-    support:
-    email-alert-api:
   actors:
     - Publisher
     - Public
@@ -164,87 +76,55 @@
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    router-api:
 - github_repo_name: email-alert-api
   type: APIs
   team: "#govuk-notifications-dev"
   metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: aws
   consume_docs_folder: true
-  dependencies:
-    signon:
-    content-store:
 - github_repo_name: imminence
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    mapit:
-    signon:
 - github_repo_name: link-checker-api
   type: APIs
   team: "#govuk-platform-health"
   consume_docs_folder: true
   production_hosted_on: aws
-  dependencies:
-    signon:
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   consume_docs_folder: true
   production_hosted_on: aws
-  dependencies:
-    signon:
-    content-store:
 - github_repo_name: search-api
   type: APIs
   team: "#govuk-platform-health"
   consume_docs_folder: true
   production_hosted_on: aws
-  dependencies:
-    signon:
-    publishing-api:
 - github_repo_name: asset-manager
   type: APIs
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    signon:
-    asset-manager:
 - github_repo_name: router-api
   type: APIs
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies: {}
 - github_repo_name: support-api
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    support:
-    support-api:
-    content-store:
-    whitehall:
 - github_repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    manuals-frontend:
-    signon:
-    publishing-api:
-    search-api:
-    content-store:
 - github_repo_name: mapit
   type: APIs
   team: "#govuk-platform-health"
   api_docs_url: https://mapit.mysociety.org/docs/
   production_hosted_on: aws
-  dependencies: {}
 
 # Services
 
@@ -252,13 +132,10 @@
   type: Services
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies: {}
 - github_repo_name: email-alert-service
   type: Services
   team: "#govuk-notifications-dev"
   production_hosted_on: aws
-  dependencies:
-    email-alert-api:
 - github_repo_name: search-analytics
   type: Services
   team: "#govuk-platform-health"
@@ -274,10 +151,6 @@
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    content-data-api:
-    support:
-    signon:
 - github_repo_name: search-admin
   type: Supporting apps
   team: "#govuk-platform-health"
@@ -286,15 +159,10 @@
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    whitehall:
 - github_repo_name: support
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    support-api:
-    signon:
 - github_repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-platform-health"
@@ -308,7 +176,6 @@
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies: {}
 - github_repo_name: govuk-load-testing
   type: Supporting apps
   production_hosted_on: none
@@ -319,59 +186,30 @@
   type: Frontend apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    static:
-    content-store:
-    publishing-api:
 - github_repo_name: collections
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://govuk-collections.herokuapp.com/component-guide
   production_hosted_on: aws
   private_repo: false
-  dependencies:
-    static:
-    email-alert-api:
-    content-store:
-    search-api:
 - github_repo_name: email-alert-frontend
   type: Frontend apps
   team: "#govuk-notifications-dev"
   production_hosted_on: aws
-  dependencies:
-    static:
-    email-alert-api:
-    content-store:
 - github_repo_name: feedback
   type: Frontend apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    static:
-    support:
-    support-api:
 - github_repo_name: finder-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
-  dependencies:
-    content-store:
-    search-api:
-    email-alert-api:
-    static:
 - github_repo_name: frontend
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    search-api:
-    imminence:
-    mapit:
-    local-links-manager:
-    content-store:
-    licensify:
   actors:
   - Public
 - github_repo_name: government-frontend
@@ -380,60 +218,37 @@
   dependencies_team: "#govuk-platform-health"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
-  dependencies:
-    content-store:
-    static:
 - github_repo_name: info-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    static:
 - github_repo_name: licence-finder
   type: Frontend apps
   puppet_name: licencefinder
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    content-store:
-    publishing-api:
-    search-api:
 - github_repo_name: manuals-frontend
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    content-store:
-    publishing-api:
 - github_repo_name: smart-answers
   type: Frontend apps
   team: "#govuk-platform-health"
   puppet_name: smartanswers
   production_hosted_on: aws
-  dependencies:
-    publishing-api:
-    static:
-    imminence:
-    whitehall:
-    content-store:
 - github_repo_name: service-manual-frontend
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   type: Frontend apps
   production_hosted_on: aws
-  dependencies:
-    content-store:
-    static:
 - github_repo_name: static
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
-  dependencies:
-    static:
 
 # Transition
 
@@ -567,7 +382,6 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
-  dependencies: {}
 - github_repo_name: govuk-display-screen
   management_url: https://dashboard.heroku.com/apps/govuk-display-screen
   production_hosted_on: heroku


### PR DESCRIPTION
`dependencies` was added to applications.yml in 80b672a with very little context
('bla'), and appears to be required by other files in that commit (AppDependencyGenerator,
AppDiagramGenerator, etc), which were once used to generate diagrams.

Those generators and diagrams no longer exist in the dev docs, but for some reason
the application dependencies config still does. This isn't ordinarily a bad thing,
but if it isn't being used, it's not serving any useful purpose as documentation,
and risks falling out of date. It also looks somewhat buggy in the first place
(notice that service-manual-publisher has a dependency of... service-manual-publisher).

Let's just delete this unused config to make the config file simpler.