### PR TITLE
Reassign notifications apps to Platform Health

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -78,7 +78,7 @@
   production_hosted_on: aws
 - github_repo_name: email-alert-api
   type: APIs
-  team: "#govuk-notifications"
+  team: "#govuk-platform-health"
   metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: aws
   consume_docs_folder: true
@@ -134,7 +134,7 @@
   production_hosted_on: aws
 - github_repo_name: email-alert-service
   type: Services
-  team: "#govuk-notifications"
+  team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: search-analytics
   type: Services
@@ -194,7 +194,7 @@
   private_repo: false
 - github_repo_name: email-alert-frontend
   type: Frontend apps
-  team: "#govuk-notifications"
+  team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: feedback
   type: Frontend apps


### PR DESCRIPTION
https://trello.com/c/GHfDidG0/656-disable-slack-notifications-as-part-of-pausing-the-team

This is because the Notifications team is pausing.