### PR TITLE
Fix relative links & images in external docs

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -5,7 +5,7 @@ require_relative "./string_to_id"
 class ExternalDoc
   def self.fetch(repository:, path:)
     contents = HTTP.get(
-      "https://raw.githubusercontent.com/#{repository}/master/#{path}",
+      "https://raw.githubusercontent.com/alphagov/#{repository}/master/#{path}",
     )
 
     context = {
@@ -13,11 +13,11 @@ class ExternalDoc
       gfm: false,
       base_url: URI.join(
         "https://github.com",
-        "#{repository}/blob/master/",
+        "alphagov/#{repository}/blob/master/",
       ),
       image_base_url: URI.join(
         "https://raw.githubusercontent.com",
-        "#{repository}/master/",
+        "alphagov/#{repository}/master/",
       ),
     }
 

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -41,16 +41,38 @@ class ExternalDoc
       .to_html(contents.force_encoding("UTF-8"), context)
   end
 
-  def self.parse(markdown)
+  def self.parse(markdown, repository: "", path: "")
+    context = {
+      # Turn off hardbreaks as they behave different to github rendering
+      gfm: false,
+      base_url: URI.join(
+        "https://github.com",
+        "alphagov/#{repository}/blob/master/",
+      ),
+      image_base_url: URI.join(
+        "https://raw.githubusercontent.com",
+        "alphagov/#{repository}/master/",
+      ),
+    }
+
+    context[:subpage_url] =
+      URI.join(context[:base_url], File.join(".", File.dirname(path), "/"))
+
+    context[:image_subpage_url] =
+      URI.join(context[:image_base_url], File.join(".", File.dirname(path), "/"))
+
     filters = [
       HTML::Pipeline::MarkdownFilter,
+      HTML::Pipeline::AbsoluteSourceFilter,
       PrimaryHeadingFilter,
       HeadingFilter,
+      AbsoluteLinkFilter,
+      MarkdownLinkFilter,
     ]
 
     HTML::Pipeline
       .new(filters)
-      .to_html(markdown.to_s.force_encoding("UTF-8"))
+      .to_html(markdown.to_s.force_encoding("UTF-8"), context)
   end
 
   def self.title(markdown)

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -66,17 +66,13 @@ class ExternalDoc
         base = if path.start_with? "/"
                  base_url
                else
-                 subpage_url
+                 context[:subpage_url]
                end
 
         element["href"] = URI.join(base, href).to_s
       end
 
       doc
-    end
-
-    def subpage_url
-      context[:subpage_url]
     end
   end
 

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -3,44 +3,6 @@ require "uri"
 require_relative "./string_to_id"
 
 class ExternalDoc
-  def self.fetch(repository:, path:)
-    contents = HTTP.get(
-      "https://raw.githubusercontent.com/alphagov/#{repository}/master/#{path}",
-    )
-
-    context = {
-      # Turn off hardbreaks as they behave different to github rendering
-      gfm: false,
-      base_url: URI.join(
-        "https://github.com",
-        "alphagov/#{repository}/blob/master/",
-      ),
-      image_base_url: URI.join(
-        "https://raw.githubusercontent.com",
-        "alphagov/#{repository}/master/",
-      ),
-    }
-
-    context[:subpage_url] =
-      URI.join(context[:base_url], File.join(".", File.dirname(path), "/"))
-
-    context[:image_subpage_url] =
-      URI.join(context[:image_base_url], File.join(".", File.dirname(path), "/"))
-
-    filters = [
-      HTML::Pipeline::MarkdownFilter,
-      HTML::Pipeline::AbsoluteSourceFilter,
-      PrimaryHeadingFilter,
-      HeadingFilter,
-      AbsoluteLinkFilter,
-      MarkdownLinkFilter,
-    ]
-
-    HTML::Pipeline
-      .new(filters)
-      .to_html(contents.force_encoding("UTF-8"), context)
-  end
-
   def self.parse(markdown, repository: "", path: "")
     context = {
       # Turn off hardbreaks as they behave different to github rendering

--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -31,6 +31,7 @@ class GitHubRepoFetcher
           path: "/apis/#{app_name}/#{filename}.html",
           title: title,
           markdown: contents,
+          relative_path: doc.path,
           source_url: doc.html_url,
           latest_commit: latest_commit(app_name, doc.path),
         }

