### PR TITLE
Update manual bump instructions for GitHub-native Dependabot

### DIFF
--- a/source/manual/manage-ruby-dependencies.html.md
+++ b/source/manual/manage-ruby-dependencies.html.md
@@ -43,7 +43,7 @@ For these reasons we’re not planning to enable auto-merge for Dependabot PRs.
 
 By default Dependabot will bump dependencies once a day, but you can ask it to bump manually:
 
-Go to [Dependabot admin][admin] and click "Bump now" for your project
+Go to your project in GitHub and click on "Insights", then "Dependency graph", then "Dependabot", then "Last checked X minutes ago" next to the package manager of choice (e.g. Gemfile). Then you can click "Check for updates".
 
 #### Audit Dependabot PRs
 


### PR DESCRIPTION
The old instructions no longer work when a repo is transferred to GitHub-native Dependabot (as most of our apps now have).

See screenshot comparing a Dependabot-dot-com project vs a GitHub-native project. Only the former has the "Bump now" button.

![](https://user-images.githubusercontent.com/5111927/119134484-17303380-ba35-11eb-949f-0be4de2d5fd4.png)