### PR TITLE
Ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config
 /.bundle
 
+# Ignore sensitive files
+.env
+
 # Ignore the build directory
 /build
 


### PR DESCRIPTION
Follow-on from #3058.

We have instructions in the README advising devs to create a .env
file for local development. If they're not careful, this file
could be committed to GitHub and they'd compromise their access
token. We should ignore it to ensure that can't happen.