### PR TITLE
Update Mapit documentation

### DIFF
--- a/source/manual/mapit-database-not-available.html.md
+++ b/source/manual/mapit-database-not-available.html.md
@@ -40,7 +40,7 @@ comments:
 1. Recreate the PostgreSQL cluster
 
    ```sh
-   $ sudo pg_dropcluster --stop 9.3 main; sudo pg_createcluster 9.3 main
+   $ sudo pg_dropcluster --stop 9.6 main; sudo pg_createcluster 9.6 main
    ```
 
 1. Run Puppet

--- a/source/manual/scale-mapit.html.md
+++ b/source/manual/scale-mapit.html.md
@@ -10,7 +10,7 @@ Mapit has a scaling process that is different to other GOV.UK applications.
 
 To scale Mapit, follow these steps:
 
-1. Edit the [Mapit machine Terraform](https://github.com/alphagov/govuk-aws/blob/a8217e42ee95b25da434fb27ab39788555a9448a/terraform/projects/app-mapit/main.tf#L157-L191) to include a `module mapit-<number>` and `resource "aws_erb_volume" "mapit-<number>"` block for each instance, e.g. for 4 instances you would need a `mapit-1`, `mapit-2`, `mapit-3` and `mapit-4`. You can copy an existing block and change the numbers.
+1. Edit the [Mapit machine Terraform](https://github.com/alphagov/govuk-aws/blob/a8217e42ee95b25da434fb27ab39788555a9448a/terraform/projects/app-mapit/main.tf#L157-L191) to include a `module mapit-<number>`, `resource "aws_erb_volume" "mapit-<number>"` and `resource "aws_iam_role_policy_attachment" "mapit_<number>_iam_role_policy_attachment"` block for each instance, e.g. for 4 instances you would need a `mapit-1`, `mapit-2`, `mapit-3` and `mapit-4`. You can copy an existing block and change the numbers.
 
 1. [Deploy the Terraform](/manual/deploying-terraform.html).
 


### PR DESCRIPTION
Updates the Mapit database initialisation instructions to use Postgres 9.6 (instead of 9.3, which we recently upgraded) and adds a missing resource to the scaling documentation.