### PR TITLE
Remove 'review_in' field (and therefore Daniel the Manual Spaniel)

### DIFF
--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -9,9 +9,10 @@ module CommitHelpers
   end
 
   def last_updated(current_page)
-    # e.g. "2020-09-03 09:53:56 UTC"
     timestamp = if current_page.data.latest_commit
                   current_page.data.latest_commit[:timestamp].to_s
+                elsif current_page.data.last_reviewed_on
+                  current_page.data.last_reviewed_on.strftime("%Y-%m-%d")
                 else
                   Git.open(".").log.path(source_file(current_page)).first.date.to_s
                 end

--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -1,7 +1,6 @@
 ---
 layout: core
 title: Accessibility statement
-review_in: 6 months
 hide_in_navigation: true
 last_reviewed_on: 2020-09-02
 ---

--- a/source/manual/2nd-line.html.md
+++ b/source/manual/2nd-line.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: 2nd line
 type: learn
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 2nd line has three main reponsibilities:

--- a/source/manual/ab-testing.html.md
+++ b/source/manual/ab-testing.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: A/B testing
 type: learn
 last_reviewed_on: 2020-02-07
-review_in: 6 months
 ---
 
 GOV.UK uses our [Content Delivery Network (Fastly)][cdn] to run A/B and multivariate tests.

