### PR TITLE
Link to 307/406 special cases in govuk-cdn-config

### DIFF
--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -45,7 +45,7 @@ We also set a grace period of 24 hours. So if the homepage server is down, we'll
 
 These are the GET request status codes that Varnish caches automatically: 200, 203, 300, 301, 302, 404 or 410. (See the [Varnish docs](https://varnish-cache.org/docs/2.1/reference/vcl.html#variables) for more detail.)
 
-We have added to these - see the [GOV.UK CDN Config repo](https://github.com/alphagov/govuk-cdn-config/) VCL for special handling of certain status codes, and for the most up-to-date version of what we're running in Fastly. Refer to the Varnish 2.1 documentation when looking at the VCL code.
+We have added to these - see the [GOV.UK CDN Config repo](https://github.com/alphagov/govuk-cdn-config/) VCL for [special handling of certain status codes](https://github.com/alphagov/govuk-cdn-config/blob/c37856f5cb463d204ef3926828f35204721eb7e9/vcl_templates/www.vcl.erb#L408-L416), and for the most up-to-date version of what we're running in Fastly. Refer to the Varnish 2.1 documentation when looking at the VCL code.
 
 ### Conditional request caching
 


### PR DESCRIPTION
I think it's helpful to refer devs to the specific lines of code where overrides happen.