### PR TITLE
RE Autom8 team are responsible for Logit

### DIFF
--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -29,6 +29,9 @@ The GOV.UK Replatforming team:
 - supports the infrastructure used to run and make changes to GOV.UK
 - handles updates to `*.gov.uk` DNS (excluding `*.publishing.service.gov.uk`)
 - obtains and renews TLS certificates
+
+The GOV.UK RE AUTOM8 team:
+
 - maintains centrally-provided services such as Logit
 
 If you and your colleagues can’t resolve a technical issue, problem or


### PR DESCRIPTION
The GOV.UK RE Autom8 team are responsible for Logit. The doc has been updated to reflect this.