### PR TITLE
Use "Warning" component to highlight old docs in the "Last updated" banner

### DIFF
--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -10,13 +10,15 @@ module CommitHelpers
 
   def last_updated(current_page)
     # e.g. "2020-09-03 09:53:56 UTC"
-    timestamp = if current_page.data.latest_commit
-                  current_page.data.latest_commit[:timestamp].to_s
-                else
-                  Git.open(".").log.path(source_file(current_page)).first.author_date.to_s
-                end
+    if current_page.data.latest_commit
+      Time.parse(current_page.data.latest_commit[:timestamp].to_s)
+    else
+      Time.parse(Git.open(".").log.path(source_file(current_page)).first.author_date.to_s)
+    end
+  end
 
-    Time.parse(timestamp).strftime("%e %b %Y").strip # e.g. "3 Sep 2020"
+  def format_timestamp(timestamp)
+    timestamp.strftime("%e %b %Y").strip # e.g. "3 Sep 2020"
   end
 
 private

--- a/source/partials/_last_updated.html.erb
+++ b/source/partials/_last_updated.html.erb
@@ -1,3 +1,13 @@
 <div class="govuk-!-font-size-16 govuk-!-margin-top-6">
+  <% if last_updated(current_page) < 6.months.ago %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        This document has not been updated for a while now. It may be out of date.
+      </strong>
+    </div>
+  <% end %>
+
   Last updated: <a href="<%= commit_url(current_page) %>"><%= format_timestamp(last_updated(current_page)) %></a>
 </div>

--- a/source/partials/_last_updated.html.erb
+++ b/source/partials/_last_updated.html.erb
@@ -1,3 +1,3 @@
 <div class="govuk-!-font-size-16 govuk-!-margin-top-6">
-  Last updated: <a href="<%= commit_url(current_page) %>"><%= last_updated(current_page) %></a>
+  Last updated: <a href="<%= commit_url(current_page) %>"><%= format_timestamp(last_updated(current_page)) %></a>
 </div>

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -30,21 +30,29 @@ RSpec.describe CommitHelpers do
   end
 
   describe "#last_updated" do
-    it "formats the commit timestamp associated with the (remote) page data, if that exists" do
-      last_committed = "2020-09-03 09:53:56 UTC"
+    it "returns the commit timestamp associated with the (remote) page data, if that exists" do
       current_page = OpenStruct.new(data: OpenStruct.new(
-        latest_commit: { timestamp: last_committed },
+        latest_commit: { timestamp: "2019-09-03 09:53:56 UTC" },
       ))
-      expect(helper.last_updated(current_page)).to eq("3 Sep 2020")
+      last_updated = helper.last_updated(current_page)
+      expect(last_updated).to be_a_kind_of(Time)
+      expect(last_updated.year).to eq(2019)
     end
 
-    it "formats the commit date of the local file if no page data exists" do
+    it "returns the commit date of the local file if no page data exists" do
       source_file = "index.html.erb"
       current_page = OpenStruct.new(
         data: OpenStruct.new,
         file_descriptor: OpenStruct.new(relative_path: source_file),
       )
-      expect(helper.last_updated(current_page)).to match(/\d{1,2} \w+ \d{4}/)
+      expect(helper.last_updated(current_page)).to be_a_kind_of(Time)
+    end
+  end
+
+  describe "#format_timestamp" do
+    it "formats a timestamp" do
+      timestamp = Time.new(2020, 9, 3, 9, 53, 56, "UTC")
+      expect(helper.format_timestamp(timestamp)).to eq("3 Sep 2020")
     end
   end
 end


### PR DESCRIPTION
This PR adds some contextual 'awareness' to the "Last updated" banner displayed on docs.
Docs that haven't been updated for more than 6 months come with a warning that the content may be out of date.

Default (unchanged) 'last updated' banner:

<img width="1069" alt="Screenshot 2020-10-30 at 15 00 06" src="https://user-images.githubusercontent.com/5111927/97721251-206da900-1ac1-11eb-96b2-3a64284a422e.png">

Example (new) 'last updated' banner for old docs:

![Screenshot 2020-11-09 at 09 55 37](https://user-images.githubusercontent.com/5111927/98527288-bef0cb80-2272-11eb-928a-408c84989613.png)

This change is intended to highlight old documentation to readers, such that they proceed with caution if a doc hasn't been updated in a while. It should also encourage the reader to update the doc to 'appease' the banner, giving us more of an incentive to keep content up to date.

Trello: https://trello.com/c/OMBV5qM4/198-retire-daniel-the-manual-spaniel