### PR TITLE
Rename 'master' to 'main'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Set commit message up front
         id: commit_message_writer

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ This will create a bunch of static files in `/build`.
 
 [MIT License](LICENCE.md)
 
-[actions]: https://github.com/alphagov/govuk-developer-docs/blob/master/.github/workflows/ci.yml
+[actions]: https://github.com/alphagov/govuk-developer-docs/blob/main/.github/workflows/ci.yml

--- a/app/content_schema.rb
+++ b/app/content_schema.rb
@@ -36,7 +36,7 @@ class ContentSchema
     end
 
     def link_to_github
-      "https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/#{schema_name}/frontend/schema.json"
+      "https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/#{schema_name}/frontend/schema.json"
     end
 
     def random_example
@@ -64,7 +64,7 @@ class ContentSchema
     end
 
     def link_to_github
-      "https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/#{schema_name}/publisher/schema.json"
+      "https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/#{schema_name}/publisher/schema.json"
     end
 
     def random_example
@@ -92,7 +92,7 @@ class ContentSchema
     end
 
     def link_to_github
-      "https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/#{schema_name}/publisher/links.json"
+      "https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/#{schema_name}/publisher/links.json"
     end
 
     def random_example

--- a/app/document_types.rb
+++ b/app/document_types.rb
@@ -1,6 +1,6 @@
 class DocumentTypes
   FACET_QUERY = "https://www.gov.uk/api/search.json?facet_content_store_document_type=500,examples:10,example_scope:global&count=0".freeze
-  DOCUMENT_TYPES_URL = "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml".freeze
+  DOCUMENT_TYPES_URL = "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/main/lib/govuk_content_schemas/allowed_document_types.yml".freeze
 
   def self.pages
     known_from_search = facet_query.dig("facets", "content_store_document_type", "options").map do |o|

--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -10,11 +10,11 @@ class ExternalDoc
       gfm: false,
       base_url: URI.join(
         "https://github.com",
-        "alphagov/#{repository}/blob/master/",
+        "alphagov/#{repository}/blob/main/",
       ),
       image_base_url: URI.join(
         "https://raw.githubusercontent.com",
-        "alphagov/#{repository}/master/",
+        "alphagov/#{repository}/main/",
       ),
     }
 
@@ -51,7 +51,7 @@ class ExternalDoc
   # continue to work when rendered as part of GOV.UK Developer Docs.
   #
   # For example a link to `lib/link_expansion.rb` would be rewritten to
-  # https://github.com/alphagov/publishing-api/blob/master/lib/link_expansion.rb
+  # https://github.com/alphagov/publishing-api/blob/main/lib/link_expansion.rb
   class AbsoluteLinkFilter < HTML::Pipeline::Filter
     def call
       doc.search("a").each do |element|

--- a/app/search_api_docs.rb
+++ b/app/search_api_docs.rb
@@ -9,6 +9,6 @@ class SearchApiReference
   end
 
   def self.field_definitions_url
-    "https://raw.githubusercontent.com/alphagov/search-api/master/config/schema/field_definitions.json"
+    "https://raw.githubusercontent.com/alphagov/search-api/main/config/schema/field_definitions.json"
   end
 end

--- a/app/source_url.rb
+++ b/app/source_url.rb
@@ -26,6 +26,6 @@ private
 
   # As the last fallback link to the source file in this repository.
   def source_from_file
-    "https://github.com/alphagov/govuk-developer-docs/blob/master/source/#{current_page.file_descriptor[:relative_path]}"
+    "https://github.com/alphagov/govuk-developer-docs/blob/main/source/#{current_page.file_descriptor[:relative_path]}"
   end
 end

--- a/source/apps/by-team.html.md.erb
+++ b/source/apps/by-team.html.md.erb
@@ -1,7 +1,7 @@
 ---
 layout: application_layout
 title: Application ownership by team
-source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/applications.yml
 parent: "/apps.html"
 ---
 

--- a/source/error.html.erb
+++ b/source/error.html.erb
@@ -10,4 +10,4 @@ index: false
 If you entered a web address, please check it was correct.
 
 If the page you are looking for has been moved, you should
-<a href='https://github.com/alphagov/govuk-developer-docs/blob/master/config/tech-docs.yml'>set up a redirect</a>.
+<a href='https://github.com/alphagov/govuk-developer-docs/blob/main/config/tech-docs.yml'>set up a redirect</a>.

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,7 +1,7 @@
 ---
 layout: core
 title: Dashboard
-source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dashboard.yml
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/dashboard.yml
 ---
 
 <% content_for :sidebar do %>

--- a/source/manual/add-a-new-document-type.html.md
+++ b/source/manual/add-a-new-document-type.html.md
@@ -55,11 +55,11 @@ See "[Adding a new schema][adding-a-new-schema]"
 See "[Make a new document type available to search][new-doc-type-search]"
 
 [document type]: https://docs.publishing.service.gov.uk/document-types.html
