### PR TITLE
Updated link on forgotten PaaS passwords

### DIFF
--- a/source/manual/data-gov-uk-operations.html.md
+++ b/source/manual/data-gov-uk-operations.html.md
@@ -30,7 +30,7 @@ cf login -a api.cloud.service.gov.uk --sso
 > If you don't have an account or if your account isn't recognised ask on #govuk-2ndline for an account.
 >
 > **Forgot your password?**
-> If you forgot your password, visit [https://login.cloud.service.gov.uk/forgot_password](https://login.cloud.service.gov.uk/forgot_password)
+> If you forgot your password, read the [PaaS documentation on forgotten passwords](https://docs.cloud.service.gov.uk/troubleshooting.html#forgotten-passwords)
 >
 > For more details, see the [PaaS documentation on signing in](https://docs.cloud.service.gov.uk/get_started.html#sign-in-to-cloud-foundry).
 


### PR DESCRIPTION
Current link in documentation is out-of-date so it's best to point users
to PaaS docs for appropriate reset links.

Fixes: #2860 