### PR TITLE
Add 'last updated' banner to internal and externally version controlled docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "govuk_tech_docs"
 gem "middleman"
 gem "middleman-search_engine_sitemap"
 
+gem "git"
 gem "github-markdown"
 gem "html-pipeline"
 gem "kramdown"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.2.0)
     ffi (1.12.0)
+    git (1.7.0)
+      rchardet (~> 1.8)
     github-markdown (0.6.9)
     govuk_schemas (4.1.1)
       json-schema (~> 2.8.0)
@@ -205,6 +207,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rchardet (1.8.0)
     redcarpet (3.5.0)
     regexp_parser (1.8.2)
     rexml (3.2.4)
@@ -292,6 +295,7 @@ DEPENDENCIES
   faraday-http-cache
   faraday_middleware
   ffi
+  git
   github-markdown
   govuk_schemas
   govuk_tech_docs

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -32,6 +32,7 @@ class GitHubRepoFetcher
           title: title,
           markdown: contents,
           source_url: doc.html_url,
+          latest_commit: latest_commit(app_name, doc.path),
         }
       end
     rescue Octokit::NotFound
@@ -45,6 +46,14 @@ private
     @all_alphagov_repos ||= CACHE.fetch("all-repos", expires_in: 1.hour) do
       client.repos("alphagov")
     end
+  end
+
+  def latest_commit(app_name, path)
+    latest_commit = client.commits("alphagov/#{app_name}", repo(app_name).default_branch, path: path).first
+    {
+      sha: latest_commit.sha,
+      timestamp: latest_commit.commit.author.date,
+    }
   end
 
   def client

--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -24,7 +24,9 @@ class ProxyPages
               markdown: page[:markdown],
             },
             data: {
+              app_name: app.app_name,
               source_url: page[:source_url],
+              latest_commit: page[:latest_commit],
             },
           },
         }

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -7,6 +7,9 @@ service_name: Developer docs
 full_service_name: GOV.UK Developer Documentation
 description: Technical documentation for developers working on GOV.UK in GDS
 
+# Suppress review banner in favour of bespoke 'Last updated' banner
+show_review_banner: false
+
 header_links:
   Dashboard: /
   Get started: /manual/get-started.html

--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -7,9 +7,14 @@ module CommitHelpers
   end
 
   def last_updated(current_page)
-    return current_page.data.latest_commit[:timestamp] if current_page.data.latest_commit
+    # e.g. "2020-09-03 09:53:56 UTC"
+    timestamp = if current_page.data.latest_commit
+                  current_page.data.latest_commit[:timestamp].to_s
+                else
+                  `TZ=UTC git log -1 --date='format-local:%Y-%m-%d %T UTC' --format="%cd" #{source_file(current_page)}`.strip
+                end
 
-    `TZ=UTC git log -1 --date='format-local:%Y-%m-%d %T UTC' --format="%cd" #{source_file(current_page)}`.strip
+    Time.parse(timestamp).strftime("%e %b %Y").strip # e.g. "3 Sep 2020"
   end
 
 private

--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -1,10 +1,14 @@
 module CommitHelpers
   def commit_url(current_page)
+    return "https://github.com/alphagov/#{current_page.data.app_name}/commit/#{current_page.data.latest_commit[:sha]}" if current_page.data.latest_commit
+
     commit_sha = `git log -1 --format=oneline #{source_file(current_page)} | cut -d ' ' -f 1`.strip
     "https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}"
   end
 
   def last_updated(current_page)
+    return current_page.data.latest_commit[:timestamp] if current_page.data.latest_commit
+
     `TZ=UTC git log -1 --date='format-local:%Y-%m-%d %T UTC' --format="%cd" #{source_file(current_page)}`.strip
   end
 

--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -1,8 +1,10 @@
+require "git"
+
 module CommitHelpers
   def commit_url(current_page)
     return "https://github.com/alphagov/#{current_page.data.app_name}/commit/#{current_page.data.latest_commit[:sha]}" if current_page.data.latest_commit
 
-    commit_sha = `git log -1 --format=oneline #{source_file(current_page)} | cut -d ' ' -f 1`.strip
+    commit_sha = Git.open(".").log.path(source_file(current_page)).first.sha
     "https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}"
   end
 
@@ -11,7 +13,7 @@ module CommitHelpers
     timestamp = if current_page.data.latest_commit
                   current_page.data.latest_commit[:timestamp].to_s
                 else
-                  `TZ=UTC git log -1 --date='format-local:%Y-%m-%d %T UTC' --format="%cd" #{source_file(current_page)}`.strip
+                  Git.open(".").log.path(source_file(current_page)).first.date.to_s
                 end
 
     Time.parse(timestamp).strftime("%e %b %Y").strip # e.g. "3 Sep 2020"

