### PR TITLE
Remove duplicate link in header

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,7 +11,6 @@ description: Technical documentation for developers working on GOV.UK in GDS
 show_review_banner: false
 
 header_links:
-  Dashboard: /
   Get started: /manual/get-started.html
   Apps: /apps.html
   Manual: /manual.html


### PR DESCRIPTION
There's already a link to `/` in the header (The main "GOV.UK Developer docs" link).

Having the same link in the header twice was flagged as an accessibility issue in [a recent audit of the tech docs template](https://docs.google.com/spreadsheets/d/1s53eGMBj2hdTVLRitwi673R-_uERWh0kOxOp9QsOVg0/edit#gid=0). This can't be fixed in the gem, but we can fix it in our docs.

Also what does "Dashboard" even mean in this context?

This might [break some people's workflows](https://xkcd.com/1172/). Happy to discuss removing the other link instead, or keeping both and ignoring the reported accessibility issue.