### PR TITLE
Update Whitehall scheduled publishing worker healthcheck docs

### DIFF
--- a/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
@@ -6,26 +6,4 @@ layout: manual_layout
 section: Icinga alerts
 ---
 
-See also: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)
-
-If the message is a warning about `scheduled_queue`, eg '850 scheduled
-edition(s); 840 job(s) queued', this alert means that the number of
-editions in the database which are scheduled to be published in the
-future is different from the number currently in the queue.
-
-Run the `publishing:scheduled:requeue_all_jobs` Rake task to requeue all
-scheduled editions:
-
-- [Run in Integration Jenkins](https://deploy.integration.publishing.service.gov.uk//job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:scheduled:requeue_all_jobs)
-- [Run in Staging Jenkins](https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:scheduled:requeue_all_jobs)
-
-Historically, this error has happened in the staging and integration
-environments, after the nightly [data sync](/manual/govuk-env-sync.html).
-We [no longer spawn scheduling workers](https://github.com/alphagov/govuk-puppet/pull/10842)
-for Whitehall on Staging and Integration, so this will no longer affect
-those environments. The alert and rake task fix could still prove useful
-on Production.
-
-If we find this never happens on Production, we should remove the alert
-altogether (from govuk-puppet and from [Whitehall](https://github.com/alphagov/whitehall/pull/5882)),
-and delete this manual.
+See: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -51,3 +51,21 @@ These documents cannot be published and will cause a
 
 The situation is likely to be re-created the next day by the above process on
 the same documents/editions.
+
+## 'scheduled publications in Whitehall not queued'
+
+This alert means that the number of editions in the database which are
+scheduled to be published in the future is different from the number currently
+in the queue.
+
+Run the `publishing:scheduled:requeue_all_jobs` Rake task to requeue all
+scheduled editions:
+
+<%= RunRakeTask.links("whitehall", "publishing:scheduled:requeue_all_jobs") %>
+
+Historically, this error has happened in the staging and integration
+environments, after the nightly [data sync](/manual/govuk-env-sync.html).
+We [no longer spawn scheduling workers](https://github.com/alphagov/govuk-puppet/pull/10842)
+for Whitehall on Staging and Integration, so this will no longer affect
+those environments. The alert and rake task fix could still prove useful
+on Production.


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/10963, we added a new healthcheck for the number of scheduled documents that are not queued. The end goal is to remove this from the generic Whitehall app healthcheck, so updating the documentation in preparation for this.

Trello card: https://trello.com/c/UAbbL13x