### PR TITLE
Change ownership to Notifications team

### DIFF
--- a/source/manual/bulk-email.html.md
+++ b/source/manual/bulk-email.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-notifications"
 title: Send a bulk email
 section: Emails
 layout: manual_layout

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-notifications"
 title: "Email notifications: how they work"
 section: Emails
 type: learn

--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-notifications"
 title: "Email troubleshooting"
 section: Emails
 type: learn

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-notifications"
 title: Receive emails from Email Alert API in integration and staging
 section: Emails
 layout: manual_layout


### PR DESCRIPTION
Makes the Notifications team the owners of some email-related pages - they have the most current working knowledge of these things, so are the best team to ensure the docs are accurate.

[Trello card](https://trello.com/c/ardPpkNW/2191-transfer-ownership-of-some-dev-docs-to-notifications-team)