### PR TITLE
Update guide to setting up Rails app and separate linting to a new document

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -40,9 +40,10 @@
       repos:
         - govuk-rfcs
         - rubocop-govuk
-        - scss-lint-govuk
         - publishing-e2e-tests
+        - scss-lint-govuk
         - styleguides
+        - stylelint-config-gds
 
 - name: Infrastructure
   sections:

--- a/source/manual/configure-linting.html.md
+++ b/source/manual/configure-linting.html.md
@@ -1,0 +1,112 @@
+---
+owner_slack: "#govuk-developers"
+title: Configure linting
+section: Applications
+type: learn
+layout: manual_layout
+parent: "/manual.html"
+last_reviewed_on: 2020-10-22
+review_in: 12 months
+---
+
+This explains how to configure [linting][] for a GOV.UK application. It is
+written with the expectation that you are configuring a
+[conventional GOV.UK Rails application][rails] although the approaches
+can be applied to non-Rails applications by minor adjustments to the steps.
+
+[linting]: https://en.wikipedia.org/wiki/Lint_(software)
+[rails]: /manual/conventions-for-rails-applications.html
+
+## Linting Ruby
+
+We use [rubocop-govuk](https://github.com/alphagov/rubocop-govuk) to lint Ruby
+projects.
+
+This is installed by adding `gem "rubocop"` to your Gemfile and then creating a
+`.rubocop.yml` file in the root of your project:
+
+```yaml
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+    - config/rake.yml
+    - config/rspec.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+```
+
+After running `bundle install` you can test the linting by running
+`bundle exec rubocop`.
+
+## Linting JavaScript and SCSS
+
+We use [StandardJS](https://standardjs.com/) for JavaScript linting and
+[Stylelint](https://stylelint.io/) for SCSS linting, using the
+[stylelint-config-gds][] configuration.
+
+To enable these in a Rails application you will first need to
+[install Yarn][yarn-install]. Then you should create a `package.json` file in
+your project root. You can use the following template:
+
+```json
+{
+  "name": "My application",
+  "description": "A brief description of the application's purpose",
+  "private": true,
+  "author": "Government Digital Service",
+  "license": "MIT",
+  "scripts": {
+    "lint": "yarn run lint:js && yarn run lint:scss",
+    "lint:js": "standard 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
+    "lint:scss": "stylelint app/assets/stylesheets/"
+  },
+  "stylelint": {
+    "extends": "stylelint-config-gds/scss"
+  }
+}
+```
+
+The dependencies can then be installed:
+
+```sh
+yarn add --dev standard stylelint stylelint-config-gds
+```
+
+You can now test the linting by running `yarn run lint`.
+
+To finish up you should add `node_modules` and `yarn-error.log` to
+your `.gitignore` file.
+
+[stylelint-config-gds]: https://github.com/alphagov/stylelint-config-gds
+[yarn-install]: https://classic.yarnpkg.com/en/docs/install/
+
+## Configuring Rails
+
+To configure this linting in Rails you should create a [rake][] task for this
+in `lib/tasks/lint.rake`:
+
+```rb
+desc "Lint files"
+task "lint" do
+  sh "bundle exec rubocop"
+  sh "yarn run lint" # lint JS and SCSS
+end
+```
+
+You should then configure the default rake task for the application to include
+linting. For example to run linting and RSpec as the default task add the
+following code to your `Rakefile`:
+
+```rb
+# undo any existing default tasks added by depenencies so we have control
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[lint spec]
+````
+
+You can confirm this works by running `bundle exec rake` and seeing your
+linting run followed by specs.
+
+[rake]: https://github.com/ruby/rake

--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -64,8 +64,6 @@ Ruby / Rails applications:
   for the current environment
 - [rubocop-govuk][] - Provides GOV.UK linting rules for Ruby, Rails, RSpec and
   Rake
-- [scss-lint-govuk][] - Provides linting for SCSS files according to GDS
-  conventions
 - [slimmer][] - Provides consistent templating for apps that serve content on
   the www.gov.uk host
 
@@ -87,9 +85,15 @@ introduced by these gems.
 [govuk_test]: https://github.com/alphagov/govuk_test
 [plek]: https://github.com/alphagov/plek
 [rubocop-govuk]: https://github.com/alphagov/rubocop-govuk
-[scss-lint-govuk]: https://github.com/alphagov/scss-lint-govuk
 [slimmer]: https://github.com/alphagov/slimmer
 [issue-example]: https://github.com/alphagov/govuk_app_config/issues/121
+
+### Lint your code
+
+We have documentation on the [tools and conventions][configure-linting] for
+linting GOV.UK Rails applications.
+
+[configure-linting]: /manual/configure-linting.html
 
 ### Gemfile organisation
 

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -27,13 +27,13 @@ applications](/manual/conventions-for-rails-applications.html) and
 
 To create a rails app, run the following (skip uncommon stuff).
 
-```
+```sh
 rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage
 ```
 
 Replace the Gemfile with the gems you need. Here is an example.
 
-```
+```rb
 source "https://rubygems.org"
 
 gem "rails", "6.0.3.4"
@@ -65,10 +65,11 @@ end
 
 Run `bundle && rails g rspec:install` and replace `spec/*helper.rb`.
 
-```
-## spec/rails_helper.rb
+```sh
 rm spec/rails_helper.rb
+```
 
+```rb
 ## spec/spec_helper.rb
 ENV["RAILS_ENV"] ||= "test"
 
@@ -90,7 +91,7 @@ end
 
 In config, replace the content of `database.yml` with the following.
 
-```
+```yaml
 default: &default
   adapter: postgresql
   encoding: unicode
@@ -115,7 +116,7 @@ production:
 
 In config, replace `credentials.yml.env` and `master.key` with `secrets.yml`.
 
-```
+```yaml
 development:
   secret_key_base: secret
 
@@ -128,23 +129,15 @@ production:
 
 In config, replace the content of `routes.rb` with the following healthcheck.
 
-```
+```rb
 Rails.application.routes.draw do
-  get "/healthcheck", to: proc { [200, {}, ["OK"]] }
+  get "/healthcheck", to: GovukHealthcheck.rack_response
 end
 ```
 
-Now is a good time to run `bin/setup`. Lastly, create `lib/tasks/lint.rake` with this.
-
-```
-desc "Lint files"
-task "lint" do
-  sh "rubocop --format clang"
-  sh "scss-lint app/assets/stylesheets"
-end
-```
-
-Then add `task default: %i(spec lint)` in Rakefile and finally run `rake`.
+Now is a good time to run `bin/setup`. Lastly, to ensure your application has
+beautiful consistent code, you should finish up by
+[configuring linting](/manual/configure-linting.html) for it.
 
 ## Add a software licence
 
@@ -187,7 +180,7 @@ We have a common structure that is used for GOV.UK apps. Fill in some basic
 details to get started with your app and flesh it out further as your project
 develops.
 
-```
+```markdown
 # App Name
 
 One paragraph description and purpose.

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -33,34 +33,32 @@ rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip
 Replace the Gemfile with the gems you need. Here is an example.
 
 ```
-ruby File.read(".ruby-version").strip
-
 source "https://rubygems.org"
 
-gem "rails", "~> 5.2"
+gem "rails", "6.0.3.4"
 
-gem "bootsnap", "~> 1"
-gem "gds-api-adapters", "~> 52"
-gem "gds-sso", "~> 13"
-gem "govuk_app_config", "~> 1"
-gem "govuk_publishing_components", "~> 9.5"
-gem "pg", "~> 1"
-gem "plek", "~> 2"
-gem "uglifier", "~> 4"
+gem "bootsnap",
+gem "gds-api-adapters"
+gem "gds-sso"
+gem "govuk_app_config"
+gem "govuk_publishing_components"
+gem "pg"
+gem "plek"
+gem "uglifier"
 
 group :development do
-  gem "listen", "~> 3"
+  gem "listen"
 end
 
 group :test do
-  gem "simplecov", "~> 0.16"
+  gem "simplecov"
 end
 
 group :development, :test do
-  gem "byebug", "~> 10"
-  gem "rspec-rails", "~> 3"
+  gem "byebug"
+  gem "govuk_test"
+  gem "rspec-rails"
   gem "rubocop-govuk"
-  gem "scss-lint-govuk"
 end
 ```
 

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -69,15 +69,16 @@ Run `bundle && rails g rspec:install` and replace `spec/*helper.rb`.
 rm spec/rails_helper.rb
 
 ## spec/spec_helper.rb
-require "byebug"
-require "simplecov"
-
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+SimpleCov.start "rails"
+
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
-SimpleCov.start
+GovukTest.configure
 
 RSpec.configure do |config|
   config.expose_dsl_globally = false

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -6,6 +6,7 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
+[mit-license]: https://en.wikipedia.org/wiki/MIT_License
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet/blob/master/docs/adding-a-new-app.md#including-the-app-on-machines
 [govuk-puppet-jenkins]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml
 [dns]: https://docs.publishing.service.gov.uk/manual/dns.html#making-changes-to-publishing-service-gov-uk
@@ -144,6 +145,83 @@ end
 ```
 
 Then add `task default: %i(spec lint)` in Rakefile and finally run `rake`.
+
+## Add a software licence
+
+Add a LICENCE file to the project root to specify the software licence. Unless
+your project has specific needs, you should use the [MIT License][mit-license].
+
+<details markdown="block">
+
+<summary>MIT License for GDS projects</summary>
+
+```
+The MIT License (MIT)
+
+Copyright (c) <year> Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+</details>
+
+## Replace the default README.md
+
+We have a common structure that is used for GOV.UK apps. Fill in some basic
+details to get started with your app and flesh it out further as your project
+develops.
+
+```
+# App Name
+
+One paragraph description and purpose.
+
+## Screenshots (if there's a client-facing aspect of it)
+
+## Live examples (if available)
+
+- [gov.uk/thing](https://www.gov.uk/thing)
+
+## Nomenclature
+
+- **Word**: definition of word, and how it's used in the code
+
+## Technical documentation
+
+Write a single paragraph including a general technical overview of the app.
+
+### Dependencies
+
+- [dependency]() - purpose
+
+### Running the application
+
+How to run the app
+
+### Running the test suite
+
+How to test the app
+
+## Licence
+
+[MIT License](LICENCE)
+```
 
 ## Puppet, DNS, Sentry and beyond
 


### PR DESCRIPTION
This sequence of commits represents me ending up rather into a rabbit hole and trying to claw my way out. Initially I intended to just update the Gemfile example of https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html to match https://github.com/alphagov/govuk-developer-docs/pull/2830. However once I started the rabbit hole grew.

A brief summary of things this includes is:

- Adding licence and readme approaches to the Setting up new Rails application guide, this is done to reflect that we no longer have the templates from https://github.com/alphagov/govuk-rails-app-template;
- Creates a new document on how to configure linting for Rails apps;
- Some basic modernisation of examples;
- Replace a couple of usages of `scss-lint-govuk` with `stylelint-config-gds` to reflect the direction of travel.

More info in the commits.