-[allowed-document-types]: https://github.com/alphagov/govuk-content-schemas/blob/master/lib/govuk_content_schemas/allowed_document_types.yml
+[allowed-document-types]: https://github.com/alphagov/govuk-content-schemas/blob/main/lib/govuk_content_schemas/allowed_document_types.yml
 [govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
 [pr-652]: https://github.com/alphagov/govuk-content-schemas/pull/652
 [pr-630]: https://github.com/alphagov/govuk-content-schemas/pull/630
 [pr-250]: https://github.com/alphagov/collections-publisher/pull/250
 [placeholder-items]: https://github.com/alphagov/content-store/blob/f5bf2ae1d86b6a38d52d22074c0d13acf2a0413c/doc/route_registration.md#placeholder-items
-[adding-a-new-schema]: https://github.com/alphagov/govuk-content-schemas/blob/master/docs/adding-a-new-schema.md
+[adding-a-new-schema]: https://github.com/alphagov/govuk-content-schemas/blob/main/docs/adding-a-new-schema.md
 [new-doc-type-search]: /manual/make-a-new-document-type-available-to-search.html

--- a/source/manual/add-authentication-to-an-application.html.md
+++ b/source/manual/add-authentication-to-an-application.html.md
@@ -96,7 +96,7 @@ is still successfully processing requests.
 [e2e-database-seeds]: https://github.com/alphagov/content-store/pull/498/commits/cf41056f3cee446ef94043f3a3b074c71bcfa7d6
 [signon-integration]: http://signon.integration.publishing.service.gov.uk
 [signon-production]: http://signon.publishing.service.gov.uk
-[app-create-rake]: https://github.com/alphagov/signon/blob/master/docs/usage.md#setup-rake-tasks
+[app-create-rake]: https://github.com/alphagov/signon/blob/main/docs/usage.md#setup-rake-tasks
 [arch-overview]: https://docs.publishing.service.gov.uk/manual/architecture.html
 [api-user-production]: https://signon.publishing.service.gov.uk/api_users
 [api-user-integration]: https://signon.integration.publishing.service.gov.uk/api_users

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -13,7 +13,7 @@ Before starting, it’s worth checking the language tag that is being added is c
 [ISO 15924]: https://en.wikipedia.org/wiki/ISO_15924
 [ISO 3166]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [Rails Translation Manager]: https://github.com/alphagov/rails_translation_manager
-[Whitehall Internationalisation guide]: https://github.com/alphagov/whitehall/blob/master/docs/internationalisation_guide.md
+[Whitehall Internationalisation guide]: https://github.com/alphagov/whitehall/blob/main/docs/internationalisation_guide.md
 
 ### 1. Update Government Frontend
 

--- a/source/manual/alerts/content-publisher-government-data-check-not-ok.html.md
+++ b/source/manual/alerts/content-publisher-government-data-check-not-ok.html.md
@@ -13,5 +13,5 @@ This means that Content Publisher is having trouble updating the data it holds o
 - Run `PopulateBulkDataJob.perform_now` manually in the [Content Publisher console][console] to see if issues occur. [Link to job][data job]
 
 [Sentry]: [https://sentry.io/organizations/govuk/issues/?project=1242052]
-[data job]: [https://github.com/alphagov/content-publisher/blob/master/app/jobs/populate_bulk_data_job.rb]
+[data job]: [https://github.com/alphagov/content-publisher/blob/main/app/jobs/populate_bulk_data_job.rb]
 [console]: [https://docs.publishing.service.gov.uk/manual/get-ssh-access.html#running-a-console]

--- a/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/datagovuk-publish-healthcheck-not-ok.html.md
@@ -8,8 +8,8 @@ section: Icinga alerts
 
 [datagovuk_publish](https://github.com/alphagov/datagovuk_publish)
 has a healthcheck that monitors two Sidekiq jobs,
-[`ckan_v26_package_sync`](https://github.com/alphagov/datagovuk_publish/blob/master/app/workers/ckan/v26/package_sync_worker.rb)
-and [`ckan_v26_ckan_org_sync`](https://github.com/alphagov/datagovuk_publish/blob/master/app/workers/ckan/v26/ckan_org_sync_worker.rb).
+[`ckan_v26_package_sync`](https://github.com/alphagov/datagovuk_publish/blob/main/app/workers/ckan/v26/package_sync_worker.rb)
+and [`ckan_v26_ckan_org_sync`](https://github.com/alphagov/datagovuk_publish/blob/main/app/workers/ckan/v26/ckan_org_sync_worker.rb).
 
 The healthcheck alert notifies us if one or both of these jobs are not running in
 the expected timeframe set. This means latest [dataset](https://ckan.publishing.service.gov.uk/dataset)

--- a/source/manual/alerts/email-alert-api-high-queue-latency.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-latency.html.md
@@ -50,7 +50,7 @@ diagnostic steps you could take are:
   instance][postgres dash].
 
 [Sidekiq]: https://docs.publishing.service.gov.uk/manual/sidekiq.html
-[queues]: https://github.com/alphagov/email-alert-api/blob/master/config/sidekiq.yml
+[queues]: https://github.com/alphagov/email-alert-api/blob/main/config/sidekiq.yml
 [Sidekiq dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now
 [technical dash]: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api_technical.json
 [Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h

--- a/source/manual/alerts/email-alert-api-unprocessed-work.html.md
+++ b/source/manual/alerts/email-alert-api-unprocessed-work.html.md
@@ -9,11 +9,11 @@ parent: "/manual.html"
 
 This alert indicates that Email Alert API has work that has not been processed in the generous amount of time we expect it to have been. Which alert you see depends on the type of work.
 
-* **[`unprocessed content changes`](https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_content_change_worker.rb)**.
+* **[`unprocessed content changes`](https://github.com/alphagov/email-alert-api/blob/main/app/workers/process_content_change_worker.rb)**.
 
   * This means there is a signficiant delay in generating emails for subscribers with "immediate" frequency subscriptions in response to [a change in some content] on GOV.UK.
 
-* **[`unprocessed messages`](https://github.com/alphagov/email-alert-api/blob/master/app/workers/process_message_worker.rb)**.
+* **[`unprocessed messages`](https://github.com/alphagov/email-alert-api/blob/main/app/workers/process_message_worker.rb)**.
 
   * This means there is a significant delay in generating emails for subscribers with "immediate" frequency subscriptions in response to [a custom message].
 
@@ -56,9 +56,9 @@ If all else fails, you can try running the work manually from a console. [The au
 > ```
 
 [Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=6h
-[a custom message]: https://github.com/alphagov/email-alert-api/blob/master/docs/api.md#post-messages
-[a change in some content]: https://github.com/alphagov/email-alert-api/blob/master/docs/api.md#post-content-changes
+[a custom message]: https://github.com/alphagov/email-alert-api/blob/main/docs/api.md#post-messages
+[a change in some content]: https://github.com/alphagov/email-alert-api/blob/main/docs/api.md#post-content-changes
 [Kibana]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(columns:!('@message',host),index:'*-*',interval:auto,query:(query_string:(query:'@type:%20sidekiq%20AND%20application:%20email-alert-api%20AND%20@fields.worker:%20ProcessContentChangeWorker')),sort:!('@timestamp',desc))
-[RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/recover_lost_jobs_worker.rb
+[RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/main/app/workers/recover_lost_jobs_worker.rb
 [Sidekiq dashboard]: https://grafana.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now
 [Email Alert API Technical dashboard]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_technical.json?refresh=1m&orgId=1

--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -81,7 +81,7 @@ page in Travel Advice Publisher and looks like `fedc13e231ccd7d63e1abf65`.
 [travel advice check]: https://deploy.blue.production.govuk.digital/job/travel-advice-email-alert-check/
 [email-alert-monitoring]: https://github.com/alphagov/email-alert-monitoring
 [2nd line password store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline
-[retire alert adr]: https://github.com/alphagov/email-alert-api/blob/master/docs/adr/adr-008-monitoring-and-alerting.md#removal-of-email-alert-monitoring
+[retire alert adr]: https://github.com/alphagov/email-alert-api/blob/main/docs/adr/adr-008-monitoring-and-alerting.md#removal-of-email-alert-monitoring
 [acknowledged email list]: https://github.com/alphagov/email-alert-monitoring/blob/master/lib/email_verifier.rb#L6-L14
 [gmail status]: https://www.google.co.uk/appsstatus#hl=en-GB&v=status
 [Sidekiq dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Interval=$__auto_interval
@@ -89,7 +89,7 @@ page in Travel Advice Publisher and looks like `fedc13e231ccd7d63e1abf65`.
 [checkbox-incident]: https://docs.google.com/document/d/1AwpXPF1c7fbsOL8KX10ko_wLok4YykabmRfkHJjRqfA/edit#
 [checkbox tech debt]: https://trello.com/c/v2ees2fD/199-all-checkbox-is-misleading-for-finderemailsignups
 [courtesy copy]: /manual/email-notifications-how-they-work.html#useful-resources
-[view_emails task]: https://github.com/alphagov/email-alert-api/blob/master/docs/support-tasks.md#view-subscribers-recent-emails
+[view_emails task]: https://github.com/alphagov/email-alert-api/blob/main/docs/support-tasks.md#view-subscribers-recent-emails
 [Kibana logs]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/goto/43fc79ee47ac49f248e0f29a174be240
 [Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h
 [resend travel advice job]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D

--- a/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
+++ b/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
@@ -12,7 +12,7 @@ have arrived in the inbox but weren't able to be processed. This is usually
 because they're missing the identification for the edition they relate to
 (which is currently stored in the subject line).
 
-[Publisher fact checking process]: https://github.com/alphagov/publisher/blob/master/doc/fact-checking.md
+[Publisher fact checking process]: https://github.com/alphagov/publisher/blob/main/docs/fact-checking.md
 
 ## Dealing with the alert
 

--- a/source/manual/alerts/smokey-loop-tests.html.md
+++ b/source/manual/alerts/smokey-loop-tests.html.md
@@ -48,7 +48,7 @@ After running the above commands, you should soon see the `/tmp/smokey.json` fil
 
 ## Try a manual run of the loop
 
-The Smokey Loop is just [a repeat run of Cucumber](https://github.com/alphagov/smokey/blob/master/tests_json_output.sh#L27), which you can do yourself.
+The Smokey Loop is just [a repeat run of Cucumber](https://github.com/alphagov/smokey/blob/main/tests_json_output.sh#L27), which you can do yourself.
 
 ```shell
 sudo su - smokey
@@ -71,6 +71,6 @@ hieradata. Here's an [example PR in govuk-secrets](https://github.com/alphagov/g
 
 [signon]: https://github.com/alphagov/signon
 [smokey]: https://github.com/alphagov/smokey
-[most Smokey features]: https://github.com/alphagov/smokey/blob/master/docs/writing-tests.md#alerting-in-icinga
+[most Smokey features]: https://github.com/alphagov/smokey/blob/main/docs/writing-tests.md#alerting-in-icinga
 [Icinga checks]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/checks/smokey.pp
 [a separate "Smokey" alert]: https://github.com/alphagov/govuk-puppet/blob/master/modules/icinga/manifests/config/smokey.pp

--- a/source/manual/analytics.html.md
+++ b/source/manual/analytics.html.md
@@ -16,8 +16,8 @@ request access to this by following the [steps in the GDS wiki](https://sites.go
 
 The GOV.UK analytics codebase is a collection of JavaScript modules spread through a few different projects:
 
-- [static](https://github.com/alphagov/static/tree/master/app/assets/javascripts/analytics) - Core analytics code (originally from [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/tree/master/javascripts/govuk/analytics) but migrated and modified) plus additional and legacy modules.
-- Supplementary tracking for application specific cases is included in several applications including [government-frontend](https://github.com/alphagov/government-frontend/blob/master/app/assets/javascripts/modules/track-radio-group.js) and [frontend](https://github.com/alphagov/frontend/tree/master/app/assets/javascripts/modules).
+- [static](https://github.com/alphagov/static/blob/main/app/assets/javascripts/analytics.js.erb) - Core analytics code (originally from [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/commit/315e46edab783321196fd4a879a97b1a1ca843b1) but migrated and modified) plus additional and legacy modules.
+- Supplementary tracking for application specific cases is included in several applications including [government-frontend](https://github.com/alphagov/government-frontend/blob/main/app/assets/javascripts/modules/track-radio-group.js) and [frontend](https://github.com/alphagov/frontend/tree/master/app/assets/javascripts/modules).
 
 ## Tracking overview
 
@@ -42,7 +42,7 @@ The javascript function
 GOVUK.analytics.addLinkedTrackerDomain('UA-43888888-1', 'someServiceTracker', ['some.service.gov.uk'])
 ```
 
-registers a _linked_ (cross domain) tracker and sends a pageview to the tracker. The [current cross domain configuration on GOV.UK](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L160) contains only those domains that have turned on cross domain tracking. More information is included in [static's analytics documentation](https://github.com/alphagov/static/blob/master/docs/analytics.md#tracking-across-domains).
+registers a _linked_ (cross domain) tracker and sends a pageview to the tracker. The current cross domain configuration on GOV.UK contains only those domains that have turned on cross domain tracking. More information is included in [static's analytics documentation](https://github.com/alphagov/static/blob/main/docs/analytics.md#tracking-across-domains).
 
 Some cross domain tracking existed prior to this work to link 19 services to GOV.UK. It exists on some transaction start pages such as [Change your driving test appointment](https://www.gov.uk/change-driving-test), where the start button contains data attributes, such as:
 

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -297,7 +297,7 @@ sending an edition downstream to the Content Store.
 [Content API]: /apps/content-store.html
 [content-store]: https://github.com/alphagov/content-store
 [govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
-[Link expansion]: https://github.com/alphagov/publishing-api/blob/master/docs/link-expansion.md
+[Link expansion]: https://github.com/alphagov/publishing-api/blob/main/docs/link-expansion.md
 [Publishing API]: https://github.com/alphagov/publishing-api
 [rendering]: #rendering
 
@@ -325,7 +325,7 @@ item via Router API. This happens inside the Sidekiq job directly, rather than
 in a downstream process.
 
 [content-store-router-api]: https://github.com/alphagov/content-store/blob/dd79a03d74f130650bc97d1c84aae557ccea58d3/app/models/content_item.rb#L33
-[message-queues-rake]: https://github.com/alphagov/email-alert-service/blob/master/lib/tasks/message_queues.rake
+[message-queues-rake]: https://github.com/alphagov/email-alert-service/blob/main/lib/tasks/message_queues.rake
 [RabbitMQ]: https://www.rabbitmq.com/
 [Sidekiq]: /manual/sidekiq.html
 
@@ -362,7 +362,7 @@ as `links.taxons`. Some apps have their own interface for tagging, or you can
 tag content independently using [content-tagger].
 
 [content-tagger]: https://github.com/alphagov/content-tagger
-[dependency resolution]: https://github.com/alphagov/publishing-api/blob/master/docs/dependency-resolution.md
+[dependency resolution]: https://github.com/alphagov/publishing-api/blob/main/docs/dependency-resolution.md
 [schema-organisations-example]: https://github.com/alphagov/govuk-content-schemas/blob/d9684140462e4a138668539c04829cd808636ed5/dist/formats/news_article/publisher_v2/schema.json#L70-L73
 [taxonomies]: /manual/taxonomy.html
 
@@ -408,7 +408,7 @@ configured to use the [govuk-jenkinslib] library to build and run the tests.
 
 The tests report back to the PR as a [GitHub check], though other checks may
 also be required before the PR can be merged ([govuk-saas-config] defines things
-such as whether branches must be up to date with 'master' before merging).
+such as whether branches must be up to date with 'main' before merging).
 
 On merge, the same Jenkins job that ran the tests runs the tests again, then
 [creates and pushes a git tag][push-tag] to GitHub, then
@@ -430,7 +430,7 @@ Some apps require extra care when deploying; see ['Static' deployment rules][sta
 [create-jenkins-job]: https://github.com/alphagov/govuk-puppet/blob/6a0b05aa1f9a90c01cefd5fc5b9c8e5f0aa030f2/hieradata/common.yaml#L422
 [deploy Jenkins]: https://deploy.integration.publishing.service.gov.uk/
 [GitHub check]: https://developer.github.com/v3/checks/
-[github-actions-rfc]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-123-github-actions-ci.md
+[github-actions-rfc]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md
 [govuk-app-deployment]: https://github.com/alphagov/govuk-app-deployment
 [govuk-jenkinslib]: https://github.com/alphagov/govuk-jenkinslib
 [govuk-saas-config]: https://github.com/alphagov/govuk-saas-config

--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -149,7 +149,7 @@ where this needs to be associated with a database [ActiveStorage][] should be
 used.
 
 [ActiveRecord]: https://guides.rubyonrails.org/active_record_basics.html
-[db/seeds.rb]: https://github.com/alphagov/content-publisher/blob/master/db/seeds.rb
+[db/seeds.rb]: https://github.com/alphagov/content-publisher/blob/main/db/seeds.rb
 [key-value datastore]: https://en.wikipedia.org/wiki/Key-value_database
 [Redis]: https://redis.io/
 [RabbitMQ]: https://www.rabbitmq.com/
@@ -373,7 +373,7 @@ to use [architectural decision records][adr] in the `/docs/adr` directory
 ([example][adr-example]).
 
 [adr]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
-[adr-example]: https://github.com/alphagov/content-publisher/blob/master/docs/adr/0002-use-local-datastore.md
+[adr-example]: https://github.com/alphagov/content-publisher/blob/main/docs/adr/0002-use-local-datastore.md
 
 ## Testing strategies
 

--- a/source/manual/cookie-consent-on-govuk.html.md
+++ b/source/manual/cookie-consent-on-govuk.html.md
@@ -54,7 +54,7 @@ Users can still change their consent via the [cookie settings page].
 
 GOV.UK uses [Google Analytics](https://docs.publishing.service.gov.uk/manual/analytics.html) to track user journeys.
 
-Unlike other cookies on GOV.UK, Google Analytics (GA) cookies are not set using our cookie helpers. GA cookies are initialised within Static. Therefore, as well as deleting the GA cookies, we also need to [wrap the initialisation of GOVUK.Analytics](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L21) to ensure the cookies are not recreated.
+Unlike other cookies on GOV.UK, Google Analytics (GA) cookies are not set using our cookie helpers. GA cookies are initialised within Static. Therefore, as well as deleting the GA cookies, we also need to [wrap the initialisation of GOVUK.Analytics](https://github.com/alphagov/static/commit/5407c0d14a4eecf03619c4d7463a1097368fae4d#diff-db159f6ce52141b9dd276c2150489d59a3481f6796cf644e5b3fe95aeb749c01L1) to ensure the cookies are not recreated.
 
 We also set the following property to disable tracking:
 

--- a/source/manual/covid-19-services.html.md
+++ b/source/manual/covid-19-services.html.md
@@ -81,7 +81,7 @@ The file information can be retrieved with the following command...
 gds aws govuk-production-poweruser aws s3api head-object --bucket govuk-production-database-backups --key coronavirus-find-support/production.sql.gzip
 ```
 
-- [Smart Answers GitHub Repository](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/find-coronavirus-support.rb)
+- [Smart Answers GitHub Repository](https://github.com/alphagov/smart-answers/blob/main/lib/smart_answer_flows/find-coronavirus-support.rb)
 - [Original GitHub Repository](https://github.com/alphagov/govuk-coronavirus-find-support)
 - [Restoring the AWS infrastructure](https://github.com/alphagov/covid-engineering/pull/890)
 

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -230,5 +230,5 @@ It is possible to access analytics for datasets. If a user requests analytics fo
 
 There is a [revision log](https://ckan.publishing.service.gov.uk/revision) which shows the most recent edits to CKAN datasets, harvester and users performed by all users.
 
-[schemas]: https://github.com/alphagov/ckanext-datagovuk/blob/master/ckanext/datagovuk/helpers.py#L119-L213
-[test-schemas]: https://github.com/alphagov/ckanext-datagovuk/blob/master/ckanext/datagovuk/tests/test_helpers.py#L63-L157
+[schemas]: https://github.com/alphagov/ckanext-datagovuk/blob/main/ckanext/datagovuk/helpers.py#L119-L213
+[test-schemas]: https://github.com/alphagov/ckanext-datagovuk/blob/main/ckanext/datagovuk/tests/test_helpers.py#L63-L157

--- a/source/manual/data-gov-uk-architecture.html.md
+++ b/source/manual/data-gov-uk-architecture.html.md
@@ -13,7 +13,7 @@ parent: "/manual.html"
 [signon]: manual/manage-sign-on-accounts
 [deployment]: manual/data-gov-uk-deployment
 [monitoring]: manual/data-gov-uk-monitoring
-[signon-adr]: https://github.com/alphagov/datagovuk_publish/blob/master/docs/adr/0002-signon.md
+[signon-adr]: https://github.com/alphagov/datagovuk_publish/blob/main/docs/adr/0002-signon.md
 [statistics]: http://statistics.data.gov.uk
 [land-registry]: http://landregistry.data.gov.uk
 [csw]: http://csw.data.gov.uk/geonetwork/srv/en/main.home

--- a/source/manual/data-gov-uk-deployment.html.md
+++ b/source/manual/data-gov-uk-deployment.html.md
@@ -18,11 +18,11 @@ parent: "/manual.html"
 [jenkins]: /manual/jenkins-ci.html
 [CKAN]: https://github.com/alphagov/ckanext-datagovuk
 [new release]: https://github.com/alphagov/datagovuk_find/releases
-[Publish's travis.yml]: https://github.com/alphagov/datagovuk_publish/blob/master/.travis.yml#L30-L50
+[Publish's travis.yml]: https://github.com/alphagov/datagovuk_publish/blob/main/.travis.yml#L30-L50
 [Find's travis.yml]: https://github.com/alphagov/datagovuk_find/blob/af8cfa61584b16e4e1ad7bedbd1b7f890cec940d/.travis.yml#L44-L48
 [cf-ssh]: https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env
 [ckanext-datagovuk]: https://github.com/alphagov/ckanext-datagovuk
-[install-dependencies]: https://github.com/alphagov/ckanext-datagovuk/blob/master/bin/install-dependencies.sh
+[install-dependencies]: https://github.com/alphagov/ckanext-datagovuk/blob/main/bin/install-dependencies.sh
 [ckan-publisher]: https://ckan.publishing.service.gov.uk
 
 ## Find and Publish (Rails Apps)
@@ -50,8 +50,8 @@ manually via command line tools.
 
 #### Staging
 
-The deployment to staging is triggered when a PR gets merged into master. You
-can check the [Travis logs of the `master` build](https://travis-ci.org/alphagov/datagovuk_find) to see progress.
+The deployment to staging is triggered when a PR gets merged into main. You
+can check the [Travis logs of the `main` build](https://travis-ci.org/alphagov/datagovuk_find) to see progress.
 
 You can check the deployment on [staging.data.gov.uk](https://staging.data.gov.uk/)
 
@@ -77,7 +77,7 @@ cf zero-downtime-push publish-data-beta-staging -f staging-app-manifest.yml
 cf zero-downtime-push publish-data-beta-staging-worker -f staging-worker-manifest.yml
 ```
 
-There are [some scripts available for datagovuk_publish](https://github.com/alphagov/datagovuk_publish/tree/master/scripts) which can run a deploy for you, for example:
+There are [some scripts available for datagovuk_publish](https://github.com/alphagov/datagovuk_publish/tree/main/scripts) which can run a deploy for you, for example:
 
 ```
 $ cd datagovuk_publish

--- a/source/manual/data-gov-uk-map-previews.html.md
+++ b/source/manual/data-gov-uk-map-previews.html.md
@@ -17,7 +17,7 @@ Manually uploading datasets will not generate map preview data, please create a 
 
 [Data.gov.uk find](https://data.gov.uk/search?q=&filters%5Bpublisher%5D=&filters%5Btopic%5D=&filters%5Bformat%5D=WMS&sort=best) provides a map preview for Web Map Service (WMS) data. This data is represented as features on a map, eg. historic landfill sites in the UK.
 
-The source code for the map rendering can be found in [alphagov/datagovuk_find javascript assets](https://github.com/alphagov/datagovuk_find/tree/master/app/assets/javascripts/map-preview). Maps are comprised of client-side javascript on top of [OpenLayers](https://openlayers.org/) and [Ext](https://www.sencha.com/extjs-for-open-source/) 3rd party javascript libraries.
+The source code for the map rendering can be found in [alphagov/datagovuk_find javascript assets](https://github.com/alphagov/datagovuk_find/tree/main/app/assets/javascripts/map-preview). Maps are comprised of client-side javascript on top of [OpenLayers](https://openlayers.org/) and [Ext](https://www.sencha.com/extjs-for-open-source/) 3rd party javascript libraries.
 
 ## Key OpenLayers map preview concepts
 

--- a/source/manual/dictionary.html.erb
+++ b/source/manual/dictionary.html.erb
@@ -4,7 +4,7 @@ parent: /manual.html
 layout: false
 section: Learning GOV.UK
 type: learn
-source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/dictionary.yml
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/dictionary.yml
 ---
 
 <% content_for :sidebar do %>

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -57,22 +57,22 @@ The email notification system generates 3 different types of email. These are tr
 
 Communication from Email Alert API to Notify is done via a HTTP API which is authenticated by [an API key][notify-api-key]. Communication from Notify to Email Alert API is [authenticated][email-spam-auth] with Signon and a bearer token.  Email Alert API is an internal application, so to enable callbacks two endpoints are [exposed][email-spam-public] publicly through <https://email-alert-api-public.publishing.service.gov.uk> (similarly for Integration and Staging).
 
-[finder-frontend-email]: https://github.com/alphagov/finder-frontend/blob/master/app/controllers/email_alert_subscriptions_controller.rb
+[finder-frontend-email]: https://github.com/alphagov/finder-frontend/blob/main/app/controllers/email_alert_subscriptions_controller.rb
 [email-frontend-readme]: https://github.com/alphagov/email-alert-frontend
 [Specialist Publisher]: /apps/specialist-publisher.html
 [Travel Advice Publisher]: /apps/travel-advice-publisher.html
 [travel-specialist-tech-debt]: https://trello.com/c/tWIZfxfc/94-travel-advice-publisher-and-specialist-publisher-talk-directly-to-email-alert-api
 [email-alert-api-technical]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_technical.json
 [email-alert-api-product]: https://grafana.production.govuk.digital/dashboard/file/email_alert_api_product.json
-[email-alert-api-matching]: https://github.com/alphagov/email-alert-api/blob/master/docs/matching-content-to-subscriber-lists.md
+[email-alert-api-matching]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md
 [receiving-integration-staging-email]: /manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html
 [google-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-email-courtesy-copies
 [courtesy-subscription-page]: https://www.gov.uk/search/all/email-signup
-[email-spam-report]: https://github.com/alphagov/email-alert-api/blob/master/app/controllers/spam_reports_controller.rb
+[email-spam-report]: https://github.com/alphagov/email-alert-api/blob/main/app/controllers/spam_reports_controller.rb
 [notify-api-key]: https://github.com/alphagov/email-alert-api/blob/05c99c4ed95f71dbca1d423dd3d5d438b93d6437/config/secrets.yml#L40
 [email-spam-auth]: https://signon.publishing.service.gov.uk/api_users/14020/edit
 [email-spam-public]: https://github.com/alphagov/govuk-aws/commit/442bd30c46f8c242a7df05a8c27a79855b5698fb#diff-069b7aaa2455edca6b507407de527eba4e4374d04b01584889519b6c5d6a4290R822
-[message-adr]: https://github.com/alphagov/email-alert-api/blob/master/docs/adr/adr-004-message-concept.md
-[brexit-checker]: https://github.com/alphagov/finder-frontend/tree/master/app/lib/brexit_checker
+[message-adr]: https://github.com/alphagov/email-alert-api/blob/main/docs/adr/adr-004-message-concept.md
+[brexit-checker]: https://github.com/alphagov/finder-frontend/tree/main/app/lib/brexit_checker
 [email-service-readme]: https://github.com/alphagov/email-alert-service
 [email-api-readme]: https://github.com/alphagov/email-alert-api

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -116,7 +116,7 @@ Caches will clear automatically.
 
 ### Background
 
-The information for the emergency banner is stored in Redis. [Static](https://github.com/alphagov/static) is responsible for displaying the data and we use Jenkins to run [rake tasks in static](https://github.com/alphagov/static/blob/master/lib/tasks/emergency_banner.rake) to set or delete the appropriate hash in Redis.
+The information for the emergency banner is stored in Redis. [Static](https://github.com/alphagov/static) is responsible for displaying the data and we use Jenkins to run [rake tasks in static](https://github.com/alphagov/static/blob/main/lib/tasks/emergency_banner.rake) to set or delete the appropriate hash in Redis.
 
 ### The banner is not showing / not clearing
 

--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -37,7 +37,7 @@ When a request to GOV.UK fails, we need to handle the error in some way, so that
 
 ## How we handle errors in our apps
 
-This policy describes what we should do for different types of errors. It applies to all apps, irrespective of other error handling by downstream servers. This policy was first proposed in [RFC 87](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-087-dealing-with-errors.md).
+This policy describes what we should do for different types of errors. It applies to all apps, irrespective of other error handling by downstream servers. This policy was first proposed in [RFC 87](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-087-dealing-with-errors.md).
 
 ### High priority errors
 

--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -24,7 +24,7 @@ rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:
 
 You can also run this task from Jenkins.
 
-[Other replay options are available](https://github.com/alphagov/publishing-api/blob/master/lib/tasks/represent_downstream.rake), for example replaying all traffic for a single publishing app or doctype.
+[Other replay options are available](https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake), for example replaying all traffic for a single publishing app or doctype.
 Be aware that these options will replay the entire Publisher API history for that app or doctype, and may take some time.
 
 ## `government`/`detailed` indexes
@@ -59,4 +59,4 @@ rake reindex_best_bets
 You can also run this task from Jenkins.
 
 [restore-backups]: https://docs.publishing.service.gov.uk/manual/elasticsearch-dumps.html
-[queue]: https://github.com/alphagov/search-api/blob/master/docs/new-indexing-process.md
+[queue]: https://github.com/alphagov/search-api/blob/main/docs/new-indexing-process.md

--- a/source/manual/global-banner.html.md
+++ b/source/manual/global-banner.html.md
@@ -43,7 +43,7 @@ re-deployed. The only way a user will see the banner again is if:
 1. the `global_bar_seen` cookie expires, or
 1. the global banner is versioned
 
-To version the global banner, increase the `BANNER_VERSION` in [`global-bar-init.js`](https://github.com/alphagov/static/blob/master/app/assets/javascripts/global-bar-init.js) by one.
+To version the global banner, increase the `BANNER_VERSION` in [`global-bar-init.js`](https://github.com/alphagov/static/blob/main/app/assets/javascripts/global-bar-init.js) by one.
 
 ## Removing the global banner
 
@@ -52,4 +52,4 @@ In [`app/views/notifications/_global_bar.html.erb`][global-bar-view]:
 1. Update the `show_global_bar` variable to `false`
 1. Deploy static
 
-[global-bar-view]: https://github.com/alphagov/static/blob/master/app/views/notifications/_global_bar.html.erb
+[global-bar-view]: https://github.com/alphagov/static/blob/main/app/views/components/_global_bar.html.erb

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -74,7 +74,7 @@ Marking content as political can happen automatically through the
 [PoliticalContentIdentifier][]. The `political` flag on an `Edition` can also
 be set manually.
 
-[PoliticalContentIdentifier]: https://github.com/alphagov/whitehall/blob/master/lib/political_content_identifier.rb
+[PoliticalContentIdentifier]: https://github.com/alphagov/whitehall/blob/main/lib/political_content_identifier.rb
 
 #### Reindexing political content in search
 
@@ -148,4 +148,4 @@ order):
 There is a similar [Rake task to change the organisations for Manuals][manuals-bulk-update-organisation].
 
 [whitehall-bulk-update-organisation]: https://github.com/alphagov/whitehall/blob/917085dca58fb58dbf65c7e226ad445cc1f27bdd/lib/tasks/data_hygiene.rake#L37
-[manuals-bulk-update-organisation]: https://github.com/alphagov/manuals-publisher/blob/master/lib/tasks/update_manual_organisation.rake
+[manuals-bulk-update-organisation]: https://github.com/alphagov/manuals-publisher/blob/main/lib/tasks/update_manual_organisation.rake

--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -50,7 +50,7 @@ for each environment):
   to users who click a survey banner or use the `Is this page useful?` feature.
 
 [Email Alert API Product dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api_product.json?refresh=1m&orgId=1
-[SendEmailWorker]: https://github.com/alphagov/email-alert-api/blob/master/app/workers/send_email_worker.rb#L4
+[SendEmailWorker]: https://github.com/alphagov/email-alert-api/blob/main/app/workers/send_email_worker.rb#L4
 
 ## Accessing the dashboard
 

--- a/source/manual/howto-add-organisation-brand-colour.html.md
+++ b/source/manual/howto-add-organisation-brand-colour.html.md
@@ -16,8 +16,8 @@ creating or editing an [organisation page in Whitehall Publisher](https://whiteh
 
 ## 1. Add the brand colour in GOV.UK Frontend
 
-Set up a fork of `govuk-frontend`, then add the colour to the [_colours-organisations.scss file](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/settings/_colours-organisations.scss) and update the [CHANGELOG](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).
-See [updating changelog](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/versioning.md#updating-changelog) and [example PR](https://github.com/alphagov/govuk-frontend/pull/1918) for more details.
+Set up a fork of `govuk-frontend`, then add the colour to the [_colours-organisations.scss file](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/settings/_colours-organisations.scss) and update the [CHANGELOG](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md).
+See [updating changelog](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/versioning.md#updating-changelog) and [example PR](https://github.com/alphagov/govuk-frontend/pull/1918) for more details.
 
 > **Note**
 >
@@ -28,15 +28,15 @@ as an example.
 
 ## 2. Add the organisation as brand colour option in Whitehall
 
-Add a new entry for the organisation in [app/models/organisation_brand_colour.rb](https://github.com/alphagov/whitehall/blob/master/app/models/organisation_brand_colour.rb), which will show
+Add a new entry for the organisation in [app/models/organisation_brand_colour.rb](https://github.com/alphagov/whitehall/blob/main/app/models/organisation_brand_colour.rb), which will show
 the organisation as an option under the [brand colour drop down field](https://github.com/alphagov/whitehall/blob/52aff8f61a29b3999054b5b5c94875a5534eaf9a/app/views/admin/organisations/_form.html.erb#L25) in Whitehall.
 The CSS class name should match the name used in `govuk-frontend`.
 
 ## Testing your changes locally
 
-1. [Install `govuk-frontend` with npm](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/running-locally.md)
+1. [Install `govuk-frontend` with npm](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/running-locally.md)
 2. In `govuk_publishing_components`, update `package.json` to point to your local
-  `govuk-frontend` repo, then update the package, see [this doc](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/tasks.md) for more details
+  `govuk-frontend` repo, then update the package, see [this doc](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/tasks.md) for more details
 3. In `collections`, update the Gemfile to point to your local version of
   `govuk_publishing_components`
 4. In `whitehall`, you should see the organisation as an option under the `brand

--- a/source/manual/intro-to-docker.html.md
+++ b/source/manual/intro-to-docker.html.md
@@ -369,4 +369,4 @@ But there's more! Check out the [next tutorial in this series](/manual/intro-to-
 [dockerignore]: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 [privileged]: https://github.com/jessfraz/dockerfiles/issues/350#issuecomment-477342782
 [docker-compose]: https://docs.docker.com/compose/
-[content-publisher-ruby]: https://github.com/alphagov/content-publisher/blob/master/.ruby-version
+[content-publisher-ruby]: https://github.com/alphagov/content-publisher/blob/main/.ruby-version

--- a/source/manual/make-a-new-document-type-available-to-search.html.md
+++ b/source/manual/make-a-new-document-type-available-to-search.html.md
@@ -66,13 +66,13 @@ You can test that the documents appear in search through the API using a query s
 - [https://www-origin.integration.publishing.service.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide][query-2]
 
 [search-api]: https://github.com/alphagov/search-api
-[doc-types]: https://github.com/alphagov/search-api/blob/master/docs/schemas.md#elasticsearch-document-types
-[edition]: https://github.com/alphagov/search-api/blob/master/config/schema/elasticsearch_types/edition.json
-[mapped-doc-types]: https://github.com/alphagov/search-api/blob/master/config/govuk_index/mapped_document_types.yaml
-[i-c-presenter]: https://github.com/alphagov/search-api/blob/master/lib/govuk_index/presenters/indexable_content_presenter.rb
-[e-s-presenter]: https://github.com/alphagov/search-api/blob/master/lib/govuk_index/presenters/elasticsearch_presenter.rb
-[migrated-list]: https://github.com/alphagov/search-api/blob/master/config/govuk_index/migrated_formats.yaml
+[doc-types]: https://github.com/alphagov/search-api/blob/main/docs/schemas.md#elasticsearch-document-types
+[edition]: https://github.com/alphagov/search-api/blob/main/config/schema/elasticsearch_types/edition.json
+[mapped-doc-types]: https://github.com/alphagov/search-api/blob/main/config/govuk_index/mapped_document_types.yaml
+[i-c-presenter]: https://github.com/alphagov/search-api/blob/main/lib/govuk_index/presenters/indexable_content_presenter.rb
+[e-s-presenter]: https://github.com/alphagov/search-api/blob/main/lib/govuk_index/presenters/elasticsearch_presenter.rb
+[migrated-list]: https://github.com/alphagov/search-api/blob/main/config/govuk_index/migrated_formats.yaml
 [reindex]: reindex-elasticsearch.html
-[task]: https://github.com/alphagov/publishing-api/blob/master/lib/tasks/represent_downstream.rake
+[task]: https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake
 [query-1]: https://www.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide
 [query-2]: https://www-origin.integration.publishing.service.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide

--- a/source/manual/make-github-repo-private.html.md
+++ b/source/manual/make-github-repo-private.html.md
@@ -22,7 +22,7 @@ To fork an existing GOV.UK repository and make it private perform the following 
 1. Add the 'GOV.UK - CI Bots' team so that Jenkins can access the repository for deployment. Make sure it is set to 'write' access because Jenkins needs to access the repository and set the release tag.
 1. Add the 'gov-uk' team and set it 'write' access so that developers can create and merge pull requests.
 1. Consider adding [a GitHub action](https://github.com/search?q=org%3Aalphagov+%22Use+GitHub+Actions%22&type=Issues) to replace Jenkins CI that will not be running on this new repo.
-1. Add a branch protection rule against the master branch. You can [use the settings in another repo](https://github.com/alphagov/government-frontend/settings/branches) as a template.
+1. Add a branch protection rule against the main branch. You can [use the settings in another repo](https://github.com/alphagov/government-frontend/settings/branches) as a template.
 
 ## Deploying the private repository
 
@@ -92,13 +92,13 @@ As part of our workflow we will need to keep our private repositories in sync wi
 $ git remote add upstream https://github.com/alphagov/frontend.git
 ```
 
-We can now fetch commits from the upstream public repository and pull them in a new branch which can be merged into master through the usual Pull Request workflow.
+We can now fetch commits from the upstream public repository and pull them in a new branch which can be merged into main through the usual Pull Request workflow.
 
 ```
 $ git fetch upstream
-$ git diff upstream/master master # check if we need to rebase at all
+$ git diff upstream/main main # check if we need to rebase at all
 $ git checkout -b update
-$ git pull upstream master
+$ git pull upstream main
 $ git push origin update
 ```
 
@@ -107,12 +107,12 @@ $ git push origin update
 In order to make our private changes public, we need to incorporate them into the public repo.
 
 1. Make sure you have pulled in the latest changes from the public repo into the private repo (detailed in 'Keeping repositories in sync').
-1. Merge any pending pull requests into the master branch of the private repo.
+1. Merge any pending pull requests into the main branch of the private repo.
 1. On the public repo, add the private repo as a new upstream remote: e.g. `git remote add upstream https://github.com/alphagov/frontend-private.git`
 1. Create a new branch on the public repo.
-1. Rebase the master branch of the private repo onto the new branch:
+1. Rebase the main branch of the private repo onto the new branch:
 1. `git fetch upstream`
-1. `git rebase upstream/master`
-1. `git rebase master`
+1. `git rebase upstream/main`
+1. `git rebase main`
 1. Raise a PR on the public repo for the new branch.
 1. Delete the private fork, once the changes have been merged into the public repo.

--- a/source/manual/manage-ruby-dependencies.html.md
+++ b/source/manual/manage-ruby-dependencies.html.md
@@ -51,9 +51,9 @@ We have the [govuk-dependencies app][app] to monitor outstanding Dependabot PRs 
 
 ### Security
 
-There are 2 safeguards to prevent unauthorised code changes. Firstly, Dependabot can only update the repositories that we [explicitly allow on GitHub][access]. This prevents code changes to other repos. Secondly, we've [set up branch protection](/manual/configure-github-repo.html#auto-configuration) for all repos with the `govuk` label. This prevents Dependabot from writing directly to master.
+There are 2 safeguards to prevent unauthorised code changes. Firstly, Dependabot can only update the repositories that we [explicitly allow on GitHub][access]. This prevents code changes to other repos. Secondly, we've [set up branch protection](/manual/configure-github-repo.html#auto-configuration) for all repos with the `govuk` label. This prevents Dependabot from writing directly to main.
 
-[RFC 126]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-126-custom-configuration-for-dependabot.md
+[RFC 126]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-126-custom-configuration-for-dependabot.md
 [ext]: https://docs.publishing.service.gov.uk/manual/merge-pr.html
 [access]: https://github.com/organizations/alphagov/settings/installations/87197
 [current]: /manual/keeping-software-current.html

--- a/source/manual/merge-pr.html.md
+++ b/source/manual/merge-pr.html.md
@@ -8,19 +8,19 @@ parent: "/manual.html"
 
 There are five rules for reviewing and merging PRs, which apply to all applications:
 
-1. The `master` branch must be able to be released at any time.
+1. The `main` branch must be able to be released at any time.
 2. The change must have two reviews from people from GDS (preferably GOV.UK). This can (and normally will) include the author.
 3. If a branch is force-pushed or rebased after a review on its PR, the author must dismiss the stale review and ask for a new one, unless the change is a rebase on top of a small piece of work and the author is confident there are no side effects.
 4. The GitHub review UI should be used to mark a PR as approved or requiring changes.
 5. The GitHub UI should be used to merge the PR. This ensures the PR number is added to the merge commit.
 
-We're doing more and more [continuous deployment](https://docs.google.com/document/d/1YhgjJjDRB57-IlgPNAAZzFTI3jIUucGJKokti_lQiRQ/edit) these days, which means that merging to `master` on some apps is [restricted to those with Production access](https://github.com/alphagov/govuk-saas-config/search?q=need_production_access_to_merge&unscoped_q=need_production_access_to_merge), as doing so auto-deploys to Production. If an app is continuously deployed, the PR template will show a warning triangle emoji. For apps that are not continuously deployed, you should deploy your changes all the way to Production as soon as possible after merging them.
+We're doing more and more [continuous deployment](https://docs.google.com/document/d/1YhgjJjDRB57-IlgPNAAZzFTI3jIUucGJKokti_lQiRQ/edit) these days, which means that merging to `main` on some apps is [restricted to those with Production access](https://github.com/alphagov/govuk-saas-config/search?q=need_production_access_to_merge&unscoped_q=need_production_access_to_merge), as doing so auto-deploys to Production. If an app is continuously deployed, the PR template will show a warning triangle emoji. For apps that are not continuously deployed, you should deploy your changes all the way to Production as soon as possible after merging them.
 
 ## Example scenarios
 
 ### A simple change
 
-A small PR for a well-understood application, written by someone with good knowledge of the problem domain and with a well-defined scope. When a PR is created, someone with similar understanding of the application and change can approve and merge the PR. Both people are very confident that `master` will be deployable once this PR is merged.
+A small PR for a well-understood application, written by someone with good knowledge of the problem domain and with a well-defined scope. When a PR is created, someone with similar understanding of the application and change can approve and merge the PR. Both people are very confident that `main` will be deployable once this PR is merged.
 
 ### A simple change for a repository that has a long-running test suite
 
@@ -87,6 +87,6 @@ If two developers worked on the same branch and individually contributed commits
 ## Other considerations
 
 1. When opening a PR, if you feel you don't have full confidence in your change and want a particular review from someone, it's OK to ask for that review in the PR description. For example, a puppet change might warrant a particular review from a member of the GOV.UK Replatforming team.
-2. It's OK for someone other than the author to merge a PR, particularly if the author is not available. That person should be confident that the change doesn't have dependencies on other changes, and that it won't break `master`.
+2. It's OK for someone other than the author to merge a PR, particularly if the author is not available. That person should be confident that the change doesn't have dependencies on other changes, and that it won't break `main`.
 3. If a PR is particularly good, remember to praise the author for it. Emoji are a great way of showing appreciation for a PR that fixes a problem you've been having, or implements something you've wanted to do for a while.
 4. It's sometimes OK for merges to happen when test suites are failing. This ability is limited to repository administrators and account owners, so ask them if you need them to force a merge. This is particularly useful in a catch-22 situation of two repositories with failing test suites that depend on each other.

--- a/source/manual/naming.html.md
+++ b/source/manual/naming.html.md
@@ -6,7 +6,7 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-This describes how you should name an application or gem on GOV.UK. It was first proposed in [RFC 63](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-063-naming-new-apps-gems-on-gov-uk.md).
+This describes how you should name an application or gem on GOV.UK. It was first proposed in [RFC 63](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-063-naming-new-apps-gems-on-gov-uk.md).
 
 Of course, break any of these rules sooner than [say anything outright barbarous](https://en.wikipedia.org/wiki/Politics_and_the_English_Language#Remedy_of_Six_Rules).
 

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -14,7 +14,7 @@ end-to-end testing.
 "Consumer-driven" means that the consumer of a service sets expectations about
 behaviour it needs from the provider.
 
-For example, [the publishing API is set up to run pact tests](https://github.com/alphagov/publishing-api/blob/master/docs/pact_testing.md).
+For example, [the publishing API is set up to run pact tests](https://github.com/alphagov/publishing-api/blob/main/docs/pact_testing.md).
 This means that any consumer of the publishing API can create contracts using the pact gem,
 and the publishing api deployment pipeline will check that consumers' contracts are still met by new builds.
 

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -91,7 +91,7 @@ connecting to the RabbitMQ control panel.
 [create_queues]: https://github.com/alphagov/email-alert-service/blob/f8485df2f0916285ade33a9cb1e4a7e73c2491ad/lib/tasks/message_queues.rake#L9
 [publishing_api_publishes_message]: https://github.com/alphagov/publishing-api/blob/1d6bf06fcb74519b5c379f803ae1df65f93f74f7/lib/queue_publisher.rb#L26
 [publish_message_call]: https://github.com/alphagov/publishing-api/blob/1d6bf06fcb74519b5c379f803ae1df65f93f74f7/lib/queue_publisher.rb#L73
-[rabbit_config_rake]: https://github.com/alphagov/email-alert-service/blob/master/lib/tasks/message_queues.rake#L17
+[rabbit_config_rake]: https://github.com/alphagov/email-alert-service/blob/main/lib/tasks/message_queues.rake#L17
 [rabbit_config_yml]: https://github.com/alphagov/email-alert-service/blob/f8485df2f0916285ade33a9cb1e4a7e73c2491ad/config/rabbitmq.yml
 [message_processors]: https://github.com/alphagov/email-alert-service/blob/f8485df2f0916285ade33a9cb1e4a7e73c2491ad/lib/tasks/message_queues.rake#L21
 [message_consumer]: https://github.com/alphagov/govuk_message_queue_consumer

--- a/source/manual/redirect-routes.html.md.erb
+++ b/source/manual/redirect-routes.html.md.erb
@@ -108,7 +108,7 @@ Sometimes, Publishing API and Content Store can end up out of sync
 with one another, whereby a redirect has been applied to a content
 item in Publishing API but hasn't been successfully processed by
 Content Store. In these cases, there are several
-[rake tasks](https://github.com/alphagov/publishing-api/blob/master/lib/tasks/represent_downstream.rake)
+[rake tasks](https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake)
 we can use to re-present the content item from Publishing API to
 Content Store.
 
@@ -329,7 +329,7 @@ The deleted routes will take effect after a short delay (for Router instances to
 ## Redirects for HMRC manuals
 [hmrc-manuals-section]: #redirects-for-hmrc-manuals
 
-There are rake tasks for redirecting HMRC manuals and HMRC manual sections, which can be [found in the hmrc-manuals-api repo](https://github.com/alphagov/hmrc-manuals-api/tree/master/lib/tasks). These can be run via the `Run rake task` jenkins job.
+There are rake tasks for redirecting HMRC manuals and HMRC manual sections, which can be [found in the hmrc-manuals-api repo](https://github.com/alphagov/hmrc-manuals-api/tree/main/lib/tasks). These can be run via the `Run rake task` jenkins job.
 
 [See example of redirecting a HMRC manual section to another section](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=hmrc-manuals-api&MACHINE_CLASS=backend&RAKE_TASK=redirect_hmrc_section[original-parent-manual-slug,original-section-slug,new-parent-manual-slug,new-section-slug])
 

--- a/source/manual/republishing-content.html.md
+++ b/source/manual/republishing-content.html.md
@@ -65,7 +65,7 @@ or you can resync all documents:
 [`resync:all`][resync-all-jenkins]
 
 [govspeak-repo]: https://github.com/alphagov/govspeak/
-[resync-rake-task]: https://github.com/alphagov/content-publisher/blob/master/lib/tasks/resync.rake
+[resync-rake-task]: https://github.com/alphagov/content-publisher/blob/main/lib/tasks/resync.rake
 [resync-single-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=resync:document[a-content-id:locale]
 [resync-all-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=resync:all
 [republish-whitehall-doc-jenkins]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug]

--- a/source/manual/review-apps.html.md
+++ b/source/manual/review-apps.html.md
@@ -101,8 +101,8 @@ environment variables configured before you can successfully deploy the app to
 Heroku.
 
 Check out the `app.json` files on both
-[collections](https://github.com/alphagov/collections/blob/master/app.json) and
-[government-frontend](https://github.com/alphagov/government-frontend/blob/master/app.json)
+[collections](https://github.com/alphagov/collections/blob/main/app.json) and
+[government-frontend](https://github.com/alphagov/government-frontend/blob/main/app.json)
 for examples of necessary environment variables.
 
 You can create the application via the `app.json` file.
@@ -124,7 +124,7 @@ If all goes well, you will be able to see your app on:
 ## Create a new pipeline on Heroku
 
 Once you have a successful deployment of your app into Heroku and the `app.json`
-file commited to the repository and in your master branch, you will now be able
+file commited to the repository and in your main branch, you will now be able
 to start using review apps.
 
 On Heroku, create a new pipeline and enable automatic review apps when prompted.

--- a/source/manual/schemas.html.md
+++ b/source/manual/schemas.html.md
@@ -65,9 +65,9 @@ This is still quite new, and we've only user-tested it once.  We found that peop
 We have a few different implementations of this right now, because it's very new and we wanted to be able to explore its use in different document types.  They are:
 
 - [The schema used on answers in GOV.UK publishing components](https://github.com/alphagov/govuk_publishing_components/blob/master/lib/govuk_publishing_components/presenters/machine_readable/faq_page_schema.rb)
-- [The schema used on most guides in Government Frontend](https://github.com/alphagov/government-frontend/blob/master/app/presenters/machine_readable/guide_faq_page_schema_presenter.rb)
-- [The schema used on "how to vote" also in Government Frontend](https://github.com/alphagov/government-frontend/blob/master/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb)
-- [The schema used for transactions in Frontend](https://github.com/alphagov/frontend/blob/master/app/presenters/machine_readable/transaction_faq_page_schema.rb)
+- [The schema used on most guides in Government Frontend](https://github.com/alphagov/government-frontend/blob/main/app/presenters/machine_readable/guide_faq_page_schema_presenter.rb)
+- [The schema used on "how to vote" also in Government Frontend](https://github.com/alphagov/government-frontend/blob/main/app/presenters/machine_readable/yaml_faq_page_schema_presenter.rb)
+- [The schema used for transactions in Frontend](https://github.com/alphagov/frontend/blob/7c6e5e342d778f1d9c136bd80e3f34a133532481/app/presenters/machine_readable/transaction_faq_page_schema.rb)
 
 We may consolidate these at some point!
 

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -71,7 +71,7 @@ Unhandled exceptions are automatically logged to Sentry, but you can also
 [trello-migrate]: https://trello.com/c/1zVPYfTR/1979-replace-sentry-raven-with-sentry-ruby
 [govuk_app_config]: https://github.com/alphagov/govuk_app_config
 [govukerror]: https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_error.rb
-[email-alert-api-example]: https://github.com/alphagov/email-alert-api/blob/master/config/initializers/govuk_error.rb
+[email-alert-api-example]: https://github.com/alphagov/email-alert-api/blob/main/config/initializers/govuk_error.rb
 [manually-report]: https://github.com/alphagov/govuk_app_config/blob/073c9b2312a4893b040c9225b713ac880c69f5b8/README.md#manual-error-reporting
 
 ## Sentry roles

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -15,7 +15,7 @@ parent: "/manual.html"
 [sentry]: https://sentry.io/settings/govuk/teams/
 [release]: https://release.publishing.service.gov.uk/applications
 [deploy-jenkins]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/
-[docs-applications]: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
+[docs-applications]: https://github.com/alphagov/govuk-developer-docs/blob/main/data/applications.yml
 [get-started]: https://docs.publishing.service.gov.uk/manual/get-started.html
 [linting]: https://docs.publishing.service.gov.uk/manual/configure-linting.html
 [rails-conv]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html

--- a/source/manual/sidekiq.html.md
+++ b/source/manual/sidekiq.html.md
@@ -65,10 +65,10 @@ You can access each application's dashboard via a URL for:
 
 - Choose a port that isn't already taken for the Sidekiq Monitoring
   app to be served from.
-- Add it to the [Procfile in the sidekiq-monitoring repository](https://github.com/alphagov/sidekiq-monitoring/blob/master/Procfile)
+- Add it to the [Procfile in the sidekiq-monitoring repository](https://github.com/alphagov/sidekiq-monitoring/blob/main/Procfile)
   maintaining the alphabetical order of the processes.
 - Update
-  [index.html](https://github.com/alphagov/sidekiq-monitoring/blob/master/public/index.html#L26-L29)
+  [index.html](https://github.com/alphagov/sidekiq-monitoring/blob/main/public/index.html#L26-L29)
   to include a link to your application's sidekiq-monitoring maintaining the
   alphabetical order of the applications. This path is configured as a location
   under the sidekiq-monitoring vhost.

--- a/source/manual/taxonomy.html.md
+++ b/source/manual/taxonomy.html.md
@@ -31,7 +31,7 @@ The link type `parent_taxons` is used to store the relationship
 between taxons. A [reverse link][reverse-link-config] called
 `child_taxons` is setup through the publishing-api.
 
-[reverse-link-config]: https://github.com/alphagov/publishing-api/blob/master/lib/expansion_rules.rb#L29
+[reverse-link-config]: https://github.com/alphagov/publishing-api/blob/main/lib/expansion_rules.rb#L29
 
 ## Tagging
 
@@ -135,4 +135,4 @@ Graphite (via StatsD).
 [dashboard]: https://grafana.publishing.service.gov.uk/dashboard/file/topic_taxonomy.json
 [record-taxonomy-metrics]: https://deploy.publishing.service.gov.uk/job/record-taxonomy-metrics/
 [override-fields]: /apis/search/search-api.html#returning-specific-document-fields
-[record-metrics]: https://github.com/alphagov/content-tagger/blob/master/lib/tasks/taxonomy_metrics.rake#L27
+[record-metrics]: https://github.com/alphagov/content-tagger/blob/main/lib/tasks/taxonomy_metrics.rake#L27

--- a/source/manual/test-and-build-a-project-with-github-actions.html.md
+++ b/source/manual/test-and-build-a-project-with-github-actions.html.md
@@ -26,7 +26,7 @@ following:
   jobs during or following a build (for example, triggering
   [publishing end-to-end tests][e2e-tests] or triggering a deployment);
 - authentication to external systems (for example, [releasing a gem
-  automatically][gem-release] during a master build).
+  automatically][gem-release] during a main build).
 
 ## GOV.UK Conventions for GitHub Actions
 
@@ -42,7 +42,7 @@ push to the repository and this will generate a build against the branch
 that was pushed. The `pull_request` event occurs whenever a pull request
 is opened and it is triggered again any time the pull request changes (such
 as extra commits or rebasing), these differ to the `push` event by merging in
-the master branch before running operations. Pull requests from forks of a
+the main branch before running operations. Pull requests from forks of a
 repo will only trigger the `pull_request` event.
 
 For example:
@@ -222,12 +222,12 @@ Notes:
 - In the underlying project (Content Publisher) `bundle exec rake` performs:
   Ruby & JS unit testing; Ruby, SCSS, JavaScript and FactoryBot linting; and
   brakeman security audit.
-- This example does not include tagging the [master branch with a particular
-  release tag][release-tag] when there is a successful master build.
+- This example does not include tagging the [main branch with a particular
+  release tag][release-tag] when there is a successful main build.
 
 [ci]: https://en.wikipedia.org/wiki/Continuous_integration
 [Jenkins]: /manual/testing-projects.html
-[GOV.UK RFC 123]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-123-github-actions-ci.md
+[GOV.UK RFC 123]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md
 [actions-secrets]: https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
 [e2e-tests]: /manual/publishing-e2e-tests.html
 [gem-release]: /manual/publishing-a-ruby-gem.html#releasing-gem-versions

--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -23,7 +23,7 @@ it, or changing the configuration of an existing site in the Transition app.
 The [transition-config README][transition-config] gives more details on how to
 edit the relevant [transition configuration file].
 
-[transition configuration file]: https://github.com/alphagov/transition-config/tree/master/data/transition-sites
+[transition configuration file]: https://github.com/alphagov/transition-config/tree/main/data/transition-sites
 
 ## Checklist for transitioning a new site
 
@@ -100,7 +100,7 @@ There are lots of file formats we don't want to provide mappings for, like
 static assets, images, or common spammy/malicious crawlers. These can be
 stripped using the [strip_mappings.sh][smsh] script.
 
-[smsh]: https://github.com/alphagov/transition-config/blob/master/tools/strip_mappings.sh
+[smsh]: https://github.com/alphagov/transition-config/blob/main/tools/strip_mappings.sh
 
 #### Query parameter analysis
 
@@ -112,8 +112,8 @@ mapped to a different new URL.
 
 There are some transition-config scripts to help analyse query param usage:
 
-- [analyse_query_params.sh](https://github.com/alphagov/transition-config/blob/master/tools/analyse_query_params.sh)
-- [analyse_query_usage.sh](https://github.com/alphagov/transition-config/blob/master/tools/analyse_query_usage.sh)
+- [analyse_query_params.sh](https://github.com/alphagov/transition-config/blob/main/tools/analyse_query_params.sh)
+- [analyse_query_usage.sh](https://github.com/alphagov/transition-config/blob/main/tools/analyse_query_usage.sh)
 
 Some common examples of significant parameters:
 
@@ -194,5 +194,5 @@ The transition checklist covers the whole process of transitioning a site from t
 
 [Transition]: /apps/transition.html
 [Bouncer]: /apps/bouncer.html
-[transition-config]: https://github.com/alphagov/transition-config/blob/master/README.md
+[transition-config]: https://github.com/alphagov/transition-config/blob/main/README.md
 [request a Fastly TLS certificate]: /manual/request-fastly-tls-certificate.html

--- a/source/manual/update-travel-advice-callout-boxes.html.md
+++ b/source/manual/update-travel-advice-callout-boxes.html.md
@@ -13,7 +13,7 @@ The travel advice callout box is used to highlight important information about t
 
 Travel advice callout boxes appear on two types of page. The [travel advice search page](https://www.gov.uk/foreign-travel-advice) and the [individual country pages](https://www.gov.uk/foreign-travel-advice/cuba).
 
-These boxes are hardcoded within [frontend](https://github.com/alphagov/frontend/blob/master/app/views/travel_advice/index.html.erb#L28) and [government-frontend](https://github.com/alphagov/government-frontend/blob/master/app/views/content_items/travel_advice.html.erb#L27). To change them, you will need to raise a new PR in both frontend and government-frontend and deploy both of them to production.
+These boxes are hardcoded within [frontend](https://github.com/alphagov/frontend/blob/master/app/views/travel_advice/index.html.erb#L28) and [government-frontend](https://github.com/alphagov/government-frontend/blob/main/app/views/content_items/travel_advice.html.erb#L27). To change them, you will need to raise a new PR in both frontend and government-frontend and deploy both of them to production.
 
 These are some example PRs:
 

--- a/source/manual/updating-brexit-transition-checker.html.md.erb
+++ b/source/manual/updating-brexit-transition-checker.html.md.erb
@@ -8,7 +8,7 @@ important: true
 ---
 
 <%= ExternalDoc.parse(
-      HTTP.get("https://raw.githubusercontent.com/alphagov/finder-frontend/master/docs/brexit-checker-content-changes.md"),
+      HTTP.get("https://raw.githubusercontent.com/alphagov/finder-frontend/main/docs/brexit-checker-content-changes.md"),
       repository: "finder-frontend",
       path: "docs/brexit-checker-content-changes.md",
     ) %>

--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -53,7 +53,7 @@ These presentations are repeated semi-regularly at the GOV.UK Tech Fortnightly m
 - News and Communities
 
 [readme]: https://docs.publishing.service.gov.uk/manual/readmes.html
-[docs-folder]: https://github.com/alphagov/publishing-api/tree/master/doc
+[docs-folder]: https://github.com/alphagov/publishing-api/tree/main/doc
 [plops]: https://gov-uk.atlassian.net/wiki/display/PLOPS/GOV.UK+Platform+Operations+Home
 [prod-docs]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Product+documentation
 [learning-govuk]: https://drive.google.com/drive/u/0/folders/1AVoV4II9e7Wl59rNrkoy17XE4MxZHCyE

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -1,7 +1,7 @@
 ---
 layout: application_layout
 parent: /apps.html
-source_url: https://github.com/alphagov/govuk-developer-docs/blob/master/data/applications.yml
+source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/applications.yml
 ---
 
 <% if application.retired? %>

--- a/spec/app/content_schema_spec.rb
+++ b/spec/app/content_schema_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ContentSchema do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").frontend_schema
 
-      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/frontend/schema.json")
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/generic/frontend/schema.json")
     end
 
     it "it has a random example" do
@@ -24,7 +24,7 @@ RSpec.describe ContentSchema do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").publisher_content_schema
 
-      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/publisher/schema.json")
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/generic/publisher/schema.json")
     end
 
     it "it has a random example" do
@@ -45,7 +45,7 @@ RSpec.describe ContentSchema do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").publisher_links_schema
 
-      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/generic/publisher/links.json")
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/generic/publisher/links.json")
     end
   end
 end

--- a/spec/app/document_types_spec.rb
+++ b/spec/app/document_types_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DocumentTypes do
           },
         )
 
-      stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/master/lib/govuk_content_schemas/allowed_document_types.yml")
+      stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/main/lib/govuk_content_schemas/allowed_document_types.yml")
         .to_return(body: File.read("spec/fixtures/allowed-document-types-fixture.yml"))
 
       document_type = DocumentTypes.pages.first

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe ExternalDoc do
       end
 
       it "converts relative links to absolute GitHub URLs" do
-        expect(html).to have_link("inline link", href: "https://github.com/alphagov/lipsum/blob/master/inline-link.md")
+        expect(html).to have_link("inline link", href: "https://github.com/alphagov/lipsum/blob/main/inline-link.md")
       end
 
       it "converts aliased links to absolute GitHub URLs" do
-        expect(html).to have_link("aliased link", href: "https://github.com/alphagov/lipsum/blob/master/lib/aliased_link.rb")
+        expect(html).to have_link("aliased link", href: "https://github.com/alphagov/lipsum/blob/main/lib/aliased_link.rb")
       end
 
       it "converts relative GitHub links to Developer Docs HTML links if it is an imported document" do
@@ -62,15 +62,15 @@ RSpec.describe ExternalDoc do
       end
 
       it "converts relative links to absolute GitHub URLs if link is outside of the `docs` folder" do
-        expect(html).to have_link("inline link", href: "https://github.com/alphagov/lipsum/blob/master/inline-link.md")
+        expect(html).to have_link("inline link", href: "https://github.com/alphagov/lipsum/blob/main/inline-link.md")
       end
 
       it "converts relative links to absolute GitHub URLs if link is in a subfolder of the `docs` folder" do
-        expect(html).to have_link("Subfolder", href: "https://github.com/alphagov/lipsum/blob/master/docs/some-subfolder/foo.md")
+        expect(html).to have_link("Subfolder", href: "https://github.com/alphagov/lipsum/blob/main/docs/some-subfolder/foo.md")
       end
 
       it "converts links relative to the 'root' to absolute GitHub URLs" do
-        expect(html).to have_link("Link relative to root", href: "https://github.com/alphagov/lipsum/blob/master/public/json_examples/requests/foo.json")
+        expect(html).to have_link("Link relative to root", href: "https://github.com/alphagov/lipsum/blob/main/public/json_examples/requests/foo.json")
       end
 
       context "the document we are parsing is in the `docs` folder" do
@@ -82,7 +82,7 @@ RSpec.describe ExternalDoc do
       end
 
       it "rewrites relative images" do
-        expect(html).to have_css('img[src="https://raw.githubusercontent.com/alphagov/lipsum/master/suspendisse_iaculis.png"]')
+        expect(html).to have_css('img[src="https://raw.githubusercontent.com/alphagov/lipsum/main/suspendisse_iaculis.png"]')
       end
 
       it "treats URLs containing non-default ports as absolute URLs" do

--- a/spec/app/github_repo_fetcher_spec.rb
+++ b/spec/app/github_repo_fetcher_spec.rb
@@ -2,13 +2,13 @@ RSpec.describe GitHubRepoFetcher do
   before :each do
     stub_request(:get, "https://api.github.com/users/alphagov/repos?per_page=100")
       .to_return(
-        body: "[ { \"name\": \"some-repo\", \"default_branch\": \"master\" } ]",
+        body: "[ { \"name\": \"some-repo\", \"default_branch\": \"main\" } ]",
         headers: { content_type: "application/json" },
       )
   end
 
   let(:private_repo) { double("Private repo", private_repo?: true) }
-  let(:public_repo) { double("Public repo", private_repo?: false, default_branch: "master") }
+  let(:public_repo) { double("Public repo", private_repo?: false, default_branch: "main") }
 
   def stub_cache
     cache = double("CACHE")
@@ -59,7 +59,7 @@ RSpec.describe GitHubRepoFetcher do
     end
 
     def readme_url
-      "https://raw.githubusercontent.com/alphagov/#{repo_name}/master/README.md"
+      "https://raw.githubusercontent.com/alphagov/#{repo_name}/main/README.md"
     end
 
     it "caches the first response" do
@@ -92,7 +92,7 @@ RSpec.describe GitHubRepoFetcher do
       allow(instance).to receive(:repo).with(repo_name) do
         OpenStruct.new(default_branch: "latest")
       end
-      stubbed_request = stub_request(:get, readme_url.sub("master", "latest"))
+      stubbed_request = stub_request(:get, readme_url.sub("main", "latest"))
         .to_return(status: 200, body: readme_contents)
 
       expect(instance.readme(repo_name)).to eq(readme_contents)

--- a/spec/app/source_url_spec.rb
+++ b/spec/app/source_url_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SourceUrl do
 
       source_url = SourceUrl.new({}, current_page).source_url
 
-      expect(source_url).to eql("https://github.com/alphagov/govuk-developer-docs/blob/master/source/foo.html.md")
+      expect(source_url).to eql("https://github.com/alphagov/govuk-developer-docs/blob/main/source/foo.html.md")
     end
   end
 end


### PR DESCRIPTION
This commit renames all references from 'master' to 'main', where:

- the repo in question has changed its default branch to 'main'
- the docs in question are generic and can be updated to refer to
  'main' without breaking the effectiveness of the docs

In a few places I've changed the URL altogether, where it
referenced 'master' in the URL and both the 'master' and 'main'
variants led to 404s, indicating the files have been moved or
deleted. In these cases, I've tried to link to the commit in which
it was deleted, or the location of the new file.