### PR TITLE
Update Zendesk documentation to reflect changes to DGU support

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -7,8 +7,7 @@ section: 2nd line
 type: learn
 ---
 
-2nd line Zendesk tickets are technical errors reported by our users - including government publishers -
-and general queries from users of data.gov.uk ("DGU"), for whom 2nd line provides 1st line support.
+2nd line Zendesk tickets are technical errors reported by our users, including government publishers.
 
 ## Get started
 


### PR DESCRIPTION
GOV.UK 2nd line no longer provides first-line support for data.gov.uk, updating the documentation to reflect that.
