### PR TITLE
Improve the "Redirect a route" documentation

### DIFF
--- a/source/manual/redirect-routes.html.md.erb
+++ b/source/manual/redirect-routes.html.md.erb
@@ -7,31 +7,39 @@ parent: "/manual.html"
 related_applications: [short-url-manager]
 ---
 
-There is a regular requirement for creating short URLs on behalf of
-departments, usually for use with for campaign materials. Content
-designers do this using the [Short URL Manager][short-url-manager] app.
-Read [more about Short URL Manager][short-url-manager-section] below,
-including how to remove routes originating from it.
+There are a number of different ways of applying redirects on GOV.UK.
+Here is a guide for choosing the right one:
 
-There are also processes for [redirecting HRMC manuals][hmrc-manuals-section]
-and [redirecting from campaign sites][campaign-sites-section].
+- Is the redirect a short URL, such as `gov.uk/dfe`?
+  [Use Short URL Manager][short-url-manager-section].
+- Are you redirecting a HMRC manual?
+  Read the [HMRC section][hmrc-manuals-section].
+- Are you redirecting from a campaign site?
+  Read the [campaign sites section][campaign-sites-section].
 
-Finally, sometimes there is a need to manually redirect existing URLs to
-another internal location, either due to an incident, content being
-archived or because the slug has been changed.
+That covers the service-specific redirects. We then have several options
+for applying redirects to most GOV.UK content:
 
