### PR TITLE
Don't hard-wrap newlines when rendering markdown

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,7 +14,8 @@ set :markdown,
     fenced_code_blocks: true,
     input: "GFM",
     tables: true,
-    no_intra_emphasis: true
+    no_intra_emphasis: true,
+    hard_wrap: false
 
 configure :development do
   # Disable Google Analytics in development


### PR DESCRIPTION
In #2785 we changed the parsing engine from Redcarpet to
Kramdown, but this slipped through. Newlines were now being
treated as explicit newlines (`<br>`).

Many of our markdown files split sentences across multiple lines
for clarity in diffs, so we don't want to actually render them
across multiple lines.

Before:

> <img width="400" alt="Screenshot 2020-09-24 at 18 36 48" src="https://user-images.githubusercontent.com/5111927/94180237-9f097200-fe95-11ea-9ad9-2a64b0950e1b.png">

After:

> <img width="400" alt="Screenshot 2020-09-24 at 18 36 40" src="https://user-images.githubusercontent.com/5111927/94180259-a3ce2600-fe95-11ea-8c43-23d58462415f.png">
