### PR TITLE
Update the GCP docs to cover DNS as well as mirrors

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -122,6 +122,7 @@ redirects:
   /manual/renew_ssl_certificates.html: /manual/renew-a-tls-certificate.html
   /manual/rummager-traffic-replay.html: /manual/search-api-traffic-replay.html
   /manual/set-up-aws-account.html: /manual/get-started.html
+  /manual/set-up-gcp-account.html: /manual/google-cloud-platform-gcp.html
   /manual/setting-up-new-sidekiq-monitoring-app.html: /manual/sidekiq.html
   /manual/technical-setup.html: /manual/on-call.html
   /manual/testing.html: https://gds-way.cloudapps.digital/manuals/programming-languages/ruby.html

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -26,14 +26,11 @@ github_repo: alphagov/govuk-developer-docs
 redirects:
   /2nd-line/mirror-fallback.html: /manual/fall-back-to-mirror.html
   /apis.html: /apps.html
-  /apis/search-api.html: /apps/search-api.html
-  /apis/search/search-api.html: /apps/search-api.html
   /apis/email-alert-api/analytics.html: /apps/email-alert-api/analytics.html
   /apis/email-alert-api/api.html: /apps/email-alert-api/api.html
   /apis/email-alert-api/data-cleanup-mechanisms.html: /apps/email-alert-api/data-cleanup-mechanisms.html
   /apis/email-alert-api/env-vars.html: /apps/email-alert-api/env-vars.html
   /apis/email-alert-api/matching-content-to-subscriber-lists.html: /apps/email-alert-api/matching-content-to-subscriber-lists.html
-  /apps/content-performance-manager.html: /apps/content-data-api.html
   /apis/email-alert-api/support-tasks.html: /apps/email-alert-api/support-tasks.html
   /apis/link-checker-api/api.html: /apps/link-checker-api/api.html
   /apis/link-checker-api/blitz.html: /apps/link-checker-api/blitz.html
@@ -45,6 +42,7 @@ redirects:
   /apis/publishing-api/pact_testing.html: /apps/publishing-api/pact_testing.html
   /apis/publishing-api/publishing-application-examples.html: /apps/publishing-api/publishing-application-examples.html
   /apis/publishing-api/rabbitmq.html: /apps/publishing-api/rabbitmq.html
+  /apis/search-api.html: /apps/search-api.html
   /apis/search-api/adding-new-fields.html: /apps/search-api/adding-new-fields.html
   /apis/search-api/content-api.html: /apps/search-api/content-api.html
   /apis/search-api/content_overview.html: /apps/search-api/content_overview.html
@@ -59,6 +57,7 @@ redirects:
   /apis/search-api/schemas.html: /apps/search-api/schemas.html
   /apis/search-api/search-api.html: /apps/search-api/search-api.html
   /apis/search-api/search-quality-metrics.html: /apps/search-api/search-quality-metrics.html
+  /apis/search/search-api.html: /apps/search-api.html
   /apis/whitehall/api.html: /apps/whitehall/api.html
   /apis/whitehall/css.html: /apps/whitehall/css.html
   /apis/whitehall/edition_workflow.html: /apps/whitehall/edition_workflow.html
@@ -69,22 +68,23 @@ redirects:
   /apis/whitehall/search_setup_guide.html: /apps/whitehall/search_setup_guide.html
   /apis/whitehall/testing_guide.html: /apps/whitehall/testing_guide.html
   /apis/whitehall/timestamps.html: /apps/whitehall/timestamps.html
+  /apps/content-performance-manager.html: /apps/content-data-api.html
   /dictionary.html: /manual/dictionary.html
   /getting-started.html: /manual/get-started.html
   /guides.html: /manual.html
   /manual/access-aws-console.html: /manual/get-started.html
+  /manual/access-ci.html: /manual/access-jenkins.html
   /manual/add-a-pingdom-check.html: /manual/pingdom.html
   /manual/alerts/applications/sidekiq-monitoring.html: /manual/setting-up-new-sidekiq-monitoring-app.html
