### PR TITLE
Add new `continuously_deployed` field for current CD-enabled apps

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -33,14 +33,17 @@
   actors:
   - Publisher
 - github_repo_name: content-publisher
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: local-links-manager
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: manuals-publisher
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -50,10 +53,12 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: publisher
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: service-manual-publisher
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -69,6 +74,7 @@
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: travel-advice-publisher
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -126,6 +132,7 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: hmrc-manuals-api
+  continuously_deployed: true
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -153,10 +160,12 @@
 # Support
 
 - github_repo_name: content-data-api
+  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: content-data-admin
+  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -173,6 +182,7 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: authenticating-proxy
+  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -210,6 +220,7 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: finder-frontend
+  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
@@ -222,12 +233,14 @@
   actors:
   - Public
 - github_repo_name: government-frontend
+  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
 - github_repo_name: info-frontend
+  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -239,6 +252,7 @@
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: manuals-frontend
+  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"


### PR DESCRIPTION
Derived this info from https://release.publishing.service.gov.uk/applications.

Depended on by https://github.com/alphagov/govuk-dependencies/pull/104.

Whilst the Release app is supposed to be the single source of
truth, in reality the Developer Docs is relied upon for its
https://docs.publishing.service.gov.uk/apps.json endpoint, so it
seems reasonable to add continuous-deployment information to our
app configuration here.