### PR TITLE
Fix broken link

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -99,7 +99,7 @@ We use a Docker environment - [govuk-docker][] - for local development.
 
 👉 [Get setup with govuk-docker][govuk-docker]
 
-[govuk-docker]: https://github.com/alphagov/govuk-docker/blob/master/docs/installation.md
+[govuk-docker]: https://github.com/alphagov/govuk-docker/blob/master/README.md
 
 ## 6. Get SSH access to integration
 

--- a/source/manual/intro-to-docker-advanced.html.md
+++ b/source/manual/intro-to-docker-advanced.html.md
@@ -302,7 +302,7 @@ $mac docker-compose run content-publisher-demo-app
 
 The reason `content-publisher-demo.intro-to-docker.gov.uk` works in your browser is because we added a custom entry in `/etc/hosts`. This approach doesn't scale to lots of entries, especially if we need to keep them in-sync across a team. We need something more dynamic, but that's not possible with `/etc/hosts`.
 
-As part of [setting-up govuk-docker](https://github.com/alphagov/govuk-docker/blob/master/docs/installation.md) you will have installed [dnsmasq][]. This gives us a little DNS server running on our Mac, which we can use instead of `/etc/hosts` to resolve `*.intro-to-docker.gov.uk` to the localhost.
+As part of [setting-up govuk-docker](https://github.com/alphagov/govuk-docker/blob/master/README.md) you will have installed [dnsmasq][]. This gives us a little DNS server running on our Mac, which we can use instead of `/etc/hosts` to resolve `*.intro-to-docker.gov.uk` to the localhost.
 
 * Remove the temporary entry in `/etc/hosts`
 

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -116,4 +116,4 @@ sudo fuser -k [port number]/tcp
 [static]: https://github.com/alphagov/static
 [govuk_publishing_components]: https://github.com/alphagov/govuk_publishing_components
 [government-frontend]: https://github.com/alphagov/government-frontend
-[govuk-docker]: https://github.com/alphagov/govuk-docker/blob/master/docs/installation.md
+[govuk-docker]: https://github.com/alphagov/govuk-docker/blob/master/README.md


### PR DESCRIPTION
## What?

Quick update to link to developer docs linking to [Docker](https://github.com/alphagov/govuk-docker/blob/master/README.md)

## Why?

Noticed 404 / Broken link