+  /manual/alerts/data-sources-for-transition.html: /manual/transition-architecture.html
   /manual/alerts/data-sync.html: /manual/govuk-env-sync.html
   /manual/alerts/email-alerts.html: /manual/alerts/email-alerts-travel-medical.html
   /manual/alerts/gor.html: /manual/alerts/goreplay.html
   /manual/alerts/process-file-handle-count-exceedes.html: /manual/alerts/process-file-handle-count-exceeds.html
   /manual/alerts/publisher-app-health-check-not-ok.html: /manual/alerts/publisher-app-healthcheck-not-ok.html
-  /manual/alerts/data-sources-for-transition.html: /manual/transition-architecture.html
-  /manual/alerts/rummager-queue-latency.html: /manual/alerts/search-api-queue-latency.html
   /manual/alerts/rummager-index-size-change.html: /manual/alerts/search-api-index-size-change.html
+  /manual/alerts/rummager-queue-latency.html: /manual/alerts/search-api-queue-latency.html
   /manual/alerts/whitehall-app-health-check-not-ok.html: /manual/alerts/whitehall-app-healthcheck-not-ok.html
-  /manual/access-ci.html: /manual/access-jenkins.html
   /manual/archiving-and-redirecting-content.html: /manual/redirect-routes.html
   /manual/bouncer.html: /manual/transition-architecture.html
   /manual/bulk-email.html: /apps/email-alert-api/bulk-email.html
@@ -94,16 +94,20 @@ redirects:
   /manual/creating-a-new-environment.html: /manual.html
   /manual/creating-pages.html: /manual/docs-style-guide.html
   /manual/data-gov-uk-backups.html: /manual/postgresql.html
-  /manual/data-sources-for-transition.html: /manual/transition-architecture.html
   /manual/data-gov-uk-hacks.html: /manual/data-gov-uk-2nd-line.html
+  /manual/data-sources-for-transition.html: /manual/transition-architecture.html
+  /manual/deploying.html: /manual/development-pipeline.html
   /manual/elasticsearch.html: /manual/elasticsearch-dumps.html
   /manual/emergency-publishing-redis.html: /manual/emergency-publishing.html
   /manual/error-reporting.html: /manual/sentry.html
   /manual/fastly-error-rate.html: /manual/alerts/fastly-error-rate.html
   /manual/fix-problems-with-vagrant.html: /manual.html
   /manual/gds-cli.html: /manual/access-aws-console.html
+  /manual/howto-manually-remove-assets.html: /manual/manage-assets.html
   /manual/howto-merge-a-pull-request-from-an-external-contributor.html: /manual/merge-pr.html
+  /manual/howto-replace-an-assets-file.html: /manual/manage-assets.html
   /manual/howto-transition-a-site-to-govuk.html: /manual/transition-a-site.html
+  /manual/howto-upload-an-asset-to-asset-manager.html: /manual/manage-assets.html
   /manual/intro-to-docker-even-more.html: /manual/how-govuk-docker-works.html
   /manual/load-test-email-alert-api.html: /apps/email-alert-api/load-test-email-alert-api.html
   /manual/manage-email-subscribers.html: /apps/email-alert-api/tasks.html
@@ -111,27 +115,23 @@ redirects:
   /manual/mirror-fallback.html: /manual/fall-back-to-mirror.html
   /manual/nagios.html: /manual.html
   /manual/offsite-backup-and-restore.html: /manual/restore-from-offsite-backups.html
-  /manual/deploying.html: /manual/development-pipeline.html
   /manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html: /apps/email-alert-api/receiving-emails-from-email-alert-api-in-integration-and-staging.html
   /manual/redirecting-content-in-the-router.html: /manual/redirect-routes.html
   /manual/releasing-software.html: /manual/development-pipeline.html
   /manual/remove-redirected-url-from-transition.html: manual/remove-site-from-transition-tool.html
   /manual/renew_ssl_certificates.html: /manual/renew-a-tls-certificate.html
