### PR TITLE
Remove or replace the use of "dummy"

### DIFF
--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -273,7 +273,7 @@ Rails application with practices such as:
 The conventional place to store secrets for a GOV.UK Rails application is
 `config/secrets.yml`. All production secrets should be populated with an
 environment variable; for dev and test environments it's preferred to leave
-a usable dummy default if an actual secret isn't needed
+a usable placeholder default if an actual secret isn't needed
 ([example][secrets-example]).
 
 We haven't migrated to using the [encrypted `config/credentials.yml.enc`

--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -466,7 +466,7 @@ If you see this error:
 ```
 
 Check that your GPG configuration is sane. Try encrypting and decrypting
-some dummy text using the `gpg` command:
+some text using the `gpg` command:
 
 ```sh
 echo 'foo' | gpg --armor --encrypt --recipient matt.bostock@digital.cabinet-office.gov.uk | gpg --decrypt


### PR DESCRIPTION
This is to avoid the use of ableist language.

The use of "dummy" doesn't make the text any clearer and removing it or
replacing it with "placeholder" leaves the text as clear as before, but
more inclusive.

Some resources:
- https://developers.google.com/style/inclusive-documentation#ableist-language
- https://english.stackexchange.com/questions/337478/is-there-a-better-term-than-dummy-to-describe-a-non-functional-part-of-a-progr