### PR TITLE
Remove corona services apps from dependapanda

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -329,38 +329,6 @@
   dashboard_url: false
   description: 'GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)'
 
-# Coronavirus
-
-- github_repo_name: govuk-coronavirus-vulnerable-people-form
-  private_repo: false
-  type: Specialist apps
-  production_hosted_on: paas
-  team: "#govuk-corona-services-tech"
-  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5170680
-  deploy_url: 'https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/blob/master/concourse/pipeline.yml'
-  dashboard_url: 'https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/d006_coronavirus?form.main.earliest=-7d%40h&form.main.latest=now&form.xhost=coronavirus-vulnerable-people.service.gov.uk'
-  description: 'Helps the public get support during the Covid-19 pandemic'
-
-- github_repo_name: govuk-coronavirus-business-volunteer-form
-  private_repo: false
-  type: Specialist apps
-  production_hosted_on: paas
-  team: "#govuk-corona-services-tech"
-  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5172100
-  deploy_url: 'https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/blob/master/concourse/pipeline.yml'
-  dashboard_url: false
-  description: 'Lets businesses volunteer with the response to the Covid-19 pandemic'
-
-- github_repo_name: govuk-coronavirus-find-support
-  private_repo: false
-  type: Specialist apps
-  production_hosted_on: paas
-  team: "#govuk-smart-answers-devs"
-  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5192076
-  deploy_url: 'https://github.com/alphagov/govuk-coronavirus-find-support/blob/master/concourse/pipeline.yml'
-  dashboard_url: false
-  description: 'Helps people in the UK find relevant support during the COVID-19 pandemic'
-
 # Utility Heroku apps (don't add apps that are only for review here)
 
 - github_repo_name: seal


### PR DESCRIPTION
What

Remove the coronavirus services apps from dependapanda.

Why

The find support service has been migrated and is now a smart answer. The
vulnerable people service has been rebuilt by #vulnerable-people-services
team, and the business volunteer service has been replace with a guidance
page.

[Trello](https://trello.com/c/mMboxOo8/570-remove-old-coronavirus-services-apps-from-dependapanda)