+  /manual/rummager-traffic-replay.html: /manual/search-api-traffic-replay.html
   /manual/set-up-aws-account.html: /manual/get-started.html
   /manual/setting-up-new-sidekiq-monitoring-app.html: /manual/sidekiq.html
-  /manual/rummager-traffic-replay.html: /manual/search-api-traffic-replay.html
   /manual/technical-setup.html: /manual/on-call.html
   /manual/testing.html: https://gds-way.cloudapps.digital/manuals/programming-languages/ruby.html
   /manual/troubleshooting-vagrant.html: /manual/fix-problems-with-vagrant.html
   /manual/upgrade-to-sentry.html: /manual/sentry.html
+  /manual/upload-asset-to-whitehall.html: /manual/manage-assets.html
   /manual/use-terraboard-to-monitor-terraform-state.html: /manual.html
   /manual/user-management-in-aws.html: /manual/get-started.html
   /manual/virus-scanning.html: /manual/alerts/virus-scanning.html
   /manual/whitelist-site-in-transition.html: /manual/allowlist-site-in-transition.html
-  /manual/howto-manually-remove-assets.html: /manual/manage-assets.html
-  /manual/howto-replace-an-assets-file.html: /manual/manage-assets.html
-  /manual/howto-upload-an-asset-to-asset-manager.html: /manual/manage-assets.html
-  /manual/upload-asset-to-whitehall.html: /manual/manage-assets.html
   /opsmanual.html: /manual.html
   /opsmanual/ab_testing.html: /manual/ab-testing.html
   /opsmanual/content-preview.html: /manual/content-preview.html

