### PR TITLE
Add requirement to add TLS certs to pass store

### DIFF
--- a/source/manual/renew-a-tls-certificate.html.md
+++ b/source/manual/renew-a-tls-certificate.html.md
@@ -32,13 +32,16 @@ Credentials for the Fastly dashboard and Zendesk support sites are in the
 8. Pay for it - we don't have a stored payment method, so find the person with
    the GDS credit card. Or raise a request for temporary credit card details from
    PMO by sending an email to pmo@digital.cabinet-office.gov.uk.
-9. Import the certificate to AWS ACM (Ireland/eu-west-1 region):
+9. Add the Certificate, Private Key, Certificate Signing Request and Intermediate Certificate
+   to the [`2ndline` pass store](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline)
+   under the `certificates` directory.
+10. Import the certificate to AWS ACM (Ireland/eu-west-1 region):
 
-   - Login to the AWS console in the appropriate environment and follow the instructions    [here](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-api-cli.html).
+    - Login to the AWS console in the appropriate environment and follow the instructions    [here](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-api-cli.html).
 
-   - The chain cert can be retrieved from Gandi by follow the instructions
-   [here](https://docs.gandi.net/en/ssl/common_operations/get_intermediate_certificate.html).
-10. **For staging and integration only:**
+    - The chain cert can be retrieved from Gandi by follow the instructions
+    [here](https://docs.gandi.net/en/ssl/common_operations/get_intermediate_certificate.html).
+11. **For staging and integration only:**
 
     - Go to the Fastly interface and then to Configure -> HTTPS and network.
 


### PR DESCRIPTION
For TLS certificates that are renewed manually, there is a need to add
the certs details in the pass store so that these can be retrieved
easily later when configuring external systems.

This PR add this requirements in the doc which was missing in #2896