### PR TITLE
Fix links that are relative to the site root

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -59,17 +59,15 @@ class ExternalDoc
 
         href = element["href"].strip
         uri = URI.parse(href)
-        path = uri.path
 
         next if uri.scheme || href.start_with?("#")
 
-        base = if path.start_with? "/"
-                 base_url
-               else
-                 context[:subpage_url]
-               end
-
-        element["href"] = URI.join(base, href).to_s
+        if href.start_with?("/")
+          # remove preceding "/" to make links relative to the repository
+          # rather than to github.com. This is what GitHub does too.
+          href = href[1..]
+        end
+        element["href"] = URI.join(context[:subpage_url], href).to_s
       end
 
       doc

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe ExternalDoc do
         expect(html).to have_link("Subfolder", href: "https://github.com/alphagov/lipsum/blob/master/docs/some-subfolder/foo.md")
       end
 
+      it "converts links relative to the 'root' to absolute GitHub URLs" do
+        expect(html).to have_link("Link relative to root", href: "https://github.com/alphagov/lipsum/blob/master/public/json_examples/requests/foo.json")
+      end
+
       context "the document we are parsing is in the `docs` folder" do
         let(:path) { "docs/some-document.md" }
 

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe GitHubRepoFetcher do
 
   describe "#repo" do
     it "fetches a repo from cache if it exists" do
-      allow(CACHE).to receive(:fetch).with("all-repos", hash_including(:expires_in)) do
+      cache = double("CACHE")
+      allow(cache).to receive(:fetch).with("all-repos", hash_including(:expires_in)) do
         [public_repo]
       end
+      stub_const("CACHE", cache)
 
       repo = GitHubRepoFetcher.instance.repo("some-repo")
 
@@ -22,7 +24,9 @@ RSpec.describe GitHubRepoFetcher do
     end
 
     it "fetches a repo from GitHub if it doesn't exist in the cache" do
-      allow(CACHE).to receive(:fetch).and_yield
+      cache = double("CACHE")
+      allow(cache).to receive(:fetch).and_yield
+      stub_const("CACHE", cache)
 
       repo = GitHubRepoFetcher.instance.repo("some-repo")
 
@@ -40,7 +44,9 @@ RSpec.describe GitHubRepoFetcher do
     let(:repo_name) { "some-repo" }
 
     before :each do
-      allow(CACHE).to receive(:fetch).and_yield
+      cache = double("CACHE")
+      allow(cache).to receive(:fetch).and_yield
+      stub_const("CACHE", cache)
     end
 
     def readme_url
@@ -53,9 +59,11 @@ RSpec.describe GitHubRepoFetcher do
         .to_return(status: 200, body: "Foo")
 
       outcome = "pending"
-      allow(CACHE).to receive(:fetch) do |&block|
+      cache = double("CACHE")
+      allow(cache).to receive(:fetch) do |&block|
         outcome = block.call
       end
+      stub_const("CACHE", cache)
 
       GitHubRepoFetcher.instance.readme(repo_name)
       expect(outcome).to eq("Foo")

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -10,13 +10,18 @@ RSpec.describe GitHubRepoFetcher do
   let(:private_repo) { double("Private repo", private_repo?: true) }
   let(:public_repo) { double("Public repo", private_repo?: false, default_branch: "master") }
 
+  def stub_cache
+    cache = double("CACHE")
+    allow(cache).to receive(:fetch).and_yield
+    stub_const("CACHE", cache)
+    cache
+  end
+
   describe "#repo" do
     it "fetches a repo from cache if it exists" do
-      cache = double("CACHE")
-      allow(cache).to receive(:fetch).with("all-repos", hash_including(:expires_in)) do
+      allow(stub_cache).to receive(:fetch).with("all-repos", hash_including(:expires_in)) do
         [public_repo]
       end
-      stub_const("CACHE", cache)
 
       repo = GitHubRepoFetcher.instance.repo("some-repo")
 
@@ -24,10 +29,7 @@ RSpec.describe GitHubRepoFetcher do
     end
 
     it "fetches a repo from GitHub if it doesn't exist in the cache" do
-      cache = double("CACHE")
-      allow(cache).to receive(:fetch).and_yield
-      stub_const("CACHE", cache)
-
+      stub_cache
       repo = GitHubRepoFetcher.instance.repo("some-repo")
 
       expect(repo).not_to be_nil
@@ -44,9 +46,7 @@ RSpec.describe GitHubRepoFetcher do
     let(:repo_name) { "some-repo" }
 
     before :each do
-      cache = double("CACHE")
-      allow(cache).to receive(:fetch).and_yield
-      stub_const("CACHE", cache)
+      stub_cache
     end
 
     def readme_url
@@ -59,11 +59,9 @@ RSpec.describe GitHubRepoFetcher do
         .to_return(status: 200, body: "Foo")
 
       outcome = "pending"
-      cache = double("CACHE")
-      allow(cache).to receive(:fetch) do |&block|
+      allow(stub_cache).to receive(:fetch) do |&block|
         outcome = block.call
       end
-      stub_const("CACHE", cache)
 
       GitHubRepoFetcher.instance.readme(repo_name)
       expect(outcome).to eq("Foo")

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -13,6 +13,8 @@ neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
 
 [Relative docs link without period](docs/no-prefix.md)
 
+[Link relative to root](/public/json_examples/requests/foo.json)
+
 [Subfolder](docs/some-subfolder/foo.md)
 
 ## Suspendisse iaculis


### PR DESCRIPTION
Imported links like `/public/foo.json` currently get converted to
https://docs.publishing.service.gov.uk/public/foo.json.
These links obviously 404.

Whilst technically they should be converted to
https://www.github.com/public/foo.json (if we were to take them
at face value), those links would also 404. What the developer
intends, and what GitHub obliges to do, is to convert them
relative to the repository, i.e.
https://github.com/alphagov/lipsum/blob/master/public/foo.json.
We must do the same.

This commit should fix a live issue I'm seeing on this page:
https://docs.publishing.service.gov.uk/apps/hmrc-manuals-api/extended_documentation.html#example-json