--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -22,6 +22,8 @@ class ProxyPages
             locals: {
               title: "#{app.app_name}: #{page[:title]}",
               markdown: page[:markdown],
+              repository: app.github_repo_name,
+              relative_path: page[:relative_path],
             },
             data: {
               app_name: app.app_name,

--- a/source/manual/updating-brexit-transition-checker.html.md.erb
+++ b/source/manual/updating-brexit-transition-checker.html.md.erb
@@ -7,4 +7,4 @@ section: Publishing
 important: true
 ---
 
-<%= ExternalDoc.fetch(repository: "alphagov/finder-frontend", path: "docs/brexit-checker-content-changes.md") %>
+<%= ExternalDoc.fetch(repository: "finder-frontend", path: "docs/brexit-checker-content-changes.md") %>

--- a/source/manual/updating-brexit-transition-checker.html.md.erb
+++ b/source/manual/updating-brexit-transition-checker.html.md.erb
@@ -7,4 +7,8 @@ section: Publishing
 important: true
 ---
 
-<%= ExternalDoc.fetch(repository: "finder-frontend", path: "docs/brexit-checker-content-changes.md") %>
+<%= ExternalDoc.parse(
+      HTTP.get("https://raw.githubusercontent.com/alphagov/finder-frontend/master/docs/brexit-checker-content-changes.md"),
+      repository: "finder-frontend",
+      path: "docs/brexit-checker-content-changes.md",
+    ) %>

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -179,7 +179,7 @@ gds govuk connect ssh -e production aws/<%= application.aws_puppet_class %>
   </div>
 
   <div class="embedded-readme">
-    <%= ExternalDoc.parse(application.readme) %>
+    <%= ExternalDoc.parse(application.readme, repository: application.github_repo_name, path: "./README.md") %>
   </div>
 <% end %>
 

--- a/source/templates/external_doc_template.html.erb
+++ b/source/templates/external_doc_template.html.erb
@@ -4,4 +4,4 @@ parent: /apis.html
 hide_from_sitemap: true
 ---
 
-<%= ExternalDoc.parse(markdown) %>
+<%= ExternalDoc.parse(markdown, repository: repository, path: relative_path) %>

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe ExternalDoc do
       Capybara.string(described_class.fetch(repository: repository, path: path))
     end
 
-    let(:repository) { "example/lipsum" }
+    let(:repository) { "lipsum" }
     let(:path) { "markdown.md" }
 
     before do
-      stub_request(:get, "https://raw.githubusercontent.com/example/lipsum/master/markdown.md")
+      stub_request(:get, "https://raw.githubusercontent.com/alphagov/lipsum/master/markdown.md")
         .to_return(body: File.read("spec/fixtures/markdown.md"))
     end
 
@@ -28,11 +28,11 @@ RSpec.describe ExternalDoc do
     end
 
     it "rewrites relative images" do
-      expect(html).to have_css('img[src="https://raw.githubusercontent.com/example/lipsum/master/suspendisse_iaculis.png"]')
+      expect(html).to have_css('img[src="https://raw.githubusercontent.com/alphagov/lipsum/master/suspendisse_iaculis.png"]')
     end
 
     it "rewrites relative URLs" do
-      expect(html).to have_link("tincidunt leo", href: "https://github.com/example/lipsum/blob/master/lib/tincidunt_leo.rb")
+      expect(html).to have_link("tincidunt leo", href: "https://github.com/alphagov/lipsum/blob/master/lib/tincidunt_leo.rb")
     end
 
     it "maintains anchor links" do

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -67,6 +67,50 @@ RSpec.describe ExternalDoc do
       expected_html = "<p>These curly quotes “make commonmarker throw an exception”</p>"
       expect(described_class.parse(markdown).to_s).to eq(expected_html)
     end
+
+    context "when passed a repository and path" do
+      subject(:html) do
+        Capybara.string(described_class.parse(
+          File.read("spec/fixtures/markdown.md"),
+          repository: "lipsum",
+          path: "markdown.md",
+        ).to_s)
+      end
+
+      it "removes the title of the page" do
+        expect(html).not_to have_selector("h1", text: "Lorem ipsum")
+      end
+
+      it "rewrites links to markdown pages" do
+        expect(html).to have_link("turpis ultrices", href: "/ultrices.html")
+      end
+
+      it "does not rewrite links to markdown pages with a host" do
+        expect(html).to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.md")
+        expect(html).not_to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.html")
+      end
+
+      it "rewrites relative images" do
+        expect(html).to have_css('img[src="https://raw.githubusercontent.com/alphagov/lipsum/master/suspendisse_iaculis.png"]')
+      end
+
+      it "rewrites relative URLs" do
+        expect(html).to have_link("tincidunt leo", href: "https://github.com/alphagov/lipsum/blob/master/lib/tincidunt_leo.rb")
+      end
+
+      it "maintains anchor links" do
+        expect(html).to have_link("Suspendisse iaculis", href: "#suspendisse-iaculis")
+      end
+
+      it "adds an id attribute to all headers so they can be accessed from a table of contents" do
+        expect(html).to have_selector("h2#tldr")
+      end
+
+      it "converts heading IDs properly" do
+        expect(html).to have_selector("h3#data-gov-uk")
+        expect(html).to have_selector("h3#patterns-style-guides")
+      end
+    end
   end
 
   describe ".title" do

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -21,11 +21,24 @@ RSpec.describe ExternalDoc do
     end
 
     context "when passed a repository and path" do
+      before do
+        lipsum = double(
+          "Lipsum",
+          app_name: "Lipsum",
+          github_repo_name: "lipsum",
+          consume_docs_folder: consume_docs_folder,
+        )
+        allow(AppDocs).to receive(:pages) { [lipsum] }
+      end
+
+      let(:consume_docs_folder) { false }
+      let(:path) { "markdown.md" }
+
       subject(:html) do
         Capybara.string(described_class.parse(
           File.read("spec/fixtures/markdown.md"),
           repository: "lipsum",
-          path: "markdown.md",
+          path: path,
         ).to_s)
       end
 
@@ -33,21 +46,52 @@ RSpec.describe ExternalDoc do
         expect(html).not_to have_selector("h1", text: "Lorem ipsum")
       end
 
-      it "rewrites links to markdown pages" do
-        expect(html).to have_link("turpis ultrices", href: "/ultrices.html")
+      it "does not rewrite links to markdown pages with a host" do
+        expect(html).to have_link("Absolute link", href: "https://nam.com/eget/dui/absolute-link.md")
       end
 
-      it "does not rewrite links to markdown pages with a host" do
-        expect(html).to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.md")
-        expect(html).not_to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.html")
+      it "converts relative links to absolute GitHub URLs" do
+        expect(html).to have_link("inline link", href: "https://github.com/alphagov/lipsum/blob/master/inline-link.md")
+      end
+
+      it "converts aliased links to absolute GitHub URLs" do
+        expect(html).to have_link("aliased link", href: "https://github.com/alphagov/lipsum/blob/master/lib/aliased_link.rb")
+      end
+
+      context "the repository's `consume_docs_folder` property evaluates to `false`" do
+        it "converts relative links to absolute GitHub URLs" do
+          expect(html).to have_link("Relative docs link with period", href: "https://github.com/alphagov/lipsum/blob/master/docs/prefixed.md")
+          expect(html).to have_link("Relative docs link without period", href: "https://github.com/alphagov/lipsum/blob/master/docs/no-prefix.md")
+        end
+      end
+
+      context "the repository is set to `consume_docs_folder: true`" do
+        let(:consume_docs_folder) { true }
+
+        it "converts relative GitHub links to Developer Docs HTML links if it is an imported document" do
+          expect(html).to have_link("Relative docs link with period", href: "/apis/lipsum/prefixed.html")
+          expect(html).to have_link("Relative docs link without period", href: "/apis/lipsum/no-prefix.html")
+        end
+
+        it "converts relative links to absolute GitHub URLs if link is outside of the `docs` folder" do
+          expect(html).to have_link("inline link", href: "https://github.com/alphagov/lipsum/blob/master/inline-link.md")
+        end
+
+        it "converts relative links to absolute GitHub URLs if link is in a subfolder of the `docs` folder" do
+          expect(html).to have_link("Subfolder", href: "https://github.com/alphagov/lipsum/blob/master/docs/some-subfolder/foo.md")
+        end
+
+        context "the document we are parsing is in the `docs` folder" do
+          let(:path) { "docs/some-document.md" }
+
+          it "converts links relative to the `docs` folder and applies the same business logic as before" do
+            expect(html).to have_link("inline link", href: "/apis/lipsum/inline-link.html")
+          end
+        end
       end
 
       it "rewrites relative images" do
         expect(html).to have_css('img[src="https://raw.githubusercontent.com/alphagov/lipsum/master/suspendisse_iaculis.png"]')
-      end
-
-      it "rewrites relative URLs" do
-        expect(html).to have_link("tincidunt leo", href: "https://github.com/alphagov/lipsum/blob/master/lib/tincidunt_leo.rb")
       end
 
       it "treats URLs containing non-default ports as absolute URLs" do

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe ExternalDoc do
         expect(html).to have_link("tincidunt leo", href: "https://github.com/alphagov/lipsum/blob/master/lib/tincidunt_leo.rb")
       end
 
+      it "treats URLs containing non-default ports as absolute URLs" do
+        expect(html).to have_link("localhost", href: "localhost:999")
+      end
+
       it "maintains anchor links" do
         expect(html).to have_link("Suspendisse iaculis", href: "#suspendisse-iaculis")
       end

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -1,54 +1,6 @@
 require "capybara/rspec"
 
 RSpec.describe ExternalDoc do
-  describe ".fetch" do
-    subject(:html) do
-      Capybara.string(described_class.fetch(repository: repository, path: path))
-    end
-
-    let(:repository) { "lipsum" }
-    let(:path) { "markdown.md" }
-
-    before do
-      stub_request(:get, "https://raw.githubusercontent.com/alphagov/lipsum/master/markdown.md")
-        .to_return(body: File.read("spec/fixtures/markdown.md"))
-    end
-
-    it "removes the title of the page" do
-      expect(html).not_to have_selector("h1", text: "Lorem ipsum")
-    end
-
-    it "rewrites links to markdown pages" do
-      expect(html).to have_link("turpis ultrices", href: "/ultrices.html")
-    end
-
-    it "does not rewrite links to markdown pages with a host" do
-      expect(html).to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.md")
-      expect(html).not_to have_link("Nam eget dui", href: "https://nam.com/eget/dui/uploading.html")
-    end
-
-    it "rewrites relative images" do
-      expect(html).to have_css('img[src="https://raw.githubusercontent.com/alphagov/lipsum/master/suspendisse_iaculis.png"]')
-    end
-
-    it "rewrites relative URLs" do
-      expect(html).to have_link("tincidunt leo", href: "https://github.com/alphagov/lipsum/blob/master/lib/tincidunt_leo.rb")
-    end
-
-    it "maintains anchor links" do
-      expect(html).to have_link("Suspendisse iaculis", href: "#suspendisse-iaculis")
-    end
-
-    it "adds an id attribute to all headers so they can be accessed from a table of contents" do
-      expect(html).to have_selector("h2#tldr")
-    end
-
-    it "converts heading IDs properly" do
-      expect(html).to have_selector("h3#data-gov-uk")
-      expect(html).to have_selector("h3#patterns-style-guides")
-    end
-  end
-
   describe ".parse" do
     it "converts arbitrary markdown to HTML" do
       markdown = <<~MD

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe GitHubRepoFetcher do
           title: "Analytics",
           path: "/apis/#{repo_name}/analytics.html",
           markdown: markdown_fixture,
+          relative_path: path,
           source_url: source_url,
           latest_commit: latest_commit,
         },

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ProxyPages do
   before do
     allow(AppDocs).to receive(:apps_with_docs)
