### PR TITLE
Update Deploy_DNS Jenkins job URL

### DIFF
--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -5,7 +5,7 @@ section: Applications
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-04-08
+last_reviewed_on: 2020-10-16
 review_in: 12 months
 ---
 
@@ -43,7 +43,7 @@ delivery network, which aim to respond with the IP address of the Fastly cache n
 which is "closest" to the user. Read more about Fastly in the next section, or
 [read more about gov.uk DNS][govuk-dns-docs].
 
-[deploy-dns]: https://deploy.publishing.service.gov.uk/job/Deploy_DNS/
+[deploy-dns]: https://deploy.blue.production.govuk.digital/job/Deploy_DNS/
 [govuk-dns repo]: https://github.com/alphagov/govuk-dns
 [govuk-dns-config repo]: https://github.com/alphagov/govuk-dns-config
 [govuk-dns-docs]: /manual/dns.html

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -5,7 +5,7 @@ section: Infrastructure
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-06-05
+last_reviewed_on: 2020-10-16
 review_in: 6 months
 ---
 
@@ -82,7 +82,7 @@ Where:
 1. `<action>` is the terraform action you want to perform. i.e. `plan` or `apply`
 1. `<aws_role>` is the govuk aws role you want to use for terraforming. i.e. `govuk-production-admin` or `govuk-production-poweruser`
 
-After you deploy, you can visit the [Jenkins job](https://deploy.publishing.service.gov.uk/job/Deploy_DNS/) to see the job running or queued.
+After you deploy, you can visit the [Jenkins job](https://deploy.blue.production.govuk.digital/job/Deploy_DNS/) to see the job running or queued.
 
 > **Note**
 >


### PR DESCRIPTION
The Jenkins job is being moved from Carrenza Production to AWS Production with new URL:
https://deploy.blue.production.govuk.digital/job/Deploy_DNS

This PR updates the URL in this repo.

Ref:
1. [Trello Card](https://trello.com/c/ti7AGfnE/3894-move-jenkins-deploy-dns-to-aws-production)
2. [govuk-puppet](https://github.com/alphagov/govuk-puppet/pull/10772)