### PR TITLE
Clarify when to use "startup.sh" scripts

### DIFF
--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -85,7 +85,6 @@ gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 ```
 
 ```shell
-bundle install
 ./startup.sh --live
 # Check the output to see what port the app is running on, e.g: localhost:3005
 ```

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -68,7 +68,9 @@ govuk-docker-up app-live
 
 ## Using startup scripts
 
-If you are making changes to a frontend app and nothing else, you can view these changes by running the application's `./startup.sh` script. This example is for [government-frontend], but these instructions apply to any frontend app.
+**NOTE:** this approach only works for frontend development and relies on live APIs. You will need to find and install any dependencies yourself. Consider using the general GOV.UK Docker environment in the first instance.
+
+If you are making changes to certain frontend apps you can also view these changes by running the application's `./startup.sh` script - if it has one. This example is for [government-frontend], but these instructions may apply to other frontend apps.
 
 ```shell
 cd /govuk/government-frontend

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -7,28 +7,6 @@ section: Frontend
 type: learn
 ---
 
-## Using startup scripts
-
-If you are making changes to a frontend app and nothing else, you can view these changes by running the application's `./startup.sh` script. This example is for [government-frontend], but these instructions apply to any frontend app.
-
-```shell
-cd /govuk/government-frontend
-./startup.sh --live
-# Check the output to see what port the app is running on, e.g: localhost:3005
-```
-
-If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile and then run the startup script:
-
-```ruby
-gem 'govuk_publishing_components', path: '../govuk_publishing_components'
-```
-
-```shell
-bundle install
-./startup.sh --live
-# Check the output to see what port the app is running on, e.g: localhost:3005
-```
-
 ## Using govuk-docker
 
 This assumes that you have already installed and setup [govuk-docker]. We will use [government-frontend] as an example here, but these instructions apply to any frontend app.
@@ -86,6 +64,28 @@ make government-frontend
 cd /govuk/government-frontend
 govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
+```
+
+## Using startup scripts
+
+If you are making changes to a frontend app and nothing else, you can view these changes by running the application's `./startup.sh` script. This example is for [government-frontend], but these instructions apply to any frontend app.
+
+```shell
+cd /govuk/government-frontend
+./startup.sh --live
+# Check the output to see what port the app is running on, e.g: localhost:3005
+```
+
+If you want to test changes in [govuk_publishing_components] against a frontend app, you need to edit your frontend app Gemfile and then run the startup script:
+
+```ruby
+gem 'govuk_publishing_components', path: '../govuk_publishing_components'
+```
+
+```shell
+bundle install
+./startup.sh --live
+# Check the output to see what port the app is running on, e.g: localhost:3005
 ```
 
 ## Components pulled in by Static

--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -40,7 +40,7 @@ cd /govuk/govuk-docker
 make government-frontend
 
 cd /govuk/government-frontend
-govuk-docker up government-frontend-app-live # or govuk-docker-up app-live
+govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 
@@ -53,7 +53,7 @@ gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 ```shell
 cd /govuk/government-frontend
 govuk-docker-run bundle install
-govuk-docker up government-frontend-app-live
+govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 
@@ -84,7 +84,7 @@ cd /govuk/govuk-docker
 make government-frontend
 
 cd /govuk/government-frontend
-govuk-docker up government-frontend-app-live
+govuk-docker-up app-live
 # You can now view the app on government-frontend.dev.gov.uk
 ```
 


### PR DESCRIPTION
This is as much a proposal as a PR, so feel free to leave
comments about your own thoughts on this:

- Update various documentation:

   - Frontend app READMEs should Point to this documentation.
   - Other apps should point to the GOV.UK Docker README.
   - Fix: https://github.com/alphagov/govuk-docker/issues/444

- Remove `startup.sh` scripts for all non-frontend apps. These are [no different](https://github.com/alphagov/asset-manager/blob/master/startup.sh) to running `rails s` manually, so we're actually making things clearer / easier by removing them for non-frontend apps.

- Change `startup.sh` scripts for frontend apps to always run with `--live`, since this is the only way they currently work. Remove `startup.sh` scripts for certain frontend apps:

   - Remove for Email Alert Frontend (doesn't work / stateful, requires local Email Alert API).
   - Remove for Feedback (doesn't work / stateful, requires local Support API).