### PR TITLE
Update the set up rails app content

### DIFF
--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -246,7 +246,7 @@ Link to the [MIT License][LICENCE].
 
 See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
 
-See the [GOV.UK Writing API reference documentation][https://www.gov.uk/guidance/writing-api-reference-documentation] for more information on API references.
+See the [GOV.UK Writing API reference documentation](https://www.gov.uk/guidance/writing-api-reference-documentation) for more information on API references.
 
 ## Prepare the Rails app to run in production
 
@@ -284,7 +284,7 @@ Open a pull request to add the Rails app to the [GOV.UK developer documentation 
 
 ### Ask GOV.UK 2nd line to update Sentry
 
-After you have added the Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support][mailto:2nd-line-support@digital.cabinet-office.gov.uk] to run the `update-project` task in [GOV.UK SaaS Config][govuk-saas-config] to update [Sentry][sentry].
+After you have added the Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support](mailto:2nd-line-support@digital.cabinet-office.gov.uk) to run the `update-project` task in [GOV.UK SaaS Config][govuk-saas-config] to update [Sentry][sentry].
 
 ### Add Rails app to Release app
 
@@ -298,4 +298,4 @@ Use the `with_migrations` option if your Rails app has a database.
 
 ### Add Rails app to GOV.UK Docker
 
-Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example GOV.UK Docker pull request][https://github.com/alphagov/govuk-docker/pull/465] for more information.
+Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example GOV.UK Docker pull request](https://github.com/alphagov/govuk-docker/pull/465) for more information.

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -16,151 +16,170 @@ parent: "/manual.html"
 [release]: https://release.publishing.service.gov.uk/applications
 [deploy-jenkins]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/
 [docs-applications]: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
+[get-started]: https://docs.publishing.service.gov.uk/manual/get-started.html
+[linting]: https://docs.publishing.service.gov.uk/manual/configure-linting.html
+[rails-conv]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html
+[naming]: https://docs.publishing.service.gov.uk/manual/naming.html
+[auto-config]: https://docs.publishing.service.gov.uk/manual/configure-github-repo.html#auto-configuration
+[app-list]: https://docs.publishing.service.gov.uk/#applications
 
+## Before you start
 
-___need to use docker to run these commands?___
+Before you create a Rails app, you must complete all steps in the [GOV.UK developer get started documentation](get-started).
 
-___where does unicorn as opposed to puma come in?___
+## Create a new Rails app
 
-___enable deployments to integration - continuous deployments?___
+1. To create a Rails app, go to your development space on your local machine and run the following in the command line:
 
-___Set up a deployment dashboard___
+    ```sh
+    rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage
+    ```
 
-___Switch on the app in staging and production environments___
+    The `--skip` commands excludes unneeded Rails plugins.
 
+1. Replace the Gemfile with the gems you need. The following code shows an example.
 
+    ```rb
+    source "https://rubygems.org"
 
+    gem "rails", "6.0.3.4"
 
-## Familiarise yourself with the conventions
+    gem "bootsnap",
+    gem "gds-api-adapters"
+    gem "gds-sso"
+    gem "govuk_app_config"
+    gem "govuk_publishing_components"
+    gem "pg"
+    gem "plek"
+    gem "uglifier"
 
-We have documented [conventions for Rails
-applications](/manual/conventions-for-rails-applications.html) and
-[conventions for naming applications](/manual/naming.html) in GOV.UK.
+    group :development do
+      gem "listen"
+    end
 
-## Bootstrapping a new application
+    group :test do
+      gem "simplecov"
+    end
 
-To create a rails app, run the following (skip uncommon stuff).
+    group :development, :test do
+      gem "byebug"
+      gem "govuk_test"
+      gem "rspec-rails"
+      gem "rubocop-govuk"
+    end
+    ```
 
-```sh
-rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage
-```
+1. Run `bundle && rails g rspec:install` to install all gems specified in the Gemfile and generate files used for testing.
 
-Replace the Gemfile with the gems you need. Here is an example.
+1. Delete `spec/rails_helper.rb`:
 
-```rb
-source "https://rubygems.org"
+    ```sh
+    rm spec/rails_helper.rb
+    ```
 
-gem "rails", "6.0.3.4"
+    Open up `spec_helper.rb` and replace its contents with the following:
 
-gem "bootsnap",
-gem "gds-api-adapters"
-gem "gds-sso"
-gem "govuk_app_config"
-gem "govuk_publishing_components"
-gem "pg"
-gem "plek"
-gem "uglifier"
+    ```rb
+    ## spec/spec_helper.rb
+    ENV["RAILS_ENV"] ||= "test"
 
-group :development do
-  gem "listen"
-end
+    require "simplecov"
+    SimpleCov.start "rails"
 
-group :test do
-  gem "simplecov"
-end
+    require File.expand_path("../../config/environment", __FILE__)
+    require "rspec/rails"
 
-group :development, :test do
-  gem "byebug"
-  gem "govuk_test"
-  gem "rspec-rails"
-  gem "rubocop-govuk"
-end
-```
+    Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+    GovukTest.configure
 
-Run `bundle && rails g rspec:install` and replace `spec/*helper.rb`.
+    RSpec.configure do |config|
+      config.expose_dsl_globally = false
+      config.infer_spec_type_from_file_location!
+      config.use_transactional_fixtures = true
+    end
+    ```
 
-```sh
-rm spec/rails_helper.rb
-```
+1. If your app has a database, replace the content of `config/database.yml` with the following:
 
-```rb
-## spec/spec_helper.rb
-ENV["RAILS_ENV"] ||= "test"
+    ```yaml
+    default: &default
+      adapter: postgresql
+      encoding: unicode
+      pool: 12
+      template: template0
 
-require "simplecov"
-SimpleCov.start "rails"
+    development:
+      <<: *default
+      database: <YOUR APP's NAME>_development
+      url: <%= ENV["DATABASE_URL"]%>
 
-require File.expand_path("../../config/environment", __FILE__)
-require "rspec/rails"
+    test:
+      <<: *default
+      database: <YOUR APP's NAME>_test
+      url: <%= ENV["TEST_DATABASE_URL"] %>
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
-GovukTest.configure
+    production:
+      <<: *default
+      database: <YOUR APP's NAME>_production
+      url: <%= ENV["DATABASE_URL"]%>
+    ```
 
-RSpec.configure do |config|
-  config.expose_dsl_globally = false
-  config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = true
-end
-```
+1. Delete the `config/credentials.yml.env` and `config/master.key` files, and create `config/secrets.yml` with the following:
 
-In config, replace the content of `database.yml` with the following.
+    ```yaml
+    development:
+      secret_key_base: secret
 
-```yaml
-default: &default
-  adapter: postgresql
-  encoding: unicode
-  pool: 12
-  template: template0
+    test:
+      secret_key_base: secret
 
-development:
-  <<: *default
-  database: myapp_development
-  url: <%= ENV["DATABASE_URL"]%>
+    production:
+      secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+    ```
 
-test:
-  <<: *default
-  database: myapp_test
-  url: <%= ENV["TEST_DATABASE_URL"] %>
+1. Replace the content of `config/routes.rb` with the following:
 
-production:
-  <<: *default
-  database: myapp_production
-  url: <%= ENV["DATABASE_URL"]%>
-```
+    ```rb
+    Rails.application.routes.draw do
+      get "/healthcheck", to: GovukHealthcheck.rack_response
+    end
+    ```
 
-In config, replace `credentials.yml.env` and `master.key` with `secrets.yml`.
+1. Configure linting for your Rails app to make sure the app's code is consistent with other GOV.UK apps. See the [GOV.UK developer documentation on configuring linting](linting) for more information.
 
-```yaml
-development:
-  secret_key_base: secret
+### Set up Unicorn web server
 
-test:
-  secret_key_base: secret
+1. Open your Gemfile and delete `gem "puma"` if needed.
 
-production:
-  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
-```
+1. Create a `Procfile` in your app's root directory with the following contents:
 
-In config, replace the content of `routes.rb` with the following healthcheck.
+    ```
+    web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}
+    ```
 
-```rb
-Rails.application.routes.draw do
-  get "/healthcheck", to: GovukHealthcheck.rack_response
-end
-```
+1. Create `config/unicorn.rb` with the following content:
 
-Now is a good time to run `bin/setup`. Lastly, to ensure your application has
-beautiful consistent code, you should finish up by
-[configuring linting](/manual/configure-linting.html) for it.
+    ```
+    require "govuk_app_config/govuk_unicorn"
+    GovukUnicorn.configure(self)
+    ```
+
+## Develop the Rails app
+
+You should:
+
+- develop your Rails app in line with the [GOV.UK developer documentation on conventions for Rails applications](rails-conv)
+- name your Rails app in line with the [GOV.UK developer documentation on conventions for naming apps](naming)
+
+## Set up GitHub repo
+
+Set up a GitHub repo for your Rails app by following the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config).
+
+You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page](app-list). If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string
 
 ## Add a software licence
 
-Add a LICENCE file to the project root to specify the software licence. Unless
-your project has specific needs, you should use the [MIT License][mit-license].
-
-<details markdown="block">
-
-<summary>MIT License for GDS projects</summary>
+Add a LICENCE file to the project root to specify the software licence. Unless your project has specific needs, you should use the [MIT License][mit-license].
 
 ```
 The MIT License (MIT)
@@ -186,77 +205,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-</details>
-
 ## Replace the default README.md
 
-We have a common structure that is used for GOV.UK apps. Fill in some basic
-details to get started with your app and flesh it out further as your project
-develops.
+Replace the default `README.md` file with the following content structure:
 
 ```markdown
 # App Name
 
-One paragraph description and purpose.
-
-## Screenshots (if there's a client-facing aspect of it)
-
-## Live examples (if available)
-
-- [gov.uk/thing](https://www.gov.uk/thing)
-
-## Nomenclature
-
-- **Word**: definition of word, and how it's used in the code
+Information about the app's description and purpose.
 
 ## Technical documentation
 
 Write a single paragraph including a general technical overview of the app.
 
-### Dependencies
+### Testing
 
-- [dependency]() - purpose
+Information about how to test the app.
 
-### Running the application
+## Further documentation
 
-How to run the app
-
-### Running the test suite
-
-How to test the app
+## API documentation
 
 ## Licence
 
-[MIT License](LICENCE)
+Link to the [MIT License](LICENCE).
 ```
+See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
 
-## Puppet, DNS, Sentry and beyond
-
-* To prepare the servers for your app, follow the doc in [govuk-puppet]
-* To configure app deployments, follow the docs in [govuk-app-deployment]
-* To enable external DNS, follow the article in the [Developer Docs][dns]
-* Make a PR to add your app to [data/applications.yml][docs-applications] for these docs
-* Then ask 2nd line to run the task in [govuk-saas-config] to update [Sentry]
-* Add the application to the [Release] app (the create button is at the bottom)
-* Add the application to the [Deploy_App job][deploy-jenkins] in Jenkins (click Configure)
-* Run the [Deploy_App job][deploy-jenkins] using with `with_migrations` option to get started
-
-When adding your application to `data/application.yml` - ensure your new repository has
-a description set in the "About" section on github. This will be used to describe what your app
-is on the [application listings](https://docs.publishing.service.gov.uk/#applications) and is also
-required to render an application page.
-
-If you do not do this, you may see Middleman errors when the docs are building which reference
-attempts to modify a frozen empty string.
+## Prepare your app to run in production
 
 
-___https://github.com/alphagov/govuk-saas-config is a little broken, it only lets you “update all” instead of targeting to a single repo - so when we went to update our sentry config it started changing other folks projects too! :scream: should be fixed from follow up PR here, but anyone still trying to run the update all like the docs say will encounter everyone else being out of sync!___
-
-
-___Configure the GitHub repo as per https://docs.publishing.service.gov.uk/manual/configure-github-repo.html#auto-configuration page___
-
-
-## Configuring the app for Jenkins
+### Configuring the app for Jenkins
 
 Create a `Jenkinsfile` in your repo with the following content.
 
@@ -272,11 +251,72 @@ node {
 
 You also need to add a Jenkins integration to the repo on GitHub:
 
+___Follow the link to the github repo config docs___
+
+___delete following 4 bullet list___
+
 1. In GitHub, go to Settings -&gt; Integrations & Services
 2. Add Jenkins (GitHub plugin)
 3. Add the link to the CI GitHub webhook
 4. Make sure Active is ticked
 
-Finally, add your app to the list of deployable applications in [govuk-puppet].
+### Set up your app in govuk-puppet
 
-___Run the deploy_app job comes after this___
+Add your app to the list of deployable applications in [govuk-puppet].
+
+### Configure your app's deployment
+
+To configure your app's deployments, follow the docs in [govuk-app-deployment]
+
+### Enable external DNS
+
+If you need to.
+
+To enable external DNS, follow the article in the [Developer Docs][dns]
+
+### Add your app to the GOV.UK Developer Docs
+
+* Make a PR to add your app to [data/applications.yml][docs-applications] for these docs
+
+### Ask GOV.UK 2nd line to update Sentry
+
+After app added to gov.uk developer docs, do this. Pre-req.
+
+Then ask 2nd line to run the update-project task in [govuk-saas-config] to update [Sentry]
+
+### Add app to Release app
+
+Complete the form at that location and then select Create
+
+Add the application to the [Release] app (the create button is at the bottom)
+
+### Run deploy app job
+
+Run the [Deploy_App job][deploy-jenkins] using with `with_migrations` option to get started
+
+include the `with_migrations` option if your app has a DATABASE
+
+### Add application to GOV.UK Docker
+
+Add app to Docker so app can be run locally. Example PR - https://github.com/alphagov/govuk-docker/pull/465
+
+
+
+
+
+
+
+* Add the application to the [Deploy_App job][deploy-jenkins] in Jenkins (click Configure) - to be moved by MSW to puppet docs___
+
+
+*
+
+
+
+.
+
+
+___https://github.com/alphagov/govuk-saas-config is a little broken, it only lets you “update all” instead of targeting to a single repo - so when we went to update our sentry config it started changing other folks projects too! :scream: should be fixed from follow up PR here, but anyone still trying to run the update all like the docs say will encounter everyone else being out of sync!___
+
+
+___Configure the GitHub repo as per https://docs.publishing.service.gov.uk/manual/configure-github-repo.html#auto-configuration page___

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -171,7 +171,7 @@ You should:
 - develop your Rails app in line with the [GOV.UK developer documentation on conventions for Rails applications](rails-conv)
 - name your Rails app in line with the [GOV.UK developer documentation on conventions for naming apps](naming)
 
-## Set up GitHub repo
+## Set up GitHub repo for the Rails app
 
 Set up a GitHub repo for your Rails app by following the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config).
 
@@ -230,12 +230,12 @@ Information about how to test the app.
 
 Link to the [MIT License](LICENCE).
 ```
+
 See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
 
-## Prepare your app to run in production
+## Prepare the Rails app to run in production
 
-
-### Configuring the app for Jenkins
+### Configure the Rails app for Jenkins
 
 Create a `Jenkinsfile` in your repo with the following content.
 
@@ -249,74 +249,38 @@ node {
 }
 ```
 
-You also need to add a Jenkins integration to the repo on GitHub:
+You also need to add a Jenkins integration to the repo on GitHub. See the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config) for more information.
 
-___Follow the link to the github repo config docs___
+### Set up the Rails app in govuk-puppet
 
-___delete following 4 bullet list___
+Add the Rails app to the list of deployable apps in `govuk-puppet`.See the [`govuk-puppet` documentation on adding a new app to GOV.UK](govuk-puppet).
 
-1. In GitHub, go to Settings -&gt; Integrations & Services
-2. Add Jenkins (GitHub plugin)
-3. Add the link to the CI GitHub webhook
-4. Make sure Active is ticked
+### Configure the Rails app's deployment
 
-### Set up your app in govuk-puppet
-
-Add your app to the list of deployable applications in [govuk-puppet].
-
-### Configure your app's deployment
-
-To configure your app's deployments, follow the docs in [govuk-app-deployment]
+To configure your app's deployment, see the [GOV.UK application deployment scripts documentation](govuk-app-deployment).
 
 ### Enable external DNS
 
-If you need to.
-
-To enable external DNS, follow the article in the [Developer Docs][dns]
+If you need to enable external DNS, follow the article in the [GOV.UK developer documentation on making changes to publishing.service.gov.uk](dns).
 
 ### Add your app to the GOV.UK Developer Docs
 
-* Make a PR to add your app to [data/applications.yml][docs-applications] for these docs
+Open a pull request to add the Rails app to the [GOV.UK developer documentation `data/applications.yml` file][docs-applications].
 
 ### Ask GOV.UK 2nd line to update Sentry
 
-After app added to gov.uk developer docs, do this. Pre-req.
+After you have added the Rails app to the GOV.UK developer documentation, ask GOV.UK 2nd line support to run the `update-project` task in `[govuk-saas-config]` to update `[Sentry]`.
 
-Then ask 2nd line to run the update-project task in [govuk-saas-config] to update [Sentry]
+### Add Rails app to Release app
 
-### Add app to Release app
+Add the Rails app to the [Release] app and select __Create__.
 
-Complete the form at that location and then select Create
+### Run the Deploy_App job
 
-Add the application to the [Release] app (the create button is at the bottom)
+Run the [Deploy_App job][deploy-jenkins].
 
-### Run deploy app job
+Use the `with_migrations` option if your Rails app has a database.
 
-Run the [Deploy_App job][deploy-jenkins] using with `with_migrations` option to get started
+### Add Rails app to GOV.UK Docker
 
-include the `with_migrations` option if your app has a DATABASE
-
-### Add application to GOV.UK Docker
-
-Add app to Docker so app can be run locally. Example PR - https://github.com/alphagov/govuk-docker/pull/465
-
-
-
-
-
-
-
-* Add the application to the [Deploy_App job][deploy-jenkins] in Jenkins (click Configure) - to be moved by MSW to puppet docs___
-
-
-*
-
-
-
-.
-
-
-___https://github.com/alphagov/govuk-saas-config is a little broken, it only lets you “update all” instead of targeting to a single repo - so when we went to update our sentry config it started changing other folks projects too! :scream: should be fixed from follow up PR here, but anyone still trying to run the update all like the docs say will encounter everyone else being out of sync!___
-
-
-___Configure the GitHub repo as per https://docs.publishing.service.gov.uk/manual/configure-github-repo.html#auto-configuration page___
+Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example pull request](https://github.com/alphagov/govuk-docker/pull/465) for more information.

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -178,7 +178,7 @@ Set up a GitHub repo for your Rails app by following the [GOV.UK developer docum
 
 You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page][app-list].
 
-If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string
+If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string.
 
 ## Add a software licence
 

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -77,7 +77,7 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     rm spec/rails_helper.rb
     ```
 
-    Open `spec_helper.rb` and replace its contents with the following:
+    Open `spec/spec_helper.rb` and replace its contents with the following:
 
     ```rb
     ENV["RAILS_ENV"] ||= "test"
@@ -244,7 +244,7 @@ If applicable, include API reference information including the following section
 Link to the [MIT License][LICENCE].
 ```
 
-See the example [account-api README.md][https://github.com/alphagov/account-api/blob/main/README.md] for more information.
+See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
 
 See the [GOV.UK Writing API reference documentation][https://www.gov.uk/guidance/writing-api-reference-documentation] for more information on API references.
 

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -29,13 +29,13 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
 
 ## Create a new Rails app
 
-1. To create a Rails app, go to your development space on your local machine and run the following in the command line:
+1. To create a Rails app, go to the development space on your local machine and run the following in the command line:
 
     ```sh
     rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage
     ```
 
-    The `--skip` commands excludes unneeded Rails plugins.
+    The `--skip` commands exclude unneeded Rails plugins.
 
 1. Replace the Gemfile with the gems you need. The following code shows an example.
 
@@ -77,7 +77,7 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     rm spec/rails_helper.rb
     ```
 
-    Open up `spec_helper.rb` and replace its contents with the following:
+    Open `spec_helper.rb` and replace its contents with the following:
 
     ```rb
     ## spec/spec_helper.rb
@@ -99,7 +99,7 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     end
     ```
 
-1. If your app has a database, replace the content of `config/database.yml` with the following:
+1. If your Rails app has a database, replace the content of `config/database.yml` with the following:
 
     ```yaml
     default: &default
@@ -110,21 +110,23 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
 
     development:
       <<: *default
-      database: <YOUR APP's NAME>_development
+      database: <APP-NAME>_development
       url: <%= ENV["DATABASE_URL"]%>
 
     test:
       <<: *default
-      database: <YOUR APP's NAME>_test
+      database: <APP-NAME>_test
       url: <%= ENV["TEST_DATABASE_URL"] %>
 
     production:
       <<: *default
-      database: <YOUR APP's NAME>_production
+      database: <APP-NAME>_production
       url: <%= ENV["DATABASE_URL"]%>
     ```
 
-1. Delete the `config/credentials.yml.env` and `config/master.key` files, and create `config/secrets.yml` with the following:
+    where `<APP-NAME>` is the name of the Rails app.
+
+1. Delete the `config/credentials.yml.env` and `config/master.key` files, and create a `config/secrets.yml` file that contains the following code:
 
     ```yaml
     development:
@@ -149,15 +151,15 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
 
 ### Set up Unicorn web server
 
-1. Open your Gemfile and delete `gem "puma"` if needed.
+1. If your Rails app's Gemfile includes `gem "puma"`, open the Gemfile and delete `gem "puma"`.
 
-1. Create a `Procfile` in your app's root directory with the following contents:
+1. Create a `Procfile` in your app's root directory that contains the following code:
 
     ```
     web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}
     ```
 
-1. Create `config/unicorn.rb` with the following content:
+1. Create `config/unicorn.rb` that contains the following code:
 
     ```
     require "govuk_app_config/govuk_unicorn"
@@ -171,11 +173,13 @@ You should:
 - develop your Rails app in line with the [GOV.UK developer documentation on conventions for Rails applications](rails-conv)
 - name your Rails app in line with the [GOV.UK developer documentation on conventions for naming apps](naming)
 
-## Set up GitHub repo for the Rails app
+## Set up a GitHub repo for the Rails app
 
 Set up a GitHub repo for your Rails app by following the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config).
 
-You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page](app-list). If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string
+You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page](app-list).
+
+If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string
 
 ## Add a software licence
 
@@ -224,7 +228,17 @@ Information about how to test the app.
 
 ## Further documentation
 
+More information on how the app works.
+
 ## API documentation
+
+If applicable, include API reference information including the following sections:
+
+- resources
+- endpoints and methods
+- parameters
+- example requests and responses
+- error codes
 
 ## Licence
 
@@ -233,35 +247,37 @@ Link to the [MIT License](LICENCE).
 
 See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
 
+See the [GOV.UK Writing API reference documentation](https://www.gov.uk/guidance/writing-api-reference-documentation) for more information on API references.
+
 ## Prepare the Rails app to run in production
 
 ### Configure the Rails app for Jenkins
 
-Create a `Jenkinsfile` in your repo with the following content.
+1. Create a `Jenkinsfile` in your repo with the following content.
 
-```
-#!/usr/bin/env groovy
+    ```
+    #!/usr/bin/env groovy
 
-library("govuk")
+    library("govuk")
 
-node {
-  govuk.buildProject()
-}
-```
+    node {
+      govuk.buildProject()
+    }
+    ```
 
-You also need to add a Jenkins integration to the repo on GitHub. See the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config) for more information.
+1. Add a Jenkins integration to the repo on GitHub. See the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config) for more information.
 
 ### Set up the Rails app in govuk-puppet
 
-Add the Rails app to the list of deployable apps in `govuk-puppet`.See the [`govuk-puppet` documentation on adding a new app to GOV.UK](govuk-puppet).
+Add the Rails app to the list of deployable apps in `govuk-puppet`.See the [`govuk-puppet` documentation on adding a new app to GOV.UK](govuk-puppet) for more information.
 
 ### Configure the Rails app's deployment
 
-To configure your app's deployment, see the [GOV.UK application deployment scripts documentation](govuk-app-deployment).
+To configure your app's deployment, see the [GOV.UK application deployment scripts documentation](govuk-app-deployment) for more information.
 
 ### Enable external DNS
 
-If you need to enable external DNS, follow the article in the [GOV.UK developer documentation on making changes to publishing.service.gov.uk](dns).
+If you need to enable external DNS, see the [GOV.UK developer documentation on making changes to publishing.service.gov.uk](dns) for more information.
 
 ### Add your app to the GOV.UK Developer Docs
 
@@ -269,11 +285,11 @@ Open a pull request to add the Rails app to the [GOV.UK developer documentation 
 
 ### Ask GOV.UK 2nd line to update Sentry
 
-After you have added the Rails app to the GOV.UK developer documentation, ask GOV.UK 2nd line support to run the `update-project` task in `[govuk-saas-config]` to update `[Sentry]`.
+After you have added the Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support](mailto:2nd-line-support@digital.cabinet-office.gov.uk) to run the `update-project` task in `[govuk-saas-config]` to update `[Sentry]`.
 
 ### Add Rails app to Release app
 
-Add the Rails app to the [Release] app and select __Create__.
+Add the Rails app to the [Release] app (requires sign in) and select __Create__.
 
 ### Run the Deploy_App job
 
@@ -283,4 +299,4 @@ Use the `with_migrations` option if your Rails app has a database.
 
 ### Add Rails app to GOV.UK Docker
 
-Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example pull request](https://github.com/alphagov/govuk-docker/pull/465) for more information.
+Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example GOV.UK Docker pull request](https://github.com/alphagov/govuk-docker/pull/465) for more information.

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -25,7 +25,7 @@ parent: "/manual.html"
 
 ## Before you start
 
-Before you create a Rails app, you must complete all steps in the [GOV.UK developer get started documentation](get-started).
+Before you create a Rails app, you must complete all steps in the [GOV.UK developer get started documentation][get-started].
 
 ## Create a new Rails app
 
@@ -35,9 +35,9 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage
     ```
 
-    The `--skip` commands exclude unneeded Rails plugins.
+    The `--skip` commands exclude unneeded Rails components.
 
-1. Replace the Gemfile with the gems you need. The following code shows an example.
+1. Replace the Gemfile with the gems you need. The following code shows an example:
 
     ```rb
     source "https://rubygems.org"
@@ -80,7 +80,6 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     Open `spec_helper.rb` and replace its contents with the following:
 
     ```rb
-    ## spec/spec_helper.rb
     ENV["RAILS_ENV"] ||= "test"
 
     require "simplecov"
@@ -147,7 +146,7 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     end
     ```
 
-1. Configure linting for your Rails app to make sure the app's code is consistent with other GOV.UK apps. See the [GOV.UK developer documentation on configuring linting](linting) for more information.
+1. Configure linting for your Rails app to make sure the app's code is consistent with other GOV.UK apps. See the [GOV.UK developer documentation on configuring linting][linting] for more information.
 
 ### Set up Unicorn web server
 
@@ -170,14 +169,14 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
 
 You should:
 
-- develop your Rails app in line with the [GOV.UK developer documentation on conventions for Rails applications](rails-conv)
-- name your Rails app in line with the [GOV.UK developer documentation on conventions for naming apps](naming)
+- develop your Rails app in line with the [GOV.UK developer documentation on conventions for Rails applications][rails-conv]
+- name your Rails app in line with the [GOV.UK developer documentation on conventions for naming apps][naming]
 
 ## Set up a GitHub repo for the Rails app
 
-Set up a GitHub repo for your Rails app by following the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config).
+Set up a GitHub repo for your Rails app by following the [GOV.UK developer documentation on automatically configuring a GitHub repo][auto-config].
 
-You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page](app-list).
+You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page][app-list].
 
 If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string
 
@@ -242,12 +241,12 @@ If applicable, include API reference information including the following section
 
 ## Licence
 
-Link to the [MIT License](LICENCE).
+Link to the [MIT License][LICENCE].
 ```
 
-See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
+See the example [account-api README.md][https://github.com/alphagov/account-api/blob/main/README.md] for more information.
 
-See the [GOV.UK Writing API reference documentation](https://www.gov.uk/guidance/writing-api-reference-documentation) for more information on API references.
+See the [GOV.UK Writing API reference documentation][https://www.gov.uk/guidance/writing-api-reference-documentation] for more information on API references.
 
 ## Prepare the Rails app to run in production
 
@@ -265,19 +264,19 @@ See the [GOV.UK Writing API reference documentation](https://www.gov.uk/guidance
     }
     ```
 
-1. Add a Jenkins integration to the repo on GitHub. See the [GOV.UK developer documentation on automatically configuring a GitHub repo](auto-config) for more information.
+1. Add a Jenkins integration to the repo on GitHub. See the [GOV.UK developer documentation on automatically configuring a GitHub repo][auto-config] for more information.
 
 ### Set up the Rails app in govuk-puppet
 
-Add the Rails app to the list of deployable apps in `govuk-puppet`.See the [`govuk-puppet` documentation on adding a new app to GOV.UK](govuk-puppet) for more information.
+Follow the [`govuk-puppet` documentation on adding a new app to GOV.UK][govuk-puppet].
 
 ### Configure the Rails app's deployment
 
-To configure your app's deployment, see the [GOV.UK application deployment scripts documentation](govuk-app-deployment) for more information.
+To configure your app's deployment, see the [GOV.UK application deployment scripts documentation][govuk-app-deployment] for more information.
 
 ### Enable external DNS
 
-If you need to enable external DNS, see the [GOV.UK developer documentation on making changes to publishing.service.gov.uk](dns) for more information.
+If you need to enable external DNS, see the [GOV.UK developer documentation on making changes to publishing.service.gov.uk][dns] for more information.
 
 ### Add your app to the GOV.UK Developer Docs
 
@@ -285,7 +284,7 @@ Open a pull request to add the Rails app to the [GOV.UK developer documentation 
 
 ### Ask GOV.UK 2nd line to update Sentry
 
-After you have added the Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support](mailto:2nd-line-support@digital.cabinet-office.gov.uk) to run the `update-project` task in `[govuk-saas-config]` to update `[Sentry]`.
+After you have added the Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support][mailto:2nd-line-support@digital.cabinet-office.gov.uk] to run the `update-project` task in [GOV.UK SaaS Config][govuk-saas-config] to update [Sentry][sentry].
 
 ### Add Rails app to Release app
 
@@ -299,4 +298,4 @@ Use the `with_migrations` option if your Rails app has a database.
 
 ### Add Rails app to GOV.UK Docker
 
-Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example GOV.UK Docker pull request](https://github.com/alphagov/govuk-docker/pull/465) for more information.
+Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example GOV.UK Docker pull request][https://github.com/alphagov/govuk-docker/pull/465] for more information.

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -17,6 +17,20 @@ parent: "/manual.html"
 [deploy-jenkins]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/
 [docs-applications]: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
 
+
+___need to use docker to run these commands?___
+
+___where does unicorn as opposed to puma come in?___
+
+___enable deployments to integration - continuous deployments?___
+
+___Set up a deployment dashboard___
+
+___Switch on the app in staging and production environments___
+
+
+
+
 ## Familiarise yourself with the conventions
 
 We have documented [conventions for Rails
@@ -235,6 +249,13 @@ required to render an application page.
 If you do not do this, you may see Middleman errors when the docs are building which reference
 attempts to modify a frozen empty string.
 
+
+___https://github.com/alphagov/govuk-saas-config is a little broken, it only lets you “update all” instead of targeting to a single repo - so when we went to update our sentry config it started changing other folks projects too! :scream: should be fixed from follow up PR here, but anyone still trying to run the update all like the docs say will encounter everyone else being out of sync!___
+
+
+___Configure the GitHub repo as per https://docs.publishing.service.gov.uk/manual/configure-github-repo.html#auto-configuration page___
+
+
 ## Configuring the app for Jenkins
 
 Create a `Jenkinsfile` in your repo with the following content.
@@ -257,3 +278,5 @@ You also need to add a Jenkins integration to the repo on GitHub:
 4. Make sure Active is ticked
 
 Finally, add your app to the list of deployable applications in [govuk-puppet].
+
+___Run the deploy_app job comes after this___

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -25,11 +25,16 @@ parent: "/manual.html"
 
 ## Before you start
 
-Before you create a Rails app, you must complete all steps in the [GOV.UK developer get started documentation][get-started].
+Before you create a Ruby on Rails (“Rails”) app, you must complete all steps in the [GOV.UK developer get started documentation][get-started].
+
+You should:
+
+- develop your Rails app in line with the [conventions for Rails applications][rails-conv]
+- name your Rails app in line with the [conventions for naming apps][naming]
 
 ## Create a new Rails app
 
-1. To create a Rails app, go to the development space on your local machine and run the following in the command line:
+1. To create a Rails app on your local machine, run the following in the command line:
 
     ```sh
     rails new myapp --skip-javascript --skip-test --skip-bundle --skip-spring --skip-action-cable --skip-action-mailer --skip-active-storage
@@ -37,7 +42,7 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
 
     The `--skip` commands exclude unneeded Rails components.
 
-1. Replace the Gemfile with the gems you need. The following code shows an example:
+1. Include the gems you need for your app in `Gemfile`. For example:
 
     ```rb
     source "https://rubygems.org"
@@ -69,15 +74,11 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     end
     ```
 
-1. Run `bundle && rails g rspec:install` to install all gems specified in the Gemfile and generate files used for testing.
+1. Run `bundle && rails g rspec:install` to install all the gems you included in `Gemfile` and generate files you can use to test your app.
 
-1. Delete `spec/rails_helper.rb`:
+1. Run `rm spec/rails_helper.rb` to delete `spec/rails_helper.rb`.
 
-    ```sh
-    rm spec/rails_helper.rb
-    ```
-
-    Open `spec/spec_helper.rb` and replace its contents with the following:
+1. Replace the contents of `spec/spec_helper.rb` with the following:
 
     ```rb
     ENV["RAILS_ENV"] ||= "test"
@@ -123,9 +124,9 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
       url: <%= ENV["DATABASE_URL"]%>
     ```
 
-    where `<APP-NAME>` is the name of the Rails app.
+    where `<APP-NAME>` is the name of your Rails app.
 
-1. Delete the `config/credentials.yml.env` and `config/master.key` files, and create a `config/secrets.yml` file that contains the following code:
+1. Delete the `config/credentials.yml.env` and `config/master.key` files, and create a `config/secrets.yml` file that contains the following:
 
     ```yaml
     development:
@@ -146,48 +147,39 @@ Before you create a Rails app, you must complete all steps in the [GOV.UK develo
     end
     ```
 
-1. Configure linting for your Rails app to make sure the app's code is consistent with other GOV.UK apps. See the [GOV.UK developer documentation on configuring linting][linting] for more information.
+1. Configure linting for your Rails app to make sure the app's code is consistent with other GOV.UK apps. Find out more information about [configuring linting][linting].
 
-### Set up Unicorn web server
+### Set up a Unicorn web server
 
-1. If your Rails app's Gemfile includes `gem "puma"`, open the Gemfile and delete `gem "puma"`.
+1. If your Rails app's `Gemfile` includes `gem "puma"`, open `Gemfile` and delete `gem "puma"`.
 
-1. Create a `Procfile` in your app's root directory that contains the following code:
+1. Create a `Procfile` in your app's root directory that contains the following:
 
     ```
     web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}
     ```
 
-1. Create `config/unicorn.rb` that contains the following code:
+1. Create a `config/unicorn.rb` file that contains the following code:
 
     ```
     require "govuk_app_config/govuk_unicorn"
     GovukUnicorn.configure(self)
     ```
 
-## Develop the Rails app
+## Set up a GitHub repo for your Rails app
 
-You should:
+When you’ve finished developing your Rails app, you can [set up a GitHub repo for your Rails app][auto-config].
 
-- develop your Rails app in line with the [GOV.UK developer documentation on conventions for Rails applications][rails-conv]
-- name your Rails app in line with the [GOV.UK developer documentation on conventions for naming apps][naming]
-
-## Set up a GitHub repo for the Rails app
-
-Set up a GitHub repo for your Rails app by following the [GOV.UK developer documentation on automatically configuring a GitHub repo][auto-config].
-
-You must add a description to the __About__ section in the GitHub repo to make sure that you can add your app to the [GOV.UK developer documentation applications page][app-list].
-
-If you do not do this, you will see Middleman errors when the GOV.UK developer documentation is building. These errors will refer to attempts to modify a frozen empty string.
+You must add a description to the _About_ section in the GitHub repo, or the GOV.UK developer documentation build will break when it tries to build the [list of apps][app-list].
 
 ## Add a software licence
 
-Add a LICENCE file to the project root to specify the software licence. Unless your project has specific needs, you should use the [MIT License][mit-license].
+You must add a `LICENCE` file to your project’s root folder that specifies the software licence. You should usually use the following MIT License text. Replace <YEAR> with the current year.
 
 ```
 The MIT License (MIT)
 
-Copyright (c) <year> Crown Copyright (Government Digital Service)
+Copyright (c) <YEAR> Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -210,10 +202,10 @@ SOFTWARE.
 
 ## Replace the default README.md
 
-Replace the default `README.md` file with the following content structure:
+Change the default `README.md` file to have the following structure:
 
 ```markdown
-# App Name
+# App name
 
 Information about the app's description and purpose.
 
@@ -241,16 +233,16 @@ If applicable, include API reference information including the following section
 
 ## Licence
 
-Link to the [MIT License][LICENCE].
+Link to your [MIT License][LICENCE] file.
 ```
 
-See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md) for more information.
+See the example [account-api README.md](https://github.com/alphagov/account-api/blob/main/README.md).
 
-See the [GOV.UK Writing API reference documentation](https://www.gov.uk/guidance/writing-api-reference-documentation) for more information on API references.
+Find out more about [writing API reference content](https://www.gov.uk/guidance/writing-api-reference-documentation).
 
-## Prepare the Rails app to run in production
+## Prepare your Rails app to run in production
 
-### Configure the Rails app for Jenkins
+### Configure your Rails app for Jenkins
 
 1. Create a `Jenkinsfile` in your repo with the following content.
 
@@ -264,31 +256,31 @@ See the [GOV.UK Writing API reference documentation](https://www.gov.uk/guidance
     }
     ```
 
-1. Add a Jenkins integration to the repo on GitHub. See the [GOV.UK developer documentation on automatically configuring a GitHub repo][auto-config] for more information.
+1. Add a Jenkins integration to the repo on GitHub. Find out more about [automatically configuring a GitHub repo][auto-config].
 
-### Set up the Rails app in govuk-puppet
+### Add your Rails app to GOV.UK
 
-Follow the [`govuk-puppet` documentation on adding a new app to GOV.UK][govuk-puppet].
+Find out how to [add your Rails app to GOV.UK using `govuk-puppet`][govuk-puppet].
 
-### Configure the Rails app's deployment
+### Configure your Rails app's deployment
 
-To configure your app's deployment, see the [GOV.UK application deployment scripts documentation][govuk-app-deployment] for more information.
+To configure your app's deployment, see the [GOV.UK application deployment scripts][govuk-app-deployment].
 
 ### Enable external DNS
 
-If you need to enable external DNS, see the [GOV.UK developer documentation on making changes to publishing.service.gov.uk][dns] for more information.
+If you need to enable external DNS, find out how to [make changes to publishing.service.gov.uk][dns].
 
-### Add your app to the GOV.UK Developer Docs
+### Add your app to the GOV.UK developer documentation
 
-Open a pull request to add the Rails app to the [GOV.UK developer documentation `data/applications.yml` file][docs-applications].
+Open a pull request to add your Rails app to the [GOV.UK developer documentation `data/applications.yml` file][docs-applications].
 
 ### Ask GOV.UK 2nd line to update Sentry
 
-After you have added the Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support](mailto:2nd-line-support@digital.cabinet-office.gov.uk) to run the `update-project` task in [GOV.UK SaaS Config][govuk-saas-config] to update [Sentry][sentry].
+After you’ve added your Rails app to the GOV.UK developer documentation, [ask GOV.UK 2nd line support](mailto:2nd-line-support@digital.cabinet-office.gov.uk) to run the `update-project` task in [GOV.UK SaaS Config][govuk-saas-config] to update Sentry.
 
-### Add Rails app to Release app
+### Add your Rails app to Release app
 
-Add the Rails app to the [Release] app (requires sign in) and select __Create__.
+Add your Rails app to the [Release][release] app and select __Create__.
 
 ### Run the Deploy_App job
 
@@ -296,6 +288,6 @@ Run the [Deploy_App job][deploy-jenkins].
 
 Use the `with_migrations` option if your Rails app has a database.
 
-### Add Rails app to GOV.UK Docker
+### Add your Rails app to GOV.UK Docker
 
-Add the Rails app to GOV.UK Docker so the Rails app can be run locally. See this [example GOV.UK Docker pull request](https://github.com/alphagov/govuk-docker/pull/465) for more information.
+Add your Rails app to GOV.UK Docker so you can run the app locally. See an [example GOV.UK Docker pull request](https://github.com/alphagov/govuk-docker/pull/465).


### PR DESCRIPTION
Account team found that the documentation for setting up a new app (https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html) is very out of date.

It has a list of steps but that list is missing things, has parts which are now wrong, and gives the steps in the wrong order.

This PR updates the content to be correct.

trello card: https://trello.com/c/mgltOCbD/671-improve-the-how-to-set-up-a-new-app-documentation
