### PR TITLE
Add link to Rake task for bulk retagging of Manuals

### DIFF
--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -145,7 +145,7 @@ order):
 | `New lead organisations` | The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations. |
 | `New supporting organisations` | The slugs of the new supporting organisations (separated by a comma). These will replace any existing organisations. |
 
-There is a similar [Rake task to change the organisations for Manuals][[manuals-bulk-update-organisation]]
+There is a similar [Rake task to change the organisations for Manuals][manuals-bulk-update-organisation].
 
 [whitehall-bulk-update-organisation]: https://github.com/alphagov/whitehall/blob/917085dca58fb58dbf65c7e226ad445cc1f27bdd/lib/tasks/data_hygiene.rake#L37
 [manuals-bulk-update-organisation]: https://github.com/alphagov/manuals-publisher/blob/master/lib/tasks/update_manual_organisation.rake

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -145,4 +145,7 @@ order):
 | `New lead organisations` | The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations. |
 | `New supporting organisations` | The slugs of the new supporting organisations (separated by a comma). These will replace any existing organisations. |
 
+There is a similar [Rake task to change the organisations for Manuals][[manuals-bulk-update-organisation]]
+
 [whitehall-bulk-update-organisation]: https://github.com/alphagov/whitehall/blob/917085dca58fb58dbf65c7e226ad445cc1f27bdd/lib/tasks/data_hygiene.rake#L37
+[manuals-bulk-update-organisation]: https://github.com/alphagov/manuals-publisher/blob/master/lib/tasks/update_manual_organisation.rake


### PR DESCRIPTION
This adds a link to the Rake task to change the organisations for Manuals. 