### PR TITLE
Explain that new repositories require github About

### DIFF
--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -227,6 +227,14 @@ How to test the app
 * Add the application to the [Deploy_App job][deploy-jenkins] in Jenkins (click Configure)
 * Run the [Deploy_App job][deploy-jenkins] using with `with_migrations` option to get started
 
+When adding your application to `data/application.yml` - ensure your new repository has
+a description set in the "About" section on github. This will be used to describe what your app
+is on the [application listings](https://docs.publishing.service.gov.uk/#applications) and is also
+required to render an application page.
+
+If you do not do this, you may see Middleman errors when the docs are building which reference
+attempts to modify a frozen empty string.
+
 ## Configuring the app for Jenkins
 
 Create a `Jenkinsfile` in your repo with the following content.


### PR DESCRIPTION
During setup of accounts-api we found CI errors and a very obscure stack
trace. It turns out the code is currently set up to expect that each
repo has an "About section". Without it the application listing renders
fine but shows up empty.

However the application page fails to render and there is an error
message when building pages with Middleman.

This was quite confusing, so until we can fix the code to fail more
gracefully or with a better warning, I have added a note for the next
folks who try and set up a repo.