### PR TITLE
Add new documentation to raise AWS support case

### DIFF
--- a/source/manual/how-to-escalate-to-AWS-support.html.md
+++ b/source/manual/how-to-escalate-to-AWS-support.html.md
@@ -1,0 +1,17 @@
+---
+owner_slack: "#govuk-developers"
+title: How to raise a support ticket with AWS
+
+section: AWS
+layout: manual_layout
+type: learn
+parent: "/manual.html"
+---
+
+Sign in to the AWS Management Console.
+
+`gds aws <command> -l`
+
+Where `<command>` maps to an AWS account and IAM role you have permissions to assume into. This should be the AWS account that the problem is associated with e.g. `govuk-production-poweruser`.
+
+Then follow steps 2-6 in the official AWS docs: [Creating a support case](https://docs.aws.amazon.com/awssupport/latest/user/case-management.html#creating-a-support-case)


### PR DESCRIPTION
These are the steps to creating a support case with
Amazon AWS.

Users need to log into the AWS console and follow the steps.

Trello: https://github.com/alphagov/govuk-developer-docs/pull/2931