### PR TITLE
Update process for Gandi TLS certs renewal

### DIFF
--- a/source/manual/renew-a-tls-certificate.html.md
+++ b/source/manual/renew-a-tls-certificate.html.md
@@ -6,10 +6,8 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-This document covers how to renew wildcard TLS certificates for
-`*.publishing.service.gov.uk`, `*.staging.publishing.service.gov.uk`
-and `*.integration.publishing.service.gov.uk`. It is a task performed
-by Reliability Engineering.
+This document covers how to renew Gandi wildcard TLS certificates (`*.publishing.service.gov.uk`, `*.staging.publishing.service.gov.uk`
+and `*.integration.publishing.service.gov.uk`) and `www.gov.uk`.
 
 Credentials for the Fastly dashboard and Zendesk support sites are in the
 [2nd line password store](https://github.com/alphagov/govuk-secrets/blob/master/pass/2ndline/fastly).
@@ -21,29 +19,36 @@ Credentials for the Fastly dashboard and Zendesk support sites are in the
 3. Go to the account dashboard and find the list of TLS certificates on the
    account.
 4. Find the certificate you wish to renew and click Renew. You need to
-   request a wildcard certificate (for example, `*.publishing.service.gov.uk`).
+   request either a wildcard certificate (for example, `*.publishing.service.gov.uk`)
+   or a standard one (for example, `www.gov.uk`).
 5. Go through the steps on the renewal form until you reach a page requesting a
    Certificate Signing Request.
 6. Upload the CSR to Gandi by pasting the contents of the .csr file into the
    text box.
 7. Next, choose DNS validation to validate it and follow the instructions to add
    the relevant DNS records.
+   For DNS validation of certificate request for `www.gov.uk`, you need to ask a
+   senior GOV.UK member to request JISC to add the new DNS record.
 8. Pay for it - we don't have a stored payment method, so find the person with
    the GDS credit card. Or raise a request for temporary credit card details from
    PMO by sending an email to pmo@digital.cabinet-office.gov.uk.
-9. Once the certificate has been renewed, paste the contents of the resulting
-   .crt file into Puppet hieradata for the relevant environment in the
-   [govuk-secrets](https://github.com/alphagov/govuk-secrets/puppet) repository.
-10. Deploy Puppet to update the certificate in the relevant environment.
-11. Import the certificate to AWS ACM. Login to the AWS console in the appropriate
-    environment and follow the instructions [here](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-api-cli.html).
-    The chain cert is the second certificate under "wildcard_publishing_certificate"
-    in [govuk-secrets](https://github.com/alphagov/govuk-secrets/puppet).
-12. *For staging and integration only:*
-    Go to the Fastly interface and then to Configure -> HTTPS and network.
-    Go to TLS certificates and upload your new cert.
+9. Import the certificate to AWS ACM (Ireland/eu-west-1 region):
+
+   - Login to the AWS console in the appropriate environment and follow the instructions    [here](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-api-cli.html).
+
+   - The chain cert can be retrieved from Gandi by follow the instructions
+   [here](https://docs.gandi.net/en/ssl/common_operations/get_intermediate_certificate.html).
+10. **For staging and integration only:**
+
+    - Go to the Fastly interface and then to Configure -> HTTPS and network.
+
+    - Go to TLS certificates and upload your new cert.
     (You do not need to do this for production because we use a different certificate
     there)
-13. *For staging and integration only:*
-    In TLS domains click on more details and then select your new certificate
+
+    - In TLS domains, click on more details and then select your new certificate
     under CERTIFICATE BEING USED.
+
+12. **For production only:**
+
+    - You need to also import the certificate in the `North Virginia` AWS ACM for use with our disaster recovery AWS CloudFront.


### PR DESCRIPTION
Following changes were made:
1. remove info about reliability engineer having to make the changes
   since now all govuk developers are expected to be able to perform
   these tasks.
2. add that there is a Gandi cert for www.gov.uk in addition to the
   wildcard ones.
3. remove the puppet instructions since the relevant Carrenza infra
   has been shutdown and AWS is not configured via Puppet.
4. Clarify that for production, the certs need to be uploaded to AWS
   ACM in North Virginia for disaster recovery cloudfront.

Refs:
1. [integration renewal trello card](https://trello.com/c/EjVHpJdg/3947-zendesk-hostmaster-gandi-expiration-of-the-certificate-ssl-standard-integrationpublishingservicegovuk-in-29-days)
2. [www.gov.uk renewal trello card](https://trello.com/c/gdIGvJNL/3946-zendesk-hostmaster-gandi-expiration-of-the-certificate-ssl-standard-wwwgovuk-in-29-days)