### PR TITLE
Adds govuk_app_config to list of applications

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -370,6 +370,12 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+- github_repo_name: govuk_app_config
+  team: "#govuk-developers"
+  production_hosted_on: none
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 - github_repo_name: govuk-content-schemas
   app_name: govuk-content-store-examples
   management_url: https://dashboard.heroku.com/apps/govuk-content-store-examples
@@ -394,6 +400,8 @@
   team: "#govuk-developers"
   production_hosted_on: none
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 - github_repo_name: govuk-puppet
   team: "#govuk-developers"
   production_hosted_on: none


### PR DESCRIPTION
This will import useful things such as the health check document: https://github.com/alphagov/govuk_app_config/blob/master/docs/healthchecks.md

Have also added the missing `sentry_url`/`dashboard_url` overrides for govuk-docker.