### PR TITLE
Skip over malformed URLs in external docs

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -58,9 +58,16 @@ class ExternalDoc
         next if element["href"].nil? || element["href"].empty?
 
         href = element["href"].strip
-        uri = URI.parse(href)
 
-        next if uri.scheme || href.start_with?("#")
+        uri =
+          begin
+            URI.parse(href)
+          rescue URI::InvalidURIError
+            element.replace(element.children)
+            nil
+          end
+
+        next if uri.nil? || uri.scheme || href.start_with?("#")
 
         if href.start_with?("/")
           # remove preceding "/" to make links relative to the repository

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe ExternalDoc do
         expect(html).to have_link("localhost", href: "localhost:999")
       end
 
+      it "skips over URLs with trailing unicode characters" do
+        expect(html).not_to have_link("http://localhost:3108")
+        expect(html).not_to have_link("http://localhost:3108”")
+        expect(html).to have_content("Visit “http://localhost:3108”")
+      end
+
       it "maintains anchor links" do
         expect(html).to have_link("Suspendisse iaculis", href: "#suspendisse-iaculis")
       end

--- a/spec/fixtures/markdown.md
+++ b/spec/fixtures/markdown.md
@@ -17,6 +17,8 @@ neque consequat porta, [Suspendisse iaculis](#suspendisse-iaculis). Sed et
 
 [Subfolder](docs/some-subfolder/foo.md)
 
+Visit “http://localhost:3108”
+
 ## Suspendisse iaculis
 
 ![Suspendisse iaculis](suspendisse_iaculis.png)


### PR DESCRIPTION
This protects against a somewhat unusual edge case [first seen in Mapit](https://github.com/alphagov/mapit/pull/133), where the Developer Docs is pulling in external documentation that refers to localhost URLs and port numbers, and wraps said URL in non-ASCII curly quotes. (Straight `"` quotes are fine).

Consider the content below:

> In the commands above, for every line where the 9th field is ‘200’, print the string “http://localhost:3108” followed by the 7th field of that line, which is the postcode.

The markdown parser was detecting the URL and attempting to convert it to a link. But it would treat the closing `”` as part of the URL, so treat `3108”` as the port number, which is invalid. It subsequently raises a `URI::InvalidURIError`.

I considered two outcomes to be desirable here:

1. Ignore the quotes but still mark up as a link, i.e. `“http://localhost:3108”` => `“<a href="http://localhost:3108">http://localhost:3108</a>”`, or
2. Simply avoid marking it up as a link, i.e. `“http://localhost:3108”` => `“http://localhost:3108”`

I initially aimed for the first outcome, but it was not simple to achieve. It effectively involved calling something along the lines of `element["href"].sub("”", "")`, but this would only fix the `href`, not the link text, which still included `”`. Fixing the link text wouldn't be straightforward, as the link text is an array `element.children`, because links may wrap multiple paragraphs, or images. The solution became increasingly brittle and hard-coded to this one particular use case.

I realised really all we want to do is prevent the build from failing; so went for pragmatic solution 2. If it's really so important for the URL to be marked up as a link, it can be easily fixed upstream by removing the unconventional non-ASCII characters.

Trello: https://trello.com/c/PMJ9MtDy/224-make-developer-docs-robust-to-inconsistent-external-docs