### PR TITLE
Change most "Reliability Engineering" references to other things

### DIFF
--- a/source/manual/alerts/renew-tls-certificate.html.md
+++ b/source/manual/alerts/renew-tls-certificate.html.md
@@ -19,19 +19,19 @@ expire.
 
 See [renew a TLS certificate for GOV.UK](/manual/renew-a-tls-certificate.html)
 for details of how to renew the relevant certificate. This is normally done by
-Reliability Engineering.
+GOV.UK Replatforming.
 
 ## Production www.gov.uk certificate
 
 The TLS certificate for www.gov.uk is managed by Fastly. They will open a support
 ticket when the certificate is due for renewal. This ticket will be picked up by
-Reliability Engineering, who will co-ordinate with Fastly to renew the
+GOV.UK Replatforming, who will co-ordinate with Fastly to renew the
 certificate.
 
 ## Production, staging and integration wildcard certificates
 
 The wildcard TLS certificates for production, staging and integration are
-managed by Reliability Engineering. Once the alert appears, they will work to
+managed by GOV.UK Replatforming. Once the alert appears, they will work to
 renew the relevant certificate and make it live. For staging and integration,
 the certificates are also provided to Fastly to enable TLS for our staging and
 integration CDN environments.

--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -24,7 +24,7 @@ The GOV.UK development community:
 - ensures missions are delivered technically in the best and most appropriate
   way
 
-The Reliability Engineering team:
+The GOV.UK Replatforming team:
 
 - supports the infrastructure used to run and make changes to GOV.UK
 - handles updates to `*.gov.uk` DNS (excluding `*.publishing.service.gov.uk`)
@@ -38,11 +38,11 @@ question, you should escalate it through, in order:
 2. The Lead Developer on the programme
 3. The Lead Architect
 
-If 2nd Line instructs you to escalate something to Reliability Engineering,
+If 2nd Line instructs you to escalate something to GOV.UK Replatforming,
 raise a ticket on Zendesk and assign it to the `3rd Line--GDS Reliability
 Engineering` queue. You should also raise a ticket if the issue is related to
 an ongoing incident for tracking purposes, but you can speak to the team
 directly to get it more immediate attention.
 
-If you speak to Reliability Engineering about a process only they know about,
+If you speak to GOV.UK Replatforming about a process only they know about,
 they will work with you to document the process for all of GOV.UK.

