### PR TITLE
Defend against repos which are missing a README.md

### DIFF
--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -164,6 +164,10 @@ gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
   <span class="govuk-error-message">
     Cannot fetch README without `GITHUB_TOKEN`.
   </span>
+<% elsif application.readme.nil? %>
+  <span class="govuk-error-message">
+    This repo doesn't have a README.md file.
+  </span>
 <% else %>
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>


### PR DESCRIPTION
GitHubRepoFetcher returns 'nil' if a README.md is missing from
the requested repo. But when we pass it to ExternalDoc.parse,
it doesn't know what to do with 'nil' and the build fails.

We're not seeing errors on CI as the README inclusion isn't
working at the moment (no ENV['GITHUB_TOKEN'] detected),
but it is failing locally on
https://github.com/alphagov/ckanext-datagovuk
(this has a README.rst, rather than a README.md).