### PR TITLE
Add `continuously_deployed` property to API payload

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -12,6 +12,7 @@ class App
       dependencies_team: dependencies_team,
       puppet_name: puppet_name,
       production_hosted_on: production_hosted_on,
+      continuously_deployed: continuously_deployed,
       links: {
         self: "https://docs.publishing.service.gov.uk/apps/#{app_name}.json",
         html_url: html_url,
@@ -53,6 +54,10 @@ class App
 
   def hosting_name
     Applications::HOSTERS.fetch(production_hosted_on)
+  end
+
+  def continuously_deployed
+    app_data["continuously_deployed"] || false
   end
 
   def html_url

--- a/spec/app/app_spec.rb
+++ b/spec/app/app_spec.rb
@@ -1,4 +1,33 @@
 RSpec.describe App do
+  describe "api_payload" do
+    it "returns a hash of keys describing the app" do
+      app_details = {
+        "github_repo_name" => "foo",
+        "team" => "bar",
+        "dependencies_team" => "baz",
+        "production_hosted_on" => "aws",
+        "continuously_deployed" => false,
+      }
+      payload = App.new(app_details).api_payload
+      expect(payload[:app_name]).to eq(app_details["github_repo_name"])
+      expect(payload[:team]).to eq(app_details["team"])
+      expect(payload[:dependencies_team]).to eq(app_details["dependencies_team"])
+      expect(payload[:production_hosted_on]).to eq(app_details["production_hosted_on"])
+      expect(payload[:continuously_deployed]).to eq(false)
+      expect(payload[:links]).to include(:self, :html_url, :repo_url, :sentry_url)
+    end
+  end
+
+  describe "continuously_deployed" do
+    it "defaults to `false`" do
+      expect(App.new("github_repo_name" => "foo").continuously_deployed).to eq(false)
+    end
+
+    it "returns `continuously_deployed` property if specified" do
+      expect(App.new("github_repo_name" => "foo", "continuously_deployed" => true).continuously_deployed).to eq(true)
+    end
+  end
+
   describe "production_url" do
     it "has a good default" do
       app = App.new("type" => "Publishing app", "github_repo_name" => "my-app")


### PR DESCRIPTION
This should have been done in #2949 - I wrongly assumed the
application.yml contents would automatically be consumed in the
apps.json endpoint. It turns out it has to be explicitly added to
the api_payload method.

This commit adds a `continuously_deployed` method to retrieve the
property of the same name from the config, defaulting to `false`
if it doesn't exist. I've added tests for this, as well as a
missing text for the `api_payload` method.