### PR TITLE
Redirect old AWS account setup docs to new Getting Started page

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -65,6 +65,7 @@ redirects:
   /manual/remove-redirected-url-from-transition.html: manual/remove-site-from-transition-tool.html
   /manual/renew_ssl_certificates.html: /manual/renew-a-tls-certificate.html
   /manual/setup-postgresql-replication.html: /manual/resync-postgres-standby.html
+  /manual/set-up-aws-account.html: /manual/get-started.html
   /manual/setting-up-new-sidekiq-monitoring-app.html: /manual/sidekiq.html
   /manual/rummager-traffic-replay.html: /manual/search-api-traffic-replay.html
   /manual/technical-setup.html: /manual/on-call.html


### PR DESCRIPTION
- My bad, should have done this in 19f539aece1fb507a4bf62d092f30f707d9e5378.