-      .and_return([double("App with docs", app_name: "", page_title: "", description: "")])
+      .and_return([double("App with docs", app_name: "", page_title: "", description: "", github_repo_name: "")])
     allow(AppDocs).to receive(:pages)
       .and_return([double("App", app_name: "", page_title: "", description: "")])
     allow(DocumentTypes).to receive(:pages)

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -7,6 +7,8 @@ neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
 [turpis ultrices](/ultrices.md), imperdiet eros ut, [tincidunt leo].
 [Nam eget dui](https://nam.com/eget/dui/uploading.md)
 
+[localhost](localhost:999)
+
 ## Suspendisse iaculis
 
 ![Suspendisse iaculis](suspendisse_iaculis.png)

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -4,16 +4,22 @@
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam efficitur lacus in
 neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
-[turpis ultrices](/ultrices.md), imperdiet eros ut, [tincidunt leo].
-[Nam eget dui](https://nam.com/eget/dui/uploading.md)
+[inline link](./inline-link.md), imperdiet eros ut, [aliased link].
+[Absolute link](https://nam.com/eget/dui/absolute-link.md)
 
 [localhost](localhost:999)
+
+[Relative docs link with period](./docs/prefixed.md)
+
+[Relative docs link without period](docs/no-prefix.md)
+
+[Subfolder](docs/some-subfolder/foo.md)
 
 ## Suspendisse iaculis
 
 ![Suspendisse iaculis](suspendisse_iaculis.png)
 
-[tincidunt leo]: ./lib/tincidunt_leo.rb
+[aliased link]: ./lib/aliased_link.rb
 
 ## Other headings to test
 


### PR DESCRIPTION
Fixes #2851. Now relative links and images in imported READMEs and documents will be rewritten to either:

1. An absolute GitHub URL to the resource, or
2. If appropriate, a relative link to the Developer Docs hosted version of the resource.

The latter can be seen for example on the "How Search Works" page under Search API, where the "learning to rank documentation" link is rewritten from `./learning-to-rank.md` to `/apis/search-api/learning-to-rank.html`.

Trello: https://trello.com/c/PLV6EPXh/199-fix-relative-links-images-on-imported-docs