### PR TITLE
Fix link to Email Alert API queue info

### DIFF
--- a/source/manual/alerts/email-alert-api-high-queue-latency.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-latency.html.md
@@ -39,6 +39,6 @@ See [here][Sidekiq] for more information about Sidekiq.
 [Sidekiq dash]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now
 [technical dash]: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api_technical.json
 [Kibana]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(columns:!('@message',host),index:'*-*',interval:auto,query:(query_string:(query:'@type:%20sidekiq%20AND%20application:%20email-alert-api')),sort:!('@timestamp',desc))
-[email queues]: https://docs.publishing.service.gov.uk/apis/email-alert-api/queues.html
+[email queues]: https://github.com/alphagov/email-alert-api/blob/master/config/sidekiq.yml
 [machine metrics]: https://grafana.blue.production.govuk.digital/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=email_alert_api*&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All
 [postgres dash]: https://grafana.production.govuk.digital/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=blue-postgresql-primary&from=now-3h&to=now


### PR DESCRIPTION
https://trello.com/c/7QA5eAoC/483-do-an-audit-to-check-for-any-more-work-to-do-on-alerts-epic

This was changed in [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1423