### PR TITLE
Document fall back to CloudFront as a manual process

### DIFF
--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -9,28 +9,47 @@ parent: "/manual.html"
 There is a backup Content Delivery Network (CDN) that can be used if Fastly is down.
 This backup CDN is currently provided by AWS CloudFront.
 
-**Important** At the time of writing, GOV.UK will be served
-by static mirrors and not the origin of GOV.UK if you fallback to the backup CDN.
+> **Important** GOV.UK will be served by static mirrors and not the origin of GOV.UK if you fallback to the backup CDN.
+> This is significantly degraded service compared to the primary CDN. Major features such as search, smart answers, and
+> postcode lookups will not work when using the secondary CDN.
 
-## Procedure
+## Fail over checklist
 
-You will have to make 2 DNS changes to GOV.UK:
+- Confirm that Fastly is the cause of the incident (check [https://status.fastly.com/](https://status.fastly.com/)
+  and keep an eye on twitter - if there's a major Fastly outage there will be a lot of noise)
+- Sign in to the AWS console as an admin (`gds aws govuk-production-admin -l`, or however you prefer to sign in to AWS)
+- Sign in to [the GCP console](https://console.cloud.google.com/home/dashboard?project=govuk-production)
+- Open the following four pages as separate tabs:
+  - [GCP Cloud DNS www-cdn.production.govuk.service.gov.uk](https://console.cloud.google.com/net-services/dns/zones/govuk-service-gov-uk/rrsets/www-cdn.production.govuk.service.gov.uk./CNAME/edit?project=govuk-production)
+  - [AWS Route 53 govuk.service.gov.uk](https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/Z22RPYZA77J620)
+  - [GCP Cloud DNS assets.publishing.service.gov.uk](https://console.cloud.google.com/net-services/dns/zones/publishing-service-gov-uk/rrsets/assets.publishing.service.gov.uk./CNAME/edit?project=govuk-production)
+  - [AWS Route 53 publishing.service.gov.uk](https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/Z3SBFBO09PD5HF)
+- Because the secondary CDN provides degraded service we have a grace period
+  before failing over
+  - For a major Fastly outage (more than 30% of requests failing) wait 15
+    minutes (from the start of the incident) before failing over
+  - For a minor Fastly outage (less than 30% of requests failing) wait at least
+    15 minutes (from the start of the incident) before failing over and escalate
+    to GOV.UK SMT to help with a decision
+- While you wait, confirm the new CNAMES for www-cdn.production.govuk.service.gov.uk and assets.publishing.service.gov.uk
+  - This [Draft PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-config/pull/714) shows the CNAMES you need to change, and how to test that they are correct
+  - You can also get the CNAMEs to use for the secondary CDN from the AWS CLI:
 
-1. The CNAME at `www-cdn.production.govuk.service.gov.uk` should point to
-   cloudfront's WWW distribution instead of Fastly
-2. The CNAME at `assets.publishing.service.gov.uk` should point to cloudfront's
-   Assets distribution instead of Fastly
+  ```
+  # www.gov.uk
+  gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='WWW'].DomainName | [0]
+  # assets.publishing.service.gov.uk
+  gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='Assets'].DomainName | [0]"
+  ```
 
-This [Draft PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-config/pull/714)
-shows the changes you need to make, and how to test the CDN before failing over.
-
-You can check the domain names of the cloudfront distributions by looking in
-the AWS web console, or with the CLI:
-
-```
-# www.gov.uk
-gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='WWW'].DomainName | [0]"
-
-# assets.publishing.service.gov.uk
-gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='Assets'].DomainName | [0]"
-```
+  - The records should look like `d0000000000000.cloudfront.net.` (with 0s replaced with letters and numbers)
+- When you are ready to fail over:
+  - Manually update the CNAME record for www-cdn.production.govuk.service.gov.uk in GCP and AWS
+  - Manually update the CNAME record for assets.publishing.service.gov.uk in GCP and AWS
+- After failing over manually:
+  - Merge [the PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-config/pull/714)
+  - [Deploy DNS using Jenkins and Terraform](/manual/dns.html#making-changes-to-publishing-service-gov-uk)
+- Once you've failed over, keep a close eye on Fastly's status
+- As soon as you are confident that Fastly has recovered
+  - Manually set the CNAME records you changed above back to www-gov-uk.map.fastly.net.
+  - Raise a PR in [govuk-dns-config](https://github.com/alphagov/govuk-dns-config) to set the records back formally. Get it approved, merged and [Deploy DNS using Jenkins and Terraform](/manual/dns.html#making-changes-to-publishing-service-gov-uk)

--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -26,11 +26,12 @@ This backup CDN is currently provided by AWS CloudFront.
   - [AWS Route 53 publishing.service.gov.uk](https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/Z3SBFBO09PD5HF)
 - Because the secondary CDN provides degraded service we have a grace period
   before failing over
+  - Escalate to GOV.UK SMT as soon as you begin to consider failing over
   - For a major Fastly outage (more than 30% of requests failing) wait 15
-    minutes (from the start of the incident) before failing over
+    minutes (from the start of the incident) and then start the fail over
   - For a minor Fastly outage (less than 30% of requests failing) wait at least
-    15 minutes (from the start of the incident) before failing over and escalate
-    to GOV.UK SMT to help with a decision
+    15 minutes (from the start of the incident) before failing over - discuss
+    the decision with the GOV.UK SMT Escalations person
 - While you wait, confirm the new CNAMES for www-cdn.production.govuk.service.gov.uk and assets.publishing.service.gov.uk
   - This [Draft PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-config/pull/714) shows the CNAMES you need to change, and how to test that they are correct
   - You can also get the CNAMEs to use for the secondary CDN from the AWS CLI:


### PR DESCRIPTION
Deploying these changes using Jenkins and Terraform is too slow and
unreliable to do during an incident.

To be honest, I think this would be better as a shell script. I'll raise
this as a PR to get people's opinions.

https://trello.com/c/LasnNuz4/561-rationalise-use-of-gcp-credentials-eg-for-dns-deployments