### PR TITLE
Review longstanding Alerts documentation

### DIFF
--- a/source/manual/alerts/aws-lb-healthyhosts.html.md
+++ b/source/manual/alerts/aws-lb-healthyhosts.html.md
@@ -4,7 +4,7 @@ title: AWS LB Healthy Hosts
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-03-05
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/backup-passive-checks.html.md
+++ b/source/manual/alerts/backup-passive-checks.html.md
@@ -4,7 +4,7 @@ title: Backup passive checks
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-03-05
+last_reviewed_on: 2020-09-17
 
 review_in: 6 months
 ---

--- a/source/manual/alerts/cdn-log-freshness.html.md
+++ b/source/manual/alerts/cdn-log-freshness.html.md
@@ -4,7 +4,7 @@ title: CDN logs from Fastly not appearing in S3
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-02-27
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -4,7 +4,7 @@ title: Data sync
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-03-05
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
@@ -4,7 +4,7 @@ title: datagovuk_publish app healthcheck not ok
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-27
+last_reviewed_on: 2020-09-17
 review_in: 3 months
 ---
 

--- a/source/manual/alerts/ddosdetected.html.md
+++ b/source/manual/alerts/ddosdetected.html.md
@@ -4,7 +4,7 @@ title: DDOS Detected
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-11-14
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -4,7 +4,7 @@ title: Elasticsearch cluster health
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/enhanced-ecommerce.html.md
+++ b/source/manual/alerts/enhanced-ecommerce.html.md
@@ -4,7 +4,7 @@ title: Enhanced Ecommerce ETL from Search API to Google Analytics
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-01-14
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/established-connections-exceed.html.md
+++ b/source/manual/alerts/established-connections-exceed.html.md
@@ -4,7 +4,7 @@ title: Established connections exceed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-01-28
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -4,7 +4,7 @@ title: Fastly error rate for GOV.UK
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-03-11
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -4,7 +4,7 @@ title: Fetch analytics data for search failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-09
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/high-nginx-5xx-rate.html.md
+++ b/source/manual/alerts/high-nginx-5xx-rate.html.md
@@ -4,7 +4,7 @@ title: High Nginx 5xx rate
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-17
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/jenkins-agent-not-connected-to-master.html.md
+++ b/source/manual/alerts/jenkins-agent-not-connected-to-master.html.md
@@ -4,7 +4,7 @@ title: Jenkins agent not connected to master
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-01-23
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -4,7 +4,7 @@ title: Low available disk space
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-28
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/mongod-replication-lag.html.md
+++ b/source/manual/alerts/mongod-replication-lag.html.md
@@ -4,7 +4,7 @@ title: mongod replication lag
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-11
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/mongodb-rollback.html.md
+++ b/source/manual/alerts/mongodb-rollback.html.md
@@ -4,7 +4,7 @@ title: MongoDB rollback
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-10
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/mysql-replication-lag.html.md
+++ b/source/manual/alerts/mysql-replication-lag.html.md
@@ -4,7 +4,7 @@ title: 'MySQL: replication lag'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-10-22
+last_reviewed_on: 2019-09-17
 review_in: 6 months
 ---
 
@@ -29,12 +29,8 @@ fab $environment -H <mysql_slave_hostname> mysql.reset_slave
 ```
 
 An alert for 'MySQL replication lag' on mysql-backup-* machines may be
-caused by a database backup or a Jenkins data synchronisation job, such
-as:
-
-<https://deploy.publishing.service.gov.uk/job/Copy_Data_to_Staging/>
-
-You can verify this by checking for a running mysqldump process on the
+caused by a database backup or a Jenkins data synchronisation job. You can
+verify this by checking for a running mysqldump process on the
 affected host, e.g.:
 
 ```

--- a/source/manual/alerts/mysql-replication-running.html.md
+++ b/source/manual/alerts/mysql-replication-running.html.md
@@ -4,7 +4,7 @@ title: 'MySQL: replication running'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-10-22
+last_reviewed_on: 2019-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/nginx-requests-too-low.html.md
+++ b/source/manual/alerts/nginx-requests-too-low.html.md
@@ -4,7 +4,7 @@ title: Nginx requests too low
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-03-10
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/offsite-backups.html.md
+++ b/source/manual/alerts/offsite-backups.html.md
@@ -4,7 +4,7 @@ title: Offsite backups
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-07
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/onsite-backups.html.md
+++ b/source/manual/alerts/onsite-backups.html.md
@@ -4,7 +4,7 @@ title: Onsite backups failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-11-21
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/pingdom-search-check.html.md
+++ b/source/manual/alerts/pingdom-search-check.html.md
@@ -4,7 +4,7 @@ title: Pingdom search check
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/postgresql-replication-too-far-behind.html.md
+++ b/source/manual/alerts/postgresql-replication-too-far-behind.html.md
@@ -4,7 +4,7 @@ title: 'PostgreSQL: replication too far behind'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-03-10
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/postgresql-s3-backups.html.md
+++ b/source/manual/alerts/postgresql-s3-backups.html.md
@@ -4,7 +4,7 @@ title: 'Carrenza/6DG PostgreSQL: S3 Backups'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2019-12-06
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -5,7 +5,7 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2020-06-15
+last_reviewed_on: 2020-09-17
 review_in: 3 months
 ---
 

--- a/source/manual/alerts/redis.html.md
+++ b/source/manual/alerts/redis.html.md
@@ -4,7 +4,7 @@ title: Redis alerts
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-10-17
+last_reviewed_on: 2019-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/ruby-version.html.md
+++ b/source/manual/alerts/ruby-version.html.md
@@ -4,7 +4,7 @@ title: App isn't running the expected Ruby version
 section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-01-23
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/runs-rake-task-search-api.html.md
+++ b/source/manual/alerts/runs-rake-task-search-api.html.md
@@ -4,7 +4,7 @@ title: Runs a rake task on Search API that generates the sitemap files
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/search-api-index-size-change.html.md
+++ b/source/manual/alerts/search-api-index-size-change.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 related_applications: [search-api]
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/search-api-queue-latency.html.md
+++ b/source/manual/alerts/search-api-queue-latency.html.md
@@ -4,7 +4,7 @@ title: High Search API Sidekiq queue latency
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/search-reindex-failed.html.md
+++ b/source/manual/alerts/search-reindex-failed.html.md
@@ -4,7 +4,7 @@ title: Search reindex failed
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-04
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/vpn-down.html.md
+++ b/source/manual/alerts/vpn-down.html.md
@@ -4,7 +4,7 @@ title: VPN down
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-02-07
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -4,7 +4,7 @@ title: Whitehall scheduled publishing
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-01-30
+last_reviewed_on: 2020-09-17
 review_in: 6 months
 ---
 


### PR DESCRIPTION
Spent some time testing each of these alert docs such that I know the
content within them are valid. Testing methodology involved running
any safe associated commands to look for errors that don't actually
exist (right now) because we're not seeing the alerts, checking links
and processes, etc.

We can't wait for these alerts to actually trigger to verify this
documentation so I did the closest next-best-thing I could think of and
tested them as if there was a valid alert I was trying to solve - within
reason.