### PR TITLE
Update Transition docs to mention creating TLS certs

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -176,6 +176,10 @@ addresses](https://github.com/alphagov/transition/blob/016c3d30e190c41eaa912ed55
 If the site is one that was [administered by GDS](https://github.com/alphagov/gds-dns-config/tree/master/zones)
 (e.g. theorytest.direct.gov.uk), you will need to [update and re-deploy the DNS config](/manual/dns.html#making-changes-to-publishing-service-gov-uk).
 
+You'll need to create a TLS certificate in Fastly for HTTPS domains, otherwise
+users will see a certificate error when being redirected from an external
+HTTPS URL to GOV.UK via Bouncer. Read how to [request a Fastly TLS certificate][]
+
 ### 10) Get the organisation to monitor the traffic data in the Transition app
 
 There are two things that need to be responded to:
@@ -191,3 +195,4 @@ The transition checklist covers the whole process of transitioning a site from t
 [Transition]: /apps/transition.html
 [Bouncer]: /apps/bouncer.html
 [transition-config]: https://github.com/alphagov/transition-config/blob/master/README.md
+[request a Fastly TLS certificate]: /request-fastly-tls-certificate.html

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -136,12 +136,13 @@ to the machines when Bouncer is deployed.
 
 #### HTTPS support for transitioned sites
 
-Bouncer does not support HTTPS for transitioned sites. This functionality is under
-investigation as of December 2018. This limitation should be investigated as part
-of any site transition, especially if the existing site uses HSTS to force secure
-connections.
+Bouncer in late 2020 began supporting HTTPS for transitioned sites, through
+a new feature in Fastly.
+
+Follow the guidance to [request a Fastly TLS certificate][].
 
 [Bouncer]: /apps/bouncer.html
 [govuk-cdn-config]: https://github.com/alphagov/govuk-cdn-config
 [Bouncer_CDN job]: https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/
 [hosts from transition]: https://transition.publishing.service.gov.uk/hosts.json
+[request a Fastly TLS certificate]: /request-fastly-tls-certificate.html


### PR DESCRIPTION
We can now have Fastly create a TLS certificate on our behalf
in order to transition sites to GOV.UK that already served over
HTTPS.

A doc already exists explaining how to do it:
https://docs.publishing.service.gov.uk/manual/request-fastly-tls-certificate.html

This change updates the transition docs to say we can actually
tranisition HTTPS sites to GOV.UK via Bouncer.