### PR TITLE
Fix intermittent tests

### DIFF
--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -1,7 +1,9 @@
 require "octokit"
 
 class GitHubRepoFetcher
-  include Singleton
+  def self.instance
+    @instance ||= new
+  end
 
   # Fetch a repo from GitHub
   def repo(repo_name)


### PR DESCRIPTION
Fixes #2940. Bug introduced in #2918.

Tests were sensitive to their order of execution. State from a
previous run of tests can remain on the `GitHubRepoFetcher`
singleton object.

The Singleton pattern is somewhat discouraged [1] [2], though it
can be useful to refer to a common instance of a class where its
fetch methods are computationally expensive and we rely heavily
on caching.

This commit follows the guidance in the second referenced article,
to retain the Singleton presentation of the class but also to
allow it to be instantiated (making it much easier to test). I've
also added a test to capture and verify the intended `.instance`
singleton behaviour.

[1]: https://www.rubyguides.com/2018/05/singleton-pattern-in-ruby/
[2]: https://8thlight.com/blog/josh-cheek/2012/10/20/implementing-and-testing-the-singleton-pattern-in-ruby.html