### PR TITLE
Update data gov uk 2ndline notes for CKAN 2.9

### DIFF
--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -226,6 +226,42 @@ Publishers upload their organograms as a Excel (XLS) file that contains macros. 
 
 It is possible to access analytics for datasets. If a user requests analytics for datasets, we can provide them with access to an analytics dashboard. Assign tickets like this to Martin Lugton or another member of the Platform Health product team.
 
+## Differences in CKAN 2.9 vs 2.7/2.8
+
+If a publisher is attempting to access data directly via the use of the CKAN API endpoints they might encounter problems processing the response:
+
+- V1 of the API endpoint has been dropped - https://github.com/ckan/ckan/blob/ckan-2.9.2/CHANGELOG.rst#v280-2018-05-09
+
+This means that the extras block in some cases has been flattened, this was the previous response:
+
+>     {
+>      "id": "<package id>",
+>      ...
+>      "extras": {
+>         "harvest_object_id": "<harvest object id>",
+>         "contact-name": "Example User",
+>         "harvest_source_title": "example harvest #1",
+>         "harvest_source_id": "<harvest source id>"
+>       }
+>     }
+
+In 2.9 the response looks like this:
+
+>     {
+>      "id": "<package id>",
+>      ...
+>      "harvest_object_id": "<harvest object id>",
+>      "contact-name": "Example User",
+>      "harvest_source_title": "example harvest #1",
+>      "harvest_source_id": "<harvest source id>"
+>     }
+
+- Accepted Solr params for dataset / package searching has changed:
+  - `limit` and `offset` have been replaced by `rows` and `start` respectively.
+  - `all_fields` is no longer supported and will cause an error response.
+
+- The `revision_id` is also no longer available, although this has long been deprecated for a number of reasons by the CKAN team - https://github.com/ckan/ckan/issues/3484.
+
 ## Revision log
 
 There is a [revision log](https://ckan.publishing.service.gov.uk/revision) which shows the most recent edits to CKAN datasets, harvester and users performed by all users.

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -262,7 +262,7 @@ In 2.9 the response looks like this:
   - `limit` and `offset` have been replaced by `rows` and `start` respectively.
   - `all_fields` is no longer supported and will cause an error response.
 
-- The `revision_id` is also no longer available, although this has long been deprecated for a number of [reasons](ckan-issue) by the CKAN team.
+- The `revision_id` is also no longer available, although this has long been deprecated for a number of [reasons][ckan-issue] by the CKAN team.
 
 ## Revision log
 

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -258,7 +258,7 @@ In 2.9 the response looks like this:
 >      "harvest_source_id": "<harvest source id>"
 >     }
 
-- Accepted Solr params for dataset / package searching has changed:
+- Accepted Solr params for dataset / package searching have changed:
   - `limit` and `offset` have been replaced by `rows` and `start` respectively.
   - `all_fields` is no longer supported and will cause an error response.
 

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -232,7 +232,7 @@ It is possible to access analytics for datasets. If a user requests analytics fo
 
 If a publisher is attempting to access data directly via the use of the CKAN API endpoints they might encounter problems processing the response:
 
-- V1 of the API endpoint has been [dropped](v1-endpoint)
+- V1 of the API endpoint has been [dropped][v1-endpoint]
 
 This means that the extras block in some cases has been flattened, this was the previous response:
 

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -10,6 +10,8 @@ parent: "/manual.html"
 [dgu-docs]: https://guidance.data.gov.uk
 [find]: apps/datagovuk_find
 [publish]: apps/datagovuk_publish
+[v1-endpoint]: https://github.com/ckan/ckan/blob/ckan-2.9.2/CHANGELOG.rst#v280-2018-05-09
+[ckan-issue]: https://github.com/ckan/ckan/issues/3484
 
 This document details some of the requests that GOV.UK 2nd line support may receive regarding data.gov.uk.  [Separate documentation][dgu-docs] exists for publishers.
 
@@ -230,7 +232,7 @@ It is possible to access analytics for datasets. If a user requests analytics fo
 
 If a publisher is attempting to access data directly via the use of the CKAN API endpoints they might encounter problems processing the response:
 
-- V1 of the API endpoint has been dropped - https://github.com/ckan/ckan/blob/ckan-2.9.2/CHANGELOG.rst#v280-2018-05-09
+- V1 of the API endpoint has been [dropped](v1-endpoint)
 
 This means that the extras block in some cases has been flattened, this was the previous response:
 
@@ -260,7 +262,7 @@ In 2.9 the response looks like this:
   - `limit` and `offset` have been replaced by `rows` and `start` respectively.
   - `all_fields` is no longer supported and will cause an error response.
 
-- The `revision_id` is also no longer available, although this has long been deprecated for a number of reasons by the CKAN team - https://github.com/ckan/ckan/issues/3484.
+- The `revision_id` is also no longer available, although this has long been deprecated for a number of [reasons](ckan-issue) by the CKAN team.
 
 ## Revision log
 

