### PR TITLE
Update Carrenza links to AWS

### DIFF
--- a/source/manual/documents-are-published-but-links-arent-updated.html.md
+++ b/source/manual/documents-are-published-but-links-arent-updated.html.md
@@ -4,7 +4,7 @@ title: Debug published documents with incorrect links
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-01-23
+last_reviewed_on: 2020-09-23
 review_in: 6 months
 ---
 
@@ -18,5 +18,5 @@ Publishing API in Jenkins,
 [`represent_downstream:high_priority:content_id['some-content-id some-other-content-id']`][jenkins-task],
 which will re-represent them downstream via the high priority queue.
 
-[sidekiq-queue]: https://docs.publishing.service.gov.uk/manual/monitor-sidekiq-workers.html#header
-[jenkins-task]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[%27some-content-id%20some-other-content-id%27]
+[sidekiq-queue]: https://docs.publishing.service.gov.uk/manual/sidekiq.html#sidekiq-web-aka-sidekiq-monitoring
+[jenkins-task]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[%27some-content-id%20some-other-content-id%27]

--- a/source/manual/documents-arent-live-after-publishing.html.md
+++ b/source/manual/documents-arent-live-after-publishing.html.md
@@ -4,7 +4,7 @@ title: If documents aren't live after being published
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2019-10-08
+last_reviewed_on: 2020-09-23
 review_in: 6 months
 ---
 
@@ -20,7 +20,7 @@ Publishing API that will check where the content is currently available.
 $ bundle exec rake data_hygiene:document_status_check[content_id,locale]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=data_hygiene:document_status_check[content_id,locale])
+[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=data_hygiene:document_status_check[content_id,locale])
 
 ## If documents aren't in the Publishing API
 
@@ -35,7 +35,7 @@ interface. If that doesn't work, there are some other things you can try:
 $ bundle exec rake publishing_api:republish_document[slug]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug])
+[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug])
 
 ### Publisher
 
@@ -43,7 +43,7 @@ $ bundle exec rake publishing_api:republish_document[slug]
 $ bundle exec rake publishing_api:republish_edition[slug]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[slug])
+[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[slug])
 
 ### Travel Advice Publisher
 
@@ -51,7 +51,7 @@ $ bundle exec rake publishing_api:republish_edition[slug]
 $ bundle exec rake publishing_api:republish_edition[country_slug]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[country_slug])
+[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[country_slug])
 
 ### Specialist Publisher
 
@@ -68,7 +68,7 @@ content item to the Content Store.
 $ bundle exec rake represent_downstream:high_priority:content_id[content_id]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[content_id])
+[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[content_id])
 
 Note that if you run this task to fix missing routes, it may not work correctly
 as the Content Store keeps a cache of what it thinks the routes are.
@@ -82,7 +82,7 @@ routes for a Content Item directly.
 $ bundle exec rake routes:register[base_path]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-store&MACHINE_CLASS=content_store&RAKE_TASK=routes:register[base_path])
+[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-store&MACHINE_CLASS=content_store&RAKE_TASK=routes:register[base_path])
 
 ## If the document isn't live after all this
 

