### PR TITLE
Update docs on Fastly, CDN source IPs, DoS mitigation.

### DIFF
--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -158,7 +158,7 @@ Banning IPs shouldn't be taken lightly as IP address can be shared by multiple u
 
 You can change the list of banned IP addresses by modifying the [YAML config file][ip_ban_config] and [deploying the configuration][ip_ban_deploy].
 
-[ip_ban_config]: https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/dictionaries/config/ip_address_blacklist.yaml
+[ip_ban_config]: https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/dictionaries/config/ip_address_denylist.yaml
 [ip_ban_deploy]: https://deploy.blue.production.govuk.digital/job/Update_CDN_Dictionaries/build
 
 ## Bouncer's Fastly service


### PR DESCRIPTION
Add a new section about the type of DoS/spam mitigation which was used in November 2020 for this incident:
https://docs.google.com/document/d/12DzQsDeu7zUcICy9zVporjprX4qZFIrpOOWtYYRx-nk/edit#

Also various small updates including:

- Our origin moved from London to Dublin quite some time ago.
- Fix confusion between the Fastly cache-clearing ACL (access control list) and the origin ACL.
- The vSphere automation stuff in govuk-provisioning is never coming back, so let's delete the mention of it.
- Clarify that the Fastly IP safelist and alert in Carrenza is only relevant to Performance Platform.
- Fix a broken link to the IP address denylist.