### PR TITLE
Accuracy updates to applications list

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -123,7 +123,7 @@ class App
   end
 
   def deploy_url
-    return if app_data["deploy_url"] == false || production_hosted_on == "heroku"
+    return if app_data["deploy_url"] == false || %w[none heroku].include?(production_hosted_on)
 
     if production_hosted_on == "paas"
       app_data["deploy_url"]

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -396,12 +396,6 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
-- github_repo_name: govuk-alert-tracker
-  management_url: https://dashboard.heroku.com/apps/govuk-alert-tracker
-  production_hosted_on: heroku
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
 - github_repo_name: govuk_app_config
   team: "#govuk-developers"
   production_hosted_on: none

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -391,7 +391,7 @@
   description: 'GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)'
 
 
-# Utility Heroku apps (don't add apps that are only for review here)
+# Utilities - supporting applications/tooling
 
 - github_repo_name: seal
   management_url: https://dashboard.heroku.com/apps/moody-seal

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -453,6 +453,12 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+- github_repo_name: special-route-publisher
+  production_hosted_on: none
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+  deploy_url: false
 - github_repo_name: tech-docs-monitor
   management_url: https://dashboard.heroku.com/apps/govuk-tech-docs-monitor
   production_hosted_on: heroku

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -297,8 +297,11 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: side-by-side-browser
+  management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
+  production_hosted_on: heroku
   type: Transition apps
-  production_hosted_on: none
+  sentry_url: false
+  dashboard_url: false
 
 # data.gov.uk
 
@@ -434,6 +437,7 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+  deploy_url: https://github.com/alphagov/govuk-secrets/blob/main/puppet_aws/deploy.sh
 - github_repo_name: govuk-zendesk-display-screen
   management_url: https://dashboard.heroku.com/apps/govuk-zendesk-display-screen
   production_hosted_on: heroku
@@ -443,12 +447,6 @@
 - github_repo_name: blinkenjs
   app_name: govuk-secondline-blinken
   management_url: https://dashboard.heroku.com/apps/govuk-secondline-blinken
-  production_hosted_on: heroku
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
-- github_repo_name: side-by-side-browser
-  management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
   production_hosted_on: heroku
   type: Utilities
   sentry_url: false


### PR DESCRIPTION
This change:

- Removes govuk-alert-tracker application, since it is no longer a running tool
- Adds special-route-publisher as an application, since that utility seems a surprising omission from this list despite being on the borderline of whether it could be considered to be an app
- Removes the broken "Deploy script" link for apps that have a production hosting of none
- Removes a duplicated entry of step-by-step-browser in the apps list
- Fixes a comment on what belongs in "Utilities", that no longer reflected usage.

Further details in the commits.