### PR TITLE
Make instructions consistent and clearer between Int & Staging

### DIFF
--- a/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
+++ b/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
@@ -13,16 +13,21 @@ sent to addresses other than those of these groups will be
 
 ## In Integration
 
-For testing in Integration there is the [Email Alert API Integration Google
+In Integration there is the [Email Alert API Integration Google
 group][integration-group]. It has an email address of
-`email-alert-api-integration@digital.cabinet-office.gov.uk` and you can use this
-address to sign up for mailing lists that you wish to test.
+`email-alert-api-integration@digital.cabinet-office.gov.uk`.
+
+This account can be used to sign up to subscriptions on
+https://www.integration.publishing.service.gov.uk/.
 
 ## In Staging
 
 In Staging there is the [Email Alert API Staging Google
-group][staging-group] and it has an email address of
+group][staging-group]. It has an email address of
 `email-alert-api-staging@digital.cabinet-office.gov.uk`.
+
+This account can be used to sign up to subscriptions on
+https://www.staging.publishing.service.gov.uk/.
 
 ## How to use
 


### PR DESCRIPTION
I ended up signing up for subscriptions to the Staging Google account on Integration (by accident), then on Production (on purpose), then on Staging. Only the latter came through with a confirmation email. This makes sense on reflection, but I think can be made a little clearer from the documentation.

Trello: https://trello.com/c/qqxUkxPX/2489-2-send-email-to-all-gds-department-subscribers-pointing-them-to-cddo-alerts