--- a/source/manual/data-gov-uk-monitoring.html.md
+++ b/source/manual/data-gov-uk-monitoring.html.md
@@ -8,9 +8,6 @@ parent: "/manual.html"
 [publish]: apps/datagovuk_publish
 [operating-dgu]: /manual/data-gov-uk-operations.html
 [find]: apps/datagovuk_find
-[paas-metric-exporter]: https://reliability-engineering.cloudapps.digital/manuals/set-up-paas-metric-exporter-with-prometheus.html#configure-container-metrics
-[grafana]: https://grafana-paas.cloudapps.digital/d/rk9fSapik/data-gov-uk-2nd-line?orgId=1
-[grafana-app-dashboard]: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
 [sentry]: https://sentry.io/govuk/
 [logit-paas]: https://docs.cloud.service.gov.uk/#set-up-the-logit-io-log-management-service
 [logit]: https://logit.io/a/1c6b2316-16e2-4ca5-a3df-ff18631b0e74
@@ -18,17 +15,6 @@ parent: "/manual.html"
 [pagerduty]: https://govuk.pagerduty.com/
 [Pingdom]: /manual/pingdom.html
 [ckan]: apps/ckanext-datagovuk
-[dgu-queue-monitor]: https://github.com/alphagov/datagovuk_publish_queue_monitor
-[dgu-elastic-monitor]: https://github.com/alphagov/datagovuk_publish_elasticsearch_monitor
-[dgu-dashboard](https://grafana-paas.cloudapps.digital/d/rk9fSapik/data-gov-uk-2nd-line?orgId=1)
-
-## Prometheus
-
-There are two dashboards: [DGU for 2nd line][grafana] displays a summary overview of key stats (including queue length), and [DGU Apps Dashboard][grafana-app-dashboard] which shows the health of each app deployment (a drop-down menu on the dashboard allows the PaaS app to be selected).
-
-Metrics are exposed to Prometheus through a `/metrics` endpoint from the PaaS-team maintained [paas-metric-exporter] app.  This provides separate stats for each app running in the DGU space on the PaaS.
-
-Two additional apps expose `/metrics` endpoints which summarise the state of various parts of data.gov.uk.  These are [datagovuk_publish_queue_monitor][dgu-queue-monitor] for the state of the Sidekiq queues used to sync data between CKAN and Publish, and [datagovuk-publish-elasticsearch-monitor][dgu-elastic-monitor] for monitoring the Elasticsearch indices.
 
 ## Pingdom
 
@@ -41,10 +27,6 @@ Two additional apps expose `/metrics` endpoints which summarise the state of var
 ## Log.it
 
 Each application sends logs to [Logit]. [Publish] and [Find] use the corresponding [PaaS Service][logit-paas]. Example query: `source_host: "gds-data-gov-uk.data-gov-uk.find-data-beta" && access.response_code: 500`.
-
-## Data.gov.uk production dashboard
-
-You can view the [DGU dashboard](https://grafana-paas.cloudapps.digital/d/rk9fSapik/data-gov-uk-2nd-line?orgId=1) to get an overview of DGU that includes Find 4xx and 5xx, Publish elasticsearch index size and Sidekiq metrics.
 
 ## Sidekiq ([Publish])
 

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -45,15 +45,14 @@ First check to see if it is possible to complete the task through the [web inter
 (credentials are available in the `govuk-secrets` password store, under `datagovuk/ckan`).
 
 For commands not available via the user interface you must connect to the server to perform these
-tasks.  Most of the commands to interact with [CKAN] use a tool called `paster`.  Many of these
+tasks.  Most of the commands to interact with [CKAN] use the `ckan` CLI.  Many of these
 commands take a path to the config file with the `-c` option, which is located at `/var/ckan/ckan.ini`
 in our deployments.
 
-On GOV.UK servers `paster` should be run with:
+On GOV.UK servers `ckan` should be run with:
 
 ```
-cd /var/apps/ckan
-sudo -u deploy govuk_setenv ckan venv/bin/paster [COMMAND] -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan -c /var/ckan/ckan29.ini [COMMAND]
 ```
 
 ### Initialising the database
@@ -63,9 +62,8 @@ The following commands will create the relevant schema for core CKAN and the har
 extension on integration.
 
 ```
-. /var/apps/ckan/venv/bin/activate
-paster --plugin=ckan db init -c /var/ckan/ckan.ini
-paster --plugin=ckanext-harvest harvester initdb -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan -c /var/ckan/ckan29.ini db init
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan -c /var/ckan/ckan29.ini harvester initdb
 ```
 
 ### Accessing the database
@@ -132,7 +130,7 @@ https://data.gov.uk/api/3/action/user_show?id=user_d484581
 ### Creating a system administrator account
 
 ```
-paster --plugin=ckan sysadmin add USERNAME email=EMAIL_ADDRESS -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan -c /var/ckan/ckan29.ini sysadmin add USERNAME email=EMAIL_ADDRESS
 ```
 
 You will be prompted twice for a password.
@@ -140,7 +138,7 @@ You will be prompted twice for a password.
 ### Removing a system administrator account
 
 ```
-paster --plugin=ckan sysadmin remove USERNAME -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan -c /var/ckan/ckan29.ini sysadmin remove USERNAME
 ```
 
 ### Managing users
@@ -148,31 +146,31 @@ paster --plugin=ckan sysadmin remove USERNAME -c /var/ckan/ckan.ini
 #### Listing users
 
 ```
-paster --plugin=ckan user list -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan user list
 ```
 
 #### Viewing a user
 
 ```
-paster --plugin=ckan user USERNAME -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan user show USERNAME
 ```
 
 #### Adding a user
 
 ```
-paster --plugin=ckan user add USERNAME email=EMAIL_ADDRESS -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan user add USERNAME email=EMAIL_ADDRESS
 ```
 
 #### Removing a user
 
 ```
-paster --plugin=ckan user remove USERNAME -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan user remove USERNAME
 ```
 
 #### Changing a user's password
 
 ```
-paster --plugin=ckan user setpass USERNAME -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan user setpass USERNAME
 ```
 
 ### Managing publishers
@@ -182,7 +180,7 @@ paster --plugin=ckan user setpass USERNAME -c /var/ckan/ckan.ini
 Change the name in the publisher page then reindex that publisher:
 
 ```
-paster --plugin=ckan search-index rebuild-publisher [PUBLISHER] -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan search-index rebuild [PUBLISHER]
 ```
 
 ### Managing datasets
@@ -205,7 +203,7 @@ Deleting a dataset:
 Purging a dataset:
 
 ```
-paster --plugin=ckan dataset purge DATASET_NAME -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan dataset purge DATASET_NAME
 ```
 
 There may be times when a large number of datasets must be deleted. This needs to be done on the CKAN machine, since [the deletion API is protected from external access][ckan-api-404]. Your API key is required, which can be obtained from your user profile on the web interface. Put a list of dataset slugs or GUIDs in a text file, with one dataset per line, then run the following.
@@ -248,13 +246,13 @@ to refresh the index, or rebuild it from scratch.
 Refresh the entire search index (this adds/removes datasets, but does not clear the index first):
 
 ```
-paster --plugin=ckan search-index rebuild -r -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan search-index rebuild -r
 ```
 
 Rebuild the entire search index (this deletes the index before re-indexing begins):
 
 ```
-paster --plugin=ckan search-index rebuild -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan search-index rebuild
 ```
 
 > Rebuilding the entire search index immediately removes all records from the search before re-indexing
@@ -265,7 +263,7 @@ paster --plugin=ckan search-index rebuild -c /var/ckan/ckan.ini
 Only reindex those packages that are not currently indexed:
 
 ```
-paster --plugin=ckan search-index -o rebuild -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan search-index -o rebuild
 ```
 
 ### `csw` endpoint
@@ -308,7 +306,7 @@ case it should fail or if the sync needs to happen sooner you can manually
 trigger the sync after Solr has been reindexed.
 
 ```sh
-$ paster --plugin=ckanext-spatial ckan-pycsw load -p /var/ckan/pycsw.cfg -u http://localhost:3220
+$ sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan ckan-pycsw load -p /var/ckan/pycsw.cfg -u http://localhost:3220
 ```
 
 ### Harvesting
@@ -322,7 +320,7 @@ Returns a list of currently running jobs.  This will contain the
 JOB_ID necessary to cancel jobs.
 
 ```
-paster --plugin=ckanext-harvest harvester jobs -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan harvester jobs
 ```
 
 It may be faster to run a SQL query to get the ID of a specific harvest job.
@@ -381,7 +379,7 @@ You can get the `JOB_ID` from the harvest dashboard under "Last Harvest Job" (or
 Then cancel the job by running:
 
 ```
-paster --plugin=ckanext-harvest harvester job_abort JOB_ID -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan harvester job-abort JOB_ID
 ```
 
 This can also be done by running SQL:
@@ -400,7 +398,7 @@ to purge the queues used in the various stages of harvesting
 > This command will empty the Redis queues
 
 ```
-paster --plugin=ckanext-harvest harvester purge_queues -c /var/ckan/ckan.ini
+sudo -u deploy govuk_setenv ckan /var/apps/ckan/venv3/bin/ckan harvester purge-queues
 ```
 
 #### Restarting the harvest service


### PR DESCRIPTION
## What 

Updated dev docs for support of CKAN 2.9 as the commands are different. 

Also removed grafana and prometheus sections and updated the deployment doc for github actions.

## Reference 

https://trello.com/c/iq6oz3CT/2412-investigate-why-ckan-api-response-extras-block-removed-and-fix-or-document-it
https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade