### PR TITLE
Remove superfluous HTML element

### DIFF
--- a/source/templates/document_type_template.html.md.erb
+++ b/source/templates/document_type_template.html.md.erb
@@ -32,7 +32,7 @@ actually any pages with this document type.
 ## Example pages
 
 <% page.examples.each do |example| %>
-- <%= link_to example['title'], "https://www.gov.uk#{example['link']}" %></li>
+- <%= link_to example['title'], "https://www.gov.uk#{example['link']}" %>
 <% end %>
 
 <%= link_to 'Source query from Search API', page.search_url %>


### PR DESCRIPTION
This closing element doesn't have a respective opening element so this
displays as plain text. It looks like this is a mistake where someone
forgot this file was markdown.

Before:

![Screenshot 2020-11-19 at 11 12 29](https://user-images.githubusercontent.com/282717/99659264-857d4480-2a58-11eb-979a-036d01567633.png)


After:

![Screenshot 2020-11-19 at 11 13 07](https://user-images.githubusercontent.com/282717/99659259-82825400-2a58-11eb-86ed-69bb986cd17d.png)
