### PR TITLE
Add important gems

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -487,6 +487,12 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+- github_repo_name: gds-api-adapters
+  team: "#govuk-developers"
+  production_hosted_on: none
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 # Retired applications
 

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -481,6 +481,12 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+- github_repo_name: slimmer
+  team: "#govuk-developers"
+  production_hosted_on: none
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 # Retired applications
 


### PR DESCRIPTION
See commits for details.

These are key parts of how GOV.UK work, but their README & docs aren't currently imported because they're omitted from this list of applications. govuk_app_config - a gem - is on the list already, so this isn't anything new.