### PR TITLE
Mark short-url-manager as continuously deployed

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -64,6 +64,7 @@
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: short-url-manager
+  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"


### PR DESCRIPTION
short-url-manager is now continuously deployed

[trello](https://trello.com/c/C5JUWz5s/2452-enable-continuous-deployment-for-short-url-manager-3)