### PR TITLE
Remove outdated/inaccurate references to Carrenza

### DIFF
--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -33,21 +33,15 @@ Used by GOV.UK product teams while deploying changes to ensure that they behave 
 in a production-like environment. This means that staging must be similar to production
 so that we're able to test things like the performance impact of changes.
 
-Staging is primarily hosted by Carrenza in their London datacentre.
-It is currently being migrated to [AWS][govuk-in-aws]. Check individual application developer
-docs to see if it is hosted with AWS or Carrenza.
+Staging is hosted on [AWS][govuk-in-aws].
 
 Access to Staging is restricted to office IPs, so you'll need to [be
 on the VPN](manual/get-started.html#4-connecting-to-the-gds-vpn).
-Carrenza configuration can be found in
-[govuk-provisioning](https://github.com/alphagov/govuk-provisioning/blob/master/vcloud-edge_gateway/rules/includes/firewall.mustache#L34),
-and AWS configuration in
+AWS configuration can be found in
 [govuk-aws-data](https://github.com/alphagov/govuk-aws/blob/master/terraform/projects/infra-security-groups/cache.tf).
 
 ## Production
 
 The thing that runs the website for real people.
 
-Production is primarily hosted by Carrenza in their Slough datacentre.
-It is currently being migrated to [AWS][govuk-in-aws]. Check individual application developer
-docs to see if it is hosted with AWS or Carrenza.
+Production is hosted on [AWS][govuk-in-aws].

--- a/source/manual/grafana.html.md
+++ b/source/manual/grafana.html.md
@@ -18,16 +18,10 @@ store, such as PromQL for Prometheus, is used to construct the graphs.
 
 ## Grafana dashboards
 
-- Production
-  - [AWS](https://grafana.blue.production.govuk.digital)
-  - [Carrenza](https://grafana.publishing.service.gov.uk)
-- Staging
-  - [AWS](https://grafana.blue.staging.govuk.digital)
-  - [Carrenza](https://grafana.staging.publishing.service.gov.uk)
-- Integration
-  - [AWS](https://grafana.integration.publishing.service.gov.uk)
-- CI
-  - [Carrenza](https://ci-grafana.integration.publishing.service.gov.uk)
+- [Production (AWS)](https://grafana.blue.production.govuk.digital)
+- [Staging (AWS)](https://grafana.blue.staging.govuk.digital)
+- [Integration (AWS)](https://grafana.integration.publishing.service.gov.uk)
+- [CI (Carrenza)](https://ci-grafana.integration.publishing.service.gov.uk)
 
 Useful Grafana dashboards:
 

--- a/source/manual/icinga.html.md
+++ b/source/manual/icinga.html.md
@@ -7,16 +7,10 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-- Production
-  - [AWS](https://alert.blue.production.govuk.digital)
-  - [Carrenza](https://alert.publishing.service.gov.uk)
-- Staging
-  - [AWS](https://alert.blue.staging.govuk.digital)
-  - [Carrenza](https://alert.staging.publishing.service.gov.uk)
-- Integration
-  - [AWS](https://alert.integration.publishing.service.gov.uk)
-- CI
-  - [Carrenza](https://ci-alert.integration.publishing.service.gov.uk)
+- [Production (AWS)](https://alert.blue.production.govuk.digital)
+- [Staging (AWS)](https://alert.blue.staging.govuk.digital)
+- [Integration (AWS)](https://alert.integration.publishing.service.gov.uk)
+- [CI (Carrenza)](https://ci-alert.integration.publishing.service.gov.uk)
 
 Icinga is used to monitor alerts that we have set up. It can be a bit hard to
 navigate but there are only a few views you need to know about (listed in the left-hand

--- a/source/manual/remove-machines.html.md
+++ b/source/manual/remove-machines.html.md
@@ -9,6 +9,56 @@ section: Infrastructure
 Before you start, make sure that the machines you are removing are no longer
 needed for anything.
 
+## Removing a class of machine
+
+If you are removing a class of machines, you will need to [remove the definitions][def] from Puppet.
+
+[def]: https://github.com/alphagov/govuk-puppet/commit/8a971370a4b35de09a2e1a83ce3421f41f5d0520
+
+## AWS
+
+### 1. Remove from Terraform
+
+If you're removing a class of machines, first [deploy Terraform][terraform]
+for the relevant project using the `destroy` action. This will remove all the
+EC2 instances.
+
+Then, remove the project itself from [govuk-aws][].
+
+If you're removing a single machine, change the `asg_size` for the
+relevant project in [govuk-aws-data][]
+([example][whitehall-backend-asg-size]) and deploy Terraform.  Unlike
+Carrenza, it is not possible to disable alerts for the machine before
+it is removed, as the ASG will terminate arbitrary instances to shrink
+to the desired size.
+
+If there are particular machines in the ASG that you do not want terminated
+you can enable "Scale in Protection" on them before you reduce the size of the ASG. You
+can find [more information on this in the AWS Docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html).
+
+[terraform]: /manual/deploying-terraform.html#ci-jenkins
+[govuk-aws]: https://github.com/alphagov/govuk-aws/tree/master/terraform/projects
+[govuk-aws-data]: https://github.com/alphagov/govuk-aws-data/tree/master/data
+[whitehall-backend-asg-size]: https://github.com/alphagov/govuk-aws-data/blob/master/data/app-whitehall-backend/production/common.tfvars#L4
+
+### 2. Remove the node from the puppetmaster
+
+Icinga will forget about the machine after Puppet runs on the
+puppetmaster and then on the monitoring machine, which could be up to
+an hour.  You can force this by running Puppet on the puppetmaster:
+
+```console
+$ gds govuk connect -e <environment> ssh puppetmaster
+$ govuk_puppet --verbose
+```
+
+And then on the monitoring machine:
+
+```console
+$ gds govuk connect -e <environment> ssh monitoring
+$ govuk_puppet --verbose
+```
+
 ## Carrenza
 
 ## 1. Remove the node from the puppetmaster
@@ -67,53 +117,3 @@ delete it.
 
 If your machine class matches a vDC, be careful not to remove firewall
 rules that apply to the vDC.
-
-## AWS
-
-### 1. Remove from Terraform
-
-If you're removing a class of machines, first [deploy Terraform][terraform]
-for the relevant project using the `destroy` action. This will remove all the
-EC2 instances.
-
-Then, remove the project itself from [govuk-aws][].
-
-If you're removing a single machine, change the `asg_size` for the
-relevant project in [govuk-aws-data][]
-([example][whitehall-backend-asg-size]) and deploy Terraform.  Unlike
-Carrenza, it is not possible to disable alerts for the machine before
-it is removed, as the ASG will terminate arbitrary instances to shrink
-to the desired size.
-
-If there are particular machines in the ASG that you do not want terminated
-you can enable "Scale in Protection" on them before you reduce the size of the ASG. You
-can find [more information on this in the AWS Docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html).
-
-[terraform]: /manual/deploying-terraform.html#ci-jenkins
-[govuk-aws]: https://github.com/alphagov/govuk-aws/tree/master/terraform/projects
-[govuk-aws-data]: https://github.com/alphagov/govuk-aws-data/tree/master/data
-[whitehall-backend-asg-size]: https://github.com/alphagov/govuk-aws-data/blob/master/data/app-whitehall-backend/production/common.tfvars#L4
-
-### 2. Remove the node from the puppetmaster
-
-Icinga will forget about the machine after Puppet runs on the
-puppetmaster and then on the monitoring machine, which could be up to
-an hour.  You can force this by running Puppet on the puppetmaster:
-
-```console
-$ gds govuk connect -e <environment> ssh puppetmaster
-$ govuk_puppet --verbose
-```
-
-And then on the monitoring machine:
-
-```console
-$ gds govuk connect -e <environment> ssh monitoring
-$ govuk_puppet --verbose
-```
-
-## Removing a class of machine
-
-If you are removing a class of machines, you will need to [remove the definitions][def] from Puppet.
-
-[def]: https://github.com/alphagov/govuk-puppet/commit/8a971370a4b35de09a2e1a83ce3421f41f5d0520

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -84,7 +84,7 @@ The username and password can be obtained by logging in to Heroku and viewing th
 ### Icinga alert summary per environment
 
 This screen shows a summary of the critical and warning alerts for our environments (production, staging, integration, CI)
-in both Carrenza and AWS environments in colour-coded boxes (red for critical errors, yellow for warnings, purple for
+in colour-coded boxes (red for critical errors, yellow for warnings, purple for
 unknown errors and green for no issues). It automatically refreshes once a minute.
 
 This is powered by [blinkenjs][] which is [deployed to Heroku][govuk-secondline-blinken-heroku]. You must be in the


### PR DESCRIPTION
Whilst we still have a lot of Carrenza documentation around [backups](https://docs.publishing.service.gov.uk/manual/alerts/postgresql-s3-backups.html), [connecting to vCloud](https://docs.publishing.service.gov.uk/manual/connect-to-vcloud-director.html), [cloning MySQL instance](https://docs.publishing.service.gov.uk/manual/clone-mysql-slave.html) etc, I'm happy to leave those as they could still be useful until we fully migrate away from Carrenza.

But we should remove references to Carrenza with regards to GOV.UK applications, as we now host everything on AWS. We've updated our Blinken dashboard, Grafana processes, etc, so I've made some modest tweaks here to have our docs reflect reality.