### PR TITLE
Update rubocop-govuk to 4.0.0.pre.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "html-pipeline"
 gem "kramdown"
 gem "mdl"
 
-gem "govuk_publishing_components", "~> 24.5"
+gem "govuk_publishing_components"
 gem "govuk_schemas"
 
 # GitHub API

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "capybara"
 gem "ffi"
 gem "rake"
 gem "rspec"
-gem "rubocop-govuk"
+gem "rubocop-govuk", "4.0.0.pre.1", require: false # Trialling pre-release
 gem "simplecov"
 gem "webmock"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,7 @@ DEPENDENCIES
   faraday_middleware
   ffi
   git
-  govuk_publishing_components (~> 24.5)
+  govuk_publishing_components
   govuk_schemas
   govuk_tech_docs
   html-pipeline

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,31 +330,32 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (0.87.1)
+    rubocop (1.10.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.1.0, < 1.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.8.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    rubocop-govuk (3.17.2)
-      rubocop (= 0.87.1)
-      rubocop-ast (= 0.8.0)
-      rubocop-rails (= 2.8.1)
+    rubocop-govuk (4.0.0.pre.1)
+      rubocop (~> 1.10.0)
+      rubocop-ast (~> 1.4.0)
+      rubocop-rails (~> 2.9.1)
       rubocop-rake (= 0.5.1)
-      rubocop-rspec (= 1.42.0)
-    rubocop-rails (2.8.1)
+      rubocop-rspec (~> 2.2.0)
+    rubocop-rails (2.9.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.87.0)
+      rubocop (>= 0.90.0, < 2.0)
     rubocop-rake (0.5.1)
       rubocop
-    rubocop-rspec (1.42.0)
-      rubocop (>= 0.87.0)
+    rubocop-rspec (2.2.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-enum (0.9.0)
       i18n
     ruby-progressbar (1.11.0)
@@ -391,7 +392,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
     unicorn (5.8.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -428,7 +429,7 @@ DEPENDENCIES
   octokit
   rake
   rspec
-  rubocop-govuk
+  rubocop-govuk (= 4.0.0.pre.1)
   simplecov
   webmock
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run RuboCop"
 task :lint, :environment do
-  sh "bundle exec rubocop --format clang"
+  sh "bundle exec rubocop"
 end
 
 desc "Run Markdownlint"

--- a/app/developer_docs_renderer.rb
+++ b/app/developer_docs_renderer.rb
@@ -3,7 +3,7 @@ require_relative "./string_to_id"
 class DeveloperDocsRenderer < GovukTechDocs::TechDocsHTMLRenderer
   def header(text, header_level)
     anchor = StringToId.convert(text)
-    tag = "h" + header_level.to_s
+    tag = "h#{header_level}"
     "<#{tag} id='#{anchor}'>#{text}</#{tag}>"
   end
 end

--- a/app/document_types.rb
+++ b/app/document_types.rb
@@ -6,7 +6,7 @@ class DocumentTypes
     known_from_search = facet_query.dig("facets", "content_store_document_type", "options").map do |o|
       Page.new(
         name: o.dig("value", "slug"),
-        total_count: o.dig("documents"),
+        total_count: o["documents"],
         examples: o.dig("value", "example_info", "examples"),
       )
     end

--- a/app/document_types_csv.rb
+++ b/app/document_types_csv.rb
@@ -22,7 +22,7 @@ class DocumentTypesCsv
       csv << row
 
       @pages.each do |page|
-        example_url = page.examples.first ? "https://www.gov.uk" + page.examples.first["link"] : nil
+        example_url = page.examples.first ? "https://www.gov.uk#{page.examples.first['link']}" : nil
 
         row = [
           page.name,

--- a/app/requires.rb
+++ b/app/requires.rb
@@ -6,5 +6,5 @@ require "json"
 
 CACHE = ActiveSupport::Cache::FileStore.new(".cache")
 
-Dir[File.dirname(__FILE__) + "/../lib/*.rb"].sort.each { |file| require file }
-Dir[File.dirname(__FILE__) + "/**/*.rb"].sort.each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/../lib/*.rb"].sort.each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/**/*.rb"].sort.each { |file| require file }

--- a/app/snippet.rb
+++ b/app/snippet.rb
@@ -1,7 +1,7 @@
 class Snippet
   def self.generate(html)
     body_text = html
-      .split("</h1>")[1..-1].join # make sure we skip anything before <h1>
+      .split("</h1>")[1..].join # make sure we skip anything before <h1>
       .gsub(/<h.+?>.+?<\/h.>/, "") # remove headings
       .gsub(/<\/?[^>]*>/, "") # remove other HTML but keep the contents
       .squish # remove whitespace

--- a/app/string_to_id.rb
+++ b/app/string_to_id.rb
@@ -3,8 +3,8 @@ class StringToId
     string
       .downcase # lower case
       .gsub(/<[^>]*>/, "") # crudely remove html tags
-      .gsub(/[^\w\-\. ]/, "") # remove any non-word, non-hyphen & non-period characters
-      .gsub(/[ \.]/, "-") # replace spaces & periods with hyphens
+      .gsub(/[^\w\-. ]/, "") # remove any non-word, non-hyphen & non-period characters
+      .gsub(/[ .]/, "-") # replace spaces & periods with hyphens
       .gsub(/-{2,}/, "-") # replace two (or more) subsequent hyphens with single hyphens
   end
 end

--- a/helpers/navigation_helpers.rb
+++ b/helpers/navigation_helpers.rb
@@ -1,7 +1,7 @@
 module NavigationHelpers
   def active_page?(page_path)
     (current_page.path == "index.html" && page_path == "/") ||
-      "/" + current_page.path == page_path ||
+      "/#{current_page.path}" == page_path ||
       current_page.data.parent == page_path
   end
 

--- a/helpers/properties_table_helpers.rb
+++ b/helpers/properties_table_helpers.rb
@@ -24,7 +24,8 @@ private
   def enums(attrs)
     return unless attrs["enum"]
 
-    "Allowed values: " + attrs["enum"].map { |value| "<code>#{value}</code>" }.join(", ")
+    values = attrs["enum"].map { |value| "<code>#{value}</code>" }
+    "Allowed values: #{values.join(', ')}"
   end
 
   def possible_types(attrs)

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require_relative "../../helpers/commit_helpers.rb"
+require_relative "../../helpers/commit_helpers"
 
 RSpec.describe CommitHelpers do
   let(:helper) { Class.new { extend CommitHelpers } }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,10 +31,4 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
-
-  class Date
-    def in_the_future?
-      self > Date.today
-    end
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/pqXbKZiC/215-test-rubocop-govuk-400pre1-prior-to-400-release

This bumps to the 4.0.0 pre release of rubocop-govuk which is part of [trialling the new rubocop-govuk release](https://github.com/alphagov/rubocop-govuk/issues/129). The gem pin to 4.0.0.pre.1 is intended to be removed once the final release of rubocop-govuk 4.0.0 is out.
