### PR TITLE
Deprecate startup.sh

### DIFF
--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -66,7 +66,9 @@ govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 
-## Using startup scripts
+## Using startup scripts (DEPRECATED)
+
+**DEPRECATED:** these scripts are superseded by GOV.UK Docker, and may no longer be present in some frontend apps. **Try GOV.UK Docker for local frontend development before using these scripts.**
 
 If you are making changes to a frontend app and nothing else, you can view these changes by running the application's `./startup.sh` script. This example is for [government-frontend], but these instructions apply to any frontend app.
 

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -7,28 +7,6 @@ section: Frontend
 type: learn
 ---
 
-## Using startup scripts
-
-If you are making changes to a frontend app and nothing else, you can view these changes by running the application's `./startup.sh` script. This example is for [government-frontend], but these instructions apply to any frontend app.
-
-```shell
-cd /govuk/government-frontend
-./startup.sh --live
-# Check the output to see what port the app is running on, e.g: localhost:3005
-```
-
-If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile and then run the startup script:
-
-```ruby
-gem 'govuk_publishing_components', path: '../govuk_publishing_components'
-```
-
-```shell
-bundle install
-./startup.sh --live
-# Check the output to see what port the app is running on, e.g: localhost:3005
-```
-
 ## Using govuk-docker
 
 This assumes that you have already installed and setup [govuk-docker]. We will use [government-frontend] as an example here, but these instructions apply to any frontend app.
@@ -86,6 +64,28 @@ make government-frontend
 cd /govuk/government-frontend
 govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
+```
+
+## Using startup scripts
+
+If you are making changes to a frontend app and nothing else, you can view these changes by running the application's `./startup.sh` script. This example is for [government-frontend], but these instructions apply to any frontend app.
+
+```shell
+cd /govuk/government-frontend
+./startup.sh --live
+# Check the output to see what port the app is running on, e.g: localhost:3005
+```
+
+If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile and then run the startup script:
+
+```ruby
+gem 'govuk_publishing_components', path: '../govuk_publishing_components'
+```
+
+```shell
+bundle install
+./startup.sh --live
+# Check the output to see what port the app is running on, e.g: localhost:3005
 ```
 
 ## Components pulled in by Static

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -40,7 +40,7 @@ cd /govuk/govuk-docker
 make government-frontend
 
 cd /govuk/government-frontend
-govuk-docker up government-frontend-app-live # or govuk-docker-up app-live
+govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 
@@ -53,7 +53,7 @@ gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 ```shell
 cd /govuk/government-frontend
 govuk-docker-run bundle install
-govuk-docker up government-frontend-app-live
+govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 
@@ -84,7 +84,7 @@ cd /govuk/govuk-docker
 make government-frontend
 
 cd /govuk/government-frontend
-govuk-docker up government-frontend-app-live
+govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 


### PR DESCRIPTION
**Deadline for discussion: 2020-12-16**

These are superseded by GOV.UK Docker, which is the official way we
develop GOV.UK apps [1]. Having alternative scripts in our repos is
confusing for new developers, and is just another thing we have to
maintain and help people troubleshoot [2].

[1]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-106-docker-for-local-development.md
[2]: alphagov/email-alert-frontend#914

This is as much a proposal as a PR, so feel free to leave
comments about your own thoughts on this. In particular, I'd
like to know if there are objective reasons why we still need
these scripts for some apps.

If this PR does go in, them I'm also proposing to modify the
startup.sh scripts to print a deprecation notice advising people
to use GOV.UK Docker instead, and warning the scripts may be
removed without notice.