### PR TITLE
Remove github-markdown gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "middleman"
 gem "middleman-search_engine_sitemap"
 
 gem "git"
-gem "github-markdown"
 gem "html-pipeline"
 gem "kramdown"
 gem "mdl"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,6 @@ GEM
     ffi (1.12.0)
     git (1.7.0)
       rchardet (~> 1.8)
-    github-markdown (0.6.9)
     govuk_schemas (4.2.0)
       json-schema (~> 2.8.0)
     govuk_tech_docs (2.1.0)
@@ -296,7 +295,6 @@ DEPENDENCIES
   faraday_middleware
   ffi
   git
-  github-markdown
   govuk_schemas
   govuk_tech_docs
   html-pipeline


### PR DESCRIPTION
This is unsupported and hasn't been updated since 2015.
Removing it doesn't appear to break anything, so I don't
think we use it anywhere anymore and it can be safely removed.