### PR TITLE
Switch to using Kramdown for parsing markdown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,5 @@ updates:
         dependency-type: direct
       - dependency-name: octokit
         dependency-type: direct
-      - dependency-name: redcarpet
+      - dependency-name: kramdown
         dependency-type: direct

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem "middleman-search_engine_sitemap", "~> 1.4"
 
 gem "github-markdown"
 gem "html-pipeline"
+gem "kramdown", "~> 2.3.0"
 gem "mdl", "~> 0.9.0"
-gem "redcarpet", "~> 3.5.0"
 
 gem "govuk_schemas", "~> 4.1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,12 +293,12 @@ DEPENDENCIES
   govuk_schemas (~> 4.1.1)
   govuk_tech_docs
   html-pipeline
+  kramdown (~> 2.3.0)
   mdl (~> 0.9.0)
   middleman (~> 4.3.11)
   middleman-search_engine_sitemap (~> 1.4)
   octokit (~> 4.18.0)
   rake
-  redcarpet (~> 3.5.0)
   rspec (~> 3.9)
   rubocop-govuk
   simplecov

--- a/app/string_to_id.rb
+++ b/app/string_to_id.rb
@@ -1,9 +1,4 @@
 class StringToId
-  # Redcarpet uses a different algo to create fragment ids than github
-  # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
-  # this implementation modified for our purposes from version at jch/html-pipeline
-  # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
-  # We now use Kramdown instead of Redcarpet, but if it ain't broke, don't fix it.
   def self.convert(string)
     string
       .downcase # lower case

--- a/app/string_to_id.rb
+++ b/app/string_to_id.rb
@@ -3,6 +3,7 @@ class StringToId
   # which has caused a TOC bug // ref https://trello.com/c/Re6fSBKj/24-change-internal-links-to-work-or-remove-internal-links
   # this implementation modified for our purposes from version at jch/html-pipeline
   # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
+  # We now use Kramdown instead of Redcarpet, but if it ain't broke, don't fix it.
   def self.convert(string)
     string
       .downcase # lower case

--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,8 @@ require_relative "./app/requires"
 
 GovukTechDocs.configure(self)
 
+set :markdown_engine, :kramdown
+
 set :markdown,
     renderer: DeveloperDocsRenderer.new(
       with_toc_data: true,
@@ -10,6 +12,7 @@ set :markdown,
       context: self,
     ),
     fenced_code_blocks: true,
+    input: "GFM",
     tables: true,
     no_intra_emphasis: true
 


### PR DESCRIPTION
Redcarpet has an [issue from 2015][issue] whereby shortcut
reference links get confused. For example:

```md
See [foo] (example: bla)
[foo]: /bar.html
```

This was being parsed as `See <a href="(example: bla)">foo<a>`,
instead of: `See <a href="/bar.html">foo</a> (example: bla)`

Changing `[foo]` to `[foo][]` explicitly marks the link as a
shortcut reference, fixing the issue, so I originally proposed
that we enforce such a style using Markdownlint. Unfortunately,
Markdownlint has no such rule, so I [raised a proposal][proposal]
with them.

Talking it through with @kevindew, we realised we could swap out
the markdown parsing library instead. Kramdown seems the obvious
choice, given that is [the library we use for GovSpeak][govspeak],
and it can be swapped in relatively easily.

The only modification I had to make was to explicitly state we're
using GitHub flavoured markdown ("GFM"), otherwise newlines inside
code blocks were not being correctly rendered. Credit to our very
own @bevanloon for that [tip][bevan].

Trello: https://trello.com/c/XSgGyudd/181-fix-url-markdown-parsing

[issue]: https://github.com/vmg/redcarpet/issues/471
[proposal]: https://github.com/markdownlint/markdownlint/issues/351
[govspeak]: https://github.com/alphagov/govspeak/blob/e19f80810c717c04cccb6e42d7f6df074a142330/govspeak.gemspec#L36
[bevan]: https://www.intenseagile.com/how-to-configure-middleman-to-use-backticks-for-fenced-code-blocks/