### PR TITLE
Adapt to Email Alert API renaming

### DIFF
--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -33,8 +33,8 @@ for each environment):
   (Notify's daily allowance with Amazon SES) meaning we should adhere to these
   limits when using Notify to deliver emails for our applications. The rate
   limit of 350 requests per second is set in email-alert-api and can be found in the
-  [DeliveryRequestWorker][DeliveryRequestWorker]. If you wish to double check
-  these figures you could ask in their slack channel #govuk-notify.
+  [SendEmailWorker][SendEmailWorker]. If you wish to double check these figures
+  you could ask in their slack channel #govuk-notify.
 
 - **GOV.UK Publishing**
 
@@ -51,7 +51,7 @@ for each environment):
   Currently it is used by [Feedback](https://github.com/alphagov/feedback) to email a survey link
   to users who click a survey banner or use the `Is this page useful?` feature.
 
-[DeliveryRequestWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/delivery_request_worker.rb#L52
+[SendEmailWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/send_email_worker.rb#L4
 
 ## Accessing the dashboard
 

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -29,7 +29,7 @@ make changes to [govuk-puppet].
 
 2. Create a branch with your changes and push them to GitHub. Deploy the changes by running the [deploy-puppet](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet) job for the environment you're testing on, providing your branch name instead of a release tag.
 
-3. Once these changes have been deployed and the environment variable `EMAIL_ADDRESS_OVERRIDE_WHITELIST` is populated with your address you can test that you can receive emails by running the [support:deliver_to_test_email[name@example.com]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=support:deliver_to_test_email[your.name@digital.cabinet-office.gov.uk]) rake task.
+3. Once these changes have been deployed and the environment variable `EMAIL_ADDRESS_OVERRIDE_WHITELIST` is populated with your address you can test that you can receive emails by running the [support:send_test_email[name@example.com]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=support:send_test_email[your.name@digital.cabinet-office.gov.uk]) rake task.
 
 ## Testing digest emails
 


### PR DESCRIPTION
Trello: https://trello.com/c/Xd47oJKZ/535-remove-the-deliveryattempt-model

In https://github.com/alphagov/email-alert-api/pull/1438 there are a number of renames of Email Alert API concepts. This adapts to these changes by replacing outdated text and links