### PR TITLE
Fix #2875 - local uncommitted files causing build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 Staticfile.auth
 coverage
+tmp

--- a/helpers/commit_helpers.rb
+++ b/helpers/commit_helpers.rb
@@ -2,18 +2,23 @@ require "git"
 
 module CommitHelpers
   def commit_url(current_page)
-    return "https://github.com/alphagov/#{current_page.data.app_name}/commit/#{current_page.data.latest_commit[:sha]}" if current_page.data.latest_commit
-
-    commit_sha = Git.open(".").log.path(source_file(current_page)).first.sha
-    "https://github.com/alphagov/govuk-developer-docs/commit/#{commit_sha}"
+    if current_page.data.latest_commit
+      "https://github.com/alphagov/#{current_page.data.app_name}/commit/#{current_page.data.latest_commit[:sha]}"
+    elsif local_commit(current_page)
+      "https://github.com/alphagov/govuk-developer-docs/commit/#{local_commit(current_page).sha}"
+    else
+      "#"
+    end
   end
 
   def last_updated(current_page)
     # e.g. "2020-09-03 09:53:56 UTC"
     if current_page.data.latest_commit
       Time.parse(current_page.data.latest_commit[:timestamp].to_s)
+    elsif local_commit(current_page)
+      Time.parse(local_commit(current_page).author_date.to_s)
     else
-      Time.parse(Git.open(".").log.path(source_file(current_page)).first.author_date.to_s)
+      Time.now
     end
   end
 
@@ -25,5 +30,9 @@ private
 
   def source_file(current_page)
     "source/#{current_page.file_descriptor.relative_path}"
+  end
+
+  def local_commit(current_page)
+    Git.open(".").log.path(source_file(current_page)).first
   end
 end

--- a/spec/helpers/commit_helpers_spec.rb
+++ b/spec/helpers/commit_helpers_spec.rb
@@ -3,6 +3,11 @@ require_relative "../../helpers/commit_helpers.rb"
 
 RSpec.describe CommitHelpers do
   let(:helper) { Class.new { extend CommitHelpers } }
+  let(:uncommitted_file) do
+    path_to_file = "tmp/tmp.md"
+    File.write(path_to_file, "new uncommitted file")
+    path_to_file
+  end
 
   describe "#commit_url" do
     it "returns the commit_url associated with the page data, if that exists" do
@@ -27,6 +32,14 @@ RSpec.describe CommitHelpers do
         /https:\/\/github.com\/alphagov\/govuk-developer-docs\/commit\/[0-9a-f]{40}$/,
       )
     end
+
+    it "returns # if the file hasn't been committed yet" do
+      current_page = OpenStruct.new(
+        data: OpenStruct.new,
+        file_descriptor: OpenStruct.new(relative_path: uncommitted_file),
+      )
+      expect(helper.commit_url(current_page)).to eq("#")
+    end
   end
 
   describe "#last_updated" do
@@ -46,6 +59,14 @@ RSpec.describe CommitHelpers do
         file_descriptor: OpenStruct.new(relative_path: source_file),
       )
       expect(helper.last_updated(current_page)).to be_a_kind_of(Time)
+    end
+
+    it "returns the current time if the file hasn't been committed yet" do
+      current_page = OpenStruct.new(
+        data: OpenStruct.new,
+        file_descriptor: OpenStruct.new(relative_path: uncommitted_file),
+      )
+      expect(helper.last_updated(current_page).to_i).to eq(Time.now.to_i)
     end
   end
 


### PR DESCRIPTION
When creating a file locally, before it has been committed to
version control, if we attempt to build and view the Developer
Docs we see errors such as
```
NoMethodError: undefined method `author_date' for nil:NilClass
```

This is because the code tries to find the last commit associated
with the file, in order to render the 'Last updated' banner. There
is no commit yet, so it errors.

To avoid complicating the 'last_updated' partial with a conditional,
I've gone down the polymorphic route of "it should be able to
render something, even if no data exists". This commit ensures
that today's date is used as the last updated date, and the link
is to nowhere ("#").

This is only an issue on the developer's local machine while
they're developing. It is never an issue on production or on CI,
by which time all files in the build have been committed.

Trello: https://trello.com/c/wrC4T1cr/220-creating-or-moving-a-page-gives-a-nil-parsing-error