### PR TITLE
Add documentation for modifying a Whitehall changelog

### DIFF
--- a/source/manual/howto-modify-change-note.html.md
+++ b/source/manual/howto-modify-change-note.html.md
@@ -1,13 +1,14 @@
 ---
 owner_slack: "#govuk-2ndline"
-title: Modify a change note in Publishing API
+title: Modify a change note in Publishing API or Whitehall
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 ---
 
-Spelling mistakes can creep into change notes, and we are often asked
-to correct them.
+Spelling mistakes can creep into change notes, and we are often asked to correct them. The instructions below cover doing this task in the Publishing API and in Whitehall - if your change note lives in Whitehall and is updated in the Publishing API it could be overwritten later.
+
+## Publishing API
 
 Connect to the Publishing API console:
 
@@ -28,3 +29,51 @@ $ d.live.change_note.update(note: "Foo")
 $ d
 => #<ChangeNote id: 397621, note: "Foo", public_timestamp: "2020-06-16 11:02:22", edition_id: 5146461, created_at: "2020-06-16 10:22:34", updated_at: "2020-06-16 15:24:53">
 ```
+
+## Whitehall
+
+The following commands show you how to find the document, get the correct edition within it, and update it. To complete this you will need the document ID, a string to search for to identify the right change log entry (search is fuzzy, be precise to get the right one), and the string you want to replace the current change log.
+
+Connect to the Whitehall console (test your change on Integration first):
+
+```
+govuk-connect app-console -e integration whitehall_backend/whitehall
+```
+
+Find the document:
+
+```
+document=Document.find_by_content_id(“YOUR_CONTENT_ID_HERE”)
+```
+
+Output will be a summary of your document. Next, select the editions:
+
+```
+editions=document.editions
+```
+
+Output is a potentially long list of the editions. Next set up the parameters for fuzzy matching:
+
+```
+fuzzy_match = FuzzyMatch.new(editions, read: :change_note)
+```
+
+Output should show the change notes. Select the relevant one:
+
+```
+edition = fuzzy_match.find(“A_STRING_FROM_YOUR_CHANGE_NOTE”, must_match_at_least_one_word: true)
+```
+
+Output shows the relevant edition that needs the change note update. Update it:
+
+```
+edition.update(change_note: “YOUR_DESIRED_CHANGE_NOTE_STRING”)
+```
+
+The response to this is "false" but the update has taken place. You can confirm this if you want to by typing "edition" to review it. Save the changes:
+
+```
+edition.save!(validate: false)
+```
+
+Republish the document using a [Whitehall Rake task](https://docs.publishing.service.gov.uk/manual/republishing-content.html)


### PR DESCRIPTION
Updating a change note is a task that comes up on 2nd Line from time to time and there was no guidance on how to action it if the content is in Whitehall. I figured out how to make it happen with a combination of this Publishing API documentation and the existing [change note remover](https://github.com/alphagov/whitehall/blob/827a41d05358ad9bc36cb443ea1d93af7ab73cae/lib/data_hygiene/change_note_remover.rb)

While this may not be the ideal approach it's a start, it works, it can be iterated on and it didn't require me making Whitehall run on my machine or learning about migrations.