### PR TITLE
Increase rate limits for GitHub API requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - run: bundle install --jobs 4 --retry 3 --deployment
       - run: bundle exec rake
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
 
   deploy:
@@ -56,6 +57,7 @@ jobs:
       - name: Build 'build' folder ready for deployment
         run: bundle exec rake build
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
We're right on the cusp of breaching the standard 60 API hits
that are allowed for unauthenticated requests to the GitHub API.
GitHub Actions automatically create a GITHUB_TOKEN for authenticated
requests: https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow

We just need to expose that as an ENV variable to each build task.
Using a token increases our limit to 15000 requests per hour.

Before:

```
2020-10-28T08:24:09.4012886Z x-ratelimit-limit: "60"
2020-10-28T08:24:09.4013490Z x-ratelimit-remaining: "1"
2020-10-28T08:24:09.4014106Z x-ratelimit-reset: "1603877018"
2020-10-28T08:24:09.4014667Z x-ratelimit-used: "59"
```

After:

```
x-ratelimit-limit: "15000"
x-ratelimit-remaining: "14995"
x-ratelimit-reset: "1603879429"
x-ratelimit-used: "5"
```