### PR TITLE
Update docs for migration of Production CDN Jenkins jobs

### DIFF
--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -5,7 +5,7 @@ section: CDN & Caching
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-02-11
+last_reviewed_on: 2020-10-26
 review_in: 6 months
 ---
 
@@ -30,8 +30,8 @@ These are deployed to [integration][integration_cdn], [staging][staging_cdn] and
 Some configuration isn't scripted, such as logging. The www, bouncer and assets services send logs to S3 which can be [queried](/manual/query-cdn-logs.html). These logging endpoints are configured directly in the Fastly UI.
 
 [integration_cdn]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_CDN/
-[staging_cdn]: https://deploy.staging.publishing.service.gov.uk/job/Deploy_CDN/
-[production_cdn]: https://deploy.publishing.service.gov.uk/job/Deploy_CDN/
+[staging_cdn]: https://deploy.blue.staging.govuk.digital/job/Deploy_CDN/
+[production_cdn]: https://deploy.blue.production.govuk.digital/job/Deploy_CDN/
 
 ## Fastly Caching
 
@@ -161,7 +161,7 @@ Banning IPs shouldn't be taken lightly as IP address can be shared by multiple u
 You can change the list of banned IP addresses by modifying the [YAML config file][ip_ban_config] and [deploying the configuration][ip_ban_deploy].
 
 [ip_ban_config]: https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/dictionaries/config/ip_address_blacklist.yaml
-[ip_ban_deploy]: https://deploy.publishing.service.gov.uk/job/Update_CDN_Dictionaries/build
+[ip_ban_deploy]: https://deploy.blue.production.govuk.digital/job/Update_CDN_Dictionaries/build
 
 ## Bouncer's Fastly service
 

--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -5,7 +5,7 @@ parent: "/manual.html"
 layout: manual_layout
 type: learn
 section: Publishing
-last_reviewed_on: 2020-07-24
+last_reviewed_on: 2020-10-26
 review_in: 6 months
 ---
 
@@ -86,7 +86,7 @@ To exclude a document type or page from having links generated _to_ it, _from_ i
 
 #### Suspending all suggested related links
 
-To immediately and temporarily stop showing all suggested related links (for example, if a problem has led to bad links being generated for a large percentage of content / high traffic content), you will need to update the CDN to set the `Govuk-Use-Recommended-Related-Links` header to `False` and then [deploy the CDN](https://deploy.publishing.service.gov.uk/job/Deploy_CDN/) for `vhost: www`.
+To immediately and temporarily stop showing all suggested related links (for example, if a problem has led to bad links being generated for a large percentage of content / high traffic content), you will need to update the CDN to set the `Govuk-Use-Recommended-Related-Links` header to `False` and then [deploy the CDN](https://deploy.blue.production.govuk.digital/job/Deploy_CDN/) for `vhost: www`.
 
 The root cause of the problem should be investigated and a new set of related links generated and ingested through the pipeline, if possible. Should the fix not be immediate, we might consider re-ingesting an older batch of related links from S3.
 


### PR DESCRIPTION
Following on from [PR](https://github.com/alphagov/govuk-puppet/pull/10796)
where we migrate the Production CDN Jenkins job to AWS, we update the
developer docs to reflect the new links.

Refs:
1. [Puppet PR](https://github.com/alphagov/govuk-puppet/pull/10796)
2. [Trello Card](https://trello.com/c/L3325c8c/3900-migrate-cdn-jenkins-jobs-to-aws-production)