### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,26 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").chomp
-
-gem "activesupport", "~> 5.2"
-gem "capybara", "~> 3.33.0"
-gem "ffi", "1.12"
+gem "activesupport"
+gem "capybara"
+gem "ffi"
 gem "rake"
-gem "rspec", "~> 3.9"
+gem "rspec"
 gem "rubocop-govuk"
 gem "simplecov"
-gem "webmock", "~> 3.8"
+gem "webmock"
 
 gem "govuk_tech_docs"
-gem "middleman", "~> 4.3.11"
-gem "middleman-search_engine_sitemap", "~> 1.4"
+gem "middleman"
+gem "middleman-search_engine_sitemap"
 
 gem "github-markdown"
 gem "html-pipeline"
-gem "kramdown", "~> 2.3.0"
-gem "mdl", "~> 0.9.0"
+gem "kramdown"
+gem "mdl"
 
-gem "govuk_schemas", "~> 4.1.1"
+gem "govuk_schemas"
 
 # GitHub API
-gem "faraday-http-cache", "~> 2.2.0"
-gem "faraday_middleware", "~> 1.0.0"
-gem "octokit", "~> 4.18.0"
+gem "faraday-http-cache"
+gem "faraday_middleware"
+gem "octokit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,28 +284,25 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 5.2)
-  capybara (~> 3.33.0)
-  faraday-http-cache (~> 2.2.0)
-  faraday_middleware (~> 1.0.0)
-  ffi (= 1.12)
+  activesupport
+  capybara
+  faraday-http-cache
+  faraday_middleware
+  ffi
   github-markdown
-  govuk_schemas (~> 4.1.1)
+  govuk_schemas
   govuk_tech_docs
   html-pipeline
-  kramdown (~> 2.3.0)
-  mdl (~> 0.9.0)
-  middleman (~> 4.3.11)
-  middleman-search_engine_sitemap (~> 1.4)
-  octokit (~> 4.18.0)
+  kramdown
+  mdl
+  middleman
+  middleman-search_engine_sitemap
+  octokit
   rake
-  rspec (~> 3.9)
+  rspec
   rubocop-govuk
   simplecov
-  webmock (~> 3.8)
-
-RUBY VERSION
-   ruby 2.6.6
+  webmock
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7.1

I've left the Ruby version as 2.6.6 since there is an automatic script to update all Ruby versions at once. 

There are still some deprecation errors: 
Faraday: 
- Fix merged but not deployed
- https://github.com/lostisland/faraday/commit/722821fab79faa65a1dd2ec0ed1667ed593f06fe

Rspec Expectations
- Fix merged but not deployed 
- https://github.com/rspec/rspec-expectations/pull/1187

Open API parser
- PR open but not merged
- https://github.com/alphagov/tech-docs-gem/pull/125