--- a/source/manual/help-with-publishing-content.html.md
+++ b/source/manual/help-with-publishing-content.html.md
@@ -29,11 +29,11 @@ necessary to help them to ensure it goes out as smoothly as possible.
 
 - If it looks as though emails haven't been sent out for a publication, there
   should be [an alert about unprocessed content changes and there is guidance on
-  how to solve this](alerts/email-alert-api-app-healthcheck-not-ok.html#unprocessed-content-changes-content_changes).
+  how to solve this](alerts/email-alert-api-unprocessed-content-changes.html).
 
   If there are no alerts, it would suggest that the content change never made it
   to the Email Alert API. In which case, you should [check that Email Alert
-  Service is correctly consuming from RabbitMQ](alerts/rabbitmq-no-consumers-consuming.html).
+  Service is correctly consuming from RabbitMQ](alerts/rabbitmq-no-consumers-listening.html).
   If all looks fine, it may be necessary to [manually create a `ContentChange` in
   Email Alert API](https://github.com/alphagov/email-alert-api/blob/1aee9703bf303d43ba4ecb5f6fd771b757d52daf/app/services/notification_handler_service.rb#L24-L43).
 
@@ -41,15 +41,13 @@ necessary to help them to ensure it goes out as smoothly as possible.
   Safety Alerts go out correctly. Although an alert won't be triggered for other
   kinds of documents, the [guidance will still apply](alerts/email-alerts-travel-medical.html).
 
-- If [a scheduled publication hasn't gone live][scheduled-publishing],
+- If [a scheduled publication hasn't gone live](alerts/whitehall-scheduled-publishing.html),
   start here: [if documents aren't live after being published][live].
   If it looks as though the content was never published from
   Whitehall, there is a Rake task available which will publish overdue
   documents. In Production, run [this Rake
-  task](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:publish).
+  task](https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:publish).
 
   ```bash
   $ bundle exec rake publishing:overdue:publish
   ```
-
-[scheduled]: alerts/whitehall-scheduled-publishing.html

--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -4,7 +4,7 @@ title: Publish special routes
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-02-28
+last_reviewed_on: 2020-09-23
 review_in: 6 months
 old_paths:
  - /manual/publish_special_routes.html
@@ -14,4 +14,4 @@ The [Special Route Publisher](https://github.com/alphagov/special-route-publishe
 
 All new special routes should be created in this tool, and existing special routes should be moved as necessary.
 
-The [Publish special routes Jenkins job](https://deploy.staging.publishing.service.gov.uk/job/Publish_Special_Routes/) will re-publish all defined special routes to the Publishing API.
+The [Publish special routes Jenkins job](https://deploy.blue.staging.govuk.digital/job/Publish_Special_Routes/) will re-publish all defined special routes to the Publishing API.

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -56,4 +56,4 @@ WeeklyDigestInitiatorWorker.perform_async
 [Notify]: https://www.notifications.service.gov.uk
 [govuk-secrets]: https://github.com/alphagov/govuk-secrets
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet
-[rake task]: https://github.com/alphagov/email-alert-api/blob/master/lib/tasks/troubleshoot.rake#L19
+[rake task]: https://github.com/alphagov/email-alert-api/blob/master/lib/tasks/support.rake#L142

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -31,9 +31,9 @@ This will update www.gov.uk/foreign-travel-advice/`<country_slug>` to www.gov.uk
   * You will see the country has updated in the list in [Travel Advice Publisher](https://travel-advice-publisher.integration.publishing.service.gov.uk/admin)
 
 3. Run Rake tasks
-  * Run [country:rename[<old_country_slug>,<new_country_slug>]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=country:rename[<old_country_slug>,<new_country_slug>]) to update the `TravelAdviceEdition`s.
-  * Run [publishing_api:republish_edition[<new_country_slug>]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[<new_country_slug>]) to update the PublishingApi.
-  * Run [publishing_api:republish_email_signups:country_edition[<country-slug>]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_email_signups:country_edition[<country-slug>]) to update email subscriptions at `/foreign-travel-advice/<country_slug>/email-signup`
+  * Run [country:rename[old_country_slug,new_country_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=country:rename[<old_country_slug>,<new_country_slug>]) to update the `TravelAdviceEdition`s.
+  * Run [publishing_api:republish_edition[new_country_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[<new_country_slug>]) to update the PublishingApi.
+  * Run [publishing_api:republish_email_signups:country_edition[country-slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_email_signups:country_edition[<country-slug>]) to update email subscriptions at `/foreign-travel-advice/<country_slug>/email-signup`
 
 4. Update the search metadata
   * In the [UI](https://travel-advice-publisher.integration.publishing.service.gov.uk/admin), go to the country and create a new edition

--- a/source/manual/republishing-content.html.md
+++ b/source/manual/republishing-content.html.md
@@ -4,7 +4,7 @@ title: Republish content
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-09-17
+last_reviewed_on: 2020-09-23
 review_in: 6 months
 ---
 
@@ -15,8 +15,8 @@ website. This process varies per app.
 
 If the document is in Whitehall, there is a Rake task you can run.
 
-[`publishing_api:republish_document[slug]`](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug])
+[`publishing_api:republish_document[slug]`](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug])
 
 For organisations, run:
 
-[`publishing_api:republish_organisation[slug]`](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_organisation[slug])
+[`publishing_api:republish_organisation[slug]`](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_organisation[slug])

--- a/source/manual/restart-application.html.md
+++ b/source/manual/restart-application.html.md
@@ -4,8 +4,10 @@ title: Restart an application
 parent: "/manual.html"
 layout: manual_layout
 section: Deployment
-last_reviewed_on: 2020-07-16
+last_reviewed_on: 2020-09-23
 review_in: 3 months
 ---
 
-To restart an application go to the Deploy app jenkins job in [Carrenza](https://deploy.publishing.service.gov.uk/job/Deploy_App/build) or [AWS](https://deploy.blue.production.govuk.digital/job/Deploy_App/build), choose your app, the **current release** and select `app:hard_restart`.
+To restart an application go to the Deploy app Jenkins job in [AWS](https://deploy.blue.production.govuk.digital/job/Deploy_App/build), choose your app, the **[current release]** and select `app:hard_restart`.
+
+[current release]:https://release.publishing.service.gov.uk/applications

--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -14,9 +14,7 @@ review_in: 6 months
 
 The name should begin with `ABTest-`.  Try to keep it short.
 
-You don't need to use the `ABTest-` prefix
-in [your code](https://github.com/alphagov/collections/blob/54dd7d22567ec932a16c262387ae609e9cc47aae/app/controllers/concerns/taxon_pages_testable.rb#L25)
-though as [it's already configured in Fastly](https://github.com/alphagov/govuk-cdn-config/blob/955dd25e6443a8fd7142cebdb60d7bee43a067b7/vcl_templates/www.vcl.erb#L348).
+You don't need to use the `ABTest-` prefix in [your code](https://github.com/alphagov/collections/blob/54dd7d22567ec932a16c262387ae609e9cc47aae/app/controllers/concerns/taxon_pages_testable.rb#L25) though as [it's already configured in Fastly](https://github.com/alphagov/govuk-cdn-config/blob/955dd25e6443a8fd7142cebdb60d7bee43a067b7/vcl_templates/www.vcl.erb#L348).
 
 ### Consider load
 
@@ -94,6 +92,6 @@ Follow these steps:
 
 [govuk-cdn-config]: https://github.com/alphagov/govuk-cdn-config
 [configuration-file]: https://github.com/alphagov/govuk-cdn-config/blob/master/ab_tests/ab_tests.yaml
-[update-cdn-dictionaries]: https://deploy.staging.publishing.service.gov.uk/job/Update_CDN_Dictionaries/
-[deploy-cdn]: https://deploy.staging.publishing.service.gov.uk/job/Deploy_CDN/
+[update-cdn-dictionaries]: https://deploy.blue.staging.govuk.digital/job/Update_CDN_Dictionaries/
+[deploy-cdn]: https://deploy.blue.staging.govuk.digital/job/Deploy_CDN/
 [register]: https://docs.google.com/spreadsheets/d/1voQzdoGAFO9Tnvl7Xq4ahLEAyGtkeAtvTC26SxEP6rE/edit

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -5,7 +5,7 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 important: true
-last_reviewed_on: 2019-07-03
+last_reviewed_on: 2020-09-23
 review_in: 12 months
 ---
 
@@ -13,13 +13,9 @@ There is a Jenkins job that can be used to run any rake task:
 
 - Integration:
   <https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/>
-- Staging (Carrenza):
-  <https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/>
-- Staging (AWS):
+- Staging:
   <https://deploy.blue.staging.govuk.digital/job/run-rake-task/>
-- Production (Carrenza):
-  <https://deploy.publishing.service.gov.uk/job/run-rake-task/>
-- Production (AWS):
+- Production:
   <https://deploy.blue.production.govuk.digital/job/run-rake-task/>
 
 Jenkins jobs are also linkable. For example:


### PR DESCRIPTION
Updated our links to rake tasks in Carrenza to AWS, as our apps
are now in AWS.

As well as making these changes I have:
- updated any broken links found
- reviewed some of the docs and updated the review date