### PR TITLE
Removed the probation exemption for supervised access to production for SREs

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -7,7 +7,7 @@ section: 2nd line
 type: learn
 ---
 
-These rules apply to developers in the GOV.UK programme and SREs in the TechOps programme.
+These rules apply to developers, SREs, and technical architects in the GOV.UK programme.
 
 ## What production access means
 

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -24,7 +24,7 @@ These rules apply to developers, SREs, and technical architects in the GOV.UK pr
 ## When you get production access
 
 - Temporary supervised access during two 2nd line shadow shifts (GOV.UK developers only)
-- Supervised access after second shadow shift and probation has been passed (probation condition does not apply to SREs in TechOps)
+- Supervised access after second shadow shift and probation has been passed
 - Permanent access once a non-shadow 2nd line shift has been completed
 
 "Supervised" means "we trust you, but just be extra careful," and the dev should


### PR DESCRIPTION
Removed the probation exemption for supervised access to production for SREs. Now they're back in GOV.UK, and there isn't the likelihood of support rotating through a pool of SREs, earning prod access should be the same for everyone.

Also, the production access guidance said that it was relevant for GOV.UK devs, and SREs from TechOps. TechOps is no longer a thing, and the SREs are back in GOV.UK.