### PR TITLE
Adjust Email Alert API queue latency for alert changes

### DIFF
--- a/source/manual/alerts/email-alert-api-high-queue-latency.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-latency.html.md
@@ -7,36 +7,53 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-### High queue latency (queue_latency)
+This alert triggers when there is a significant delay in the time from the
+Email Alert API system creating an email until it is sent.
 
-This means the time it takes for a job to be processed is unusually high. See
-the Sidekiq ['Queue Latency'][Sidekiq dash] graph for more detail.
+## Understanding the alert
 
-For more information on the individual queues and what they do, see
-[here][email queues].
+The latency value itself is a measure, in seconds, of the amount of time that
+the oldest email in the [Sidekiq] queue has been waiting. This latency builds
+up when there are more emails to send than workers to send them and this alert
+triggers once this latency reaches an alarming level.
 
-Some diagnostic steps you could take are below:
+## Impact
 
-* Check the Sidekiq ['Queue Length'][Sidekiq dash] graph to see if we have a
-  high number of emails queued up.
-* If there is a high amount of emails in the queue, are we processing them at a
-  normal speed? Under high load we regularly send requests to Notify at a rate
-  of ~300 email requests per second. To check this, look at the ['Email Send
-  Attempts'][technical dash] graph.
-* If we're sending email requests slower than usual, refer to the [Email Alert
-  API machine metrics dashboard][machine metrics] or the [AWS RDS postgres
-  dashboard][postgres dash] to see if we're experiencing resourcing issues.
-* Are the workers reporting any problems or any issues being raised in
-  [Sentry]?
-* Check [Kibana] to see our Sidekiq logs for Email Alert API.
+The user impact of this alert depends on the queue. A delay for the
+`send_email_transactional` queue indicates that users are blocked from
+completing user journeys (such as sign-in or sign up), thus a delay of minutes
+is frustrating.
 
-See [here][Sidekiq] for more information about Sidekiq.
+For the other [queues] the impact of delayed email is less significant for
+users (there aren't assurances on how rapidly an email should be sent)
+and indicates a risk that the system is experiencing significantly
+degraded performance and may become perpetually overloaded. For
+example, if there aren't sufficient resources to send all of Monday's emails
+on Monday we could find there aren't resources to send both Monday _and_
+Tuesday's emails the next day and so forth.
+
+## How to investigate
+
+You should be looking for evidence of performance degradation, the presence of
+errors and whether an abnormal quantity of emails is being created. Some
+diagnostic steps you could take are:
+
+* check the [Sidekiq dashboard] to understand the level of work Sidekiq is
+  doing and has to do;
+* monitor the [Email Alert API Technical dashboard][technical dash] to see
+  the rate emails are being sent at and look at broader view of Email Alert API
+  status;
+* check whether workers are raising errors to [Sentry];
+* check [Kibana] to see the Sidekiq logs for Email Alert API;
+* you can investigate the health of the [underlying application
+  machines][machine metrics] and the [RDS PostgeSQL database
+  instance][postgres dash].
 
 [Sidekiq]: https://docs.publishing.service.gov.uk/manual/sidekiq.html
-[Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h
-[Sidekiq dash]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now
+[queues]: https://github.com/alphagov/email-alert-api/blob/master/config/sidekiq.yml
+[Sidekiq dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now
 [technical dash]: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api_technical.json
+[Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h
 [Kibana]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(columns:!('@message',host),index:'*-*',interval:auto,query:(query_string:(query:'@type:%20sidekiq%20AND%20application:%20email-alert-api')),sort:!('@timestamp',desc))
-[email queues]: https://github.com/alphagov/email-alert-api/blob/master/config/sidekiq.yml
 [machine metrics]: https://grafana.blue.production.govuk.digital/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=email_alert_api*&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All
 [postgres dash]: https://grafana.production.govuk.digital/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=blue-postgresql-primary&from=now-3h&to=now


### PR DESCRIPTION
Trello: https://trello.com/c/il1TsI3e/658-tweak-alert-latency-thresholds-for-email-alert-api-sidekiq-queues

We're changing the queue latency alerts in https://github.com/alphagov/govuk-puppet/pull/10868 this commit updates the documentation to match those better.