### PR TITLE
Provide specific instruction for local testing

### DIFF
--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -92,5 +92,5 @@ Due to the co-dependent nature of Pact providers and consumers, changes need to 
   - Its build should fail at the Pact test stage, because it is testing against the default branch of the provider.
 1. Run a parameterised build of the consumer, specifying the new branch name of the provider to test against.
   - The build should pass.
-  - It should also be possible to [test this locally, if your provider is set up to do so](https://github.com/alphagov/frontend/blob/master/CONTRIBUTING.md#pact-tests).
+  - It should also be possible to test this locally e.g. `bundle exec rake PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-collections_organisation_api.json" pact:verify`.
 1. Merge the consumer PR, followed by the provider PR.


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This is based on the commands we have in other repos, which we can
centralise here [1][2]. In future we should consider improving this
manual further, so there are clear and simple steps to follow for
local development. For now, this will DRY-up our READMEs.

[1]: https://github.com/alphagov/frontend/blob/1f4cb6049f14da2b595597f28c0fe5af18c4f3b4/CONTRIBUTING.md#pact-tests
[2]: https://github.com/alphagov/collections/blame/102836b66772c0c63630e054a15a88859c814fcd/README.md#L190