### PR TITLE
Add link for smokey doc

### DIFF
--- a/source/manual/alerts/smokey-loop-tests.html.md
+++ b/source/manual/alerts/smokey-loop-tests.html.md
@@ -24,7 +24,7 @@ failure, so you can diagnose the problem.
 ## Nginx
 
 If many of the tests are failing in an AWS environment, it may be because the Nginx services haven't registered new
-boxes coming online or old ones going offline. You can try to restart the following services:
+boxes coming online or old ones going offline. You can try to restart the following services using the [fabric scripts](https://github.com/alphagov/fabric-scripts):
 
 ```bash
 $ fab $environment class:cache app.reload:nginx

--- a/source/manual/alerts/smokey-loop-tests.html.md
+++ b/source/manual/alerts/smokey-loop-tests.html.md
@@ -43,6 +43,8 @@ $ ssh monitoring-1.production
 > sudo less /var/log/upstart/smokey-loop.log
 ```
 
+It may be necessary to kill all the smokey processes. There is further guidance on doing this [here](/manual/alerts/smokey-json-older-than-30m.html).
+
 ### `HTTP status code 550 (RestClient::RequestFailed)`
 
 This usually means that the BrowserMob Proxy java process is running as part of a previously aborted


### PR DESCRIPTION
Link together a few repos and documents in one place to help track down pages

- link to fabric scripts repo where the docs instruct to run fabric scripts to help people who don't have it set up on their machine.
- Link relevant docs on fixing smokey-loop errors