### PR TITLE
Fix rendering of app pages

### DIFF
--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -42,7 +42,7 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/ap
       value: partial("partials/application/links"),
     },
   ].reject(&:nil?),
-) %>
+).strip %>
 
 <% if manual.pages_for_application(application.app_name).any? %>
 ## Relevant manual pages


### PR DESCRIPTION
In 21b47c9a2ac6d4805fdaabd6a5480c706377cea3, we switched back to
Redcarpet for markdown rendering, removing the Kramdown dependency.

Redcarpet takes into account spacing when rendering HTML; if it
sees some indented HTML, it assumes it is markdown and attempts to
render it as a code block. This was leading to a very broken page:

> <img width="1056" alt="borked" src="https://user-images.githubusercontent.com/5111927/112299273-8c7ac480-8c8f-11eb-93ef-8011a73a57af.png">

We now call `.strip` to remove indentation from the output, which
fixes Redcarpet's parsing of the HTML:

> <img width="921" alt="good" src="https://user-images.githubusercontent.com/5111927/112299276-8dabf180-8c8f-11eb-8608-8c24ae27485d.png">