### PR TITLE
Switch to Redcarpet for Markdown parsing, and fix shortcut reference link bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,5 @@ updates:
         dependency-type: direct
       - dependency-name: octokit
         dependency-type: direct
-      - dependency-name: kramdown
+      - dependency-name: redcarpet
         dependency-type: direct

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,2 @@
+rulesets ["#{File.dirname(__FILE__)}/mdl/rules.rb"]
 style "#{File.dirname(__FILE__)}/markdown_lint.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "middleman-search_engine_sitemap"
 
 gem "git"
 gem "html-pipeline"
-gem "kramdown"
 gem "mdl"
 
 gem "govuk_publishing_components"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_tech_docs
   html-pipeline
-  kramdown
   mdl
   middleman
   middleman-search_engine_sitemap

--- a/config.rb
+++ b/config.rb
@@ -3,8 +3,6 @@ require_relative "./app/requires"
 
 GovukTechDocs.configure(self)
 
-set :markdown_engine, :kramdown
-
 set :markdown,
     renderer: DeveloperDocsRenderer.new(
       with_toc_data: true,
@@ -12,7 +10,6 @@ set :markdown,
       context: self,
     ),
     fenced_code_blocks: true,
-    input: "GFM",
     tables: true,
     no_intra_emphasis: true,
     hard_wrap: false

--- a/mdl/rules.rb
+++ b/mdl/rules.rb
@@ -1,0 +1,7 @@
+rule "MY001", "No parentheses allowed after shortcut reference link (use collapsed reference link instead, e.g. `[foo]` => `[foo][]`)" do
+  aliases "no-parentheses-after-shortcut-reference-link"
+  check do |doc|
+    # matches `[foo] (bar)`, doesn't match `[foo][baz] (bar)`
+    doc.matching_lines(/ \[[^\]]+\] \(/)
+  end
+end

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -246,7 +246,7 @@ of 'router'. You can swap `www` for `draft-origin` to view the draft stack at
 origin. The draft stack is not IP-restricted, as we need to be able to share
 links to be reviewed ("2i'd") or fact-checked by non-Government departments.
 It is, however, only visible to users who have been verified through
-Authenticating Proxy, by signing into [signon] (an authentication and
+Authenticating Proxy, by signing into [signon][] (an authentication and
 authorisation portal) or by providing a valid `auth_bypass_id` (as a URI
 parameter or session cookie). Read more about previews in ["How the draft stack works"].
 

--- a/source/manual/howto-find-hardcoded-markup-govspeak.html.md
+++ b/source/manual/howto-find-hardcoded-markup-govspeak.html.md
@@ -10,7 +10,7 @@ Usually to find usage of markup we can look in our source code.
 
 For example if we wanted to see which templates use a class called 'button' you could search in GitHub.
 
-However [GovSpeak] (our variant of Markdown) includes markup such as buttons that will be in published content.
+However [GovSpeak][] (our variant of Markdown) includes markup such as buttons that will be in published content.
 
 So, with this in mind you'll need to search all published content.
 


### PR DESCRIPTION
In a9905710c83097b0cebd1e7cbe1a94c64b167fda, we swapped out Redcarpet for Kramdown, as Redcarpet had an [issue parsing shortcut reference links](https://github.com/vmg/redcarpet/issues/471).

However, tech_docs_gem uses Redcarpet for its markdown parsing, and there has been a lot of work recently to improve the
accessibility of its output, so our override was preventing us from benefiting from these improvements.

In this PR, I've removed Kramdown and the Developer Docs uses Redcarpet for its markdown engine, which gives us the accessibility improvements we wanted. I've also added a custom Markdown Lint rule to find and report any occurrences of shortcut reference links followed by parentheses, which exhibit the bug (screenshot of bug below):

> ![](https://user-images.githubusercontent.com/5111927/112168271-0dcb4c00-8be9-11eb-9235-026c68af1019.png)

This PR was raised for https://trello.com/c/eTzcjz5u/2422-3-update-govuk-developer-docs-re-accessibility-by-end-march, to enable accessibility improvements on the Developer Docs.

