### PR TITLE
Update whitehall translation documentation to match correct process

### DIFF
--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -36,10 +36,12 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 
 1. Add the new locale to `lib/whitehall.rb` and `config/locales/en.yml`
 2. Run `export LOCALE=<new_locale>; rake "translation:export[tmp/locale_csv,en,${LOCALE}]" && rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"` to generate the locale files from the English template.
-3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key. For example:
+3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key and the language direction under the `i18n.direction` key. For example:
 
    ```yaml
    it:
+     i18n:
+       direction: ltr
      language_name:
        it: italiano
    ```

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -20,7 +20,13 @@ In [Government Frontend](https://github.com/alphagov/government-frontend):
 
 1. Add the new locale to `config/application.rb` and `config/locales/en.yml`
 2. Run `export LOCALE=<new_locale>; rake "translation:export[tmp/locale_csv,en,${LOCALE}]" && rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"` to generate the locale files from the English template.
-3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
+3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key. For example:
+
+   ```yaml
+   it:
+     language_name:
+       it: italiano
+   ```
 
 ### 2. Update Whitehall
 
@@ -30,7 +36,13 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 
 1. Add the new locale to `lib/whitehall.rb` and `config/locales/en.yml`
 2. Run `export LOCALE=<new_locale>; rake "translation:export[tmp/locale_csv,en,${LOCALE}]" && rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"` to generate the locale files from the English template.
-3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
+3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key. For example:
+
+   ```yaml
+   it:
+     language_name:
+       it: italiano
+   ```
 
 ### 3. Update GOV.UK Content Schemas
 

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -19,9 +19,8 @@ Useful links:
 In [Government Frontend](https://github.com/alphagov/government-frontend):
 
 1. Add the new locale to `config/application.rb` and `config/locales/en.yml`
-2. Run `rake translation:regenerate` to regenerate all translations from the EN locale
-3. Run `rake translation:import[locale,path]` to import a specific locale CSV to YAML within the app. You can also use `rake translation:import:all[directory]` to import all locales but there's no timeline for how frequently this is done, so you can expect many translation values to be missing in non EN locales.
-4. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
+2. Run `export LOCALE=<new_locale>; rake "translation:export[tmp/locale_csv,en,${LOCALE}]" && rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"` to generate the locale files from the English template.
+3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
 
 ### 2. Update Whitehall
 
@@ -30,9 +29,8 @@ In [Government Frontend](https://github.com/alphagov/government-frontend):
 In [Whitehall](https://github.com/alphagov/whitehall):
 
 1. Add the new locale to `lib/whitehall.rb` and `config/locales/en.yml`
-2. Run `rake translation:regenerate` to regenerate all translations from the EN locale
-3. Run `rake translation:import[locale,path]` to import a specific locale CSV to YAML within the app. You can also use `rake translation:import:all[directory]` to import all locales but there's no timeline for how frequently this is done, so you can expect many translation values to be missing in non EN locales.
-4. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
+2. Run `export LOCALE=<new_locale>; rake "translation:export[tmp/locale_csv,en,${LOCALE}]" && rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"` to generate the locale files from the English template.
+3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
 
 ### 3. Update GOV.UK Content Schemas
 

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -12,32 +12,7 @@ Useful links:
 - [Rails Translation Manager](https://github.com/alphagov/rails_translation_manager)
 - [Internationalisation guide](https://github.com/alphagov/whitehall/blob/master/docs/internationalisation_guide.md)
 
-### 1. Update GOV.UK Content Schemas
-
-[Example PR](https://github.com/alphagov/govuk-content-schemas/pull/906)
-
-In [GOV.UK Content Schemas](https://github.com/alphagov/govuk-content-schemas):
-
-1. Edit `formats/shared/definitions/locale.jsonnet` to include the new locale
-2. Run `rake` to generate all the schemas
-
-### 2. Update Content Store
-
-[Example PR](https://github.com/alphagov/content-store/pull/580)
-
-In [Content Store](https://github.com/alphagov/content-store):
-
-- Add the locale key to `config/application.rb`
-
-### 3. Update Publishing API
-
-[Example PR](https://github.com/alphagov/publishing-api/pull/1524)
-
-In [Publishing API](https://github.com/alphagov/publishing-api):
-
-- Add the locale key to `config/application.rb`
-
-### 4. Update Government Frontend
+### 1. Update Government Frontend
 
 [Example PR](https://github.com/alphagov/government-frontend/pull/1382)
 
@@ -48,7 +23,7 @@ In [Government Frontend](https://github.com/alphagov/government-frontend):
 3. Run `rake translation:import[locale,path]` to import a specific locale CSV to YAML within the app. You can also use `rake translation:import:all[directory]` to import all locales but there's no timeline for how frequently this is done, so you can expect many translation values to be missing in non EN locales.
 4. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
 
-### 5. Update Whitehall
+### 2. Update Whitehall
 
 [Example PR](https://github.com/alphagov/whitehall/pull/4861)
 
@@ -58,3 +33,28 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 2. Run `rake translation:regenerate` to regenerate all translations from the EN locale
 3. Run `rake translation:import[locale,path]` to import a specific locale CSV to YAML within the app. You can also use `rake translation:import:all[directory]` to import all locales but there's no timeline for how frequently this is done, so you can expect many translation values to be missing in non EN locales.
 4. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key
+
+### 3. Update GOV.UK Content Schemas
+
+[Example PR](https://github.com/alphagov/govuk-content-schemas/pull/906)
+
+In [GOV.UK Content Schemas](https://github.com/alphagov/govuk-content-schemas):
+
+1. Edit `formats/shared/definitions/locale.jsonnet` to include the new locale
+2. Run `rake` to generate all the schemas
+
+### 4. Update Content Store
+
+[Example PR](https://github.com/alphagov/content-store/pull/580)
+
+In [Content Store](https://github.com/alphagov/content-store):
+
+- Add the locale key to `config/application.rb`
+
+### 5. Update Publishing API
+
+[Example PR](https://github.com/alphagov/publishing-api/pull/1524)
+
+In [Publishing API](https://github.com/alphagov/publishing-api):
+
+- Add the locale key to `config/application.rb`


### PR DESCRIPTION
Part of the government-frontend and whitehall steps of the process needs to be done before the content-schemas in order to ensure that the content-schema tests pass.