### PR TITLE
Separate out the search-api reranker alert

### DIFF
--- a/source/manual/alerts/search-api-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/search-api-app-healthcheck-not-ok.html.md
@@ -29,29 +29,5 @@ Find out why the Search API can't connect to elasticsearch.
 - Look at the [elasticsearch cluster health][cluster-health]
 - Check the status of the Elasticsearch cluster in the AWS console
 
-## Reranker is not OK
-
-The Search API uses machine learning to rank search results based on
-analytics data.  If this alert fires, something has gone wrong with
-that process and we're serving results as they were ordered by
-elasticsearch.
-
-Unlike the other healthcheck failures, this does not mean that Search
-API is serving errors.  Only that it is serving potentially worse
-results.
-
-The machine learning model is hosted in [Amazon SageMaker][aws-sagemaker].
-
-### How do I investigate this?
-
-Find out why the Search API can't connect to elasticsearch.
-
-- Look at the error message in the healthcheck response
-- Look at the Search API logs
-- Check the status of the SageMaker endpoint in the AWS console
-
-[sentry]: /manual/error-reporting.html
-[search-github-repo]: https://github.com/alphagov/search-api/
 [cluster-health]: /manual/alerts/elasticsearch-cluster-health.html
 [aws-elasticsearch]: https://aws.amazon.com/elasticsearch-service/
-[aws-sagemaker]: https://aws.amazon.com/sagemaker/

--- a/source/manual/alerts/search-reranker-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/search-reranker-healthcheck-not-ok.html.md
@@ -1,0 +1,28 @@
+---
+owner_slack: "#govuk-2ndline"
+title: Search reranker healthcheck not ok
+parent: "/manual.html"
+layout: manual_layout
+section: Icinga alerts
+---
+
+The Search API uses machine learning to rank search results based on
+analytics data.  If this alert fires, something has gone wrong with
+that process and we're serving results as they were ordered by
+elasticsearch.
+
+Unlike the other healthcheck failures, this does not mean that Search
+API is serving errors.  Only that it is serving potentially worse
+results.
+
+The machine learning model is hosted in [Amazon SageMaker][aws-sagemaker].
+
+### How do I investigate this?
+
+Find out why the Search API can't connect to SageMaker.
+
+- Look at the error message in the healthcheck response
+- Look at the Search API logs
+- Check the status of the SageMaker endpoint in the AWS console
+
+[aws-sagemaker]: https://aws.amazon.com/sagemaker/


### PR DESCRIPTION
This is now a separate alert, see
https://github.com/alphagov/govuk-puppet/pull/11051

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)