### PR TITLE
Correct the 'Writing Pact tests' section & add 'Updating' section

### DIFF
--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -76,8 +76,21 @@ This has to be done in several stages:
 1. Write the provider pact ([example](https://github.com/alphagov/frontend/pull/2643)).
   - You'll need to write these two in conjunction with each other.
 1. Merge both of the above PRs.
-1. Configure the consumer to test against the provider as part of its deployment pipeline ([example](https://github.com/alphagov/frontend/pull/2644)).
-  - You'll need to provide a way of testing against different branches of the provider, so that changes can be made to the API in future. See the example PR above.
+1. Configure the provider to test against the default branch of the consumer as part of its deployment pipeline ([example](https://github.com/alphagov/frontend/pull/2644)).
+  - You'll need to expose this as a rake task that takes a branch argument (see the example PR above). This is needed in the next step.
 1. Merge.
-1. Configure the provider to test against the consumer as part of its deployment pipeline ([example](https://github.com/alphagov/gds-api-adapters/pull/1036)).
+1. Configure the consumer to test against the provider as part of its deployment pipeline, using the rake task defined above ([example](https://github.com/alphagov/gds-api-adapters/pull/1036)).
 1. Merge.
+
+### Updating Pact tests
+
+Due to the co-dependent nature of Pact providers and consumers, changes need to be made in a particular order:
+
+1. Make the change to the API (your provider, e.g. Frontend), in a branch.
+  - Its build should fail at the Pact test stage, because it is testing against the default branch of the consumer.
+1. Make the change to the pactfile in the consumer (e.g. gds-api-adapters), in a branch.
+  - Its build should fail at the Pact test stage, because it is testing against the default branch of the provider.
+1. Run a parameterised build of the consumer, specifying the new branch name of the provider to test against.
+  - The build should pass.
+  - It should also be possible to [test this locally, if your provider is set up to do so](https://github.com/alphagov/frontend/blob/master/CONTRIBUTING.md#pact-tests).
+1. Merge the consumer PR, followed by the provider PR.


### PR DESCRIPTION
I'd gotten my provider and consumer mixed up in #2982.
I've also added a section on changing the Provider's API, which
needs to be co-ordinated in a particular way.