### PR TITLE
Add a line about failed reindex task

### DIFF
--- a/source/manual/reindex-elasticsearch.html.md
+++ b/source/manual/reindex-elasticsearch.html.md
@@ -111,6 +111,12 @@ This is running in a Jenkins job that clears any index over 7 days old, and will
 
 ### Troubleshooting
 
+#### Failed to switch to new index
+
+The final part of the reindex is to switch Elasticsearch over to the newly created indexes. We've noticed recently that this isn't always successful. It appears to be that if content is written to the database while the reindex task is running, the task will fail at the end as it detects a difference in the data.
+
+**Re-running the reindex task usually fixes this.**
+
 #### To stop the reindexing job
 
 If you need to cancel the reindexing while it's in progress:


### PR DESCRIPTION
We should fix this problem, but at the moment we don't have capacity to do so. Adding a line should prevent people asking questions on Slack and know what to do when it doesn't work.

[Trello Card](https://trello.com/c/9ww3pD2p/1009-add-search-reindex-problems-to-tech-debt-board)