--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -1,0 +1,16 @@
+module CommitHelpers
+  def commit_url(current_page)
+    commit_sha = `git log -1 --format=oneline #{source_file(current_page)} | cut -d ' ' -f 1`.strip
+    "https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}"
+  end
+
+  def last_updated(current_page)
+    `TZ=UTC git log -1 --date='format-local:%Y-%m-%d %T UTC' --format="%cd" #{source_file(current_page)}`.strip
+  end
+
+private
+
+  def source_file(current_page)
+    "source/#{current_page.file_descriptor.relative_path}"
+  end
+end

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <% wrap_layout :core do %>
-  <%= partial 'partials/header' %>
   <%= partial 'partials/last_updated' %>
+  <%= partial 'partials/header' %>
   <%= yield %>
 <% end %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -15,10 +15,6 @@
 
 <% wrap_layout :core do %>
   <%= partial 'partials/header' %>
-  <% if current_page.data.app_name # This conditional is for "/apis.html" %>
-    <div>
-      Last updated: <a href="https://github.com/alphagov/<%= current_page.data.app_name %>/commit/<%= current_page.data.latest_commit[:sha] %>"><%= current_page.data.latest_commit[:timestamp] %></a>
-    </div>
-  <% end %>
+  <%= partial 'partials/last_updated' %>
   <%= yield %>
 <% end %>

--- a/source/layouts/api_layout.html.erb
+++ b/source/layouts/api_layout.html.erb
@@ -15,5 +15,10 @@
 
 <% wrap_layout :core do %>
   <%= partial 'partials/header' %>
+  <% if current_page.data.app_name # This conditional is for "/apis.html" %>
+    <div>
+      Last updated: <a href="https://github.com/alphagov/<%= current_page.data.app_name %>/commit/<%= current_page.data.latest_commit[:sha] %>"><%= current_page.data.latest_commit[:timestamp] %></a>
+    </div>
+  <% end %>
   <%= yield %>
 <% end %>

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -7,9 +7,7 @@
 %>
 
 <% last_updated_banner = capture do %>
-  <div>
-    Last updated: <a href="<%= commit_url(current_page) %>"><%= last_updated(current_page) %></a>
-  </div>
+  <%= partial 'partials/last_updated' %>
 <% end %>
 
 <% html = "#{breadcrumb} <h1 id='header'>#{current_page.data.title}</h1> #{last_updated_banner} #{yield}" %>

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -10,7 +10,7 @@
   <%= partial 'partials/last_updated' %>
 <% end %>
 
-<% html = "#{breadcrumb} <h1 id='header'>#{current_page.data.title}</h1> #{last_updated_banner} #{yield}" %>
+<% html = "#{breadcrumb} #{last_updated_banner} <h1 id='header'>#{current_page.data.title}</h1> #{yield}" %>
 
 <% content_for :page_description, Snippet.generate(html) %>
 

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -5,7 +5,14 @@
                  "<p><a href='/manual.html##{section_url}'>#{current_page.data.section}</a></p>"
                end
 %>
-<% html = "#{breadcrumb} <h1 id='header'>#{current_page.data.title}</h1>#{yield}" %>
+
+<% last_updated_banner = capture do %>
+  <div>
+    Last updated: <a href="<%= commit_url(current_page) %>"><%= last_updated(current_page) %></a>
+  </div>
+<% end %>
+
+<% html = "#{breadcrumb} <h1 id='header'>#{current_page.data.title}</h1> #{last_updated_banner} #{yield}" %>
 
 <% content_for :page_description, Snippet.generate(html) %>
 

--- a/source/partials/_last_updated.html.erb
+++ b/source/partials/_last_updated.html.erb
@@ -1,0 +1,3 @@
+<div>
+  Last updated: <a href="<%= commit_url(current_page) %>"><%= last_updated(current_page) %></a>
+</div>

--- a/source/partials/_last_updated.html.erb
+++ b/source/partials/_last_updated.html.erb
@@ -1,3 +1,3 @@
-<div>
+<div class="govuk-!-font-size-16 govuk-!-margin-top-6">
   Last updated: <a href="<%= commit_url(current_page) %>"><%= last_updated(current_page) %></a>
 </div>

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -82,39 +82,42 @@ RSpec.describe GitHubRepoFetcher do
   end
 
   describe "#docs" do
+    let(:repo_name) { SecureRandom.uuid }
+
     def docs_url(repo_name)
       "https://api.github.com/repos/alphagov/#{repo_name}/contents/docs"
     end
 
     it "returns an array of hashes including title derived from markdown contents" do
