### PR TITLE
Document how to deploy Fastly from our individual accounts

### DIFF
--- a/source/manual/cdn.html.md
+++ b/source/manual/cdn.html.md
@@ -20,12 +20,36 @@ The CDN is responsible for retrying requests against the [static mirror](/manual
 
 Most of the CDN config is versioned and scripted:
 
-- [CDN configuration](https://github.com/alphagov/govuk-cdn-config/)
-- [CDN config secrets](https://github.com/alphagov/govuk-cdn-config-secrets)
-
-These are deployed to [integration][integration_cdn], [staging][staging_cdn] and [production][production_cdn].
+- [govuk-cdn-config](https://github.com/alphagov/govuk-cdn-config/)
+- [govuk-cdn-config-secrets](https://github.com/alphagov/govuk-cdn-config-secrets)
 
 Some configuration isn't scripted, such as logging. The www, bouncer and assets services send logs to S3 which can be [queried](/manual/query-cdn-logs.html). These logging endpoints are configured directly in the Fastly UI.
+
+### Deploying Fastly
+
+To deploy Fastly, you'll need to run the `Deploy_CDN` job on the relevant Jenkins environment: [integration][integration_cdn], [staging][staging_cdn] or [production][production_cdn]. This job deploys the public and secret CDN configuration referenced above.
+
+Note that there are two configurations: one for `www` and one for `assets`.
+Choose the correct `vhost` for the configuration you'd like to deploy.
+
+You'll need to provide a `FASTLY_API_KEY`. To do this:
+
+1. Log into your Fastly account.
+1. Click on "Account", under your name in the top right corner.
+1. Click "[Personal API tokens](https://manage.fastly.com/account/personal/tokens)"
+1. Click "Create Token"
+
+Then follow the steps to create a token with the minimum privileges required for the task at hand:
+
+1. The token name is unimportant; you'll be deleting it shortly.
+1. For "Service Access", choose the service you'll be deploying,
+   e.g. "Integration GOV.UK" (for `www`) or "Integration Assets" (for `assets`).
+1. For "Scope", you'll need to pick "Global API access" (i.e. the most permissive)
+1. Under "Expiration", choose tomorrow's date
+1. Click "Create Token"
+
+You can now copy and paste the token into the `FASTLY_API_KEY` in the Jenkins job.
+Once you've run the job successfully, you can delete the token.
 
 [integration_cdn]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_CDN/
 [staging_cdn]: https://deploy.blue.staging.govuk.digital/job/Deploy_CDN/

--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -62,7 +62,7 @@ need more data.
 1. Add your test to the [A/B test register][register].
 1. If you want to use Google Analytics to monitor the A/B test, talk to a performance analyst and pick a [GA dimension][analytics-dimensions] to use for your test.
 1. Create dictionary and A/B test files in [the govuk-cdn-config repo][govuk-cdn-config]. See an [example for the dictionaries][dictionary-config-example] and an [example for the A/B configuration][cdn-config-example] (these used to be in a different repo). For more details, see the [dictionaries README][dictionaries-readme].
-1. Deploy the dictionary changes to each environment using the [Update_CDN_Dictionaries][update-cdn-dictionaries] Jenkins job. The API key is in the [govuk-secrets repo][govuk-secrets-fastly] and the dictionaries must be deployed to the `www` vhost.
+1. Deploy the dictionary changes to each environment using the [Update_CDN_Dictionaries][update-cdn-dictionaries] Jenkins job. The dictionaries must be deployed to the `www` vhost.
 1. Deploy the Fastly configuration to each environment using the [Deploy_CDN][deploy-cdn] Jenkins job. Use the same parameters as in step 4. You can test it on staging by visiting <https://www.staging.publishing.service.gov.uk>. Changes should appear almost immediately - there is no caching of the CDN config.
 1. Use the [govuk_ab_testing gem][govuk_ab_testing] to serve different versions to your users. It can be configured with the analytics dimension selected in step 2.
 1. To activate or deactivate the test, or to change the B percentage, update your test in [the govuk-cdn-config repo][govuk-cdn-config] and deploy the dictionaries.
@@ -73,7 +73,6 @@ In which case, you'll need to [add your AB test](https://github.com/alphagov/sea
 deploy it to Heroku.
 
 [analytics-dimensions]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Analytics+on+GOV.UK
-[govuk-secrets-fastly]: https://github.com/alphagov/govuk-secrets/blob/master/pass/2ndline/fastly/2nd_line_api_token.gpg
 [dictionaries-readme]: https://github.com/alphagov/govuk-cdn-config#fastly-dictionaries
 [dictionary-config-example]: https://github.com/alphagov/govuk-cdn-config-secrets/commit/ba3ec923c0bb5bdf17bdaf02419ff4e049516fda
 [govuk_ab_testing]: https://github.com/alphagov/govuk_ab_testing


### PR DESCRIPTION
We no longer have a shared 2nd line account for Fastly, so can
no longer rely on a centrally stored API key for deployments. This
PR documents how to create an access token linked to your own
Fastly account, and how to use it to deploy the CDN configuration
for `assets` and `www`. (There is also a third option,
`performanceplatform`, but as this is retired, I assume it should
be removed and we've no need to document it here).

Trello: https://trello.com/c/ShvEW3om/2560-add-documentation-on-how-to-use-individual-fastly-accounts-2