--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -79,7 +79,7 @@ Fastly publish their cache node [IP address ranges as JSON from their API][fastl
 - Origin has [firewall rules][] in place so that only our office and Fastly can connect.
 - Our [Fastly Varnish config][vcl_config] restricts HTTP purges to specific IP addresses (otherwise anyone would be able to purge the cache).
 
-We have [a Jenkins job "Check CDN IP Ranges"][check-cdn-ip-ranges] which will start to fail if our Fastly IPs don't match the IPs returned from the Fastly API. If you see this alert, you can [let Reliability Engineering know][raise-with-re] and they will update our list of Fastly IPs to match the ones listed by Fastly.
+We have [a Jenkins job "Check CDN IP Ranges"][check-cdn-ip-ranges] which will start to fail if our Fastly IPs don't match the IPs returned from the Fastly API. If you see this alert, you can [let GOV.UK Replatforming know][raise-with-re] and they will update our list of Fastly IPs to match the ones listed by Fastly.
 
 Updating the firewall rules in Carrenza with new Fastly IPs used to be done by committing the change to the [govuk-provisioning][govuk-provisioning] repo and to then deploy the firewall through a Jenkins job. This process is broken at the moment since the code base has diverged from the state of the firewall. While this is remedied we have to add the new rules manually - this is how to do it:
 

--- a/source/manual/concourse.html.md
+++ b/source/manual/concourse.html.md
@@ -9,7 +9,7 @@ parent: "/manual.html"
 
 Concourse is a continuous integration and continuous deployment system similar to Jenkins.
 
-The Reliability Engineering team runs a [hosted Concourse](https://cd.gds-reliability.engineering/) service for all GDS teams.
+The RE Autom8 team runs a [hosted Concourse](https://cd.gds-reliability.engineering/) service for all GDS teams.
 
 Concourse is built on the concept of pipelines. Each pipeline can be compared to a collection of related Jenkins jobs. Pipelines consist of multiple jobs and resources. Jobs are collections of commands that are run, and are stateless since they are run inside disposable Docker containers. All state needs to be stored and read from resources, which may be a git repository, an AWS S3 bucket or another storage medium. Triggers allow changes to resources to start a job, and jobs can trigger other jobs.
 
@@ -52,7 +52,7 @@ Some of our Concourse pipelines use the beta Concourse "self-update" feature tha
 1. Double-check the diff to ensure you're happy with what is about to be applied
 1. Enter `y` to make the changes
 
-GDS Reliability Engineering provide [further documentation][big-concourse-docs]. More information on working with Concourse and the Fly CLI can be found in [the official documentation][concourse-docs].
+RE Autom8 provide [further documentation][big-concourse-docs]. More information on working with Concourse and the Fly CLI can be found in [the official documentation][concourse-docs].
 
 [big-concourse]: https://cd.gds-reliability.engineering/
 [big-concourse-docs]: https://reliability-engineering.cloudapps.digital/continuous-deployment.html#getting-started-with-concourse

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -7,7 +7,7 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-The Reliability Engineering team is responsible for managing several DNS zones.
+The GOV.UK Replatforming team is responsible for managing several DNS zones.
 
 By default, zones are hosted by AWS (Route 53) and Google Cloud Platform (Cloud DNS)
 
@@ -112,7 +112,7 @@ Currently these zones are only used in environments running on AWS.
 These DNS zones are hosted in Route53 and managed by Terraform. Changes can be
 made in the [govuk-aws](https://github.com/alphagov/govuk-aws/) and
 [govuk-aws-data](https://github.com/alphagov/govuk-aws-data/) repositories.
-While GOV.UK migrates to AWS speak with Reliability Engineering for support
+While GOV.UK migrates to AWS speak with GOV.UK Replatforming for support
 making your changes.
 
 ## DNS for the `gov.uk` top level domain
@@ -120,10 +120,11 @@ making your changes.
 [Jisc](https://www.jisc.ac.uk/) is a non-profit which provides networking to
 UK education and government. They control the `gov.uk.` top-level domain.
 
-Requests to modify the DNS records for `gov.uk.` should be sent by email to
-`naming@ja.net` from someone on Jisc's approved contacts list. Speak to a
-senior technologist member of GOV.UK or Reliability Engineering if you need to
-make a change and don't have access.
+Requests to modify the DNS records for `gov.uk.` should be sent by
+email to `naming@ja.net` from someone on Jisc's approved contacts
+list. Speak to a senior technologist member of GOV.UK or someone in
+GOV.UK Replatforming if you need to make a change and don't have
+access.
 
 2nd line should be notified of any planned changes via email.
 
@@ -136,7 +137,7 @@ make a change and don't have access.
 
 ## Delegating `service.gov.uk` domains
 
-At the moment Reliability Engineering are also responsible for delegating DNS
+At the moment GOV.UK Replatforming are also responsible for delegating DNS
 to other government services.
 
 The request will arrive by email or Zendesk from a member of the GOV.UK Proposition

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -223,7 +223,7 @@ An account in AWS doesn't give you access to anything, you'll need to be given r
 
 Add yourself to a lists of users found in [the data for the infra-security project][infra-terra]. There are 5 groups:
 
-- `govuk-administrators`: people in Reliability Engineering who are working on GOV.UK infrastructure
+- `govuk-administrators`: people who are working on GOV.UK infrastructure
 - `govuk-internal-administrators`: people in GOV.UK who are working on GOV.UK infrastructure including Architects, Lead Developers and anyone else working on the AWS migration
 - `govuk-powerusers`: anyone else who can have production access on GOV.UK
 - `govuk-platformhealth-powerusers`: as above but for members of the GOV.UK Platform Health team. (Same access rights as above, we just have limits on the number of users per role).

--- a/source/manual/govuk-app-domain-handling-during-migration.html.md
+++ b/source/manual/govuk-app-domain-handling-during-migration.html.md
@@ -33,4 +33,4 @@ Note: we use [Plek](https://github.com/alphagov/plek) to generate the correct ba
 
 Since setting the correct service discovery environment for a particular app is complicated due to the migration to AWS, please take extra care to make sure you understand the effects of changes to the app_domain parameter and Plek URI overrides via environment variables.
 
-If in doubt, please [talk to Reliability Engineering](https://docs.publishing.service.gov.uk/manual/raising-issues-with-reliability-engineering.html) to make sure your changes will not have unintended side effects.
+If in doubt, please [talk to GOV.UK Replatforming](https://docs.publishing.service.gov.uk/manual/raising-issues-with-reliability-engineering.html) to make sure your changes will not have unintended side effects.

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -86,7 +86,7 @@ If two developers worked on the same branch and individually contributed commits
 
 ## Other considerations
 
-1. When opening a PR, if you feel you don't have full confidence in your change and want a particular review from someone, it's OK to ask for that review in the PR description. For example, a puppet change might warrant a particular review from a member of the Reliability Engineering team.
+1. When opening a PR, if you feel you don't have full confidence in your change and want a particular review from someone, it's OK to ask for that review in the PR description. For example, a puppet change might warrant a particular review from a member of the GOV.UK Replatforming team.
 2. It's OK for someone other than the author to merge a PR, particularly if the author is not available. That person should be confident that the change doesn't have dependencies on other changes, and that it won't break `master`.
 3. If a PR is particularly good, remember to praise the author for it. Emoji are a great way of showing appreciation for a PR that fixes a problem you've been having, or implements something you've wanted to do for a while.
 4. It's sometimes OK for merges to happen when test suites are failing. This ability is limited to repository administrators and account owners, so ask them if you need them to force a merge. This is particularly useful in a catch-22 situation of two repositories with failing test suites that depend on each other.

--- a/source/manual/move-apps-between-servers.html.md
+++ b/source/manual/move-apps-between-servers.html.md
@@ -12,7 +12,7 @@ Most frontend and backend apps on GOV.UK share a small number of servers. In som
 
 > **Note**
 >
-> You need to be at least a Power User in AWS to be able to run the following procedure. You can check by looking in the [govuk-aws-data] repository. Some IAM changes may require Administrator access, so you'll need to ask someone in the Reliability Engineering team to run these for you.
+> You need to be at least a Power User in AWS to be able to run the following procedure. You can check by looking in the [govuk-aws-data] repository. Some IAM changes may require Administrator access, so you'll need to ask someone in the GOV.UK Replatforming team to run these for you.
 
 1. Add Terraform configuration ([1][aws-terraform-config-1], [2][aws-terraform-config-2], [3][aws-terraform-config-3]) to create the new servers, load balancers, security groups, DNS entries etc.
 1. Add data to complement the configuration above ([1][aws-terraform-data-1], [2][aws-terraform-data-2]).

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -78,7 +78,7 @@ Request any public DNS entries be removed. If the app had an admin UI, it will
 have had public DNS entries in the `publishing.service.gov.uk` domain.
 
 Follow the [instructions for DNS changes][dns-changes] in order to remove
-these, and ask the Reliability Engineering team to approve any necessary Pull
+these, and ask the GOV.UK Replatforming team to approve any necessary Pull
 Requests.
 
 [dns-changes]: https://docs.publishing.service.gov.uk/manual/dns.html#making-changes-to-publishingservicegovuk

--- a/source/manual/set-up-gcp-account.html.md
+++ b/source/manual/set-up-gcp-account.html.md
@@ -10,9 +10,12 @@ parent: "/manual.html"
 
 ## Request GCP access
 
-Permission to Google Cloud Platform (GCP) is managed by RE GOV.UK team. Access to GCP is granted when [permanent Production access](manual/rules-for-getting-production-access.html) is approved and merged to
-[GOV.UK user reviewer](https://github.com/alphagov/govuk-user-reviewer) repository.
+Permission to Google Cloud Platform (GCP) is managed by the GOV.UK
+Replatforming team. Access to GCP is granted when [permanent
+Production access](manual/rules-for-getting-production-access.html) is
+approved and merged to [GOV.UK user
+reviewer](https://github.com/alphagov/govuk-user-reviewer) repository.
 
-To request GCP access, [raise a Zendesk ticket with Reliability Engineering](https://docs.publishing.service.gov.uk/manual/raising-issues-with-reliability-engineering.html#raising-a-zendesk-ticket-with-reliability-engineering). Include the user reviewer PR in the ticket body.
+To request GCP access, [raise a Zendesk ticket with GOV.UK Replatforming](https://docs.publishing.service.gov.uk/manual/raising-issues-with-reliability-engineering.html#raising-a-zendesk-ticket-with-reliability-engineering). Include the user reviewer PR in the ticket body.
 
 You'll be notified when GCP access granted and able to login to [GCP console](https://console.cloud.google.com/) using your `@digital.cabinet-office.gov.uk` email address.


### PR DESCRIPTION
I'm not sure where these "Reliability Engineering" references came
from, but it's never been particularly accurate as far as I
understand. Reliability Engineering has always been a vague way of
referencing either those who support specific things. In particular RE
Autom8 support Concourse and Logit and RE GOV.UK when it existed
supported GOV.UK and DNS. It's always been more helpful to be more
specific than Reliability Engineering.

This issue is more apparent now given that RE GOV.UK no longer exists,
and that the most similar team is the GOV.UK Replatforming team within
the GOV.UK program, which currently has some SRE's on loan. This means
that saying "Reliability Engineering" is now wrong in many cases, as
the documentation should reference the Replatforming team within
GOV.UK.

I think the changes in this commit make things less wrong. There's
still some more work to remove or change the documentation about
raising things with Reliability Engineering, as I think that was only
correct while the RE GOV.UK team existed.

(this is from a fork as I no longer have sufficient access to raise Pull Requests directly)