### PR TITLE
Fix links for a manual to request TLS certs

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -195,4 +195,4 @@ The transition checklist covers the whole process of transitioning a site from t
 [Transition]: /apps/transition.html
 [Bouncer]: /apps/bouncer.html
 [transition-config]: https://github.com/alphagov/transition-config/blob/master/README.md
-[request a Fastly TLS certificate]: /request-fastly-tls-certificate.html
+[request a Fastly TLS certificate]: /manual/request-fastly-tls-certificate.html

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -145,4 +145,4 @@ Follow the guidance to [request a Fastly TLS certificate][].
 [govuk-cdn-config]: https://github.com/alphagov/govuk-cdn-config
 [Bouncer_CDN job]: https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/
 [hosts from transition]: https://transition.publishing.service.gov.uk/hosts.json
-[request a Fastly TLS certificate]: /request-fastly-tls-certificate.html
+[request a Fastly TLS certificate]: /manual/request-fastly-tls-certificate.html


### PR DESCRIPTION
It seems the source document was moved into a "manual" section so old links do not work at the moment. 