### PR TITLE
Changes Document Type to be a required column in the CSV

### DIFF
--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -141,7 +141,7 @@ order):
 | Column Header | Description |
 | --- | --- |
 | `Slug` | The slug of the document. |
-| `Document type` | Optionally, the type of the document. `Publication` for example. This is required when more than one document is matched by the `Slug`. |
+| `Document type` | The type of the document, for example `Publication`. This is used when more than one document is matched by the `Slug`. |
 | `New lead organisations` | The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations. |
 | `New supporting organisations` | The slugs of the new supporting organisations (separated by a comma). These will replace any existing organisations. |
 


### PR DESCRIPTION
This lists Document Type as a required column in the CSV file for bulk retagging of content - where this hasn't been included in the past, a developer has had to add and populate it manually. 