### PR TITLE
Update doc on how to add translations in Whitehall

### DIFF
--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -35,15 +35,28 @@ In [Government Frontend](https://github.com/alphagov/government-frontend):
 In [Whitehall](https://github.com/alphagov/whitehall):
 
 1. Add the new locale to `lib/whitehall.rb` and `config/locales/en.yml`
-2. Run `export LOCALE=<new_locale>; rake "translation:export[tmp/locale_csv,en,${LOCALE}]" && rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"` to generate the locale files from the English template.
-3. In `config/locales/<new_locale>.yml` add the language translation under the `language_names` key and the language direction under the `i18n.direction` key. For example:
+2. Run the following commands to generate the locale files from the English template:
+
+    ```bash
+    $ export LOCALE=<new_locale>
+    $ rake "translation:export[tmp/locale_csv,en,${LOCALE}]"
+    $ rake "translation:import[${LOCALE},tmp/locale_csv/${LOCALE}.csv]"
+    ```
+
+3. In `config/locales/<new_locale>.yml` add:
+  - the language direction under the `i18n.direction` key
+  - the appropriate boolean under the `i18n.latin_script?` key
+  - the language translation under the `language_names` key
+
+  For example:
 
    ```yaml
    it:
      i18n:
        direction: ltr
-     language_name:
-       it: italiano
+       latin_script?: true
+     language_names:
+       it: Italiano
    ```
 
 ### 3. Update GOV.UK Content Schemas


### PR DESCRIPTION
This updates the doc to reflect the change introduced in https://github.com/alphagov/whitehall/pull/5916 (a new mandatory `latin_script?:` key has been added).