-## Choosing a redirect strategy
+- Are you having an incident and need to apply a redirect _urgently_?
+  You can [apply the redirect directly in Router API][apply-redirect-in-router-api-section]
+  (though you'll need to do some housekeeping afterwards).
+- Is the redirect correctly showing in Content Store, but not in Router API?
+  You may just need to [nudge Content Store into updating Router API][register-redirect-from-content-store-section].
+- Is the redirect correctly showing in Publishing API, but not in Content Store?
+  Try [re-presenting the content item downstream][represent-content-item-section].
+- Does the redirect not exist anywhere yet?
+  You'll need to [apply a redirect from within the relevant publishing app][apply-redirect-from-publishing-app-section].
 
-Does something exist at the incoming URL already? There's a
-[simple way of checking][check-route-exists-section].
-
-If no route exists, and if you have the time to wait for a content
-designer to review the proposal, you should just use Short URL Manager.
-If the route already exists, or if you're in a hurry, you'll need to take
-a different approach.
+## Manually apply a redirect from any publishing app
+[apply-redirect-from-publishing-app-section]: #manually-apply-a-redirect-from-any-publishing-app
 
 The preferred method of creating redirects is to use the publishing app that
-originally published the content to set up the redirect. This usually
+originally published the content to set up the redirect. You can find out
+[what exists at the incoming URL already][check-route-exists-section] (if
+anything), and [which app owns the route][find-owning-app].
+
+Once you've established which app owns the route, you should see if it is
+possible to set up the redirect from within the app UI itself. This usually
 involves unpublishing the content, whereupon the app gives the option to
 redirect the old route to another route. This approach is preferred as it
 keeps the workflow and publishing history within the app, as well as
@@ -39,22 +47,16 @@ correctly propagating the changes through Publishing API, Content Store and
 Router API.
 
 Not all applications support unpublishing / setting redirects. In these
-cases, you should change the content item in Publishing API manually.
+cases, you'll need to interact with Publishing API manually - see below.
 
-### Manually apply a redirect in Publishing API
-
-Note that this won't work if the thing you're redirecting originates from
-the Short URL Manager: there's [a rake task][short-url-manager-section-remove-route]
-for that.
+> Note that this won't work if the thing you're redirecting originates from
+> the Short URL Manager: there's [a rake task][short-url-manager-section-remove-route]
+> for that.
 
 You'll need to get the content ID of the current thing that exists at the
 route you want to redirect from. This is generally just a case of visiting
 the route prefixed with `/api/content` to expose its Content Store
 information.
-
-Now, log into the app console:
-
-`$ gds govuk connect app-console -e production publishing_api/publishing-api`
 
 You may want to log into the Content Store app console in another shell:
 
@@ -64,42 +66,77 @@ In the Content Store console, run
 `content_item = ContentItem.find_by(content_id: "CONTENT_ID")` to get a
 handle on the current state of the content item. If the content item
 already has a `document_type` of `redirect` and the `redirects` property
-has the `path` and `destination` properties you're aiming for, then you
-may just need to [nudge Content Store into talking to Router API][[register-redirect-from-content-store-section].
+has the `path` and `destination` properties you're aiming for, then all
+you may need to do is
+[nudge Content Store into talking to Router API][register-redirect-from-content-store-section].
+If your content item doesn't have a redirect in Content Store, but you
+know a redirect has been applied in Publishing API, you may need to
+[re-present the edition in Publishing API][represent-content-item-section].
 
-In the Publishing API console, make a call to `Unpublish`:
+Assuming the redirect doesn't exist yet, and you know no attempt has been
+made to redirect the item in Publishing API, your next step is to open a
+console on the publishing app in question. Then run this command:
 
 ```ruby
-Commands::V2::Unpublish.call(
-  content_id: "CONTENT_ID",
+GdsApi.publishing_api.unpublish(
+  content_id,
   type: "redirect",
   explanation: "manually redirected by YOUR_NAME",
   alternative_path: "/new-path",
-  discard_drafts: true,
-  unpublished_at: Time.now,
+  discard_drafts: true
 )
 ```
 
-You should now see an Unpublishing record in Publishing API:
+You should see a 200 response:
 
-```ruby
-Unpublishing.last
-=> #<Unpublishing id: 435518, edition_id: 1, type: "redirect", explanation: "manually redirected by Chris", alternative_path: "/new-path", created_at: "2020-11-27 14:03:08", updated_at: "2020-11-27 14:20:47", unpublished_at: nil, redirects: [{"path"=>"/old-path", "type"=>"exact", "destination"=>"/new-path"}]>
+```
+#<GdsApi::Response:0x00007f81feba4c30 @http_response=<RestClient::Response 200 "{\"content_i...">, @web_urls_relative_to=nil>
 ```
 
-And you should see that the content item in the Content Store
-console has been updated, if you run `content_item.reload`.
+And you will see that the content item in the Content Store
+console has been updated, if you run `content_item.reload` in
+your other console.
 
-[Content Store talks directly to Router API](https://github.com/alphagov/content-store/blob/dd79a03d74f130650bc97d1c84aae557ccea58d3/app/models/content_item.rb#L33)
-to update the route. Now when you visit the route in your
-browser, you should be redirected.
+When Content Store is updated with a new route, it
+[talks directly to Router API](https://github.com/alphagov/content-store/blob/dd79a03d74f130650bc97d1c84aae557ccea58d3/app/models/content_item.rb#L33).
+You should now be redirected when you visit the route in your browser.
+
+### Manually re-present the content item in Publishing API
+[represent-content-item-section]: #manually-re-present-the-content-item-in-publishing-api
+
+Sometimes, Publishing API and Content Store can end up out of sync
+with one another, whereby a redirect has been applied to a content
+item in Publishing API but hasn't been successfully processed by
+Content Store. In these cases, there are several
+[rake tasks](https://github.com/alphagov/publishing-api/blob/master/lib/tasks/represent_downstream.rake)
+we can use to re-present the content item from Publishing API to
+Content Store.
+
+First, you'll need the content ID of the content item. Here we have
+a Publishing API console and we've retrieved the Unpublishing record
+(which has the redirect information) for the content item. We find
+its associated content ID and can then use this in one of the linked
+rake tasks.
+
+```
+unpublishing = Unpublishing.find_by(alternative_path: "/foo")
+
+unpublishing.edition.content_id
+=> "ddcab6e2-8985-4646-9f3d-82d2f4770186"
+```
 
 ### Manually register a route in Content Store
 [register-redirect-from-content-store-section]: #manually-register-a-route-in-content-store
 
-Sometimes Content Store is unsuccessful in updating a route in
-Router API, e.g. if the call from Content Store happens while
-the Router machines are being deployed.
+Sometimes, our publishing platform prevents the creation of
+new routes (and the addition/removal of redirects) while we
+are scaling up certain parts of the stack.
+
+If the content item in Content Store is showing the correct
+route, but Router API is not, then re-publishing the item will
+not work, as the route in Content Store will be unchanged.
+Content Store only updates Router API
+[if it detects the route has changed](https://github.com/alphagov/content-store/blob/8651b9245046f0a0ae125dde018d39f8507226c5/app/models/content_item.rb#L224-L232).
 
 In such cases, you can get Content Store to register the route
 again, by opening the Content Store console and running:
@@ -109,6 +146,7 @@ ContentItem.find_by(base_path: "/old-path-to-be-redirected").route_set.register!
 ```
 
 ### Manually apply a redirect in Router API
+[apply-redirect-in-router-api-section]: #manually-apply-a-redirect-in-router-api
 
 You might need to urgently apply a redirect, and Publishing API
 might have a large backlog of publishing in its downstream_high
@@ -116,7 +154,7 @@ queue, making the Publishing API approach too slow.
 
 First, connect to the Router API console:
 
-`$ gds govuk connect -e production app-console draft_cache/router-api`
+`$ gds govuk connect -e production app-console router_backend/router-api`
 
 Then update the route directly:
 
@@ -145,6 +183,21 @@ Then search for the incoming path you are interested in:
 
 If a route is found, and it has the handler `redirect`, then there is
 already a redirect in place.
+
+## Find out which app owns the route
+[find-owning-app]: #find-out-which-app-owns-the-route
+
+Open a Content Store console:
+
+```console
+$ gds govuk connect app-console -e production content_store/content-store
+```
+
+Then search for the incoming path you are interested in:
+
+```console
+ContentItem.find_by(base_path: "/path-to-item").publishing_app
+```
 
 ## Redirect using the Short URL Manager
 [short-url-manager-section]: #redirect-using-the-short-url-manager

--- a/source/manual/redirect-routes.html.md.erb
+++ b/source/manual/redirect-routes.html.md.erb
@@ -62,7 +62,10 @@ You may want to log into the Content Store app console in another shell:
 
 In the Content Store console, run
 `content_item = ContentItem.find_by(content_id: "CONTENT_ID")` to get a
-handle on the current state of the content item.
+handle on the current state of the content item. If the content item
+already has a `document_type` of `redirect` and the `redirects` property
+has the `path` and `destination` properties you're aiming for, then you
+may just need to [nudge Content Store into talking to Router API][[register-redirect-from-content-store-section].
 
 In the Publishing API console, make a call to `Unpublish`:
 
@@ -90,6 +93,20 @@ console has been updated, if you run `content_item.reload`.
 [Content Store talks directly to Router API](https://github.com/alphagov/content-store/blob/dd79a03d74f130650bc97d1c84aae557ccea58d3/app/models/content_item.rb#L33)
 to update the route. Now when you visit the route in your
 browser, you should be redirected.
+
+### Manually register a route in Content Store
+[register-redirect-from-content-store-section]: #manually-register-a-route-in-content-store
+
+Sometimes Content Store is unsuccessful in updating a route in
+Router API, e.g. if the call from Content Store happens while
+the Router machines are being deployed.
+
+In such cases, you can get Content Store to register the route
+again, by opening the Content Store console and running:
+
+```ruby
+ContentItem.find_by(base_path: "/old-path-to-be-redirected").route_set.register!
+```
 
 ### Manually apply a redirect in Router API
 

--- a/source/manual/redirect-routes.html.md.erb
+++ b/source/manual/redirect-routes.html.md.erb
@@ -7,17 +7,114 @@ parent: "/manual.html"
 related_applications: [short-url-manager]
 ---
 
-Sometimes, there is a need to manually redirect existing URLs to another
-internal location, usually due to content being archived or because the
-slug has been changed.
+There is a regular requirement for creating short URLs on behalf of
+departments, usually for use with for campaign materials. Content
+designers do this using the [Short URL Manager][short-url-manager] app.
+Read [more about Short URL Manager][short-url-manager-section] below,
+including how to remove routes originating from it.
 
-There is also a regular requirement for creating short URLs on behalf of
-departments, usually for use with for campaign materials.
+There are also processes for [redirecting HRMC manuals][hmrc-manuals-section]
+and [redirecting from campaign sites][campaign-sites-section].
 
-## Getting information on current redirects
+Finally, sometimes there is a need to manually redirect existing URLs to
+another internal location, either due to an incident, content being
+archived or because the slug has been changed.
 
-To find if there is already a redirect for a particular path, open a router-api
-console:
+## Choosing a redirect strategy
+
+Does something exist at the incoming URL already? There's a
+[simple way of checking][check-route-exists-section].
+
+If no route exists, and if you have the time to wait for a content
+designer to review the proposal, you should just use Short URL Manager.
+If the route already exists, or if you're in a hurry, you'll need to take
+a different approach.
+
+The preferred method of creating redirects is to use the publishing app that
+originally published the content to set up the redirect. This usually
+involves unpublishing the content, whereupon the app gives the option to
+redirect the old route to another route. This approach is preferred as it
+keeps the workflow and publishing history within the app, as well as
+correctly propagating the changes through Publishing API, Content Store and
+Router API.
+
+Not all applications support unpublishing / setting redirects. In these
+cases, you should change the content item in Publishing API manually.
+
+### Manually apply a redirect in Publishing API
+
+Note that this won't work if the thing you're redirecting originates from
+the Short URL Manager: there's [a rake task][short-url-manager-section-remove-route]
+for that.
+
+You'll need to get the content ID of the current thing that exists at the
+route you want to redirect from. This is generally just a case of visiting
+the route prefixed with `/api/content` to expose its Content Store
+information.
+
+Now, log into the app console:
+
+`$ gds govuk connect app-console -e production publishing_api/publishing-api`
+
+You may want to log into the Content Store app console in another shell:
+
+`$ gds govuk connect app-console -e production content_store/content-store`
+
+In the Content Store console, run
+`content_item = ContentItem.find_by(content_id: "CONTENT_ID")` to get a
+handle on the current state of the content item.
+
+In the Publishing API console, make a call to `Unpublish`:
+
+```ruby
+Commands::V2::Unpublish.call(
+  content_id: "CONTENT_ID",
+  type: "redirect",
+  explanation: "manually redirected by YOUR_NAME",
+  alternative_path: "/new-path",
+  discard_drafts: true,
+  unpublished_at: Time.now,
+)
+```
+
+You should now see an Unpublishing record in Publishing API:
+
+```ruby
+Unpublishing.last
+=> #<Unpublishing id: 435518, edition_id: 1, type: "redirect", explanation: "manually redirected by Chris", alternative_path: "/new-path", created_at: "2020-11-27 14:03:08", updated_at: "2020-11-27 14:20:47", unpublished_at: nil, redirects: [{"path"=>"/old-path", "type"=>"exact", "destination"=>"/new-path"}]>
+```
+
+And you should see that the content item in the Content Store
+console has been updated, if you run `content_item.reload`.
+
+[Content Store talks directly to Router API](https://github.com/alphagov/content-store/blob/dd79a03d74f130650bc97d1c84aae557ccea58d3/app/models/content_item.rb#L33)
+to update the route. Now when you visit the route in your
+browser, you should be redirected.
+
+### Manually apply a redirect in Router API
+
+You might need to urgently apply a redirect, and Publishing API
+might have a large backlog of publishing in its downstream_high
+queue, making the Publishing API approach too slow.
+
+First, connect to the Router API console:
+
+`$ gds govuk connect -e production app-console draft_cache/router-api`
+
+Then update the route directly:
+
+```ruby
+Route.find_by(incoming_path: "...").update!(redirect_to: "...", handler: "redirect", redirect_type: "permanent")
+```
+
+You should always go back and fix things properly in Publishing
+API afterwards, as a republish could easily undo any changes you've
+made.
+
+## Find out if the route exists
+[check-route-exists-section]: #find-out-if-the-route-exists
+
+Open a router-api console:
 
 ```console
 $ gds govuk connect app-console -e production router_backend/router-api
@@ -29,18 +126,11 @@ Then search for the incoming path you are interested in:
 > Route.where(incoming_path: '/path-to-item')
 ```
 
-Redirect routes have the handler `redirect`.
+If a route is found, and it has the handler `redirect`, then there is
+already a redirect in place.
 
-## Redirecting from the original publishing app
-
-The preferred method of creating redirects is to use the publishing app that
-originally published the content to unpublish it and redirect it to another
-page using the Publishing API.
-
-This ensures that the workflow and publishing history stays within the app
-wherever possible.
-
-## Using the Short URL Manager
+## Redirect using the Short URL Manager
+[short-url-manager-section]: #redirect-using-the-short-url-manager
 
 If the redirect is from a URL that is not a currently-published content item,
 you should first look to use the [Short URL Manager][short-url-manager] to
@@ -59,6 +149,7 @@ and using non-default values for the `segments_mode`.
 [short-url-manager-permissions]: https://github.com/alphagov/short-url-manager/#permissions
 
 ### Removing a route created in the Short URL Manager
+[short-url-manager-section-remove-route]: #removing-a-route-created-in-the-short-url-manager
 
 First find the `content_id` of the URL that needs to be removed. This can be found by using the Content Store API: `www.gov.uk/api/content/<path goes here>`.
 
@@ -170,12 +261,14 @@ RouterReloader.reload
 ```
 
 ## Redirects for HMRC manuals
+[hmrc-manuals-section]: #redirects-for-hmrc-manuals
 
 There are rake tasks for redirecting HMRC manuals and HMRC manual sections, which can be [found in the hmrc-manuals-api repo](https://github.com/alphagov/hmrc-manuals-api/tree/master/lib/tasks). These can be run via the `Run rake task` jenkins job.
 
 [See example of redirecting a HMRC manual section to another section](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=hmrc-manuals-api&MACHINE_CLASS=backend&RAKE_TASK=redirect_hmrc_section[original-parent-manual-slug,original-section-slug,new-parent-manual-slug,new-section-slug])
 
 ## Redirects from campaign sites
+[campaign-sites-section]: #redirects-from-campaign-sites
 
 The campaigns platform is a WordPress site managed by dxw. Redirects from a
 `*.campaign.gov.uk` site require a support ticket. Currently, James Whitmarsh or


### PR DESCRIPTION
It is crucial that we know how to manually redirect routes if we run into issues. Prior to this commit, this knowledge wasn't
particularly well documented anywhere.

Rather than list all the different scenarios in which we want to redirect and making the reader scan the page for the option
relevant to them, I've attempted to provide some brief context at the top of the document, followed by a flow chart of sorts.
The first heading, "Choosing a redirect strategy", describes the thought processes we should follow before applying any redirects.

I've documented the preferred approach for manual redirects, as well as warn the reader that it won't work for Short URL Manager routes (something I discovered by accident while trying the code out!). And, in a recent incident, we were forced to apply redirects at the Router API level, which is also a useful thing to document.

Additionally, there was recently a case where a redirect had been removed, and was showing as such in the Content Store, but the redirect was still happening. It turns out the route registration had failed because of reprovisioning of the Router machines.

This same situation could easily happen in reverse: a redirect being ADDED, but failing to make its way into Router API. Rather
than semi-polluting the content item in Publishing API to force through the redirect, it's better in cases such as these to just
give Content Store a bit of a kick, as it's already in the state we want it to be in. Router API just needs to catch up.