### PR TITLE
Update docs to reflect route updates within Router

### DIFF
--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -145,10 +145,12 @@ from a MongoDB database of all known routes.
 
 The MongoDB database is written to via [router-api] whenever a route is
 added or changed: the Content Store (which we'll cover later) talks to
-Router API [directly][register-route] to do this. Router API then
-[sends POST requests to every instance of Router][router-api-updating-router],
-whereupon each [Router then reloads all routes][router-reloading-routes]
-from MongoDB.
+Router API [directly][register-route] to do this.
+
+Every Router instance [polls periodically][router-polls-periodically]
+for any changes to the MongoDB database; if and when changes are detected
+by a particular instance it reloads all routes held in memory - a process
+which is repeated across all instances.
 
 Routes have different handlers. Routes marked as `gone` return a 410 Gone
 response. Routes marked as `redirect` serve a 301 Moved Permanently
@@ -170,8 +172,7 @@ application.
 [prefix trie]: https://en.wikipedia.org/wiki/Trie
 [register-route]: https://github.com/alphagov/content-store/blob/08f02f990e621c9d2fd473e12a70a6805ddd8dcb/app/models/route_set.rb#L58-L82
 [router-api]: https://github.com/alphagov/router-api
-[router-api-updating-router]: https://github.com/alphagov/router-api/blob/master/lib/router_reloader.rb#L45-L48
-[router-reloading-routes]: https://github.com/alphagov/router/blob/1e1d5c1563136ba340e1fba838d9b52e283ed815/router_api.go#L26-L42
+[router-polls-periodically]: https://github.com/alphagov/router/blob/811ed82d0ecc23b8077ed5dd2c460ccdfe2808ab/router.go#L154-L194
 [short-url-manager]: https://github.com/alphagov/short-url-manager
 
 ### Rendering

--- a/source/manual/check-for-gone-route.html.md
+++ b/source/manual/check-for-gone-route.html.md
@@ -29,5 +29,4 @@ to Whitehall):
 
 ```ruby
 > r.destroy
-> RouterReloader.reload
 ```

--- a/source/manual/editing-an-existing-route.html.md
+++ b/source/manual/editing-an-existing-route.html.md
@@ -37,8 +37,4 @@ govuk_app_console router-api
 > r.save!
 ```
 
-4. Once you've edited the route appropriately and saved it, reload the router
-
-```console
-> RouterReloader.reload
-```
+4. Once you've edited the route appropriately and saved it, your changes will be applied and visible shortly after.

--- a/source/manual/redirect-routes.html.md.erb
+++ b/source/manual/redirect-routes.html.md.erb
@@ -324,11 +324,7 @@ English version to a translation, for example:
 Route.find('579a109cd068b406250014e4').destroy
 ```
 
-For the deleted routes to take effect, you need to reload the router.
-
-```ruby
-RouterReloader.reload
-```
+The deleted routes will take effect after a short delay (for Router instances to poll and apply updates).
 
 ## Redirects for HMRC manuals
 [hmrc-manuals-section]: #redirects-for-hmrc-manuals


### PR DESCRIPTION
This PR updates the docs to reflect the recent changes to Router and Router API. Router API previously called the `/reload` endpoint of every Router instance to perform a full route reload; this has now been superseded with [Router polling for and applying updates itself](https://github.com/alphagov/router/commit/811ed82d0ecc23b8077ed5dd2c460ccdfe2808ab), which was a result of [RFC 135](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-135-updating-routes-in-router.md).