### PR TITLE
Remove 'review_in'/'last_reviewed_on' fields

### DIFF
--- a/source/manual/alerts/rabbitmq-dead-nodes.html.md
+++ b/source/manual/alerts/rabbitmq-dead-nodes.html.md
@@ -4,8 +4,6 @@ title: 'RabbitMQ: Dead nodes in cluster'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
-last_reviewed_on: 2020-10-30
-review_in: 12 months
 ---
 
 

--- a/source/manual/configure-linting.html.md
+++ b/source/manual/configure-linting.html.md
@@ -5,8 +5,6 @@ section: Applications
 type: learn
 layout: manual_layout
 parent: "/manual.html"
-last_reviewed_on: 2020-10-22
-review_in: 12 months
 ---
 
 This explains how to configure [linting][] for a GOV.UK application. It is

--- a/source/manual/mapit-database-not-available.html.md
+++ b/source/manual/mapit-database-not-available.html.md
@@ -4,8 +4,6 @@ title: Fix Mapit database not available
 layout: manual_layout
 parent: "/manual.html"
 section: Databases
-last_reviewed_on: 2020-11-02
-review_in: 6 months
 ---
 
 Each Mapit machine has its own PostgreSQL database which powers the Mapit


### PR DESCRIPTION
Since #2837, we don't use these anymore. These particular ones
were updated whilst the PR was open.