### PR TITLE
Remove redundant leaver step for old CI env

### DIFF
--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -25,14 +25,12 @@ will remain on our servers forever more.
 1. Create another PR for Puppet that:
   - Removes the user manifest file
   - Removes the user from [Integration users][integration-users]
-  - Removes the user from [CI users][ci-users]
 1. Once these have been merged, deploy Puppet again to all environments.
 
 [what-to-do-when-someone-leaves]: https://docs.publishing.service.gov.uk/manual/encrypted-hiera-data.html#what-to-do-when-someone-leaves
 [manifest-path]: https://github.com/alphagov/govuk-puppet/tree/master/modules/users/manifests
 [absent-example]: https://github.com/alphagov/govuk-puppet/commit/0757bad41ed577f15c7f5d9e508f55e78c612ddb
 [integration-users]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/integration.yaml
-[ci-users]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata/integration.yaml
 [govuk-secrets]: https://github.com/alphagov/govuk-secrets
 [production-hieradata]: https://github.com/alphagov/govuk-secrets/tree/master/puppet/hieradata
 [aws-production-hieradata]: https://github.com/alphagov/govuk-secrets/tree/master/puppet_aws/hieradata


### PR DESCRIPTION
https://trello.com/c/DRbio3g9/1002-leaver-christopher-baines

CI is now part of the same AWS Integration environment, for which
we have another step to remove people from it.