### PR TITLE
Change ownership of some applications

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -211,6 +211,7 @@
   production_hosted_on: aws
 - github_repo_name: govuk-load-testing
   type: Supporting apps
+  team: "#govuk-platform-health"
   production_hosted_on: none
 
 # frontend
@@ -466,6 +467,7 @@
   sentry_url: false
   dashboard_url: false
 - github_repo_name: govuk-pact-broker
+  team: "#govuk-platform-health"
   production_hosted_on: paas
   type: Utilities
   sentry_url: false
@@ -477,6 +479,7 @@
   sentry_url: false
   dashboard_url: false
 - github_repo_name: govuk-jenkinslib
+  team: "#govuk-platform-health"
   production_hosted_on: aws
   type: Utilities
   sentry_url: false


### PR DESCRIPTION
This sets the ownership of some applications to reflect reality (they were previously unowned). 

[Trello](https://trello.com/c/jrlfr67p/2617-1-change-dependabot-responsibility-for-some-apps)