### PR TITLE
Rewrite README and simplify GitHub Token setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "activesupport"
 gem "capybara"
+gem "dotenv"
 gem "ffi"
 gem "rake"
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   capybara
+  dotenv
   faraday-http-cache
   faraday_middleware
   ffi

--- a/README.md
+++ b/README.md
@@ -2,17 +2,12 @@
 
 👉 https://docs.publishing.service.gov.uk
 
-## Technical documentation
+This is a static site generated with Middleman, using [alphagov/tech-docs-template](https://github.com/alphagov/tech-docs-template).
 
-This is a static site generated with Middleman.
-
-## Tech docs template
-
-This project uses [alphagov/tech-docs-template](https://github.com/alphagov/tech-docs-template).
-
-This means that some of the files (like the CSS, javascripts and layouts) are
-managed in the template and are not supposed to be modified here. Any project-specific
+Some of the files (like the CSS, javascripts and layouts) are managed in the template and are not supposed to be modified here. Any project-specific
 Ruby code needs to go into `/app`.
+
+## Technical documentation
 
 You can pull down the latest version of the template by running:
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,6 @@ You may find it easier to save the token to a file and then refer to it dynamica
 GITHUB_TOKEN=$(cat ~/github_token.txt) ./startup.sh
 ```
 
-### Building the project
-
-Build the site with:
-
-```sh
-NO_CONTRACTS=true bundle exec middleman build
-```
-
-This will create a bunch of static files in `/build`.
-
 ### Testing
 
 ```
@@ -63,6 +53,15 @@ bin/update
 
 This project is hosted on GitHub Pages. It is [redeployed hourly on weekdays][actions]
 (to pick up changes to external docs) and whenever a PR is merged.
+
+As part of the deployment, we build a static set of pages to minimise the response time
+and potential issues with remote API calls.
+
+```sh
+NO_CONTRACTS=true bundle exec middleman build
+```
+
+This will create a bunch of static files in `/build`.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,9 @@ Ruby code needs to go into `/app`.
 
 ## Technical documentation
 
-### Running locally
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-The first time you'll need to bundle:
-
-```sh
-bundle install
-```
-
-If you have issues installing mimemagic, you may need to `brew install shared-mime-info`.
-
-To run the app locally:
-
-```sh
-./startup.sh
-```
-
-The app will appear at [http://localhost:4567/](http://localhost:4567/)
+**Use GOV.UK Docker to run any commands that follow.**
 
 ### GitHub token
 
@@ -61,7 +47,9 @@ This will create a bunch of static files in `/build`.
 
 ### Testing
 
-`bundle exec rake`
+```
+bundle exec rake
+```
 
 ### Updating the template
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ Ruby code needs to go into `/app`.
 
 ## Technical documentation
 
-You can pull down the latest version of the template by running:
-
-```sh
-bin/update
-```
-
 ### Running locally
 
 The first time you'll need to bundle:
@@ -68,6 +62,14 @@ This will create a bunch of static files in `/build`.
 ### Testing
 
 `bundle exec rake`
+
+### Updating the template
+
+You can pull down the latest version of the Tech Docs template by running:
+
+```sh
+bin/update
+```
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ You can pull down the latest version of the template by running:
 bin/update
 ```
 
-### Dependencies
-
-- Ruby
-
 ### Running locally
 
 The first time you'll need to bundle:

--- a/README.md
+++ b/README.md
@@ -13,29 +13,17 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 
 **Use GOV.UK Docker to run any commands that follow.**
 
-### GitHub token
+### Running the app
 
-You will need a GitHub auth token to build the project or run the full test suite,
-otherwise you will find yourself rate limited. You can create one here:
+You will need to [create a GitHub auth token](https://github.com/settings/tokens/new) to build the project or run the full test suite, otherwise you will find yourself rate limited. It doesn't need any permissions.
 
-https://github.com/settings/tokens/new
+Store the token in a `.env` file like this:
 
-It doesn't need any permissions.
-
-Use it like this:
-
-```sh
-export GITHUB_TOKEN=somethingsomething
-./startup.sh
+```
+GITHUB_TOKEN=somethingsomething
 ```
 
-You may find it easier to save the token to a file and then refer to it dynamically:
-
-```sh
-GITHUB_TOKEN=$(cat ~/github_token.txt) ./startup.sh
-```
-
-### Testing
+### Testing the app
 
 ```
 bundle exec rake


### PR DESCRIPTION
This follows the changes we're applying to other GOV.UK repos. My
original motivation for this change was just to simplify the GitHub
setup, so if the rest of this PR proves contentious, we could just
focus on that commit instead.