### PR TITLE
Adds keyword "GDPR"

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -67,7 +67,7 @@ in the "Public reply" as appropriate and click "Submit as Pending".
 
 ## Subject Access Requests
 
-This [Google Doc describes what to do if you receive a Subject Access Request through Zendesk][doc].
+This [Google Doc describes what to do if you receive a GDPR Subject Access Request through Zendesk][doc].
 
 ## Closing a ticket
 


### PR DESCRIPTION
Zendesk ticket title was "GDPR Subject Access Request". Searching for the title found 0 results in Dev Docs.

Let's do some keyword stuffing to make it easier to find for developers.