### PR TITLE
Remove fabric tasks from a few docs

### DIFF
--- a/source/manual/alerts/free-memory-warning-on-backend.html.md
+++ b/source/manual/alerts/free-memory-warning-on-backend.html.md
@@ -48,5 +48,5 @@ Sidekiq worker), restart it to reset the memory usage, and increase free memory
 on the host:
 
 ```sh
-$ fab $environment -H whitehall-backend-1.backend app.restart:whitehall-admin-procfile-worker
+sudo service whitehall-admin-procfile-worker restart
 ```

--- a/source/manual/alerts/free-memory-warning-on-backend.html.md
+++ b/source/manual/alerts/free-memory-warning-on-backend.html.md
@@ -35,15 +35,11 @@ memory.
 Once you've identified a Unicorn application with a memory leak, you can
 gracefully kill a Unicorn worker to reclaim some memory. Sending a `SIGQUIT` to
 the worker causes it to finish serving its current request then exit, the
-master will notice this and spawn a fresh worker. This Fabric task will kill
-the worker using the most memory:
+master will notice this and spawn a fresh worker.
 
 ```sh
-$ fab $environment -H backend-1.backend app.respawn_large_unicorns:APP-NAME
+sudo kill --signal QUIT <worker process>
 ```
-
-This will only kill the most bloated Unicorn worker, so you may need to run
-it multiple times if the alert persists.
 
 ### Restart other memory leaking apps
 

--- a/source/manual/alerts/goreplay.html.md
+++ b/source/manual/alerts/goreplay.html.md
@@ -47,10 +47,11 @@ If that's the case, make sure that the following file exists on the host:
 
 and that it is in a proper state (i.e. empty).
 
-If not, restart the GoReplay processes with the following Fabric command:
+If not, restart the GoReplay processes:
 
 ```sh
-fab $environment puppet_class:gor sdo:'rm /etc/govuk/env.d/FACTER_data_sync_in_progress' app.start:goreplay
+sudo rm /etc/govuk/env.d/FACTER_data_sync_in_progress
+sudo service goreplay start
 ```
 
 This will remove the file and restart GoReplay from all hosts running it.

--- a/source/manual/alerts/ntp-drift-too-high.html.md
+++ b/source/manual/alerts/ntp-drift-too-high.html.md
@@ -12,19 +12,22 @@ time synchronised with standard time servers on the Internet.
 The `ntpd.drift` file records the latest estimate of clock frequency error. If this value gets too high, this can be
 an indicator of large error between the system clock and the real time.
 
-```
-fab $environment -H jumpbox-1.management ntp.status
-fab $environment -H jumpbox-1.management ntp.resync
+SSH to the affected machine, then run:
+
+```bash
+sudo service ntp stop
+sudo ntpdate -B ntp.ubuntu.com
+sudo service ntp start
 ```
 
 > **Note**
 >
-> The fab script will try to slew the time offset, which means continually adding/subtracting little bits of time until
+> `ntpdate -B` will try to slew the time offset, which means continually adding/subtracting little bits of time until
 > the clock is in sync. This is in contrast to a step change, where the clock's time is just changed. Step changes
 > can cause - for example - log timestamp inconsistencies.
 >
-> According to the [`ntpdate` man page](https://www.freebsd.org/cgi/man.cgi?query=ntpdate&sektion=8), the slew forced
-> by the `-B` flag can take **hours** to gradually take effect.
+> According to the [`ntpdate` man page](https://www.freebsd.org/cgi/man.cgi?query=ntpdate&sektion=8), the slew can take
+> **hours** to gradually take effect.
 >
 > Additionally, the `ntpdate` functionality has been made available in the `ntpd` program. To resync an offset bigger than
 > 1000, you can run `sudo service ntp stop; sudo ntpd -gq; sudo service ntp start`.

--- a/source/manual/alerts/unicorn-herder.html.md
+++ b/source/manual/alerts/unicorn-herder.html.md
@@ -12,21 +12,27 @@ This alert means the Unicorn Herder process has disappeared for the
 named app, so the app is still running but we don't know about it and
 can't control it.
 
-At the moment, the fix is to run the [Fabric](/manual/tools.html#fabric-scripts)
-task `vm.bodge_unicorn` for that app. (The name of the task should give a clue
-as to why I say "At the moment".)
+To fix this, manually kill off the unicorn workers for the app and
+restart the herder process.
 
-Configure and activate your fabric environment as described in the
-[fabric-scripts README](https://github.com/alphagov/fabric-scripts/blob/master/README.md).
-
-Then run the `vm.bodge_unicorn` task for the affected machine and application:
+SSH into the affected machine and get the process ID of the unicorn
+master:
 
 ```bash
