### PR TITLE
Add entry for GOV.UK Accounts

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -1,3 +1,17 @@
+# GOV.UK Account
+- github_repo_name: govuk-account-manager-prototype
+  type: GOV.UK Account
+  team: "#govuk-accounts-tech"
+  production_hosted_on: paas
+  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5370953
+  dashboard_url: false
+- github_repo_name: govuk-attribute-service-prototype
+  type: GOV.UK Account
+  team: "#govuk-accounts-tech"
+  production_hosted_on: paas
+  sentry_url: https://sentry.io/organizations/govuk/issues/?project=5371008
+  dashboard_url: false
+
 # publishing apps
 
 - github_repo_name: collections-publisher

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -1,6 +1,7 @@
 # These sections are magically populated from applications.yml
 - name: "Applications"
   sections:
+    - name: GOV.UK Account
     - name: Publishing apps
     - name: APIs
     - name: Services

--- a/source/manual/govuk-account.html.md.erb
+++ b/source/manual/govuk-account.html.md.erb
@@ -1,0 +1,21 @@
+---
+owner_slack: "#govuk-accounts-tech"
+title: Use GOV.UK Account
+section: GOV.UK Account
+layout: manual_layout
+parent: "/manual.html"
+---
+
+GOV.UK Account is a centralised account infrastructure for GOV.UK. It gives GOV.UK users continuity across their different interactions with the government.
+
+For information on how to use GOV.UK Account, see the following:
+
+- the [GOV.UK Account team manual](https://team-manual.account.publishing.service.gov.uk/#gov-uk-account-team-manual)
+- the [GOV.UK Account technical documentation](https://docs.account.publishing.service.gov.uk/#gov-uk-accounts-technical-documentation)
+
+Use the team manual if you are a member of the GOV.UK Account team and need to find out information on internal GOV.UK Account team processes such as handling Zendesk tickets or deploying a branch to the staging environment.
+
+Use the technical documentation if you not a member of the GOV.UK Account team and need to find out how to:
+
+- use GOV.UK Account
+- integrate your service with GOV.UK Account


### PR DESCRIPTION
We didn't have anything in our main developer docs for these.

# Screenshots

<img width="1144" alt="Screenshot 2020-12-31 at 16 43 47" src="https://user-images.githubusercontent.com/424772/103418611-5db8ea80-4b87-11eb-8458-dc4a0268f1fb.png">

<img width="1144" alt="Screenshot 2020-12-31 at 16 36 48" src="https://user-images.githubusercontent.com/424772/103418591-4548d000-4b87-11eb-9221-5df698cddb4b.png">
