### PR TITLE
Updating republishing steps

### DIFF
--- a/source/manual/republishing-content.html.md
+++ b/source/manual/republishing-content.html.md
@@ -8,17 +8,31 @@ parent: "/manual.html"
 
 Sometimes it may be necessary to republish content to make it show up on the website. For example if we make an update to [govspeak][govspeak-repo] that would require us to re-render and save new HTML for content.
 
-This process varies per app.
+This process varies per app and requires
+
+- Connection to the [VPN][vpn] and
+- [Production access][production-access]
 
 ## Whitehall
 
-If the document is in Whitehall, there is a Rake task you can run.
+If the document is in Whitehall, there is a Rake task you can run:
 
 [`publishing_api:republish_document[slug]`][republish-whitehall-doc-jenkins]
 
 For organisations, run:
 
 [`publishing_api:republish_organisation[slug]`][republish-whitehall-org-jenkins]
+
+for document type, run:
+
+[`publishing_api:bulk_republish:document_type[DocumentClass]`][republish-whitehall-document-type-jenkins]
+
+For example:
+`/government/case-studies/alexander-dennis-maximum-capacity`
+`publishing_api:bulk_republish:document_type[CaseStudies]`
+
+You may wish to test first on Integration:
+[`publishing_api:bulk_republish:document_type[DocumentClass]`][republish-whitehall-document-type-jenkins-integration]
 
 ## Content Publisher
 
@@ -38,3 +52,7 @@ or you can resync all documents:
 [resync-all-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=resync:all
 [republish-whitehall-doc-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug]
 [republish-whitehall-org-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_organisation[slug]
+[republish-whitehall-document-type-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:bulk_republish:document_type[DocumentClass]
+[vpn]:https://docs.publishing.service.gov.uk/manual/vpn.html
+[republish-whitehall-document-type-jenkins-integration]:https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:bulk_republish:document_type[DocumentClass]
+[production-access]:https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html


### PR DESCRIPTION
## What

Adding some more Content for republishing 

## Why

[govspeak](https://github.com/alphagov/govspeak/pull/210) updates prompted to add more detail to documentation on how to republish - https://docs.publishing.service.gov.uk/manual/republishing-content.html