### PR TITLE
Signpost the reprovisioning docs a bit more

### DIFF
--- a/source/manual/alerts/app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/app-healthcheck-not-ok.html.md
@@ -11,7 +11,15 @@ Many apps on GOV.UK have a healthcheck endpoint.
 - This is usually `/healthcheck` [[1](https://github.com/alphagov/govuk-puppet/blob/2693343ebc1aced7a7f94e8aba31fee8b05df8a5/modules/govuk/manifests/apps/email_alert_api.pp#L166)].
 - Some apps just pick a random page [[1](https://github.com/alphagov/govuk-puppet/blob/2693343ebc1aced7a7f94e8aba31fee8b05df8a5/modules/govuk/manifests/apps/collections.pp#L51)].
 
-The alert works by [making a request for the healthcheck endpoint](https://github.com/alphagov/govuk-puppet/blob/fab936cb82be7fad42636fcafca3718a8368ebfe/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck#L155) on the machine where the app is running. If you need to test the healthcheck endpoint manually, you can SSH on to the machine and `curl` it yourself.
+The alert works by [making a request for the healthcheck endpoint](https://github.com/alphagov/govuk-puppet/blob/fab936cb82be7fad42636fcafca3718a8368ebfe/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck#L155) on the machine where the app is running.
+
+## Check if the app is running
+
+If the alert is appearing alongside an [`upstart not up` alert](/manual/alerts/check-process-running.html), it's likely that the process isn't even running, therefore any requests to the healthcheck endpoint will also fail.
+
+## Test the healthcheck endpoint manually
+
+You can SSH onto the machine and `curl` it yourself.
 
 ```
 # SSH on to a machine running Content Publisher

--- a/source/manual/alerts/check-process-running.html.md
+++ b/source/manual/alerts/check-process-running.html.md
@@ -26,6 +26,8 @@ You can also list services with `sudo service --status-all`, though this doesn't
 
 ## Fixing the issue
 
+### Restarting the service
+
 If the service isn't running, it can be enough to just restart the service by using:
 
 ```bash
@@ -37,6 +39,18 @@ If the service is referring to a GOV.UK application, it may be necessary to also
 ```bash
 sudo service <service>-procfile-worker restart
 ```
+
+Check that the service has now started, by running:
+
+```bash
+sudo service <service> status
+```
+
+If the service didn't start, check whether the app was successfully deployed to the machine.
+You should be able to `cd /data/vhost/{SERVICE NAME}/`, run `ls` and see a `releases` folder.
+If not, it is likely the [machine failed to provision](/manual/new-instances-fail-to-provision.html) correctly.
+
+### Fixing a stalled process
 
 Sometimes, a process might appear to be running, but is actually stalled by a child process that has completed but not been garbage collected:
 
@@ -57,13 +71,3 @@ investigating by looking in the log files which could be in one of the following
 - `/var/log/upstart/<process>.log`
 - `/var/log/<process>/`
 - `/var/log/<process>.log`
-
-If you see something in the logs such as
-
-```bash
----> Spinning up 'govuk_crawler_worker' (type bare) in 'production' environment
-/usr/local/bin/govuk_spinup: 30: cd: can't cd to /var/apps/govuk_crawler_worker
-```
-
-This suggests that the crawler hasn't been deployed to the machine. You can try re-deploying
-via [deploy jenkins](https://deploy.blue.staging.govuk.digital/).

--- a/source/manual/new-instances-fail-to-provision.html.md
+++ b/source/manual/new-instances-fail-to-provision.html.md
@@ -43,6 +43,6 @@ init scripts have been run.
 
 Replatforming have a [card](https://trello.com/c/uymM8qmy/538-fix-intermittently-broken-provisioning-in-ec2-govuk-because-of-unattended-reboot) to fix this.
 
-Until then, the recommended fix is to run `/usr/local/bin/govuk_sync_apps` once puppet has run cleanly on the machine. Note that the script takes some time to complete as there is a `sleep 180` in it.
+Until then, the recommended fix is to run `sudo /usr/local/bin/govuk_sync_apps` once puppet has run cleanly on the machine. Note that the script takes some time to complete as there is a `sleep 180` in it.
 
 Failing that, you could try [reprovisioning the machine](/manual/reprovision.html). If the issue persists, you may need to temporarily disable `unattended reboot` by adding `govuk_unattended_reboot::enabled: false` to the relevant hiera. You'll need to deploy the branch of Puppet before creating the new instances again.


### PR DESCRIPTION
Even though I documented this yesterday, I struggled to find the
doc by searching, and it wasn't linked to from the "check process
running" doc. I knew the underlying cause but couldn't remember
the fix.

This improves the signposting to the doc, and also clarifies that
the workaround requires `sudo`.