### PR TITLE
update jenkins used to deploy saas config

### DIFF
--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -32,5 +32,5 @@ When your repo is tagged with `govuk`, it will be auto-configured by [govuk-saas
 If you create a new repo, [kick off a build of the Jenkins job][jenkins-job] and everything will be done for you.
 
 [govuk-saas-config]: https://github.com/alphagov/govuk-saas-config
-[jenkins-job]: https://deploy.integration.publishing.service.gov.uk/job/configure-github-repos
+[jenkins-job]: https://deploy.production.govuk.digital/job/configure-github-repos
 [alphagov]: https://github.com/alphagov


### PR DESCRIPTION
the jenkins job has been moved from integration to production in PR: https://github.com/alphagov/govuk-puppet/commit/a679f00f7cefc26e18e9e6e92d4a8fbd81788934 so need to update the job link in the docs too.