### PR TITLE
Update link to Special Route Publisher's Jenkins task

### DIFF
--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -12,4 +12,7 @@ The [Special Route Publisher](https://github.com/alphagov/special-route-publishe
 
 All new special routes should be created in this tool, and existing special routes should be moved as necessary.
 
-The [Publish special routes Jenkins job](https://deploy.blue.staging.govuk.digital/job/Publish_Special_Routes/) will re-publish all defined special routes to the Publishing API.
+There are two Jenkins jobs to publish special routes:
+
+- Publish a single special route: [Integration](https://deploy.integration.publishing.service.gov.uk/job/Publish_Single_Special_Route/), [Staging](https://deploy.blue.staging.govuk.digital/job/Publish_Single_Special_Route/) and [Production](https://deploy.blue.production.govuk.digital/job/Publish_Single_Special_Route/).
+- Publish all special routes: [Integration](https://deploy.integration.publishing.service.gov.uk/job/Publish_Special_Routes/), [Staging](https://deploy.blue.staging.govuk.digital/job/Publish_Special_Routes/) and [Production](https://deploy.blue.production.govuk.digital/job/Publish_Special_Routes/).


### PR DESCRIPTION
This previously linked to the "publish all special routes" task in staging. Updating to link to both available tasks in all environments.

Trello card:  https://github.com/alphagov/govuk-developer-docs/pull/new/update-special-routes