--- a/source/manual/google-cloud-platform-gcp.html.md
+++ b/source/manual/google-cloud-platform-gcp.html.md
@@ -6,18 +6,63 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-[Static mirrors of GOV.UK](/manual/fall-back-to-mirror.html) are hosted in storage buckets within AWS and Google Cloud Platform (GCP). You may need login to GCP to [remove an asset](/manual/howto-manually-remove-assets.html) or to [emergency publish content using the static mirrors](/manual/fall-back-to-mirror.html#emergency-publishing-using-the-static-mirror).
+GOV.UK uses Google Cloud Platform (GCP) for three main things:
 
-## Request GCP access
+- [Static mirrors of GOV.UK](/manual/fall-back-to-mirror.html) (these are hosted in AWS and GCP).
+- [DNS](/manual/dns.html) (DNS for www.gov.uk, service.gov.uk and other domains we manage is mirrored to name servers in AWS Route53 and Google CloudDNS)
+- Various data science tasks such as [BigQuery](/manual/view-extract-feedback-data-bigquery.html)
 
-Permission to Google Cloud Platform (GCP) is managed through the [GOV.UK GCP
-access Google Group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-gcp-access).
+## GCP access
 
-Access to GCP is granted when [permanent Production access](/manual/rules-for-getting-production-access.html) is
+Access to GCP is managed through the [GOV.UK GCP access Google Group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-gcp-access).
+
+Access to this group is granted manually once [permanent Production access](/manual/rules-for-getting-production-access.html) is
 approved and merged to [GOV.UK user reviewer](https://github.com/alphagov/govuk-user-reviewer) repository.
 
-If you should have access but don't, the 2nd line team should be able to add
-you to the Google Group.
+If you should have access but don't, the 2nd line team should be able to add you to the Google Group.
+
+### Accessing the console
 
 You can login to the GCP console at [https://console.cloud.google.com/](https://console.cloud.google.com/) using
 your `@digital.cabinet-office.gov.uk` email address.
+
+There are four main GCP projects in GOV.UK:
+
+- [GOVUK Production](https://console.cloud.google.com/home/dashboard?project=govuk-production)
+- [GOVUK Integration](https://console.cloud.google.com/home/dashboard?project=govuk-integration)
+- [GOVUK Staging](https://console.cloud.google.com/home/dashboard?project=govuk-staging-160211)
+- [GOVUK Test](https://console.cloud.google.com/home/dashboard?project=govuk-test)
+
+The interesting services are:
+
+- [Google Cloud Storage](https://console.cloud.google.com/storage/browser?project=govuk-production) - where the static mirrors are stored
+- [Google Cloud DNS](https://console.cloud.google.com/net-services/dns/zones?project=govuk-production) - where the DNS is configured
+
+### Using the CLI
+
+As with AWS, you can access GCP using the command line. The standard GCP command line interface is `gcloud`.
+
+You can install `gcloud` with `brew cask install google-cloud-sdk` or by following the instructions at [google's installation instructions][].
+
+NOTE: By default `gcloud` doesn't put itself on your PATH, so there's an extra manual step to add it.
+Make sure you follow all of the instructions from [homebrew's google-cloud-sdk cask](https://formulae.brew.sh/cask/google-cloud-sdk)
+or [google's installation instructions][].
+
+Once you've installed `gcloud` you can check it's working using some of these commands:
+
+- `gcloud help` - get help
+- `gcloud auth login` - sign in
+- `gcloud config set project govuk-production` - select the GOVUK Production project
+- `gcloud dns managed-zones list` - list the managed DNS zones
+- `gcloud dns record-sets list --zone alpha-gov-uk` - list the DNS record sets for the alpha.gov.uk. zone
+
+If you need to interact with the Cloud Storage (e.g. for the mirrors) from the CLI, you need to install the separate `gsutil` CLI.
+
+## Support tasks which involve GCP
+
+You may need login to GCP to [remove an asset](/manual/howto-manually-remove-assets.html) or
+to [emergency publish content using the static mirrors](/manual/fall-back-to-mirror.html#emergency-publishing-using-the-static-mirror).
+
+You will also need GCP access to update DNS if you need to [Fall back to the secondary CDN (AWS CloudFront)](/manual/fall-back-to-aws-cloudfront.html.md).
+
+[google's installation instructions]: https://cloud.google.com/sdk/docs/quickstart#mac

--- a/source/manual/google-cloud-platform-gcp.html.md
+++ b/source/manual/google-cloud-platform-gcp.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Set up your GCP account
+title: Google Cloud Platform (GCP)
 section: AWS
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -16,7 +16,7 @@ These rules apply to developers in the GOV.UK programme and SREs in the TechOps 
 - Access to Production Deploy Jenkins and Staging Deploy Jenkins to deploy applications via the [GOV.UK Production GitHub team](https://github.com/orgs/alphagov/teams/gov-uk-production)
 - SSH access to production and staging servers via [govuk-puppet](https://github.com/alphagov/govuk-puppet)
 - AWS [PowerUser Access](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/production/common.tfvars) via the `role_poweruser_user_arns` role
-- [Google Cloud Platform](/manual/set-up-gcp-account.html) (GCP) access with `Storage Admin` role to manage [static mirrors](/manual/fall-back-to-mirror.html)
+- [Google Cloud Platform (GCP)](/manual/google-cloud-platform-gcp.html) access to role to manage [static mirrors](/manual/fall-back-to-mirror.html) and DNS
 - Signon "Super Admin" access in production
 - GOV.UK PaaS [Space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer)
   access to all spaces in [the govuk_development organisation](https://admin.cloud.service.gov.uk/organisations/f8718311-b9a4-49d3-b1c7-7c5345a74e35)


### PR DESCRIPTION
Add explanations that we have four projects, and document how to use the `gcloud` CLI.

I've also moved the doc from `set-up-gcp-account` to `google-cloud-platform-gcp` to reflect its increased scope. I've put a redirect in, just in case there are any links elsewhere to the old doc.

I'll raise a follow up PR to update the on-call checklist to include making sure you have `gcloud` installed.

https://trello.com/c/LasnNuz4/561-rationalise-use-of-gcp-credentials-eg-for-dns-deployments