### PR TITLE
Add 'govuk-docker' to list of GOV.UK applications

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -386,6 +386,10 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+- github_repo_name: govuk-docker
+  team: "#govuk-developers"
+  production_hosted_on: none
+  type: Utilities
 - github_repo_name: govuk-puppet
   team: "#govuk-developers"
   production_hosted_on: none


### PR DESCRIPTION
It could be considered a utility, like 'govuk-dependencies'.
Including this repo pulls in its README and `docs/` folder, which
should be useful for developers.