### PR TITLE
Use app-console command when replacing assets

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -96,8 +96,7 @@ changing the URL, follow these steps:
 0. Get an app console on that same server:
 
     ```sh
-    $ gds govuk connect ssh -e <environment> aws/backend:1
-    $ govuk_app_console asset-manager
+    $ gds govuk connect app-console -e <environment> aws/backend:1
     ```
 
 0. Find the asset:


### PR DESCRIPTION
The instructions say to ssh into a machine, then load an app console.  But we can do all this within gds-cli, which saves a step.