### PR TITLE
Add row headers to tables which have more than 2 columns

### DIFF
--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -25,7 +25,6 @@ We’ve also made the website text as simple as possible to understand.
 We know some parts of this website are not fully accessible.
 
 - Some links are broken.
-- Some tables are structured in an inaccessible way.
 - Some headings do not fit with the content that follows.
 - Some links do not clearly explain where they lead, or that they lead to external sites.
 - Some pages skip heading levels.
@@ -62,7 +61,6 @@ The content listed below is non-accessible for the following reasons.
 #### Non-compliance with the accessibility regulations
 
 - Some links are broken, which fails WCAG 2.1 success criterion 2.1.1 Keyboard.
-- Some tables are structured in a way that fails WCAG 2.1 success criteria 1.3.1 Info and Relationships and 1.3.2 Meaningful Sequence.
 - Some content uses emojis without alternative text, which fails WCAG 2.1 success criteria 1.1.1 Non-text Content.
 - Some headings do not fit with the content that follows, which fails WCAG 2.1 success criterion 2.4.6 Headings and Labels.
 - Some links do not clearly explain where they lead, or that they lead to external sites. This fails WCAG 2.1 success criteria 2.4.4 Link Purpose (In Context) and 2.4.4 Link Purpose (In Context).

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -11,7 +11,7 @@ separate applications. Most of them are built using [Ruby on Rails][rails].
 | Hosting | Count | Applications |
 | --- | --- | --- |
 <% Applications::hosters_descending.each do |id, name| %>
-| <%= name %> | <%= Applications::on_host(id).count %> | <%= Applications::on_host(id).map { |app| "[#{app.app_name}](/apps/#{app.app_name}.html)" }.join(", ") %> |
+| # <%= name %> | <%= Applications::on_host(id).count %> | <%= Applications::on_host(id).map { |app| "[#{app.app_name}](/apps/#{app.app_name}.html)" }.join(", ") %> |
 <% end %>
 
 ## Reuse this data

--- a/source/manual/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/pingdom-bouncer-canary-check.html.md
@@ -34,14 +34,13 @@ Possible causes of errors on the canary route include:
 The database tables checked by the canary route (in order) and the
 effect on requests for transitioned sites of errors when querying them:
 
-  Database table         | HTTP status codes for requests for transitioned sites | |
-  -----------------------| -------------------------------|-----------------------
-  table name             | when table inaccessible | when table missing data
-  `hosts`                | `500` for all requests | `404` for all requests
-  `sites`                | `500` for all requests | `500` for all requests
-  `mappings`             | `500` for most requests | `404` for most requests
-  `whitelisted_hosts`    | `500` for requests which should redirect to non-`*.gov.uk`/`*.mod.uk`/`*.nhs.uk` domains | `501` for those requests
-  `organisations`        | `500` for most requests which should<br>serve a 404 or 410 page | `500` for those requests
+| Database table name   | HTTP response when table inaccessible | HTTP response when table missing data |
+|-----------------------| --------------------------------------|---------------------------------------|
+| # `hosts`             | `500` for all requests  | `404` for all requests |
+| # `sites`             | `500` for all requests  | `500` for all requests |
+| # `mappings`          | `500` for most requests | `404` for most requests |
+| # `whitelisted_hosts` | `500` for requests which should redirect to non-`*.gov.uk`/`*.mod.uk`/`*.nhs.uk` domains | `501` for those requests |
+| # `organisations`     | `500` for most requests which should<br>serve a 404 or 410 page | `500` for those requests |
 
 There are other tables in the `transition_production` database but they
 are only used by Transition and not by Bouncer.


### PR DESCRIPTION
As per the guidance in the attached Trello card, tables with more than 2 columns should have a row-level header as well as the column headers.

There were only two tables that qualified in govuk-developer-docs. I took the opportunity to fix up the unsemantic table structure in https://docs.publishing.service.gov.uk/manual/pingdom-bouncer-canary-check.html

Before:

> <img width="785" alt="Screenshot 2021-03-24 at 09 27 46" src="https://user-images.githubusercontent.com/5111927/112286464-415ab480-8c83-11eb-81fd-8b725e419027.png">


After:

> <img width="789" alt="Screenshot 2021-03-24 at 09 27 52" src="https://user-images.githubusercontent.com/5111927/112286480-4586d200-8c83-11eb-9ccb-b864b8bbe2a6.png">


Trello: https://trello.com/c/eTzcjz5u/2422-3-update-govuk-developer-docs-re-accessibility-by-end-march