### PR TITLE
Update hieradata path to hieradata_aws

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ end
 desc "Find deployable applications that are not in this repo"
 task :verify_deployable_apps do
   common_yaml = suppress_output do
-    HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata/common.yaml")
+    HTTP.get_yaml("https://raw.githubusercontent.com/alphagov/govuk-puppet/master/hieradata_aws/common.yaml")
   end
   deployable_applications = common_yaml["deployable_applications"].map { |k, v| v["repository"] || k }
   our_applications = Applications.all.map(&:github_repo_name)

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -364,6 +364,29 @@
   dashboard_url: false
   description: 'GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)'
 
+- github_repo_name: licensify-admin
+  private_repo: true
+  type: Licensing apps
+  production_hosted_on: aws
+  team: "#govuk-licensing"
+  puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify_admin.pp
+  sentry_url: false
+  deploy_url: false
+  dashboard_url: false
+  description: 'GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)'
+
+- github_repo_name: licensify-feed
+  private_repo: true
+  type: Licensing apps
+  production_hosted_on: aws
+  team: "#govuk-licensing"
+  puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify_feed.pp
+  sentry_url: false
+  deploy_url: false
+  dashboard_url: false
+  description: 'GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)'
+
+
 # Utility Heroku apps (don't add apps that are only for review here)
 
 - github_repo_name: seal


### PR DESCRIPTION
hieradata has been deleted as obsolete in govuk-puppet as per:
https://github.com/alphagov/govuk-puppet/pull/11037