### PR TITLE
Replace mentions of `brew cask` with plain `brew install`

### DIFF
--- a/source/manual/concourse.html.md
+++ b/source/manual/concourse.html.md
@@ -44,7 +44,7 @@ Whenever a pipeline YAML is created or changed, it needs to be applied for the c
 
 Some of our Concourse pipelines use the beta Concourse "self-update" feature that runs a task whenever a change to the pipeline YAML is merged to master. For others, like the [repo mirroring job](/manual/repository-mirroring.html), or if you're writing a new Concourse pipeline, you have to run `fly set-pipeline` manually:
 
-1. If this is your first time using Concourse, download the `fly` CLI by clicking the appropriate OS logo at the bottom right corner of the [team page](https://cd.gds-reliability.engineering/teams/govuk-tools) and move it to somewhere in your `$PATH`. If that doesn't download an executable file, try `brew cask install fly`.
+1. If this is your first time using Concourse, download the `fly` CLI by clicking the appropriate OS logo at the bottom right corner of the [team page](https://cd.gds-reliability.engineering/teams/govuk-tools) and move it to somewhere in your `$PATH`. If that doesn't download an executable file, try `brew install fly`.
 1. Set a target for the team you want to login to: `fly login -c https://cd.gds-reliability.engineering -n govuk-tools -t cd-govuk-tools`
 1. Navigate to the folder that contains the pipeline config YAML file
 1. Run `fly -t cd-govuk-tools set-pipeline -p [pipeline name] -c [pipeline config YAML file name]`

--- a/source/manual/create-a-gpg-key.html.md
+++ b/source/manual/create-a-gpg-key.html.md
@@ -10,7 +10,7 @@ We use GPG keys to encrypt our secrets. Documentation for using your GPG key can
 
 ## Prerequisites
 
-Install `gpg` if you don't already have it. Use `brew cask install gpg-suite` to install the graphical [GPG Suite](https://gpgtools.org/).
+Install `gpg` if you don't already have it. Use `brew install gpg-suite` to install the graphical [GPG Suite](https://gpgtools.org/).
 
 Once installed, you will likely have both `gpg` and `gpg2` on your machine. Always use `gpg2`.
 

--- a/source/manual/publish-to-puppet-forge.html.md
+++ b/source/manual/publish-to-puppet-forge.html.md
@@ -34,7 +34,7 @@ If you get the "this action has been replaced by Puppet Development
 Kit" error, run these commands instead:
 
 ```sh
-$ brew cask install puppetlabs/puppet/pdk
+$ brew install puppetlabs/puppet/pdk
 $ pdk build
 ```
 

--- a/source/manual/restore-from-offsite-backups.html.md
+++ b/source/manual/restore-from-offsite-backups.html.md
@@ -23,7 +23,7 @@ On the machine where you want to restore the backup:
 For the backup and restore drill, you will restore and unpack a MySQL database
 on a Vagrant VM.
 
-1. Install Vagrant and VirtualBox with `brew cask install virtualbox vagrant`
+1. Install Vagrant and VirtualBox with `brew install virtualbox vagrant`
 1. In the root of the `govuk-puppet` directory, run `vagrant up mysql-master-1.backend to create a new mySQL VM
 1. Access the new VM with `vagrant ssh mysql-master-1.backend`
 


### PR DESCRIPTION
- Usage of `brew cask install` returns "Error: Calling brew cask install is disabled! Use brew install [--cask] instead." since Homebrew 2.6.0 (released in December). None of the software installed in these docs is both a cask and a formulae, so there's no need to explicitly pick the cask with `--cask`.

:sparkling_heart:
