### PR TITLE
Flag Service Manual Frontend as CD

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -263,6 +263,7 @@
   puppet_name: smartanswers
   production_hosted_on: aws
 - github_repo_name: service-manual-frontend
+  continuously_deployed: true
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   type: Frontend apps


### PR DESCRIPTION
Dependant on the other PRs contained within [this
ticket](https://trello.com/c/zu7IYR6C/2385-enable-continuous-deployment-for-service-manual-frontend).

Trello:
https://trello.com/c/zu7IYR6C/2385-enable-continuous-deployment-for-service-manual-frontend