### PR TITLE
Add the new `account-api` app to our docs

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -90,6 +90,10 @@
 
 # api
 
+- github_repo_name: account-api
+  type: APIs
+  team: "#govuk-accounts-tech"
+  production_hosted_on: aws
 - github_repo_name: content-store
   type: APIs
   team: "#govuk-platform-health"


### PR DESCRIPTION
This is a step in our documentation on [how to set up a new app][0].

[0]: https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html#puppet-dns-sentry-and-beyond

Trello card: https://trello.com/c/ZeAKl2SM/651-set-up-a-new-app