### PR TITLE
Update docs for associating a route with a template

### DIFF
--- a/source/manual/find-a-rails-template-based-on-a-govuk-url.html.md
+++ b/source/manual/find-a-rails-template-based-on-a-govuk-url.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#govuk-developers"
+title: Find a rails template based on a GOV.UK URL or vice verca
+section: Frontend
+layout: manual_layout
+type: learn
+parent: "/manual.html"
+---
+When making changes to a template in one of our frontend apps it's often beneficial to see a rendered page with your change so that you can effectively test it. This can be difficult when developing within gov.uk as we have several frontend apps which control different parts of the site, sometimes overlapping in sections that they take responsibility for. This document details ways in which you can bypass this issue.
+
+## Option 1: Use the GOV.UK browser extension
+[The GOV.UK browser extension](https://github.com/alphagov/govuk-browser-extension) provides a number of details on a given page on GOV.UK, including the app which renders that page. This can be a good start in working out which template renders a particular page, however doesn't help when ou are trying to find a URL based on static analysis of our frontend apps.
+
+## Option 2: Check the routes file in a given app
+As our frontend apps are all ruby on rails apps, it can be assumed that most views follow [the typical MVC flow](https://www.sitepoint.com/model-view-controller-mvc-architecture-rails/) of a route being specified in `routes.rb`, this route calling a controller, that controller rendering a view and that view being located in `app/views` of a given application, identified in line with the name of the controller and the action within that controller. For example: a route could be specified that whenever the path `/government/organisations` is hit, it calls the `index` action of the `organisations` controller (shorthanded to `organisations#index`), this controller would then render at `app/views/organisations/index.html.erb`. You can follow this both path to template and template to path.
+
+A downside of this technique is that we allow publishers to set unique slugs for their content, which can't be easily interpreted via static analysis.
+
+## Option 3: Use Kibana to find a controller or path
+Kibana is an interface for traversing logs on GOV.UK and includes a lot of useful information, such which controller and which route a given path is rendered by. In order to access it you'll first need access to [logit](/manual/logit.html) (specific instructions on how to successfully sign into logit can be found [here](https://reliability-engineering.cloudapps.digital/logging.html#content), ensure that you're part of the govuk gmail group before following these steps).
+
+You can find a lot of useful tips and instructions on using Kibana, including this particular use case, [here](/manual/kibana.html).

--- a/source/manual/find-a-rails-template-based-on-a-govuk-url.html.md
+++ b/source/manual/find-a-rails-template-based-on-a-govuk-url.html.md
@@ -9,14 +9,17 @@ parent: "/manual.html"
 When making changes to a template in one of our frontend apps it's often beneficial to see a rendered page with your change so that you can effectively test it. This can be difficult when developing within gov.uk as we have several frontend apps which control different parts of the site, sometimes overlapping in sections that they take responsibility for. This document details ways in which you can bypass this issue.
 
 ## Option 1: Use the GOV.UK browser extension
+
 [The GOV.UK browser extension](https://github.com/alphagov/govuk-browser-extension) provides a number of details on a given page on GOV.UK, including the app which renders that page. This can be a good start in working out which template renders a particular page, however doesn't help when ou are trying to find a URL based on static analysis of our frontend apps.
 
 ## Option 2: Check the routes file in a given app
+
 As our frontend apps are all ruby on rails apps, it can be assumed that most views follow [the typical MVC flow](https://www.sitepoint.com/model-view-controller-mvc-architecture-rails/) of a route being specified in `routes.rb`, this route calling a controller, that controller rendering a view and that view being located in `app/views` of a given application, identified in line with the name of the controller and the action within that controller. For example: a route could be specified that whenever the path `/government/organisations` is hit, it calls the `index` action of the `organisations` controller (shorthanded to `organisations#index`), this controller would then render at `app/views/organisations/index.html.erb`. You can follow this both path to template and template to path.
 
 A downside of this technique is that we allow publishers to set unique slugs for their content, which can't be easily interpreted via static analysis.
 
 ## Option 3: Use Kibana to find a controller or path
+
 Kibana is an interface for traversing logs on GOV.UK and includes a lot of useful information, such which controller and which route a given path is rendered by. In order to access it you'll first need access to [logit](/manual/logit.html) (specific instructions on how to successfully sign into logit can be found [here](https://reliability-engineering.cloudapps.digital/logging.html#content), ensure that you're part of the govuk gmail group before following these steps).
 
 You can find a lot of useful tips and instructions on using Kibana, including this particular use case, [here](/manual/kibana.html).

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -12,11 +12,41 @@ access through [Logit](logit.html).
 Kibana can be [searched using the Lucene search syntax or full JSON-based
 Elasticsearch queries][kibana-search].
 
+## Set up the UI
+
+The default view for Kibana includes a timestamp and a grouped `_source` column of all information per log. Depending on what you're trying to achieve, you may find it beneficial to re-organise your view.
+
+You can specify a field in the logs list by navigating the "Available Fields" list on the left hand side, hovering over a field you want to interrogate and clicking "add". Some useful fields include:
+
+- application
+- controller
+- route
+- path
+- status
+- request
+- tags
+
+You can additionally remove fields by following the same steps above for "Selected Fields" and clicking "remove".
+
+You can also manage the timeline bar chart at the top fo the view by changing the dropdown above the bar chart from "auto" to whichever delimitater suits your needs (hourly, daily, weekly etc) and specify the time frame of the bar chart by clicking the time range in the top right-hand corner.
+
 ## Examples
 
 You can save and load queries using the buttons in the top right. You may want to use one of the existing queries as a starting point instead of writing a query from scratch.
 
 ![Kibana saved searches](images/kibana_saved_searches.png)
+
+### All requests rendered by the content_items controller in government-frontend
+
+```rb
+application: government-frontend AND tags: request AND controller: content_items
+```
+
+### All requests within the /government/groups path
+
+```rb
+tags: request AND path: \/government\/groups\/*
+```
 
 ### 5xx errors returned from cache layer
 


### PR DESCRIPTION
## What
Adds a new doc around associating a rails `.erb` template with a path on GOV.UK and updates the Kibana docs with some information about one method to do this using Kibana.

## Why
The pair of problems of not being able to work out where your work is being rendered and vice versa are fairly uncommon problems for most govuk devs but are both very difficult to overcome when you run into them. This in particular impacts frontend developers as their changes more often are visual/user facing and testing in situ is critical. This is exacerbated when working within our more legacy apps like whatehall-frontend, adding a risk that tech debt continues to go unnoticed and grow further out of date.

These docs are intended to act as a starting point to help developers work out where they are.