-      repo_name = SecureRandom.uuid
       markdown_url = "https://raw.githubusercontent.com/alphagov/#{repo_name}/master/docs/analytics.md"
       source_url = "https://github.com/alphagov/#{repo_name}/blob/master/docs/analytics.md"
       markdown_fixture = "# Analytics \n Foo"
-      api_response = [
-        {
-          name: "analytics.md",
-          download_url: markdown_url,
-          html_url: source_url,
-        },
-      ]
-      expected_output = [
+      path = "docs/analytics.md"
+      default_branch = "main"
+      latest_commit = { sha: SecureRandom.hex(40), timestamp: Time.now.utc.to_s }
+      doc_response = [{ name: "analytics.md", path: path, download_url: markdown_url, html_url: source_url }]
+      commit_response = [{ sha: latest_commit[:sha], commit: { author: { date: latest_commit[:timestamp] } } }]
+
+      allow(GitHubRepoFetcher.instance).to receive(:repo)
+        .with(repo_name) { OpenStruct.new(default_branch: default_branch) }
+      stub_request(:get, docs_url(repo_name))
+        .to_return(body: doc_response.to_json, headers: { content_type: "application/json" })
+      stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/commits?path=#{path}&per_page=100&sha=#{default_branch}")
+        .to_return(body: commit_response.to_json, headers: { content_type: "application/json" })
+      stub_request(:get, markdown_url).to_return(body: markdown_fixture)
+
+      expect(GitHubRepoFetcher.instance.docs(repo_name)).to eq([
         {
           title: "Analytics",
           path: "/apis/#{repo_name}/analytics.html",
           markdown: markdown_fixture,
           source_url: source_url,
+          latest_commit: latest_commit,
         },
-      ]
-      stub_request(:get, docs_url(repo_name))
-        .to_return(body: api_response.to_json, headers: { content_type: "application/json" })
-      stub_request(:get, markdown_url).to_return(body: markdown_fixture)
-
-      expect(GitHubRepoFetcher.instance.docs(repo_name)).to eq(expected_output)
+      ])
     end
 
     it "skips over any non-markdown files" do
-      repo_name = SecureRandom.uuid
       api_response = [
         {
           "name": "digests.png",
@@ -128,7 +131,6 @@ RSpec.describe GitHubRepoFetcher do
     end
 
     it "returns nil if no docs folder exists" do
-      repo_name = SecureRandom.uuid
       stub_request(:get, docs_url(repo_name))
         .to_return(status: 404, body: "{}", headers: { content_type: "application/json" })
 

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -9,7 +9,16 @@ RSpec.describe ProxyPages do
     allow(Supertypes).to receive(:all)
       .and_return([double("Supertype", name: "", description: "", id: "")])
     allow(GitHubRepoFetcher.instance).to receive(:docs)
-      .and_return([{ title: "A doc page", filename: "doc", markdown: "# A doc page\n Foo" }])
+      .and_return([
+        {
+          title: "A doc page",
+          markdown: "# A doc page\n Foo",
+          latest_commit: {
+            sha: SecureRandom.hex(40),
+            timestamp: Time.now.utc,
+          },
+        },
+      ])
   end
 
   describe ".api_docs" do

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -18,15 +18,14 @@ RSpec.describe CommitHelpers do
     end
 
     it "returns commit URL for the commit associated with the source file of current_page" do
-      source_file = "foo/bar.md"
-      commit_sha = SecureRandom.hex(40)
+      source_file = "index.html.erb"
       current_page = OpenStruct.new(
         data: OpenStruct.new,
         file_descriptor: OpenStruct.new(relative_path: source_file),
       )
-      allow(helper).to receive(:`).and_return(commit_sha)
-      expect(helper.commit_url(current_page))
-        .to eq("https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}")
+      expect(helper.commit_url(current_page)).to match(
+        /https:\/\/github.com\/alphagov\/govuk-developer-docs\/commit\/[0-9a-f]{40}$/,
+      )
     end
   end
 

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require_relative "../../helpers/commit_helpers.rb"
+
+RSpec.describe CommitHelpers do
+  let(:helper) { Class.new { extend CommitHelpers } }
+
+  describe "#commit_url" do
+    it "returns commit URL for the commit associated with the source file of current_page" do
+      source_file = "foo/bar.md"
+      commit_sha = SecureRandom.hex(40)
+      current_page = OpenStruct.new(file_descriptor: OpenStruct.new(relative_path: source_file))
+      allow(helper).to receive(:`).and_return(commit_sha)
+      expect(helper.commit_url(current_page))
+        .to eq("https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}")
+    end
+  end
+
+  describe "#last_updated" do
+    it "returns a datetime string of the form 'YYYY-MM-DD HH:mm:ss UTC'" do
+      source_file = "index.html.erb"
+      current_page = OpenStruct.new(file_descriptor: OpenStruct.new(relative_path: source_file))
+      expect(helper.last_updated(current_page)).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/)
+    end
+  end
+end

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -31,21 +31,21 @@ RSpec.describe CommitHelpers do
   end
 
   describe "#last_updated" do
-    it "returns the commit timestamp associated with the (remote) page data, if that exists" do
+    it "formats the commit timestamp associated with the (remote) page data, if that exists" do
       last_committed = "2020-09-03 09:53:56 UTC"
       current_page = OpenStruct.new(data: OpenStruct.new(
         latest_commit: { timestamp: last_committed },
       ))
-      expect(helper.last_updated(current_page)).to eq(last_committed)
+      expect(helper.last_updated(current_page)).to eq("3 Sep 2020")
     end
 
-    it "returns a datetime string of the form 'YYYY-MM-DD HH:mm:ss UTC' for the local file" do
+    it "formats the commit date of the local file if no page data exists" do
       source_file = "index.html.erb"
       current_page = OpenStruct.new(
         data: OpenStruct.new,
         file_descriptor: OpenStruct.new(relative_path: source_file),
       )
-      expect(helper.last_updated(current_page)).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/)
+      expect(helper.last_updated(current_page)).to match(/\d{1,2} \w+ \d{4}/)
     end
   end
 end

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -5,10 +5,25 @@ RSpec.describe CommitHelpers do
   let(:helper) { Class.new { extend CommitHelpers } }
 
   describe "#commit_url" do
