### PR TITLE
Remove reference to broken tech docs template

### DIFF
--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -73,6 +73,6 @@ We plan to fix the accessibility issues in the content by the end of September 2
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 2 September 2020. It was last reviewed on 30 December 2020.
+This statement was prepared on 2 September 2020. It was last reviewed on 26 March 2021.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.

--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -67,11 +67,7 @@ The content listed below is non-accessible for the following reasons.
 - Some pages skip heading levels, which fails WCAG 2.1 success criteria 1.3.1 Info and Relationships, 2.4.1 Bypass Blocks and 2.4.6 Headings and Labels.
 - Some images do not have good alternative text or are missing alternative text, which fails WCAG 2.1 success criterion 1.1.1 Non-text Content.
 
-There are also parts of this documentation that are not accessible because of [issues caused by our Technical Documentation](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
-
 ## What we’re doing to improve accessibility
-
-We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
 We plan to fix the accessibility issues in the content by the end of September 2021.
 


### PR DESCRIPTION
This was fixed in https://github.com/alphagov/govuk-developer-docs/pull/3013 followed by https://github.com/alphagov/govuk-developer-docs/pull/3029.

Trello: https://trello.com/c/eTzcjz5u/2422-3-update-govuk-developer-docs-re-accessibility-by-end-march-5