### PR TITLE
Add docs on accessing alphagov repos

### DIFF
--- a/source/manual/github.html.md.erb
+++ b/source/manual/github.html.md.erb
@@ -15,6 +15,10 @@ This can sometimes make it hard to find repositories that belong to our team. We
 GitHub "topics" to organise the repos. All repos owned by us should be tagged with
 [`govuk`](https://github.com/search?q=topic:govuk).
 
+If you are unable to access an alphagov repository you can contact the
+[GDS Github Owners Google group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-github-owners), where members of that group have superadmin access to give you permissions to
+contribute to a repo.
+
 We use [govuk-saas-config][] to configure our repositories.
 
 [alphagov]: https://github.com/alphagov


### PR DESCRIPTION
I wasn't sure if this was the best place to add this, suggestions are welcome!

Trello card: https://trello.com/c/mwVIeHl5/1101-document-access-to-inaccessible-alphagov-repos