+    it "returns the commit_url associated with the page data, if that exists" do
+      app_name = "some-repo"
+      commit_sha = SecureRandom.hex(40)
+      current_page = OpenStruct.new(data: OpenStruct.new(
+        app_name: app_name,
+        latest_commit: {
+          sha: commit_sha,
+        },
+      ))
+      expect(helper.commit_url(current_page)).to eq("https://github.com/alphagov/#{app_name}/commit/#{commit_sha}")
+    end
+
     it "returns commit URL for the commit associated with the source file of current_page" do
       source_file = "foo/bar.md"
       commit_sha = SecureRandom.hex(40)
-      current_page = OpenStruct.new(file_descriptor: OpenStruct.new(relative_path: source_file))
+      current_page = OpenStruct.new(
+        data: OpenStruct.new,
+        file_descriptor: OpenStruct.new(relative_path: source_file),
+      )
       allow(helper).to receive(:`).and_return(commit_sha)
       expect(helper.commit_url(current_page))
         .to eq("https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}")
@@ -16,9 +31,20 @@ RSpec.describe CommitHelpers do
   end
 
   describe "#last_updated" do
-    it "returns a datetime string of the form 'YYYY-MM-DD HH:mm:ss UTC'" do
+    it "returns the commit timestamp associated with the (remote) page data, if that exists" do
+      last_committed = "2020-09-03 09:53:56 UTC"
+      current_page = OpenStruct.new(data: OpenStruct.new(
+        latest_commit: { timestamp: last_committed },
+      ))
+      expect(helper.last_updated(current_page)).to eq(last_committed)
+    end
+
+    it "returns a datetime string of the form 'YYYY-MM-DD HH:mm:ss UTC' for the local file" do
       source_file = "index.html.erb"
-      current_page = OpenStruct.new(file_descriptor: OpenStruct.new(relative_path: source_file))
+      current_page = OpenStruct.new(
+        data: OpenStruct.new,
+        file_descriptor: OpenStruct.new(relative_path: source_file),
+      )
       expect(helper.last_updated(current_page)).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/)
     end
   end


### PR DESCRIPTION
This PR removes the old "last reviewed on" banner from the bottom of the internally hosted docs. In their place - and as a new feature for the externally hosted docs - there's now a "Last updated" banner at the top of each doc. The date is clickable and links to the commit SHA on GitHub so that the changes can be viewed easily.

"Last updated" on internal docs:

<img width="1025" alt="Screenshot 2020-10-12 at 18 42 30" src="https://user-images.githubusercontent.com/5111927/95775690-cac09080-0cba-11eb-9b66-1be0a1158e3a.png">

"Last updated" on external docs:

<img width="1057" alt="Screenshot 2020-10-12 at 18 42 39" src="https://user-images.githubusercontent.com/5111927/95775717-d2803500-0cba-11eb-9496-bef070465d9a.png">

This is phase 1 of removing Daniel the Manual Spaniel. Once the 'last reviewed' date is no longer surfaced visually, there's no point in keeping it - we'll remove the 'last_reviewed' and 'review_in' properties from files and discontinue the spaniel.

Trello: https://trello.com/c/OMBV5qM4/198-retire-daniel-the-manual-spaniel