--- a/source/manual/access-jenkins.html.md
+++ b/source/manual/access-jenkins.html.md
@@ -5,7 +5,6 @@ section: Accounts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-10-22
-review_in: 12 months
 ---
 
 Our Jenkins installations ([deploy](https://deploy.integration.publishing.service.gov.uk/) and [CI](https://ci.integration.publishing.service.gov.uk/)) use GitHub for authentication and authorisation.

--- a/source/manual/add-a-new-document-type.html.md
+++ b/source/manual/add-a-new-document-type.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 last_reviewed_on: 2020-01-17
-review_in: 6 months
 ---
 
 The [document type] describes what a page on GOV.UK looks like.

--- a/source/manual/add-a-pingdom-check.html.md
+++ b/source/manual/add-a-pingdom-check.html.md
@@ -5,7 +5,6 @@ section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-08
-review_in: 12 months
 ---
 
 GOV.UK uses [Pingdom](https://www.pingdom.com/) to provide an external view of

--- a/source/manual/add-an-icinga-passive-check.html.md
+++ b/source/manual/add-an-icinga-passive-check.html.md
@@ -5,7 +5,6 @@ section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-28
-review_in: 6 months
 ---
 
 If you would like Icinga to raise an alert when a Jenkins job has not completed

--- a/source/manual/add-authentication-to-an-application.html.md
+++ b/source/manual/add-authentication-to-an-application.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Applications
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 The process outlined here relies on the [data sync][] to synchronise

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 last_reviewed_on: 2020-01-27
-review_in: 9 months
 ---
 
 Useful links:

--- a/source/manual/adding-disks-in-vcloud.html.md
+++ b/source/manual/adding-disks-in-vcloud.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-12
-review_in: 6 months
 ---
 
 > **Note**

--- a/source/manual/alerts/app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/app-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-11
-review_in: 6 months
 ---
 
 Many apps on GOV.UK have a healthcheck endpoint.

--- a/source/manual/alerts/athena-fastly-logs-check.html.md
+++ b/source/manual/alerts/athena-fastly-logs-check.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-02-19
-review_in: 12 months
 ---
 
 The monitoring for `Athena has recent results for fastly_logs {database_name}`

--- a/source/manual/alerts/aws-cache-cpu.html.md
+++ b/source/manual/alerts/aws-cache-cpu.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-05-12
-review_in: 6 months
 ---
 
 This alert relates to the ElastiCache Instance CPU Utilization. In AWS, we use

--- a/source/manual/alerts/aws-cache-memory.html.md
+++ b/source/manual/alerts/aws-cache-memory.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-05-05
-review_in: 6 months
 ---
 
 This alert relates to the ElastiCache Instance Memory Utilization. In AWS we

--- a/source/manual/alerts/aws-lb-healthyhosts.html.md
+++ b/source/manual/alerts/aws-lb-healthyhosts.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This alert relates to the number of healthy hosts behind AWS LoadBalancing services. We use AWS ELB (Classic) and ALB services to route traffic from internet facing or internal clients to the application instances.

--- a/source/manual/alerts/aws-rds-cpu.html.md
+++ b/source/manual/alerts/aws-rds-cpu.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-05-13
-review_in: 6 months
 ---
 
 This alert relates to the AWS relational database service (RDS) CPU

--- a/source/manual/alerts/aws-rds-memory.html.md
+++ b/source/manual/alerts/aws-rds-memory.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-05-12
-review_in: 6 months
 ---
 
 This alert relates to memory usage of our database (RDS) instances in AWS.

--- a/source/manual/alerts/aws-rds-storage.html.md
+++ b/source/manual/alerts/aws-rds-storage.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-05-12
-review_in: 6 months
 ---
 
 This alert relates to disk usage of our databases (RDS) in AWS. There are two

--- a/source/manual/alerts/backup-passive-checks.html.md
+++ b/source/manual/alerts/backup-passive-checks.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
 
-review_in: 6 months
 ---
 
 These checks ensure that the backups have run within the last day (specifically

--- a/source/manual/alerts/cannot-ping-across-AWS-Carrenza-VPN.html.md
+++ b/source/manual/alerts/cannot-ping-across-AWS-Carrenza-VPN.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-06-01
-review_in: 6 months
 ---
 
 There is a VPN tunnel between AWS and Carrenza for both the Staging and

--- a/source/manual/alerts/cdn-log-freshness.html.md
+++ b/source/manual/alerts/cdn-log-freshness.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 ## Meaning and impact

--- a/source/manual/alerts/check-process-running.html.md
+++ b/source/manual/alerts/check-process-running.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This alert means that a process which should be running is not. It's highly likely that this process corresponds to a service.

--- a/source/manual/alerts/clamav-definitions-out-of-date.html.md
+++ b/source/manual/alerts/clamav-definitions-out-of-date.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-07-16
-review_in: 6 months
 ---
 
 This could be because of a number of reasons. Check that the database is up to

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-30
-review_in: 6 months
 ---
 
 If there is a health check error showing for Content Data API, click

--- a/source/manual/alerts/content-publisher-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/content-publisher-app-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-11
-review_in: 12 months
 ---
 
 See also: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)

--- a/source/manual/alerts/data-sync.html.md
+++ b/source/manual/alerts/data-sync.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 ## govuk_env_sync (the new way)

--- a/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 3 months
 ---
 
 [datagovuk_publish](https://github.com/alphagov/datagovuk_publish)

--- a/source/manual/alerts/ddosdetected.html.md
+++ b/source/manual/alerts/ddosdetected.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 If there is a Distributed Denial of Service (DDoS) alert in Icinga this means that AWS have detected a probable DDoS attack on one or more of the AWS Shield Advanced

--- a/source/manual/alerts/duplicate-ssh-host-keys.html.md
+++ b/source/manual/alerts/duplicate-ssh-host-keys.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-05-12
-review_in: 6 months
 ---
 
 This check indicates that more than one machine in an environment is

--- a/source/manual/alerts/elasticsearch-cluster-health.html.md
+++ b/source/manual/alerts/elasticsearch-cluster-health.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 Elasticsearch reports cluster health as one of three possible states, based on

--- a/source/manual/alerts/email-alert-api-high-queue-latency.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-latency.html.md
@@ -6,7 +6,6 @@ subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-05
-review_in: 6 months
 ---
 
 ### High queue latency (queue_latency)

--- a/source/manual/alerts/email-alert-api-unprocessed-work.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-work.html.md
@@ -6,7 +6,6 @@ subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-05
-review_in: 6 months
 ---
 
 This alert indicates that Email Alert API has work that has not been processed in the generous amount of time we expect it to have been. Which alert you see depends on the type of work.

--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -6,7 +6,6 @@ subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-18
-review_in: 6 months
 ---
 
 We expect that when new GOV.UK content is published, or when existing content

--- a/source/manual/alerts/enhanced-ecommerce.html.md
+++ b/source/manual/alerts/enhanced-ecommerce.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This process is related to collection of data for analytics and is run daily to

--- a/source/manual/alerts/established-connections-exceed.html.md
+++ b/source/manual/alerts/established-connections-exceed.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This alert triggers when the number of established connections to a

--- a/source/manual/alerts/fastly-error-rate.html.md
+++ b/source/manual/alerts/fastly-error-rate.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 We get response code reporting from Fastly (with a 15 minute delay). It

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This checks the latest build state of [a job in production

--- a/source/manual/alerts/free-memory-warning-on-backend.html.md
+++ b/source/manual/alerts/free-memory-warning-on-backend.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-06-24
-review_in: 6 months
 ---
 
 This alert is often caused by an application slowly leaking memory, which

--- a/source/manual/alerts/goreplay.html.md
+++ b/source/manual/alerts/goreplay.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 [GoReplay][goreplay-gh] (previously ["gor"][rename]) is an open source tool we use

--- a/source/manual/alerts/grafana-dashboards.html.md
+++ b/source/manual/alerts/grafana-dashboards.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-08-17
-review_in: 6 months
 ---
 
 This alert means there are dashboards that exist only in the database of a single Grafana instance.

--- a/source/manual/alerts/high-memory-for-application.html.md
+++ b/source/manual/alerts/high-memory-for-application.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-07-31
-review_in: 12 months
 ---
 
 This alert triggers when the application process uses too much memory. If this

--- a/source/manual/alerts/high-nginx-5xx-rate.html.md
+++ b/source/manual/alerts/high-nginx-5xx-rate.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 You can view the 5xx logs across all machines on these two dashboards:

--- a/source/manual/alerts/high-zombie-procs.html.md
+++ b/source/manual/alerts/high-zombie-procs.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-03-30
-review_in: 6 months
 ---
 
 You can check what the zombie processes are by SSHing onto the machine

--- a/source/manual/alerts/jenkins-agent-not-connected-to-master.html.md
+++ b/source/manual/alerts/jenkins-agent-not-connected-to-master.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 If the Jenkins agent is not connect to the master you can have a look at the [Jenkins Nodes UI][jenkins-nodes] and see

--- a/source/manual/alerts/low-available-disk-inodes.html.md
+++ b/source/manual/alerts/low-available-disk-inodes.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-04-20
-review_in: 6 months
 ---
 
 The inode usage on a machine can be checked using:

--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 ## Low available disk space on root

--- a/source/manual/alerts/low-space-for-automongodbbackup.html.md
+++ b/source/manual/alerts/low-space-for-automongodbbackup.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-22
-review_in: 6 months
 ---
 
 ### Running out of space for `automongodbbackup`

--- a/source/manual/alerts/mirror-sync.html.md
+++ b/source/manual/alerts/mirror-sync.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-28
-review_in: 6 months
 ---
 
 This is [a script that runs hourly](https://github.com/alphagov/govuk-puppet/blob/99486124689b198120800572b331b38b87a18a6c/modules/govuk_crawler/manifests/init.pp#L220-L227) to sync the mirror contents to S3.

--- a/source/manual/alerts/mongod-replication-lag.html.md
+++ b/source/manual/alerts/mongod-replication-lag.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 ### Investigating the problem

--- a/source/manual/alerts/mongodb-rollback.html.md
+++ b/source/manual/alerts/mongodb-rollback.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 ### What is a rollback

--- a/source/manual/alerts/mysql-replication-lag.html.md
+++ b/source/manual/alerts/mysql-replication-lag.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 Checks the value of `Seconds_Behind_Master` to a threshold. As described

--- a/source/manual/alerts/mysql-replication-running.html.md
+++ b/source/manual/alerts/mysql-replication-running.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 Checks whether `Slave_IO_Running` and `Slave_SQL_Running` both return

--- a/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
+++ b/source/manual/alerts/mysql-xtrabackups-to-s3.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-04-22
-review_in: 6 months
 ---
 
 We send backups to an Amazon S3 bucket every 15 minutes. This is

--- a/source/manual/alerts/nginx-requests-too-low.html.md
+++ b/source/manual/alerts/nginx-requests-too-low.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 We monitor the number of requests reaching our Nginx servers. We expect that

--- a/source/manual/alerts/ntp-drift-too-high.html.md
+++ b/source/manual/alerts/ntp-drift-too-high.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-03-30
-review_in: 6 months
 ---
 
 The [Network Time Protocol (NTP) daemon](http://doc.ntp.org/4.1.0/ntpd.htm) (`ntpd`) is responsible for keeping system

--- a/source/manual/alerts/offsite-backups.html.md
+++ b/source/manual/alerts/offsite-backups.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 All of our offsite backups use duplicity. Most, but not all, are encrypted using GPG.

--- a/source/manual/alerts/onsite-backups.html.md
+++ b/source/manual/alerts/onsite-backups.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 The backup machine (e.g. `backup-1.management.integration`) collects backups from the various data stores at 9am every morning.

--- a/source/manual/alerts/pingdom-homepage-check.html.md
+++ b/source/manual/alerts/pingdom-homepage-check.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 [Pingdom][] monitors externally (from ~10 locations in Europe and America)

--- a/source/manual/alerts/pingdom-search-check.html.md
+++ b/source/manual/alerts/pingdom-search-check.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 If Pingdom can't retrieve the search results page, it means that while GOV.UK

--- a/source/manual/alerts/postgresql-replication-too-far-behind.html.md
+++ b/source/manual/alerts/postgresql-replication-too-far-behind.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 > "replication on the postgres standby is too far behind primary [value in bytes]"

--- a/source/manual/alerts/postgresql-s3-backups.html.md
+++ b/source/manual/alerts/postgresql-s3-backups.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 There are two passive checks related to PostgreSQL S3 backups:

--- a/source/manual/alerts/process-file-handle-count-exceeds.html.md
+++ b/source/manual/alerts/process-file-handle-count-exceeds.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This check fails when the monitored processes use more file handles

--- a/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/publisher-app-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-11
-review_in: 12 months
 ---
 
 See also: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)

--- a/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
+++ b/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
@@ -6,7 +6,6 @@ subsection: Email alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-12
-review_in: 6 months
 ---
 
 As part of the [Publisher fact checking process], this alert appears if emails

--- a/source/manual/alerts/puppet-last-run-errors.html.md
+++ b/source/manual/alerts/puppet-last-run-errors.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-07-16
-review_in: 6 months
 ---
 
 This alert triggers when there's an error while running Puppet on a machine.

--- a/source/manual/alerts/rabbitmq-high-number-of-unprocessed-messages.html.md
+++ b/source/manual/alerts/rabbitmq-high-number-of-unprocessed-messages.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-07
-review_in: 6 months
 ---
 
 For information about how we use RabbitMQ, see [here][rabbitmq_doc].

--- a/source/manual/alerts/rabbitmq-high-watermark.html.md
+++ b/source/manual/alerts/rabbitmq-high-watermark.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-04-01
-review_in: 6 months
 ---
 
 The RabbitMQ server detects the total amount of RAM installed on startup. By

--- a/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
+++ b/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-07
-review_in: 6 months
 ---
 
 ## Check that there is at least one non-idle consumer for rabbitmq queue {queue_name}

--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 parent: "/manual.html"
 important: true
 last_reviewed_on: 2020-09-17
-review_in: 3 months
 ---
 
 Under normal circumstances most machines reboot automatically when an update is required.

--- a/source/manual/alerts/recreate-a-mongo-instance-in-aws.html.md
+++ b/source/manual/alerts/recreate-a-mongo-instance-in-aws.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-12
-review_in: 6 months
 ---
 
 ## Symptom

--- a/source/manual/alerts/redis.html.md
+++ b/source/manual/alerts/redis.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 We have a few monitoring checks for Redis:

--- a/source/manual/alerts/renew-tls-certificate.html.md
+++ b/source/manual/alerts/renew-tls-certificate.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-06-15
-review_in: 6 months
 ---
 
 These checks look at the validity of the TLS certificates for:

--- a/source/manual/alerts/ruby-version.html.md
+++ b/source/manual/alerts/ruby-version.html.md
@@ -5,7 +5,6 @@ section: Icinga alerts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 We have checks to ensure that the version of Ruby the application is using is

--- a/source/manual/alerts/runs-rake-task-search-api.html.md
+++ b/source/manual/alerts/runs-rake-task-search-api.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 At 2:30am every day, a [Jenkins job][jenkins] runs a rake task on search-api

--- a/source/manual/alerts/search-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/search-api-app-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-11
-review_in: 6 months
 ---
 
 See also: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)

--- a/source/manual/alerts/search-api-index-size-change.html.md
+++ b/source/manual/alerts/search-api-index-size-change.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Icinga alerts
 related_applications: [search-api]
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 This alert indicates that a large number of documents have been added to or

--- a/source/manual/alerts/search-api-queue-latency.html.md
+++ b/source/manual/alerts/search-api-queue-latency.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 [Search API](/apps/search-api.html) uses Sidekiq to offload indexing work.

--- a/source/manual/alerts/search-reindex-failed.html.md
+++ b/source/manual/alerts/search-reindex-failed.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 The reindex task is run weekly on a Monday at 9pm on integration. It

--- a/source/manual/alerts/security-updates.html.md
+++ b/source/manual/alerts/security-updates.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 parent: "/manual.html"
 important: true
 last_reviewed_on: 2020-07-27
-review_in: 6 months
 ---
 
 Machines are configured to [automatically install security updates](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package) on a daily basis.

--- a/source/manual/alerts/signon-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/signon-app-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-11
-review_in: 12 months
 ---
 
 [signon]: https://signon.publishing.service.gov.uk/api_users

--- a/source/manual/alerts/smokey-loop-tests.html.md
+++ b/source/manual/alerts/smokey-loop-tests.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-07-08
-review_in: 6 months
 ---
 
 [Smokey][smokey] runs in a continuous loop in each environment.

--- a/source/manual/alerts/unicorn-herder.html.md
+++ b/source/manual/alerts/unicorn-herder.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-04-20
-review_in: 6 months
 ---
 
 ### 'app unicornherder running'

--- a/source/manual/alerts/unknown-error-with-postgresql-mapit.html.md
+++ b/source/manual/alerts/unknown-error-with-postgresql-mapit.html.md
@@ -5,7 +5,6 @@ layout: manual_layout
 parent: "/manual.html"
 section: Icinga alerts
 last_reviewed_on: 2020-03-30
-review_in: 6 months
 ---
 
 We have seen an error previously where postgresql services appear to have failed

--- a/source/manual/alerts/user-monitor.html.md
+++ b/source/manual/alerts/user-monitor.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-10
-review_in: 6 months
 ---
 
 This alert is triggered by the [User Monitor Jenkins job][user-monitor-job]. This task [runs a script][repo] that verifies only the correct users have access to things like GitHub.

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-03-30
-review_in: 6 months
 ---
 
 Under high load, it is possible that the Varnish child process which handles

--- a/source/manual/alerts/vpn-down.html.md
+++ b/source/manual/alerts/vpn-down.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 We use VPNs to connect between datacentres. Please see [GOV.UK and Virtual Private Networks (VPNs)](/manual/vpn.html) for details of the VPNs we have and a description of the impact of each VPN failing. These should appear as Icinga Alerts on the dashboards.

--- a/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-11
-review_in: 12 months
 ---
 
 See also: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 ## 'overdue publications in Whitehall'

--- a/source/manual/allowlist-site-in-transition.html.md
+++ b/source/manual/allowlist-site-in-transition.html.md
@@ -5,7 +5,6 @@ section: Transition
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-08
-review_in: 6 months
 related_applications: [transition]
 ---
 

--- a/source/manual/analytics.html.md
+++ b/source/manual/analytics.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-05-13
-review_in: 6 months
 related_applications: [govuk_frontend_toolkit static frontend government-frontend]
 ---
 

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-16
-review_in: 12 months
 ---
 
 We can cover a lot of GOV.UK architecture by asking ourselves three questions:

--- a/source/manual/architecture.html.md
+++ b/source/manual/architecture.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-01-24
-review_in: 6 months
 ---
 
 <iframe src="https://www.draw.io/?lightbox=1&highlight=0000ff&layers=1&nav=1&title=Logical#Uhttps%3A%2F%2Fdrive.google.com%2Fa%2Fdigital.cabinet-office.gov.uk%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload" style="width:700pt;height:400pt; display: block; border:none"></iframe>

--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Learning GOV.UK
 last_reviewed_on: 2020-07-21
-review_in: 1 year
 ---
 
 The GOV.UK 2nd Line team:

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-01-30
-review_in: 6 months
 related_applications: [asset-manager]
 ---
 

--- a/source/manual/auto-scaling-groups.html.md
+++ b/source/manual/auto-scaling-groups.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 In AWS, [we use auto scaling groups][asg] to ensure we have the right number of

--- a/source/manual/aws-iam-key-rotation.html.md
+++ b/source/manual/aws-iam-key-rotation.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: AWS
 last_reviewed_on: 2020-07-29
-review_in: 6 months
 ---
 
 ## Overview

--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-26
-review_in: 12 months
 ---
 
 [Brakeman][brakeman] is a static analysis tool which checks Rails applications

--- a/source/manual/browser-support.html.md
+++ b/source/manual/browser-support.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Frontend
 type: learn
 last_reviewed_on: 2020-10-12
-review_in: 12 months
 ---
 
 GOV.UK [shares the same browser support matrix with GOV.UK Frontend](https://github.com/alphagov/govuk-frontend#browser-and-assistive-technology-support) for pages served to the general public.

--- a/source/manual/bulk-email.html.md
+++ b/source/manual/bulk-email.html.md
@@ -5,7 +5,6 @@ section: Emails
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-03-26
-review_in: 12 months
 related_applications: [email-alert-api]
 ---
 

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-26
-review_in: 6 months
 ---
 
 GOV.UK uses Fastly as a CDN. Public users aren't accessing GOV.UK servers directly, they connect via the CDN. This is better because:

--- a/source/manual/change-base-path-in-specialist-publisher.html.md
+++ b/source/manual/change-base-path-in-specialist-publisher.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 last_reviewed_on: 2019-12-05
-review_in: 3 months
 ---
 
 In [Specialist Publisher](https://specialist-publisher.publishing.service.gov.uk/), the base path is automatically generated based on the title when the specialist document is first created. We sometimes receive Zendesk tickets to change a base path when the title has been updated, as the publisher does not have the ability to do this.

--- a/source/manual/change-in-hours-time-period-for-dst.html.md
+++ b/source/manual/change-in-hours-time-period-for-dst.html.md
@@ -5,7 +5,6 @@ section: 2nd line
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-07
-review_in: 191 days
 ---
 
 We call people for different things in-hours and out-of-hours.  The

--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Routing
 last_reviewed_on: 2020-02-18
-review_in: 6 months
 ---
 
 > **Note**

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -5,7 +5,6 @@ section: Routing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-09-13
-review_in: 6 months
 ---
 
 When a Whitehall document fails to appear on the frontend, and the user

--- a/source/manual/clone-mysql-slave.html.md
+++ b/source/manual/clone-mysql-slave.html.md
@@ -5,7 +5,6 @@ section: Databases
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-14
-review_in: 6 months
 ---
 
 > **Note**

--- a/source/manual/components.html.md
+++ b/source/manual/components.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-21
-review_in: 6 months
 ---
 
 Components are packages of template, style, behaviour and documentation. Components live in your application unless needed by multiple applications, then they are shared using the [govuk_publishing_components gem](https://github.com/alphagov/govuk_publishing_components).

--- a/source/manual/concourse.html.md
+++ b/source/manual/concourse.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-08-17
-review_in: 3 months
 ---
 
 Concourse is a continuous integration and continuous deployment system similar to Jenkins.

--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -5,7 +5,6 @@ parent: /manual.html
 layout: manual_layout
 section: GitHub
 last_reviewed_on: 2020-06-05
-review_in: 6 months
 ---
 
 Repositories in GOV.UK must:

--- a/source/manual/connect-to-vcloud-director.html.md
+++ b/source/manual/connect-to-vcloud-director.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-15
-review_in: 6 months
 ---
 
 vCloud Director is the interface we use to manage our infrastructure in

--- a/source/manual/content-preview.html.md
+++ b/source/manual/content-preview.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Publishing
 last_reviewed_on: 2020-04-06
-review_in: 6 months
 ---
 
 The "draft stack" on GOV.UK, is intended to be

--- a/source/manual/content-security-policy.html.md
+++ b/source/manual/content-security-policy.html.md
@@ -5,7 +5,6 @@ section: Security
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
-review_in: 3 months
 ---
 
 Content Security Policy (CSP) is a browser standard to prevent cross-site scripting (XSS), clickjacking and other code

--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-22
-review_in: 12 months
 ---
 
 The majority of GOV.UK applications are built using [Ruby on Rails][] and over

--- a/source/manual/cookie-consent-on-govuk.html.md
+++ b/source/manual/cookie-consent-on-govuk.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Cookies
 last_reviewed_on: 2020-10-06
-review_in: 6 months
 ---
 
 This is technical documentation for the [GOV.UK](https://www.gov.uk/) team in the [Government Digital Service (GDS)](https://gds.blog.gov.uk/about/).

--- a/source/manual/cookies-and-sessions-in-frontend-apps.html.md
+++ b/source/manual/cookies-and-sessions-in-frontend-apps.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Cookies
 last_reviewed_on: 2020-06-30
-review_in: 6 months
 ---
 
 GOV.UK frontend applications, with the exception of Licensing and Email Alert Frontend, do not currently require cookies.

--- a/source/manual/covid-19-services.html.md
+++ b/source/manual/covid-19-services.html.md
@@ -5,7 +5,6 @@ section: Services
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-03
-review_in: 1 month
 ---
 
 GOV.UK operates three standalone services for COVID-19 response:

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Accounts
 last_reviewed_on: 2020-07-15
-review_in: 6 months
 ---
 
 We use GPG keys to encrypt our secrets. Documentation for using your GPG key can be found [here](/manual/encrypted-hiera-data.html#common-tasks-for-handling-encrypted-hiera-data).

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -5,7 +5,6 @@ section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-15
-review_in: 6 months
 ---
 [ckan]: https://ckan.publishing.service.gov.uk
 [ckan-app]: apps/ckanext-datagovuk

--- a/source/manual/data-gov-uk-architecture.html.md
+++ b/source/manual/data-gov-uk-architecture.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-03-31
-review_in: 6 months
 ---
 [publish]: apps/datagovuk_publish
 [find]: apps/datagovuk_find

--- a/source/manual/data-gov-uk-contracts-archive.html.md
+++ b/source/manual/data-gov-uk-contracts-archive.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-12-12
-review_in: 6 months
 ---
 
 ## Application

--- a/source/manual/data-gov-uk-deployment.html.md
+++ b/source/manual/data-gov-uk-deployment.html.md
@@ -5,7 +5,6 @@ section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-07
-review_in: 6 months
 ---
 [publish]: apps/datagovuk_publish
 [find]: apps/datagovuk_find

--- a/source/manual/data-gov-uk-map-previews.html.md
+++ b/source/manual/data-gov-uk-map-previews.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-04-15
-review_in: 6 months
 ---
 
 ## Harvesting data for Web Map Service map previews

--- a/source/manual/data-gov-uk-monitoring.html.md
+++ b/source/manual/data-gov-uk-monitoring.html.md
@@ -5,7 +5,6 @@ section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-03-03
-review_in: 6 months
 ---
 [publish]: apps/datagovuk_publish
 [operating-dgu]: /manual/data-gov-uk-operations.html

--- a/source/manual/data-gov-uk-operations.html.md
+++ b/source/manual/data-gov-uk-operations.html.md
@@ -5,7 +5,6 @@ section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-01-21
-review_in: 6 months
 ---
 
 [find]: apps/datagovuk_find

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -5,7 +5,6 @@ section: data.gov.uk
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-03-05
-review_in: 6 months
 ---
 [ckan]: https://ckan.org
 [dgu-ckan]: https://ckan.publishing.service.gov.uk

--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -5,7 +5,6 @@ section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-15
-review_in: 6 months
 ---
 
 This page explains how we manage our Debian packaging.

--- a/source/manual/debug-underperforming-search.html.md
+++ b/source/manual/debug-underperforming-search.html.md
@@ -5,7 +5,6 @@ section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-21
-review_in: 3 months
 ---
 
 Search is one of the more load-sensitive parts of GOV.UK, as it can't

--- a/source/manual/deploy-puppet.html.md
+++ b/source/manual/deploy-puppet.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-25
-review_in: 6 months
 ---
 
 ## Deploying a branch

--- a/source/manual/deploy-static.html.md
+++ b/source/manual/deploy-static.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-15
-review_in: 6 months
 ---
 
 [Static](https://github.com/alphagov/static) requires extra care when deploying.

--- a/source/manual/deploying-terraform.html.md
+++ b/source/manual/deploying-terraform.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-08
-review_in: 6 months
 ---
 
 We use [Terraform](https://terraform.io) for configuring GOV.UK infrastructure in AWS.

--- a/source/manual/deployment-dashboards.html.md
+++ b/source/manual/deployment-dashboards.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-08
-review_in: 6 months
 ---
 
 ## Deployment Dashboards

--- a/source/manual/development-pipeline.html.md
+++ b/source/manual/development-pipeline.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Deployment
 type: learn
 last_reviewed_on: 2020-06-10
-review_in: 6 months
 ---
 
 > When responding to a security incident, you should make any code changes in private, so that you don't accidentally disclose the vulnerability. To do this, follow the instructions for [making a repo private](make-github-repo-private.html).

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-16
-review_in: 6 months
 ---
 
 The Reliability Engineering team is responsible for managing several DNS zones.

--- a/source/manual/docs-style-guide.html.md
+++ b/source/manual/docs-style-guide.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 12 months
 ---
 
 ## What pages should be about

--- a/source/manual/documents-are-published-but-links-arent-updated.html.md
+++ b/source/manual/documents-are-published-but-links-arent-updated.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-23
-review_in: 6 months
 ---
 
 This can happen when the Publishing API is still working through all of the

--- a/source/manual/documents-arent-live-after-publishing.html.md
+++ b/source/manual/documents-arent-live-after-publishing.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-23
-review_in: 6 months
 ---
 
 If a document isn't live on GOV.UK after a publisher has published the document

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -5,7 +5,6 @@ section: Routing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 The Router API database is populated from the Publishing API, and also

--- a/source/manual/elasticsearch-dumps.html.md
+++ b/source/manual/elasticsearch-dumps.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Backups
 last_reviewed_on: 2020-08-10
-review_in: 6 months
 ---
 
 GOV.UK uses AWS Managed Elasticsearch which takes daily snapshots of

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-07-13
-review_in: 6 months
 ---
 
 ## High-level overview

--- a/source/manual/email-troubleshooting.html.md
+++ b/source/manual/email-troubleshooting.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-14
-review_in: 6 months
 ---
 
 This document has tips for troubleshooting unsent emails. For an overview of our

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Publishing
 important: true
 last_reviewed_on: 2020-08-07
-review_in: 6 months
 ---
 
 There are three types of events that would lead GOV.UK to add an emergency

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Deployment
 last_reviewed_on: 2020-01-28
-review_in: 9 months
 ---
 
 [Hiera](https://docs.puppetlabs.com/hiera/1/) is a key-value lookup tool

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 3 months
 ---
 
 GOV.UK has several environments with different purposes.

--- a/source/manual/error-reporting.html.md
+++ b/source/manual/error-reporting.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Monitoring
 type: learn
 last_reviewed_on: 2020-06-04
-review_in: 1 year
 ---
 
 We use [Sentry][] to notify us of exceptions that happen in all environments.

--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -5,7 +5,6 @@ section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 ## How we serve errors on GOV.UK

--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 3 months
 ---
 
 There is a backup Content Delivery Network (CDN) that can be used if Fastly is down.

--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 We maintain a static copy of most of the site, which gets used by the content delivery

--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Backups
 last_reviewed_on: 2020-08-21
-review_in: 3 months
 ---
 
 If the data in the search index is out-of-sync with the Publishing API,

--- a/source/manual/frontend-architecture.html.md
+++ b/source/manual/frontend-architecture.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Frontend
 last_reviewed_on: 2020-08-21
-review_in: 3 months
 related_applications:
  - static
  - slimmer

--- a/source/manual/frontend-performance.html.md
+++ b/source/manual/frontend-performance.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Frontend
 last_reviewed_on: 2020-07-20
-review_in: 12 months
 ---
 
 We have an account on [SpeedCurve](https://speedcurve.com/) to track the performance of the frontend. The account is administered by the head of the frontend community, [Matt Hobbs](https://gds.slack.com/messages/@matthew.hobbs/).

--- a/source/manual/generate-csr.html.md
+++ b/source/manual/generate-csr.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-01
-review_in: 6 months
 ---
 
 A certificate signing request is required when buying or renewing a TLS certificate for a GOV.UK domain.

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -5,7 +5,6 @@ description: Guide for new developers on GOV.UK
 layout: manual_layout
 section: Learning GOV.UK
 last_reviewed_on: 2020-08-17
-review_in: 3 months
 ---
 
 This is the guide for new technical staff working on GOV.UK in [GDS][]. If you just joined, 👋 welcome!

--- a/source/manual/github-trello-poster.html.md
+++ b/source/manual/github-trello-poster.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-04-22
-review_in: 6 months
 ---
 
 This app uses GitHub webhooks to be notified when a pull request is opened or changed on GitHub. When it finds a link to a Trello card in the pull request, it posts a link to that pull request to a checklist on the given card. When a pull request is merged or closed the app checks the pull request off the checklist.

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 ## Public GitHub (application code)

--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -6,7 +6,6 @@ layout: manual_layout
 section: GitHub
 type: learn
 last_reviewed_on: 2020-04-21
-review_in: 6 months
 ---
 
 We share the [alphagov GitHub organisation][alphagov] with the other teams in the

--- a/source/manual/give-a-content-designer-access-to-github.html.md
+++ b/source/manual/give-a-content-designer-access-to-github.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Accounts
 last_reviewed_on: 2020-03-10
-review_in: 12 months
 ---
 
 Content designers working on GOV.UK may need GitHub access to edit content

--- a/source/manual/global-banner.html.md
+++ b/source/manual/global-banner.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Publishing
 important: true
 last_reviewed_on: 2020-06-15
-review_in: 6 months
 ---
 
 A site-wide banner can be activated to convey important information on GOV.UK

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-01-27
-review_in: 6 months
 ---
 
 ## Change a government in Whitehall

--- a/source/manual/govuk-app-domain-handling-during-migration.html.md
+++ b/source/manual/govuk-app-domain-handling-during-migration.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-08-12
-review_in: 4 months
 ---
 
 > Deprecation note:

--- a/source/manual/govuk-env-sync.html.md
+++ b/source/manual/govuk-env-sync.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-15
-review_in: 6 months
 ---
 
 The govuk_env_sync data sync has been created to replace the [env-sync-and-backup] data sync in context of the GOV.UK AWS migration work. It is currently in use for backup and sync tasks in the GOV.UK AWS environments.

--- a/source/manual/govuk-in-aws.html.md
+++ b/source/manual/govuk-in-aws.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 3 months
 ---
 
 To bring the GOV.UK platform in line with the [guidance detailed in the Service Manual](https://www.gov.uk/service-manual/technology/deciding-how-to-host-your-service),

--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-04
-review_in: 6 months
 ---
 
 [GOV.UK Notify][notify] is a Government-as-a-Platform service that allows

--- a/source/manual/grafana.html.md
+++ b/source/manual/grafana.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-30
-review_in: 6 months
 ---
 
 [Grafana](https://grafana.com/) is an open-source visualisation tool.

--- a/source/manual/graphite-and-deployment-dashboards.html.md
+++ b/source/manual/graphite-and-deployment-dashboards.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-17
-review_in: 6 months
 ---
 
 ## How Graphite is used with deployment dashboards

--- a/source/manual/help-with-publishing-content.html.md
+++ b/source/manual/help-with-publishing-content.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 When a department is publishing content that is high priority, it may be

--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -5,7 +5,6 @@ section: Accounts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 We use Heroku to host some non-critical applications like the [monitoring-screen][] and also for auto-deploying [Heroku Review Apps](review-apps.html).

--- a/source/manual/hmrc-paye-files.html.md
+++ b/source/manual/hmrc-paye-files.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-17
-review_in: 6 months
 ---
 
 [Basic PAYE Tools](https://www.gov.uk/basic-paye-tools) is a free software package HMRC provide for small employers to run their payroll. This is available on Windows, Linux, and OS X.

--- a/source/manual/howto-add-organisation-brand-colour.html.md
+++ b/source/manual/howto-add-organisation-brand-colour.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-28
-review_in: 6 months
 related_applications: [whitehall, government-frontend]
 ---
 

--- a/source/manual/howto-backup-and-restore-in-aws-rds.html.md
+++ b/source/manual/howto-backup-and-restore-in-aws-rds.html.md
@@ -5,7 +5,6 @@ section: Backups
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 3 months
 ---
 
 Backups of RDS instances are [taken

--- a/source/manual/howto-block-arbitrary-urls.html.md
+++ b/source/manual/howto-block-arbitrary-urls.html.md
@@ -5,7 +5,6 @@ section: Security
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 6 months
 ---
 During a recent security incident it became necessary to block a GOV.UK
 section in order to prevent access to sensitive data.

--- a/source/manual/howto-change-slug-and-create-redirect.html.md
+++ b/source/manual/howto-change-slug-and-create-redirect.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-24
-review_in: 6 months
 ---
 
 ## Change a slug and create a redirect in Whitehall

--- a/source/manual/howto-copy-postgresql-between-machines.html.md
+++ b/source/manual/howto-copy-postgresql-between-machines.html.md
@@ -5,7 +5,6 @@ section: Databases
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-28
-review_in: 6 months
 ---
 
 This document explains how to back up a PostgreSQL database from one machine

--- a/source/manual/howto-find-hardcoded-markup-govspeak.html.md
+++ b/source/manual/howto-find-hardcoded-markup-govspeak.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-29
-review_in: 6 months
 ---
 
 Usually to find usage of markup we can look in our source code.

--- a/source/manual/howto-manually-remove-assets.html.md
+++ b/source/manual/howto-manually-remove-assets.html.md
@@ -5,7 +5,6 @@ section: Assets
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-27
-review_in: 6 months
 ---
 
 If you need to remove an asset manually from `assets.publishing.service.gov.uk`,

--- a/source/manual/howto-modify-change-note.html.md
+++ b/source/manual/howto-modify-change-note.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-16
-review_in: 6 months
 ---
 
 Spelling mistakes can creep into change notes, and we are often asked

--- a/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
+++ b/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-11-11
-review_in: 6 months
 ---
 
 HtmlAttachments belong to an Edition of a Document. When an Edition is unpublished or withdrawn,

--- a/source/manual/howto-remove-change-note-from-whitehall.html.md
+++ b/source/manual/howto-remove-change-note-from-whitehall.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-09-12
-review_in: 6 months
 ---
 
 Change notes are called editorial remarks in Whitehall. An Edition can

--- a/source/manual/howto-remove-invalid-about-page-drafts-from-world-organisations.html.md
+++ b/source/manual/howto-remove-invalid-about-page-drafts-from-world-organisations.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-06
-review_in: 6 months
 ---
 
 A CorporateInformationPage is a Whitehall document that is attached to Organisation and WorldwideOrganisation models. For Organisations, it is accessed as the organisations `/about` page.

--- a/source/manual/howto-replace-an-assets-file.html.md
+++ b/source/manual/howto-replace-an-assets-file.html.md
@@ -5,7 +5,6 @@ section: Assets
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-18
-review_in: 6 months
 ---
 
 *Note: This will not apply to any file that has not already been uploaded. If you're trying to upload a large file for a client, [upload a small one first](upload-asset-to-whitehall.html) then replace with the below steps. If you're trying to fix a file that is stuck uploading in Whitehall, [look here](whitehall-file-stuck-uploading.html).*

--- a/source/manual/howto-restore-an-individual-postgres-database.html.md
+++ b/source/manual/howto-restore-an-individual-postgres-database.html.md
@@ -5,7 +5,6 @@ section: Backups
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-13
-review_in: 3 months
 ---
 
 > If you need to restore an entire RDS instance please see [this manual page](https://docs.publishing.service.gov.uk/manual/howto-backup-and-restore-in-aws-rds.html) instead.

--- a/source/manual/howto-ssh-to-machines.html.md
+++ b/source/manual/howto-ssh-to-machines.html.md
@@ -5,7 +5,6 @@ section: AWS
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-21
-review_in: 6 months
 ---
 
 This document explains how to SSH into machines, and what commands exist to navigate machines and applications quickly. We use a tool called [GOV.UK Connect] to make this easier.

--- a/source/manual/howto-switch-off-app.html.md
+++ b/source/manual/howto-switch-off-app.html.md
@@ -5,7 +5,6 @@ layout: manual_layout
 section: Deployment
 parent: "/manual.html"
 last_reviewed_on: 2019-07-04
-review_in: 12 months
 ---
 
 In the event of a security incident an app may need to be switched off until it

--- a/source/manual/howto-upload-an-asset-to-asset-manager.html.md
+++ b/source/manual/howto-upload-an-asset-to-asset-manager.html.md
@@ -5,7 +5,6 @@ section: Assets
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-16
-review_in: 6 months
 ---
 
 Some publishing apps such as [Mainstream Publisher](/apps/publisher.html) do not provide the facility for editors to upload

--- a/source/manual/icinga.html.md
+++ b/source/manual/icinga.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-03-11
-review_in: 12 months
 ---
 
 - Production

--- a/source/manual/incident-management-guidance.html.md
+++ b/source/manual/incident-management-guidance.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Incidents
 last_reviewed_on: 2019-11-11
-review_in: 3 months
 ---
 
 When something goes wrong on GOV.UK we follow the incident management procedure:

--- a/source/manual/incident-reports.html.md
+++ b/source/manual/incident-reports.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Incidents
 last_reviewed_on: 2020-07-06
-review_in: 3 months
 ---
 
 This page is for reference only. Use the [incident report template][tpl] on Google Drive when drafting the report.

--- a/source/manual/incident-what-to-do.html.md
+++ b/source/manual/incident-what-to-do.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Incidents
 last_reviewed_on: 2019-11-11
-review_in: 3 months
 ---
 
 This [Google Doc describes what to do in case of an incident][doc].

--- a/source/manual/incorrect-content-in-search-or-navigation.html.md
+++ b/source/manual/incorrect-content-in-search-or-navigation.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 last_reviewed_on: 2020-08-10
-review_in: 6 months
 related_applications: [search-api]
 ---
 

--- a/source/manual/intro-to-docker-advanced.html.md
+++ b/source/manual/intro-to-docker-advanced.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
-review_in: 6 months
 ---
 
 In the [Intro to Docker tutorial](/manual/intro-to-docker.html) we began with a generic container running the `ruby` image, and finished with a powerful `docker-compose` command to run the [content-publisher][] tests against a Postgres DB.

--- a/source/manual/intro-to-docker.html.md
+++ b/source/manual/intro-to-docker.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-03
-review_in: 6 months
 ---
 
 We use [govuk-docker] to help us develop stuff on GOV.UK. If you're new to Docker, this will provide useful insights into how we use it in the context of the GOV.UK stack.

--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Testing
 last_reviewed_on: 2020-02-26
-review_in: 6 months
 ---
 
 ## Introduction

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Dependencies
 type: learn
 last_reviewed_on: 2020-04-06
-review_in: 6 months
 ---
 
 One of our core values is to use secure and up to date software. This document lays out the policy for keeping our Ruby on Rails software current.

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -6,7 +6,6 @@ parent: "/manual.html"
 section: Logging
 important: true
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 All logs for GOV.UK on all environments are collected in Kibana, which you can
 access through [Logit](logit.html).

--- a/source/manual/knowledge-graph.html.md
+++ b/source/manual/knowledge-graph.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Knowledge Graph
 last_reviewed_on: 2020-06-08
-review_in: 6 months
 ---
 
 ## Overview

--- a/source/manual/learn-govuk.html.md.erb
+++ b/source/manual/learn-govuk.html.md.erb
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Learning GOV.UK
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 Welcome to GOV.UK! Let's start off by saying that GOV.UK publishing system is quite complex. It can be daunting task to get to know the platform. This page is meant as a starter guide to learning about GOV.UK.

--- a/source/manual/licensing.html.md
+++ b/source/manual/licensing.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: 2nd line
 type: learn
 last_reviewed_on: 2020-09-10
-review_in: 9 months
 ---
 
 GOV.UK runs a Scala application ([Licensify](/apps/licensify.html)) which allows users to apply and pay for licences from local authorities and other competent authorities.

--- a/source/manual/load-test-email-alert-api.html.md
+++ b/source/manual/load-test-email-alert-api.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Emails
 last_reviewed_on: 2020-06-10
-review_in: 12 months
 ---
 
 You may wish to load test email-alert-api to get a realistic idea of how the system performs under high load, or if you're making changes to how emails are processed to ensure your changes have the desired effect.

--- a/source/manual/load-testing.html.md.erb
+++ b/source/manual/load-testing.html.md.erb
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Infrastructure
 last_reviewed_on: 2020-09-17
-review_in: 18 months
 ---
 
 We sometimes need to run load tests against GOV.UK and for that we use a tool

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Frontend
 type: learn
 last_reviewed_on: 2020-09-29
-review_in: 6 months
 ---
 
 ## Using startup scripts

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-02-20
-review_in: 12 months
 ---
 
 ![](/manual/images/logging.png)

--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -5,7 +5,6 @@ section: Logging
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-26
-review_in: 6 months
 ---
 
 ## How GOV.UK use Logit

--- a/source/manual/make-a-new-document-type-available-to-search.html.md
+++ b/source/manual/make-a-new-document-type-available-to-search.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 last_reviewed_on: 2020-08-21
-review_in: 3 months
 related_applications: [search-api]
 ---
 

--- a/source/manual/make-github-repo-private.html.md
+++ b/source/manual/make-github-repo-private.html.md
@@ -5,7 +5,6 @@ parent: /manual.html
 layout: manual_layout
 section: GitHub
 last_reviewed_on: 2020-08-17
-review_in: 3 months
 ---
 
 In cases of an ongoing security incident, or when working on politically sensitive changes, we may want to work in private rather than public. We do this by creating a private fork of the application.

--- a/source/manual/manage-ruby-dependencies.html.md
+++ b/source/manual/manage-ruby-dependencies.html.md
@@ -6,7 +6,6 @@ section: Dependencies
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 We're [obliged to keep our software current][current].

--- a/source/manual/manage-sign-on-accounts.html.md
+++ b/source/manual/manage-sign-on-accounts.html.md
@@ -5,7 +5,6 @@ section: Accounts
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-16
-review_in: 12 months
 ---
 
 [Signon](https://docs.publishing.service.gov.uk/apps/signon.html) is the

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -5,7 +5,6 @@ section: GitHub
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-17
-review_in: 6 months
 ---
 
 There are five rules for reviewing and merging PRs, which apply to all applications:

--- a/source/manual/metrics.html.md
+++ b/source/manual/metrics.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-17
-review_in: 6 months
 ---
 
 Metrics are measurements of something. GOV.UK use metrics to monitor

--- a/source/manual/mongodb.html.md
+++ b/source/manual/mongodb.html.md
@@ -6,7 +6,6 @@ parent: "/manual.html"
 section: Backups
 type: learn
 last_reviewed_on: 2020-10-15
-review_in: 6 months
 ---
 
 There are two ways of taking MongoDB backups.

--- a/source/manual/monitor-docs-traffic.html.md
+++ b/source/manual/monitor-docs-traffic.html.md
@@ -5,7 +5,6 @@ section: Documentation
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 12 months
 ---
 
 This site is served by S3 via a [proxy defined in govuk-puppet][proxy].

--- a/source/manual/move-apps-between-servers.html.md
+++ b/source/manual/move-apps-between-servers.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-04
-review_in: 6 months
 ---
 
 Most frontend and backend apps on GOV.UK share a small number of servers. In some circumstances, apps may use more than their share of resources and may affect other apps on the same server. In these cases, apps can be moved to their own servers using the appropriate steps for either Carrenza or AWS.

--- a/source/manual/mysql.html.md
+++ b/source/manual/mysql.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-12
-review_in: 6 months
 ---
 
 > Deprecation note:

--- a/source/manual/nagios-nrpe-connection-failures.html.md
+++ b/source/manual/nagios-nrpe-connection-failures.html.md
@@ -5,7 +5,6 @@ section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 Nagios uses a protocol called NRPE (Nagios Remote Plugin Executor) to perform

--- a/source/manual/nagstamon.html.md
+++ b/source/manual/nagstamon.html.md
@@ -5,7 +5,6 @@ section: Monitoring
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-14
-review_in: 6 months
 ---
 
 ![nagstamon](images/nagstamon.png)

--- a/source/manual/naming.html.md
+++ b/source/manual/naming.html.md
@@ -5,7 +5,6 @@ section: Applications
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-06
-review_in: 12 months
 ---
 
 This describes how you should name an application or gem on GOV.UK. It was first proposed in [RFC 63](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-063-naming-new-apps-gems-on-gov-uk.md).

--- a/source/manual/non-ha-node-classes.html.md
+++ b/source/manual/non-ha-node-classes.html.md
@@ -7,7 +7,6 @@ parent: "/manual.html"
 section: Applications
 important: true
 last_reviewed_on: 2020-08-12
-review_in: 6 months
 ---
 
 Below we provide a list of node classes that are not configured to be highly available (HA). This means that short outages of these machines are architecturally considered acceptable.

--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-10-14
-review_in: 6 months
 ---
 
 > See [So, you're having an incident]!

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 [Pact](https://docs.pact.io/) is a tool for *consumer-driven contract testing*.

--- a/source/manual/pagerduty.html.md
+++ b/source/manual/pagerduty.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-17
-review_in: 6 months
 ---
 
 Some alerts are urgent enough to warrant immediate attention, such as parts of the site becoming

--- a/source/manual/patching-jenkins.html.md
+++ b/source/manual/patching-jenkins.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Infrastructure
 last_reviewed_on: 2020-09-15
-review_in: 6 months
 ---
 
 Jenkins should be regularly patched when possible, including all plugins.

--- a/source/manual/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/pingdom-bouncer-canary-check.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Monitoring
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 Bouncer has a canary route at <https://www.direct.gov.uk/__canary__>

--- a/source/manual/post-a-statuspage-message.html.md
+++ b/source/manual/post-a-statuspage-message.html.md
@@ -5,7 +5,6 @@ section: Incidents
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 3 months
 important: true
 ---
 

--- a/source/manual/postgresql-backups.html.md
+++ b/source/manual/postgresql-backups.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 6 months
 ---
 
 ## AWS RDS PostgreSQL Backups

--- a/source/manual/provision-machines-for-data-science-research.html.md
+++ b/source/manual/provision-machines-for-data-science-research.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-03-09
-review_in: 6 months
 ---
 
 Data science research frequently requires high-powered machines for

--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-23
-review_in: 6 months
 old_paths:
  - /manual/publish_special_routes.html
 ---

--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -5,7 +5,6 @@ section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-11
-review_in: 6 months
 ---
 
 ## Logging in to the Forge

--- a/source/manual/publishing-a-ruby-gem.html.md
+++ b/source/manual/publishing-a-ruby-gem.html.md
@@ -5,7 +5,6 @@ section: Packaging
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-11-04
-review_in: 12 months
 ---
 
 ## Naming

--- a/source/manual/publishing-e2e-tests.html.md
+++ b/source/manual/publishing-e2e-tests.html.md
@@ -5,7 +5,6 @@ section: Testing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 Most GOV.UK applications are run against a [end-to-end test suite](https://github.com/alphagov/publishing-e2e-tests) as part of their build process. This is done to determine if a change in one application has a negative impact on a dependant application and to test the changed application is functioning correctly in a quasi-production environment.

--- a/source/manual/purge-cache.html.md
+++ b/source/manual/purge-cache.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 parent: "/manual.html"
 important: true
 last_reviewed_on: 2020-04-20
-review_in: 6 months
 ---
 
 The `www.gov.uk` domain is served through Fastly, which honours the

--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -5,7 +5,6 @@ section: CDN & Caching
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-20
-review_in: 12 months
 ---
 
 The [CDN](/manual/cdn.html) log files are sent to Amazon S3 every 15 minutes

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-07
-review_in: 6 months
 ---
 
 [RabbitMQ][RabbitMQ] is a message broker based on the [Advanced Message Queuing

--- a/source/manual/raising-issues-with-reliability-engineering.html.md
+++ b/source/manual/raising-issues-with-reliability-engineering.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
 last_reviewed_on: 2020-08-12
-review_in: 4 months
 ---
 
 Reliability Engineering are a programme in GDS, they are responsible for the

--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2019-11-04
-review_in: 12 months
 ---
 
 This is a guide to writing and maintaining README documents for GOV.UK's public repositories.

--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -5,7 +5,6 @@ section: Emails
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-29
-review_in: 6 months
 ---
 
 In `integration` and `staging` Email Alert API defaults to sending emails

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -5,7 +5,6 @@ section: Routing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2019-09-02
-review_in: 6 months
 related_applications: [short-url-manager]
 ---
 

--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-08-10
-review_in: 6 months
 related_applications: [search-api]
 ---
 

--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Publishing
 last_reviewed_on: 2020-10-26
-review_in: 6 months
 ---
 
 ## Manual

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Infrastructure
 last_reviewed_on: 2020-05-13
-review_in: 6 months
 ---
 
 Before you start, make sure that the machines you are removing are no longer

--- a/source/manual/remove-site-from-transition-tool.html.md
+++ b/source/manual/remove-site-from-transition-tool.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Transition
 last_reviewed_on: 2020-08-17
-review_in: 12 months
 ---
 
 Sometimes we get requests to delete sites from the [Transition tool](https://transition.publishing.service.gov.uk).

--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Accounts
 last_reviewed_on: 2020-09-10
-review_in: 12 months
 ---
 
 Removing a user from our infrastructure via Puppet is a 2 change process that

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Publishing
 last_reviewed_on: 2020-08-05
-review_in: 6 months
 related_applications: [travel-advice-publisher, content-tagger, whitehall]
 ---
 > **Note**

--- a/source/manual/renew-a-tls-certificate.html.md
+++ b/source/manual/renew-a-tls-certificate.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-24
-review_in: 6 months
 ---
 
 This document covers how to renew wildcard TLS certificates for

--- a/source/manual/repository-mirroring.html.md
+++ b/source/manual/repository-mirroring.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 last_reviewed_on: 2020-04-06
-review_in: 6 months
 ---
 
 We mirror all GitHub repositories tagged with `govuk` to AWS CodeCommit every 2 hours using a [Concourse pipeline configured in alphagov/govuk-repo-mirror](https://github.com/alphagov/govuk-repo-mirror).

--- a/source/manual/reprovision.html.md
+++ b/source/manual/reprovision.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 6 months
 ---
 
 Make sure you are aware what the consequences will be of removing a

--- a/source/manual/republishing-content.html.md
+++ b/source/manual/republishing-content.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-23
-review_in: 6 months
 ---
 
 Sometimes it may be necessary to republish content to make it show up on the

--- a/source/manual/restart-application.html.md
+++ b/source/manual/restart-application.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Deployment
 last_reviewed_on: 2020-09-23
-review_in: 3 months
 ---
 
 To restart an application go to the Deploy app Jenkins job in [AWS](https://deploy.blue.production.govuk.digital/job/Deploy_App/build), choose your app, the **[current release]** and select `app:hard_restart`.

--- a/source/manual/restore-from-offsite-backups.html.md
+++ b/source/manual/restore-from-offsite-backups.html.md
@@ -5,7 +5,6 @@ section: Backups
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-12
-review_in: 6 months
 ---
 
 We use [Duplicity][duplicity] to perform offsite backups. Some backups are

--- a/source/manual/restrict-paas-applications-to-gds-office-ips.html.md
+++ b/source/manual/restrict-paas-applications-to-gds-office-ips.html.md
@@ -5,7 +5,6 @@ parent: /manual.html
 layout: manual_layout
 section: PaaS
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 When deploying applications to the PaaS, it is possible to limit access to the application to GDS office IPs only.
 

--- a/source/manual/resync-mongo-db.html.md
+++ b/source/manual/resync-mongo-db.html.md
@@ -5,7 +5,6 @@ section: Databases
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-08
-review_in: 6 months
 ---
 
 > **WARNING**

--- a/source/manual/resync-postgres-standby.html.md
+++ b/source/manual/resync-postgres-standby.html.md
@@ -5,7 +5,6 @@ section: Databases
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-09
-review_in: 6 months
 ---
 
 If there is a need to resync the Postgresql standby machine from its primary,

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -5,7 +5,6 @@ section: Applications
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-01-31
-review_in: 6 months
 ---
 
 ## 1. Remove app from puppet

--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -5,7 +5,6 @@ section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-28
-review_in: 6 months
 ---
 
 [Review apps](https://devcenter.heroku.com/articles/github-integration-review-apps)

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -7,11 +7,10 @@ parent: "/manual.html"
 last_reviewed_on: 2020-01-23
 ---
 
-We have [a system to make sure we regularly review pages](https://github.com/alphagov/tech-docs-monitor) in the manual.
+Every page in the manual has a "Last updated" value, based on its `last_reviewed_on` value at the top of the source file. The more recent the date, the more confidence the reader can have that the content is accurate.
+If that is missing, the date of the most recent commit applied to the file will be used.
 
-Main pages in the manual are reviewed every 3-12 months.
-
-We also document Icinga alerts. These explain what to do when a certain alert triggers ([example](/manual/alerts/fastly-error-rate.html)). Because these can be very rare and hard to review, we should review these around the same time every six months. This is best done by people with a lot of 2nd line context. To make sure we've documented all alerts, you can [run `rake lint_alert_docs` in govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/master/lib/tasks/lint_alert_docs.rake), which will output alerts that can be removed/need to be added.
+It is helpful to review a document at the point of using it, as you likely have the most context for the problem at that moment in time.
 
 ## How to review
 
@@ -29,7 +28,7 @@ We also document Icinga alerts. These explain what to do when a certain alert tr
 - Assign it for someone else to review
 - Confirm the page is OK and set a new review date
 
-These tasks can be achieved by editing the metadata at the top of the source for that page. See the [govuk-developer-docs github repo](https://github.com/alphagov/govuk-developer-docs).
+These tasks can be achieved by editing the metadata at the top of the source for that page.
 
 ### Choose a review by date
 
@@ -41,6 +40,6 @@ These tasks can be achieved by editing the metadata at the top of the source for
 
 Is there a relevant blog post to the page you're reviewing? Would linking to it help the reader complete their task?
 
-You can find [GOV.UK blog posts on the  GDS Tech blog](https://gdstechnology.blog.gov.uk/category/gov-uk/).
+You can find [GOV.UK blog posts on the GDS Tech blog](https://gdstechnology.blog.gov.uk/category/gov-uk/).
 
 [redirects]: https://github.com/alphagov/govuk-developer-docs/blob/master/config/tech-docs.yml

--- a/source/manual/review-page.html.md
+++ b/source/manual/review-page.html.md
@@ -5,7 +5,6 @@ section: Documentation
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-01-23
-review_in: 12 months
 ---
 
 We have [a system to make sure we regularly review pages](https://github.com/alphagov/tech-docs-monitor) in the manual.

--- a/source/manual/rotate-offsite-backup-gpg-keys.html.md
+++ b/source/manual/rotate-offsite-backup-gpg-keys.html.md
@@ -5,7 +5,6 @@ section: Backups
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-22
-review_in: 6 months
 ---
 
 To encrypt our offsite backups, we use GPG keys which are valid for a year. For

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -5,7 +5,6 @@ section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-04-02
-review_in: 6 months
 ---
 
 The [Ruby language](https://www.ruby-lang.org/en/) is a core part of GOV.UK - most of our applications are written in it.

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: 2nd line
 type: learn
 last_reviewed_on: 2020-03-10
-review_in: 12 months
 ---
 
 These rules apply to developers in the GOV.UK programme and SREs in the TechOps programme.

--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: A/B testing
 last_reviewed_on: 2020-02-07
-review_in: 6 months
 ---
 
 ## 1. Preparation

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 parent: "/manual.html"
 important: true
 last_reviewed_on: 2020-09-23
-review_in: 12 months
 ---
 
 There is a Jenkins job that can be used to run any rake task:

--- a/source/manual/schemas.html.md
+++ b/source/manual/schemas.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 type: learn
 section: Publishing
 last_reviewed_on: 2020-05-19
-review_in: 6 months
 ---
 
 [Schema.org](https://schema.org/) is a community driven vocabulary (founded by Google, Microsoft et al) that allows us to add structured data to content.

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 section: Monitoring
 last_reviewed_on: 2020-03-02
-review_in: 12 months
 ---
 
 ## Search screen

--- a/source/manual/set-up-gcp-account.html.md
+++ b/source/manual/set-up-gcp-account.html.md
@@ -5,7 +5,6 @@ section: AWS
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-26
-review_in: 6 months
 ---
 
 [Static mirrors of GOV.UK](/manual/fall-back-to-mirror.html) are hosted in storage buckets within AWS and Google Cloud Platform (GCP). You may need login to GCP to [remove an asset](/manual/howto-manually-remove-assets.html) or to [emergency publish content using the static mirrors](/manual/fall-back-to-mirror.html#emergency-publishing-using-the-static-mirror).

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -5,7 +5,6 @@ section: Applications
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-15
-review_in: 6 months
 ---
 
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet/blob/master/docs/adding-a-new-app.md#including-the-app-on-machines

--- a/source/manual/setting-up-request-tracing.html.md
+++ b/source/manual/setting-up-request-tracing.html.md
@@ -5,7 +5,6 @@ section: Logging
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 6 months
 ---
 
 Request tracing makes it easier to understand how requests originating from

--- a/source/manual/sidekiq.html.md
+++ b/source/manual/sidekiq.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Monitoring
 type: learn
 last_reviewed_on: 2020-04-26
-review_in: 6 months
 ---
 
 Many of our applications use

--- a/source/manual/stop-all-email-subscription-sending.html.md
+++ b/source/manual/stop-all-email-subscription-sending.html.md
@@ -5,7 +5,6 @@ section: Emails
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-15
-review_in: 6 months
 ---
 
 In an emergency, the following steps will immediately stop all emails being sent

--- a/source/manual/subject-access-requests.html.md
+++ b/source/manual/subject-access-requests.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: 2nd line
 last_reviewed_on: 2020-09-18
-review_in: 6 months
 related_applications: [email-alert-api]
 ---
 

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Publishing
 type: learn
 last_reviewed_on: 2020-01-23
-review_in: 6 months
 related_applications: [content-tagger]
 ---
 

--- a/source/manual/test-and-build-a-project-on-jenkins-ci.html.md
+++ b/source/manual/test-and-build-a-project-on-jenkins-ci.html.md
@@ -5,7 +5,6 @@ section: Testing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-02-28
-review_in: 6 months
 ---
 
 Application tests run in a continuous integration (CI) environment.

--- a/source/manual/test-and-build-a-project-with-github-actions.html.md
+++ b/source/manual/test-and-build-a-project-with-github-actions.html.md
@@ -5,7 +5,6 @@ section: Testing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-11
-review_in: 6 months
 ---
 
 [GitHub Actions](https://github.com/features/actions) is an automated workflow

--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-17
-review_in: 6 months
 ---
 
 ## Icinga

--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -5,7 +5,6 @@ section: Transition
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-28
-review_in: 1 year
 related_applications: [bouncer, transition]
 ---
 

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-14
-review_in: 1 year
 related_applications: [bouncer, transition]
 ---
 

--- a/source/manual/troubleshooting-jenkins-performance.html.md
+++ b/source/manual/troubleshooting-jenkins-performance.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Testing
 last_reviewed_on: 2020-04-07
-review_in: 12 months
 ---
 
 There are many reasons Jenkins could perform poorly, this document attempts to

--- a/source/manual/update-promo-boxes.html.md
+++ b/source/manual/update-promo-boxes.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Publishing
 important: true
 last_reviewed_on: 2020-07-17
-review_in: 6 months
 ---
 
 The three promo boxes on the homepage are used to highlight important information on GOV.UK.

--- a/source/manual/updating-brexit-transition-checker.html.md.erb
+++ b/source/manual/updating-brexit-transition-checker.html.md.erb
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Publishing
 important: true
 last_reviewed_on: 2020-04-20
-review_in: 6 months
 ---
 
 <%= ExternalDoc.fetch(repository: "alphagov/finder-frontend", path: "docs/brexit-checker-content-changes.md") %>

--- a/source/manual/upgrade-terraform.html.md
+++ b/source/manual/upgrade-terraform.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-07-01
-review_in: 6 months
 ---
 
 Terraform should be regularly upgraded. New releases happen very often, with bug fixes and improvements.

--- a/source/manual/upload-asset-to-whitehall.html.md
+++ b/source/manual/upload-asset-to-whitehall.html.md
@@ -5,7 +5,6 @@ section: Assets
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-09-17
-review_in: 6 months
 ---
 
 Sometimes publishers ask us to help them upload very large attachments to

--- a/source/manual/uptime-metrics.html.md
+++ b/source/manual/uptime-metrics.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 12 months
 related_applications:
   - content-store
   - hmrc-manuals-api

--- a/source/manual/vpn.html.md
+++ b/source/manual/vpn.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-06-01
-review_in: 6 months
 ---
 
 GOV.UK uses several VPNs to connect environments. This page explains what they

--- a/source/manual/web_application_firewall_rules.html.md
+++ b/source/manual/web_application_firewall_rules.html.md
@@ -5,7 +5,6 @@ section: Security
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-10-13
-review_in: 3 months
 ---
 
 Web Application Firewall (WAF) rules enable blocking potentially

--- a/source/manual/welcome-to-2nd-line.html.md
+++ b/source/manual/welcome-to-2nd-line.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: 2nd line
 type: learn
 last_reviewed_on: 2019-11-11
-review_in: 3 months
 ---
 
 If you’re new to 2nd line or have not worked with us for a while, here’s a brief introduction to what we do and how we work.

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -6,7 +6,6 @@ type: learn
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-05-18
-review_in: 12 months
 ---
 
 ## Individual repos

--- a/source/manual/whitehall-file-stuck-uploading.html.md
+++ b/source/manual/whitehall-file-stuck-uploading.html.md
@@ -5,7 +5,6 @@ parent: "/manual.html"
 layout: manual_layout
 section: Assets
 last_reviewed_on: 2020-09-18
-review_in: 6 months
 ---
 
 In rare cases, typically when a user has uploaded a large archive of multiple files, the Whitehall backend can become stuck and not correctly update the uploading status of the file.

--- a/source/manual/whitehall-historical-accounts.html.md
+++ b/source/manual/whitehall-historical-accounts.html.md
@@ -5,7 +5,6 @@ section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 last_reviewed_on: 2020-03-11
-review_in: 6 months
 ---
 
 ## Adding Historical Accounts to Whitehall

--- a/source/manual/world-taxonomy.html.md
+++ b/source/manual/world-taxonomy.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: Publishing
 type: learn
 last_reviewed_on: 2020-02-05
-review_in: 6 months
 related_applications: [content-tagger]
 ---
 

--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -6,7 +6,6 @@ layout: manual_layout
 section: 2nd line
 type: learn
 last_reviewed_on: 2020-09-02
-review_in: 3 months
 ---
 
 2nd line Zendesk tickets are technical errors reported by our users - including government publishers -

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe CommitHelpers do
       expect(helper.last_updated(current_page)).to eq("3 Sep 2020")
     end
 
+    it "formats the last_reviewed_on date of the local file if that exists" do
+      source_file = "index.html.erb"
+      current_page = OpenStruct.new(
+        data: OpenStruct.new(last_reviewed_on: Date.new(2020, 9, 3)),
+        file_descriptor: OpenStruct.new(relative_path: source_file),
+      )
+      expect(helper.last_updated(current_page)).to eq("3 Sep 2020")
+    end
+
     it "formats the commit date of the local file if no page data exists" do
       source_file = "index.html.erb"
       current_page = OpenStruct.new(


### PR DESCRIPTION
## What
This PR removes the `review_in` field from the documentation, so that **Daniel the Manual Spaniel will no longer post messages to Slack** for GOV.UK developers. The spaniel will continue to work for other departments in GDS who may use the tool more effectively. For GOV.UK, the 'spaniel' approach to keeping documentation up to date, while well intentioned, was not working well.

## Why
Daniel the Manual Spaniel's purpose is to make sure we regularly review and keep our documentation up to date. In practice:

- Many pages go unreviewed long past their "review by" date. This is down to a number of reasons:
  - lack of ownership (in the case of docs attributed to the generic #govuk-developers)
  - lack of knowledge on the subject matter (a lot of our docs are very niche and therefore difficult to review)
  - frequency of review on certain pages. Our 'review_in' values are picked quite arbitrarily, so many docs are probably reviewed too often; others, not enough.
- When pages do eventually get re-reviewed, the quality of the reviewing ranges enormously. Many developers simply bump the review date; it's hard to believe they've thoroughly examined the documentation and ensured it's all fully working and up to date.

People are 'reviewing' docs because there's an annoying Slack message every day, not because the doc needs updating.

We had an open meeting on Thursday 17th September (attended by Chris A, Kevin, Ben, Deborah, and with notes from Bruce) to discuss the effectiveness of our documentation reviewing workflow, and concluded that a more 'self-organising' approach made sense. A "Last updated" banner was decided on as an improvement to the current tool.

With the new banner, it is up to the developer to determine how much they trust the documentation they are reading, based on the subject matter and the last updated value, much like people are cautious when they see a 'This article is more than 3 months old' notice on various news sites. Developers will still be able to edit the `last_reviewed_on` field to mark a document as up-to-date.

The new banner works for both docs hosted inside govuk-developer-docs _and_ docs pulled in from other repositories. This allows us to localise our documentation to their respective repositories (i.e. closer to the source code), which is hugely beneficial particularly in cases such as documenting rake tasks. We anticipate auto-importing all `docs/` folders into govuk-developer-docs in the near future.

Trello: https://trello.com/c/OMBV5qM4/198-retire-daniel-the-manual-spaniel