### PR TITLE
Set Corona services as dependencies team for 3 app

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -20,7 +20,7 @@
   continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
-  dependencies_team: "#govuk-platform-health"
+  dependencies_team: "#govuk-corona-services-tech"
   production_hosted_on: aws
   actors:
   - Publisher
@@ -44,6 +44,7 @@
   continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-corona-services-tech"
   production_hosted_on: aws
 - github_repo_name: manuals-publisher
   continuously_deployed: true
@@ -217,6 +218,7 @@
   continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
+  dependencies_team: "#govuk-corona-services-tech"
   component_guide_url: https://govuk-collections.herokuapp.com/component-guide
   production_hosted_on: aws
   private_repo: false


### PR DESCRIPTION
It's more helpful that #govuk-corona-services-tech gets to see information about
these Dependabot PRs.

[trello](https://trello.com/c/XtUQU9Dj/426-assign-this-team-as-dependabot-maintainers-of-collections-collections-publisher-and-local-links-manager)