-# Replace the machine_ip with the host IP of the machine that is showing the
-# error in Icinga - e.g. ip-10-1-4-159.eu-west-1.compute.internal
-
-# Replace the app_name with the relevant app  - e.g whitehall
-fab $environment -H $machine_ip vm.bodge_unicorn:$app_name
+ps aux | grep "unicorn master" | grep "<app name>" | awk '{ print $2 }'
 ```
 
-Job done. The Nagios alert should clear within a few minutes.
+If there is no `unicorn master` process for the app, then it has
+crashed.
+
+Kill the process:
+
+```bash
+kill -9 <pid>
+```
+
+Then start the app again:
+
+```bash
+sudo service <app-name> start
+```

--- a/source/manual/alerts/varnish-port-not-responding.html.md
+++ b/source/manual/alerts/varnish-port-not-responding.html.md
@@ -18,7 +18,7 @@ an urgent alert as this might lead to 1/3 of user requests failing.
 To diagnose, check for messages like this:
 
 ```sh
-$ fab $environment -H cache-3.router sdo:'grep varnishd /var/log/messages'
+$ grep varnishd /var/log/messages
 [cache-3.router] out: Jul  7 00:17:02 cache-3 varnishd[1620]: Child (1630) died signal=3
 [cache-3.router] out: Jul  7 00:17:03 cache-3 varnishd[1620]: child (27973) Started
 [cache-3.router] out: Jul  7 00:17:25 cache-3 varnishd[1620]: Child (27973) said Child starts
@@ -30,7 +30,7 @@ You may see only one process called `/usr/sbin/varnishd` in the process table,
 with owner root. The child process if it exists will be owned by nobody:
 
 ```sh
-$ fab $environment -H cache-3.router do:'ps -ef | grep [/]usr/sbin/varnishd'
+$ ps -ef | grep [/]usr/sbin/varnishd
 [cache-3.router] out: root      8273     1  0 06:08 ?        00:00:00 /usr/sbin/varnishd -P /var/run/varnishd.pid -a :7999 -f /etc/varnish/default.vcl -T 127.0.0.1:6082 -t 900 -w 1,1000,120 -S /etc/varnish/secret -s malloc,5985M
 [cache-3.router] out: nobody    8277  8273  1 06:08 ?        00:03:52 /usr/sbin/varnishd -P /var/run/varnishd.pid -a :7999 -f /etc/varnish/default.vcl -T 127.0.0.1:6082 -t 900 -w 1,1000,120 -S /etc/varnish/secret -s malloc,5985M
 ```
@@ -39,7 +39,7 @@ Check whether there are any children of the current parent process (this check
 will fail where it succeeds below):
 
 ```sh
-$ fab $environment -H cache-3.router do:'/usr/lib/nagios/plugins/check_procs -c 1:1 -C 'varnishd' -p `< /var/run/varnishd.pid`'
+$ /usr/lib/nagios/plugins/check_procs -c 1:1 -C 'varnishd' -p `< /var/run/varnishd.pid`
 [cache-3.router] out: PROCS OK: 1 process with command name 'varnishd', PPID = 8273
 ```
 
@@ -57,7 +57,7 @@ host:cache* AND @fields.status:[500 TO 599]
 Restart Varnish on this machine:
 
 ```sh
-$ fab $environment -H cache-3.router cache.restart
+$ sudo /etc/init.d/varnish restart
 ```
 
 [logit]: /manual/logit.html


### PR DESCRIPTION
A lot of the fab tasks are one or two commands, and the only utility the script gives is not needing to SSH into a machine.

For those cases, just replace the task with the actual commands it runs.

I've left references to `fab` where the behaviour is quite complex (eg, [mysql.reset_slave](https://github.com/alphagov/fabric-scripts/blob/master/mysql.py#L105)), or where it's used to run a task across a `class` of machines.