### PR TITLE
Create Data Labs team manual

### DIFF
--- a/source/manual/datalabs-aws-sagemaker.html.md
+++ b/source/manual/datalabs-aws-sagemaker.html.md
@@ -47,7 +47,6 @@ You are now ready to use your newly created instance.
 
 For more information on creating a new instance, see the [AWS documentation on creating an Amazon SageMaker Notebook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/gs-setup-working-env.html).
 
-
 ## Open an existing instance
 
 1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.

--- a/source/manual/datalabs-aws-sagemaker.html.md
+++ b/source/manual/datalabs-aws-sagemaker.html.md
@@ -1,0 +1,75 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Manage your machine's resources with AWS Sagemaker
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+You may find that you reach your local machine’s resource limit when running intensive tasks and/or when using large datasets, or that computations are taking a long time. You should use [AWS Sagemaker](https://eu-west-1.console.aws.amazon.com/sagemaker/home?region=eu-west-1#/landing) to manage these resource issues.
+
+The following documentation applies to on-demand notebook instances.
+
+AWS Sagemaker lets you create instances with different numbers of virtual CPUs and memory at a cost. See the [documentation on AWS Sagemaker pricing](https://aws.amazon.com/sagemaker/pricing/) for more information.
+
+## Access AWS Sagemaker
+
+Before you start, you must have [set up your AWS account](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access).
+
+1. [Sign in to AWS](https://console.aws.amazon.com/console/home).
+1. Select your name in the top right of the screen and select __Switch roles__.
+1. Under __Account__, you can select select __govuk-infrastructure-integration__ or __210287912431__.
+1. Under __Role__, select __govuk-datascienceusers__.
+1. You can enter any text into __Display name__ or leave this field empty.
+1. You can select any colour in __Colour__. Best practice is to select green for integration, amber for staging and red for production.
+1. Select __Switch Role__.
+1. Enter “Sagemaker” into the search field and select __Amazon Sagemaker__.
+1. In the left hand navigation, select __Notebook__ and then __Notebook instances__.
+
+You have now accessed AWS Sagemaker. You can:
+
+- create a new instance
+- open or close an existing instance
+- edit an existing instance
+
+## Create a new instance
+
+1. Select __Create notebook instance__ on the __Notebook instances__ page.
+1. In the __Notebook instance setting__ section:
+     - enter a valid __Notebook instance name__
+     - choose an appropriate instance type depending on the amount of resources you require
+1. Select the __Additional configuration__ menu to see more options.
+1. The __Volume size in GB__ field defines the amount of storage available on your Sagemaker instance. Set this to a reasonable amount for storing data on your instance locally to the notebook. If you change this amount in future, you may lose any existing code and data on your instance.
+1. In the __Permissions and encryption__ section, set the __IAM role__ to __govuk-integration-data-science-role__.
+1. Select __Create notebook instance__.
+
+You are now ready to use your newly created instance.
+
+For more information on creating a new instance, see the [AWS documentation on creating an Amazon SageMaker Notebook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/gs-setup-working-env.html).
+
+
+## Open an existing instance
+
+1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.
+1. In the __Actions__ column of the instance you want to open, select __Start__. AWS will then find the resources for your instance.
+1. When the __Status__ of your instance shows __InService__, select the __Open Jupyter__ or __Open JupyterLab__ as needed to open the Jupyter or JupyterLab instance.
+
+You have opened your instance.
+
+## Close an existing instance
+
+When you have finished with an instance, you should close that instance to minimise costs.
+
+1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.
+1. Select the radio button next to the name of the instance you want to close. To the right of the __Notebook instances__ title, the __Actions__ drop-down menu should become accessible.
+1. In this drop-down menu, select __Stop__, and wait for the instance status to change to __Stopped__.
+
+You have closed your instance.
+
+## Edit an existing AWS Sagemaker instance
+
+1. Double-click on the __Name__ of your instance you’d like to edit. You now should see the settings for this instance.
+1. Select __Edit__ for the __Notebook instance settings__ and change any of the available options.
+1. Once you’ve edited your instance, select __Update notebook instance__.
+
+You have edited your instance.

--- a/source/manual/datalabs-bigquery.html.md
+++ b/source/manual/datalabs-bigquery.html.md
@@ -18,7 +18,11 @@ Universal Analytics (UA) sends GOV.UK visitor journey data to the `govuk-bigquer
 - `ga_sessions_intraday_YYYYMMDD` is the table name
 - `YYYYMMDD` is the current date in year-month-day format
 
-At the end of the day, UA automatically moves the data in this intraday table to a `ga_sessions_YYYYMMDD` table, and creates a new intraday table for the next day.
+At the end of the day, UA automatically:
+
+- moves the data in this intraday table to a `ga_sessions_YYYYMMDD` table
+- deletes this intraday table
+- creates a new intraday table for the next day
 
 If there are any issues with this process, you should contact a Google BigQuery administrator. The administrator will raise a request with Merkle, the agency that manages our Google Analytics / BigQuery relationship to fix the issue. Ask in the [GOV.UK Data Labs slack channel](https://gds.slack.com/archives/CHR4UQKU4) who the current admins are.
 
@@ -28,7 +32,7 @@ See the [GOV.UK Analytics page on Confluence](https://gov-uk.atlassian.net/wiki/
 
 There are many other datasets and tables on Google BigQuery. Each project usually has its own dataset.
 
-See the [example queries page](LINK) for more information.
+See the [code examples on the reference information page](/manual/datalabs-reference-info.html#code-examples) for more information.
 
 ## Get access to Google BigQuery
 
@@ -57,13 +61,17 @@ Google BigQuery charges based on the amount of data queried. You should try to m
 
 You should not use `SELECT *` in your queries if possible, as you could potentially be querying many unnecessary columns of data. Also, you should make sure you do not [query too many tables when using wildcards](https://cloud.google.com/bigquery/docs/querying-wildcard-tables).
 
-Use the query validator to the bottom right of the editor in the console to check query costs before running that query. For API queries, for example using Python, consider [using a dry run step to validate the query costs before running the code](https://cloud.google.com/bigquery/docs/best-practices-costs#performing_a_dry_run).
+Use the query validator to the bottom right of the editor in the console to check query costs before running that query. For API queries, for example using Python, consider [using a dry run step to validate the query costs before running the code](https://cloud.google.com/bigquery/docs/best-practices-costs#python).
 
 If you are developing queries, consider using an intraday table. It has the same schema as the main `ga_sessions_YYYYMMDD` tables, but has less data stored for most of the day which makes queries cheaper to run.
 
 Be aware that intraday tables may not be representative behaviour. Queries using intraday tables are also likely to break the next day, as UA automatically moves the intraday table.
 
-See the [introduction to controlling BigQuery costs](https://cloud.google.com/bigquery/docs/controlling-costs) for more information.
+For more information, see the:
+
+- [introduction to controlling BigQuery costs](https://cloud.google.com/bigquery/docs/controlling-costs)
+- GOV.UK Data Labs BigQuery training [lesson 1: Getting started with Google Cloud](https://docs.google.com/document/d/1DY5f6Q-5ZApFq3OefbgGjx_TefT1ffFzoGu2RIUC1PM/edit)
+- GOV.UK Data Labs BigQuery training [lesson 2: BigQuery and GOV.UK Analytics](https://docs.google.com/document/d/1hF1U9XUrv5qEX97nthrKkPRuaDbOIQH64JiyZDrT0NQ/edit)
 
 ### Optimise Google BigQuery performance
 
@@ -83,4 +91,12 @@ See the [BigQuery documentation on creating datasets](https://cloud.google.com/b
 
 ### Team-developed tools for Google BigQuery
 
-The GOV.UK Data Labs team has developed some tools to access Google BigQuery. These tools are for users outside of the team with limited SQL experience. One such tool is [alphagov/modular_sql](https://github.com/alphagov/modular_sql), a lightweight pipeline to combine multiple SQL scripts and generate Google BigQuery tables.
+The GOV.UK Data Labs team has developed some tools to access Google BigQuery. These tools are for users outside of the team with limited SQL experience.
+
+If you are this type of user, you should start with [modular_sql](https://github.com/alphagov/modular_sql), a lightweight pipeline to combine multiple SQL scripts and generate Google BigQuery tables.
+
+You should also use [govuk-network-data](https://github.com/alphagov/govuk-network-data), a data pipeline for extracting and preprocessing BigQuery user journey data. This tool can be useful for A/B testing and creating structured data at the session level.
+
+### Further information
+
+For more information, see the [GOV.UK Data Labs training on how to use BigQuery to analyse user journeys](https://docs.google.com/document/d/1ojeqYDdxo9R-N8ivXu3UfHUVG0NczgNJydylNUbwXec/edit#heading=h.bz8ye39uw6m2).

--- a/source/manual/datalabs-bigquery.html.md
+++ b/source/manual/datalabs-bigquery.html.md
@@ -1,0 +1,86 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Use Google BigQuery
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+
+Google BigQuery is a cloud-based SQL database. This database stores most GOV.UK visitor data. This data is primarily visitor journey data from visitors navigating through GOV.UK. BigQuery only stores visitor data if that visitor has accepted cookies.
+
+## How BigQuery data is populated
+
+Universal Analytics (UA) sends GOV.UK visitor journey data to the `govuk-bigquery-analytics.87773428.ga_sessions_intraday_YYYYMMDD` table 3 times a day, where:
+
+- `govuk-bigquery-analytics` is the project ID
+- `87773428` is the dataset name
+- `ga_sessions_intraday_YYYYMMDD` is the table name
+- `YYYYMMDD` is the current date in year-month-day format
+
+At the end of the day, UA automatically moves the data in this intraday table to a `ga_sessions_YYYYMMDD` table, and creates a new intraday table for the next day.
+
+If there are any issues with this process, you should contact a Google BigQuery administrator. The administrator will raise a request with Merkle, the agency that manages our Google Analytics / BigQuery relationship to fix the issue. Ask in the [GOV.UK Data Labs slack channel](https://gds.slack.com/archives/CHR4UQKU4) who the current admins are.
+
+The schema of these tables is defined by the [UA BigQuery Export schema](https://support.google.com/analytics/answer/3437719?hl=en). However, not all columns are filled in our tables.
+
+See the [GOV.UK Analytics page on Confluence](https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/23855552/Analytics+on+GOV.UK#AnalyticsonGOV.UK-customDimensionsCustomdimensions) for definitions of our custom dimensions.
+
+There are many other datasets and tables on Google BigQuery. Each project usually has its own dataset.
+
+See the [example queries page](LINK) for more information.
+
+## Get access to Google BigQuery
+
+To get access to Google BigQuery, ask the Data Labs team admins to set you up with a service account and access to the Google BigQuery console. Ask in the [GOV.UK Data Labs slack channel](https://gds.slack.com/archives/CHR4UQKU4) who the current admins are.
+
+Once you have a service account, store your account credentials safely. For example, store the credentials in your home directory if you have a Unix machine.
+
+Access the [Google BigQuery console](http://console.cloud.google.com/bigquery?organizationId=262359340232&project=govuk-bigquery-analytics&ws=). You can use the console to:
+
+- view projects, datasets, and tables
+- write and manage queries in the editor
+- run those queries
+
+See the [Google BigQuery documentation](https://cloud.google.com/bigquery/docs/how-to) for more information on how to use BigQuery.
+
+## Google BigQuery best practice
+
+When using Google BigQuery you should:
+
+- minimise costs
+- optimise performance
+
+### Minimise Google BigQuery costs
+
+Google BigQuery charges based on the amount of data queried. You should try to minimise the amount of data you query to minimise costs.
+
+You should not use `SELECT *` in your queries if possible, as you could potentially be querying many unnecessary columns of data. Also, you should make sure you do not [query too many tables when using wildcards](https://cloud.google.com/bigquery/docs/querying-wildcard-tables).
+
+Use the query validator to the bottom right of the editor in the console to check query costs before running that query. For API queries, for example using Python, consider [using a dry run step to validate the query costs before running the code](https://cloud.google.com/bigquery/docs/best-practices-costs#performing_a_dry_run).
+
+If you are developing queries, consider using an intraday table. It has the same schema as the main `ga_sessions_YYYYMMDD` tables, but has less data stored for most of the day which makes queries cheaper to run.
+
+Be aware that intraday tables may not be representative behaviour. Queries using intraday tables are also likely to break the next day, as UA automatically moves the intraday table.
+
+See the [introduction to controlling BigQuery costs](https://cloud.google.com/bigquery/docs/controlling-costs) for more information.
+
+### Optimise Google BigQuery performance
+
+For complex queries, Google BigQuery automatically scales resources without extra charges to us. However, complex queries can take a long time to run, and even fail if Google BigQuery cannot scale enough resources.
+
+To mitigate these issues and to speed up analysis, you should optimise your queries before running them.
+
+See the [introduction to optimising query performance](https://cloud.google.com/bigquery/docs/best-practices-performance-overview) for more information.
+
+### Other best practice
+
+You should consider deleting datasets that you no longer use as we are charged a small fee for data storage. This also helps make sure you do not run queries incorrectly against old data.
+
+Consider creating a dataset for your own personal use. For example, use your personal dataset when conducting peer reviews so you do not overwrite live data. You must set the location to `EU`. You could set a table expiry condition to delete tables after a certain number of days.
+
+See the [BigQuery documentation on creating datasets](https://cloud.google.com/bigquery/docs/datasets) for more information.
+
+### Team-developed tools for Google BigQuery
+
+The GOV.UK Data Labs team has developed some tools to access Google BigQuery. These tools are for users outside of the team with limited SQL experience. One such tool is [alphagov/modular_sql](https://github.com/alphagov/modular_sql), a lightweight pipeline to combine multiple SQL scripts and generate Google BigQuery tables.

--- a/source/manual/datalabs-content-store.html.md
+++ b/source/manual/datalabs-content-store.html.md
@@ -52,7 +52,7 @@ To access the Content Store, you:
 
 ### Query the local production version of the Content Store using Docker
 
-1.  Set up a local Docker instance by following the instructions in the [govuk-mongodb-content GitHub repo readme file](https://github.com/alphagov/govuk-mongodb-content).
+1. Set up a local Docker instance by following the instructions in the [govuk-mongodb-content GitHub repo readme file](https://github.com/alphagov/govuk-mongodb-content).
 
 1. Access your local version of the Content Store through your local Docker instance by [using the Mongo Express graphical interface](https://github.com/alphagov/govuk-mongodb-content#interact-with-mongodb-instance).
 

--- a/source/manual/datalabs-content-store.html.md
+++ b/source/manual/datalabs-content-store.html.md
@@ -1,0 +1,52 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Use Content Store
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+The [Content Store](https://docs.publishing.service.gov.uk/apps/content-store.html) is a MongoDB database of almost all the content published on GOV.UK.
+
+The Content Store does not have all GOV.UK content. The Content Store has the content itself, but does not include dynamic elements such as top links on taxon pages, navigation elements, or search result pages.
+
+Contact a GOV.UK Data Labs software developer through the [GOV.UK Data Labs slack channel](https://gds.slack.com/archives/CHR4UQKU4) for more information.
+
+Consider using the [GOV.UK mirror](link) if you need a more representative data source of what users actually see on the website.
+
+## Get access to the Content Store
+
+To access the Content Store, you download a copy of the production version of the Content Store and query that local version using Docker.
+
+1. Sign into AWS. See the [GOV.UK Developer Docs on getting AWS access](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access) for more information.
+
+1. Go to the [`govuk-integration-database-backups` AWS S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/govuk-integration-database-backups?prefix=mongo-api%2F&region=eu-west-1) and then go to the `mongo-api` folder.
+
+1. Download a copy of the production version of the Content Store. The production version file is `{DATETIME}-content_store_production.gz`, where `{DATETIME}` is a date and time in `YYYY-MM-DDTHH:MM:SS` format.
+
+1. Run the following in the command line to extract the `content_items.bson` file from the `content_store_production` folder of the downloaded production version file:
+
+    ```
+    tar -xvf PATH/TO/DATETIME-content_store_production.gz content_store_production/content_items.bson
+    ```
+
+1.  Set up a local Docker instance by following the instructions in the [govuk-mongodb-content GitHub repo readme file](https://github.com/alphagov/govuk-mongodb-content).
+
+1. Access your local version of the Content Store through your local Docker instance by [using the Mongo Express graphical interface](https://github.com/alphagov/govuk-mongodb-content#interact-with-mongodb-instance).
+
+Instead of using Docker, you can query the Content Store database using the:
+
+- [Content Store API](https://docs.publishing.service.gov.uk/apps/content-store/content-store-api.html)
+- [Python `pymongo` package](https://github.com/alphagov/govuk-intent-detector/blob/define-content-schemas/notebooks/writing_aggregation_queries_for_content_store_with_pymongo.ipynb)
+
+## Content Store best practice
+
+You should use the Mongo query language to transform your data as much as possible before exporting to another programming language.
+
+This makes sure that you use MongoDB’s power to do most of the resource-intensive data processing. Doing this is especially important with a NoSQL database like MongoDB, as MongoDB does not have a stable schema.
+
+Therefore it can be difficult to unnest or replicate Mongo queries in another language, for example using base Python to unnest fields.
+
+MongoDB drivers, such as the [Python driver `pymongo`](https://pymongo.readthedocs.io/), can help you run Mongo queries from an alternative language.
+
+The [GOV.UK Developer Docs “schema” page](https://docs.publishing.service.gov.uk/content-schemas.html) describes possible fields for each document type. However, this is incomplete, and document type schemas are not enforced due to the nature of NoSQL databases. See the [MongoDB NoSQL documentation](https://www.mongodb.com/nosql-explained) for more information.

--- a/source/manual/datalabs-content-store.html.md
+++ b/source/manual/datalabs-content-store.html.md
@@ -12,23 +12,45 @@ The Content Store does not have all GOV.UK content. The Content Store has the co
 
 Contact a GOV.UK Data Labs software developer through the [GOV.UK Data Labs slack channel](https://gds.slack.com/archives/CHR4UQKU4) for more information.
 
-Consider using the [GOV.UK mirror](link) if you need a more representative data source of what users actually see on the website.
+Consider using the [GOV.UK mirror](/manual/datalabs-govuk-mirror.html) if you need a more representative data source of what users actually see on the website.
 
 ## Get access to the Content Store
 
-To access the Content Store, you download a copy of the production version of the Content Store and query that local version using Docker.
+To access the Content Store, you:
+
+- sign into AWS and assume the correct AWS role
+- download a copy of the production version of the Content Store to your local machine
+- query the local production version of the Content Store using Docker
+
+### Sign into AWS and select the correct AWS role
 
 1. Sign into AWS. See the [GOV.UK Developer Docs on getting AWS access](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access) for more information.
 
+1. Select your name in the top right of the screen and select __Switch roles__.
+
+1. Under __Account__, you can select select __govuk-infrastructure-integration__ or __210287912431__.
+
+1. Under __Role__, select __govuk-datascienceusers__.
+
+1. You can enter any text into __Display name__ or leave this field empty.
+
+1. You can select any colour in __Colour__. Best practice is to select green for integration, amber for staging and red for production.
+
+1. Select __Switch Role__.
+
+### Download a copy of the production version of the Content Store
+
 1. Go to the [`govuk-integration-database-backups` AWS S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/govuk-integration-database-backups?prefix=mongo-api%2F&region=eu-west-1) and then go to the `mongo-api` folder.
 
-1. Download a copy of the production version of the Content Store. The production version file is `{DATETIME}-content_store_production.gz`, where `{DATETIME}` is a date and time in `YYYY-MM-DDTHH:MM:SS` format.
+1. Download a copy of the production version of the Content Store. The production version file is `{DATETIME}-content_store_production.gz`, where `{DATETIME}` is a date and time in `YYYY-MM-DDTHH_MM_SS` format.
 
 1. Run the following in the command line to extract the `content_items.bson` file from the `content_store_production` folder of the downloaded production version file:
 
     ```
     tar -xvf PATH/TO/DATETIME-content_store_production.gz content_store_production/content_items.bson
     ```
+
+### Query the local production version of the Content Store using Docker
 
 1.  Set up a local Docker instance by following the instructions in the [govuk-mongodb-content GitHub repo readme file](https://github.com/alphagov/govuk-mongodb-content).
 

--- a/source/manual/datalabs-govuk-knowledge-graph.html.md
+++ b/source/manual/datalabs-govuk-knowledge-graph.html.md
@@ -1,0 +1,38 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Use GOV.UK Knowledge Graph
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+The [GOV.UK Knowledge Graph](https://github.com/alphagov/govuk-knowledge-graph), also known as govGraph, is a knowledge graph tool that allows us to:
+
+- explore graph databases and knowledge graphs for GOV.UK applications
+- collaborate with other teams and communities to help them find content more easily
+- build products and apps that allow further insights about our content such as the journey visualisation app
+- upskill colleagues and drive culture change to make better use of data and improve data literacy in GOV.UK
+- provide early adopters with access and training to help scale use of our data apps and product
+
+One of the most common uses is that GOV.UK Knowledge Graph provides a queryable platform for content designers to answer common content questions.
+
+There are two versions of the graph:
+
+- a [stable graph](https://knowledge-graph.integration.govuk.digital:7473/browser/) for content designers to query
+- an [experimental graph](https://knowledge-graph-lab.integration.govuk.digital:7473/browser/) for the Data Labs team which includes extra NLP derived features
+
+The graph connects siloed data from analytics (the functional network) to content data metadata such as the title, body, or which organisations publish content. We also use graph algorithms to derive new features, such as the popularity of content with the weighted PageRank algorithm.
+
+Complete this [introduction lesson](https://docs.google.com/document/d/1R8vati8E5aPJk_p0RYxu2yw2gJK_y6ikvi5VReV4YVs/edit) to understand more about how GOV.UK Knowledge Graph works.
+
+For more information, see the following:
+
+- this [blog post on Knowledge Graph](https://insidegovuk.blog.gov.uk/2020/08/07/one-graph-to-rule-them-all/)
+- the [GOV.UK developer documentation Knowledge Graph page](https://docs.publishing.service.gov.uk/manual/knowledge-graph.html)
+- [example queries](https://github.com/alphagov/govuk-knowledge-graph/tree/master/src/neo4j/favourite_queries) in the repo
+- [example requests](https://drive.google.com/drive/u/0/folders/1uh7tKgHDkQF12pXS9-q7rUa2pHq8fGdo) from content designers
+
+If you have questions, you can contact:
+
+- the [GOV.UK Data Labs team on Slack](https://gds.slack.com/archives/CHR4UQKU4)
+- [Esther Woods](mailto:esther.woods@digital.cabinet-office.gov.uk) in the content community

--- a/source/manual/datalabs-govuk-mirror.html.md
+++ b/source/manual/datalabs-govuk-mirror.html.md
@@ -54,7 +54,6 @@ The following content assumes that you want to copy the GOV.UK mirror to the `go
     ```
     gds aws govuk-integration-datascience --assume-role-ttl 480m aws s3 sync s3://govuk-production-mirror-replica/www.gov.uk s3://govuk-data-infrastructure-integration/{YYYYMMDD}-govuk-production-mirror-replica
     ```
-    
     where `{YYYYMMDD}` is today’s date in year-month-day format.
 
     The `--assume-role-ttl 480m` allows 8 hours (480 minutes) to transfer the data between the two S3 buckets. Using `aws s3 sync` also allows you to restart the transfer from where you left off if there are any errors.

--- a/source/manual/datalabs-govuk-mirror.html.md
+++ b/source/manual/datalabs-govuk-mirror.html.md
@@ -1,0 +1,74 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Use GOV.UK Mirror
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+The GOV.UK mirror is a static version of the entire GOV.UK website. A crawler generates the mirror every hour by navigating through most of the site and saving each HTML page it visits. See the [Developer docs on updating the GOV.UK mirror](https://docs.publishing.service.gov.uk/manual/fall-back-to-mirror.html#updates-to-the-mirror) for more information.
+
+The GOV.UK mirror provides a static backup of GOV.UK as a fallback, and is not designed for analytics. As such, the GOV.UK mirror:
+
+- only stores pages that can be accessed by the crawler
+- skips search pages, and [pages that mandate a user input](https://www.gov.uk/child-benefit-tax-calculator/y?response=&next=1)
+- stores [pages with default or blank answers if user input is optional](https://www.gov.uk/transition-check/questions?page=6)
+- does not cache mirror versions, but instead replaces those versions once it completes each crawl
+
+The following example pages show what page types are cached by the crawler.
+
+Smart answer start pages and their first pages, such as the [Child Benefit Tax calculator]((https://www.gov.uk/child-benefit-tax-calculator/y)), are included in the mirror. However, all other pages are missing as they require user input.
+
+Internal search result pages requiring user input and pre-populated internal search pages, such as the [“Services” internal search page](https://www.gov.uk/search/services), are not stored.
+
+Local transaction result pages, such as the [“Request a repair to a council property” page](https://www.gov.uk/repair-council-property/tower-hamlets), are not cached as they require user input.
+
+For special checkers like the [Brexit checker](https://www.gov.uk/brexit), only the start, first question and results pages are stored as the intermediate question pages are query strings. The results page has no useful content, as there is no user input.
+
+## Get access to the GOV.UK mirror
+
+Before you start, you must have:
+
+- access to AWS
+- installed the GDS command line tools
+
+See the [Get started on GOV.UK developer documentation](https://docs.publishing.service.gov.uk/manual/get-started.html) for more information on how to do this.
+
+### Copy GOV.UK mirror from AWS S3 bucket
+
+The GOV.UK mirror is stored in the AWS `govuk-production-mirror-replica` S3 bucket.
+
+To work with the GOV.UK mirror remotely, you should copy the GOV.UK mirror from the `govuk-production-mirror-replica` bucket to another bucket.
+
+The following content assumes that you want to copy the GOV.UK mirror to the `govuk-data-infrastructure-integration` S3 bucket.
+
+1. [Sign into AWS](https://s3.console.aws.amazon.com/).
+1. Select the `govuk-datascienceusers` role.
+1. Run the following in your command line:
+
+    ```
+    gds aws govuk-integration-datascience --assume-role-ttl 480m aws s3 sync s3://govuk-production-mirror-replica/www.gov.uk s3://govuk-data-infrastructure-integration/{YYYYMMDD}-govuk-production-mirror-replica
+    ```
+    where `{YYYYMMDD}` is today’s date in year-month-day format.
+
+    The `--assume-role-ttl 480m` allows 8 hours (480 minutes) to transfer the data between the two S3 buckets. Using `aws s3 sync` also allows you to restart the transfer from where you left off if there are any errors.
+
+### Download the GOV.UK mirror to your local machine
+
+You can download the GOV.UK mirror to your local machine.
+
+You must first copy the GOV.UK mirror from the `govuk-production-mirror-replica` AWS S3 bucket to another bucket, and then download from that second bucket to your local machine.
+
+The following content assumes that you want to download the GOV.UK mirror from the `govuk-data-infrastructure-integration` S3 bucket.
+
+1. [Sign into AWS](https://s3.console.aws.amazon.com/).
+1. Select the `govuk-datascienceusers` role.
+1. Run the following code in your terminal to download the mirror locally:
+
+    ```
+    gds aws govuk-integration-datascience --assume-role-ttl 480m aws s3 sync s3://govuk-data-infrastructure-integration/{YYYYMMDD}-govuk-production-mirror-replica YOUR_LOCAL_FOLDER
+    ```
+
+    where `{YYYYMMDD}` is today’s date in year-month-day format, and `YOUR_LOCAL_FOLDER` is a folder on your machine.
+
+Downloading the mirror locally is time and resource-intensive. To save time and resources, you can instead run your code on [AWS Sagemaker](/manual/datalabs-start-new-project.html#manage-your-machine39s-resources-with-aws-sagemaker) and stream the data from S3.

--- a/source/manual/datalabs-govuk-mirror.html.md
+++ b/source/manual/datalabs-govuk-mirror.html.md
@@ -54,6 +54,7 @@ The following content assumes that you want to copy the GOV.UK mirror to the `go
     ```
     gds aws govuk-integration-datascience --assume-role-ttl 480m aws s3 sync s3://govuk-production-mirror-replica/www.gov.uk s3://govuk-data-infrastructure-integration/{YYYYMMDD}-govuk-production-mirror-replica
     ```
+
     where `{YYYYMMDD}` is today’s date in year-month-day format.
 
     The `--assume-role-ttl 480m` allows 8 hours (480 minutes) to transfer the data between the two S3 buckets. Using `aws s3 sync` also allows you to restart the transfer from where you left off if there are any errors.

--- a/source/manual/datalabs-govuk-mirror.html.md
+++ b/source/manual/datalabs-govuk-mirror.html.md
@@ -54,6 +54,7 @@ The following content assumes that you want to copy the GOV.UK mirror to the `go
     ```
     gds aws govuk-integration-datascience --assume-role-ttl 480m aws s3 sync s3://govuk-production-mirror-replica/www.gov.uk s3://govuk-data-infrastructure-integration/{YYYYMMDD}-govuk-production-mirror-replica
     ```
+    
     where `{YYYYMMDD}` is today’s date in year-month-day format.
 
     The `--assume-role-ttl 480m` allows 8 hours (480 minutes) to transfer the data between the two S3 buckets. Using `aws s3 sync` also allows you to restart the transfer from where you left off if there are any errors.

--- a/source/manual/datalabs-govuk-mirror.html.md
+++ b/source/manual/datalabs-govuk-mirror.html.md
@@ -43,7 +43,12 @@ To work with the GOV.UK mirror remotely, you should copy the GOV.UK mirror from 
 The following content assumes that you want to copy the GOV.UK mirror to the `govuk-data-infrastructure-integration` S3 bucket.
 
 1. [Sign into AWS](https://s3.console.aws.amazon.com/).
-1. Select the `govuk-datascienceusers` role.
+1. Select your name in the top right of the screen and select __Switch roles__.
+1. Under __Account__, you can select select __govuk-infrastructure-integration__ or __210287912431__.
+1. Under __Role__, select __govuk-datascienceusers__.
+1. You can enter any text into __Display name__ or leave this field empty.
+1. You can select any colour in __Colour__. Best practice is to select green for integration, amber for staging and red for production.
+1. Select __Switch Role__.
 1. Run the following in your command line:
 
     ```

--- a/source/manual/datalabs-onboarding-guidance.html.md
+++ b/source/manual/datalabs-onboarding-guidance.html.md
@@ -17,7 +17,7 @@ This onboarding guide contains information and best practice on the following:
 - using the [GOV.UK mirror](/manual/datalabs-govuk-mirror.html)
 - using [GOV.UK Knowledge Graph](/manual/datalabs-govuk-knowledge-graph.html), otherwise known as GovGraph
 - organising your work using [Trello](/manual/datalabs-start-new-project.html#organise-your-workload-using-trello)
-- using [AWS Sagemaker](/manual/datalabs-start-new-project.html#manage-your-machine39s-resources-with-aws-sagemaker) to manage your machine's resources
+- using [AWS Sagemaker](/manual/datalabs-aws-sagemaker.html) to manage your machine's resources
 
 The onboarding guidance also has [reference information](/manual/datalabs-reference-info.html) on the following:
 

--- a/source/manual/datalabs-onboarding-guidance.html.md
+++ b/source/manual/datalabs-onboarding-guidance.html.md
@@ -1,0 +1,32 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Onboarding for new starters
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+Use this onboarding guide if you are a new member of the Data Labs team.
+
+This onboarding guide contains information and best practice on the following:
+
+- [setting up your local machine](/manual/datalabs-setup-local-machine.html)
+- [starting a new project](/manual/datalabs-start-new-project.html)
+- using [Google BigQuery](/manual/datalabs-bigquery.html) to analyse data
+- using the [GOV.UK Content Store](/manual/datalabs-content-store.html) database
+- using the [GOV.UK mirror](/manual/datalabs-govuk-mirror.html)
+- using [GOV.UK Knowledge Graph](/manual/datalabs-govuk-knowledge-graph.html), otherwise known as GovGraph
+- organising your work using [Trello](/manual/datalabs-start-new-project.html#organise-your-workload-using-trello)
+- using [AWS Sagemaker](/manual/datalabs-start-new-project.html#manage-your-machine39s-resources-with-aws-sagemaker) to manage your machine's resources
+
+The onboarding guidance also has [reference information](/manual/datalabs-reference-info.html) on the following:
+
+- the GDS wiki
+- Cabinet Office Intranet (CabWeb)
+- Single Operating Platform (SOP)
+- the GDS Way
+- GOV.UK Confluence
+- the Aqua book for maintaining analytical quality assurance (AQA)
+- pre-existing code to reuse
+- learning and development resources
+- example code

--- a/source/manual/datalabs-onboarding-guidance.html.md
+++ b/source/manual/datalabs-onboarding-guidance.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-data-labs"
-title: Onboarding for new starters
+title: Onboard new starters
 section: Data Labs Team Manual
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/datalabs-reference-info.html.md
+++ b/source/manual/datalabs-reference-info.html.md
@@ -118,6 +118,15 @@ See the [documentation on content schemas](https://docs.publishing.service.gov.u
 
 This page is useful if you are working with the Content Store as it tells you what fields are available for different content document types again. This list may be incomplete.
 
+## View the JSON of a GOV.UK page
+
+You can view the JSON on a GOV.UK page by either:
+
+- using the [GOV.UK Toolkit for Chrome and Firefox Chrome extension](https://github.com/alphagov/govuk-browser-extension)
+- adding `/api/content` into a page URL, for example, you can change `https://www.gov.uk/browse/benefits/disability` to `https://www.gov.uk/api/content/browse/benefits/disability`
+
+Using either of these methods lets you view the A and B versions of a page.
+
 ## Pre-existing code to reuse
 
 GOV.UK Data Labs has worked on many projects, and has developed code and features you can reuse.

--- a/source/manual/datalabs-reference-info.html.md
+++ b/source/manual/datalabs-reference-info.html.md
@@ -1,0 +1,310 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Reference information
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+As a new starter in the GOV.UK Data Labs team, you should use the following reference information:
+
+- the GDS wiki
+- Cabinet Office Intranet (CabWeb)
+- Single Operating Platform (SOP)
+- the GDS Way
+- GOV.UK Confluence
+- the Aqua book for maintaining analytical quality assurance (AQA)
+- the GOV.UK developer documentation
+- pre-existing code to reuse
+- learning and development resources
+- example code
+
+## GDS wiki
+
+The [GDS Wiki](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds) contains GDS-specific information. Some useful pages include:
+
+- specific [guidance for new starters](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/people-team/people-line-manager-support-page/new-starters-leavers-internal-moves-and-recruitment/new-starters)
+- guidance on [performance management](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/people-team/people-line-manager-support-page/performance-management)
+- [learning and development](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/people-team/training-and-development-available-at-gds), including mandatory training, and [using the learning and development budget](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/operations/people-team/learning-and-development)
+
+The GDS Wiki is being phased out in Summer 2021, and will be replaced with an updated version.
+
+## Cabinet Office Intranet (CabWeb)
+
+You must sign into the GDS Virtual Private Network (VPN) before you can access CabWeb. See the [guidance on signing into the GDS VPN using your Google credentials](https://docs.google.com/document/d/1O1LmLByDLlKU4F1-3chwS8qddd2WjYQgMaaEgTfK5To) for more information.
+
+Once you’re signed into the VPN, you can access [CabWeb](http://intranet.cabinetoffice.gov.uk). Some useful pages include:
+
+- the [Cabinet Office Analysis hub](https://intranet.cabinetoffice.gov.uk/analysis-hub/)
+- [human resources (HR) guidance](https://intranet.cabinetoffice.gov.uk/how-do-i/hr-policy-hub/) on the HR hub
+- [SOP guidance](https://co.myhub.sscl.com/) on MyHub
+
+## Single Operating Platform (SOP)
+
+SOP is a Cabinet Office-wide platform for most human resource functions, including editing your personal information, accessing your payslip, logging expenses, and requesting special leave. For more information on how to use SOP, see the [SOP guidance on CabWeb](https://docs.google.com/document/d/1MPFvIkAc_0HhujOl-hXSfUimP2EWBWNq1IddWFhKN9k/edit?pli=1#heading=h.cfm3uejborh5).
+
+To access SOP:
+
+- sign into the [GDS Virtual Private Network (VPN) using your Google account](https://docs.google.com/document/d/1O1LmLByDLlKU4F1-3chwS8qddd2WjYQgMaaEgTfK5To)
+- [sign into SOP](https://sop.govsharedservices.gov.uk:4450/OA_HTML/AppsLogin)
+
+## The GDS Way
+
+[The GDS Way](https://gds-way.cloudapps.digital/) is a public-facing website that documents the specific technology, tools, and processes used at GDS and CDDO.
+
+Although software developer-focused, some useful pages include:
+
+- [style guides for different programming languages](https://gds-way.cloudapps.digital/manuals/programming-languages.html), including the [GDS Python style guide](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html)
+- tracking, and [managing third-party software dependencies](https://gds-way.cloudapps.digital/standards/tracking-dependencies.html)
+- [building accessible services, and understanding WCAG 2.1](https://gds-way.cloudapps.digital/manuals/accessibility.html), which is a legal responsibility of public sector websites
+- best practice on using [version control](https://gds-way.cloudapps.digital/#version-control-and-deployments)
+
+## GOV.UK Confluence
+
+[Contact the GOV.UK Data Labs delivery manager](https://gds.slack.com/archives/CHR4UQKU4) and ask for access to the [GOV.UK Confluence workspace](https://gov-uk.atlassian.net/wiki/spaces/GOVUK/).
+
+Once you have access to GOV.UK Confluence, go to the [Analytics on GOV.UK Confluence page](https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/23855552/Analytics+on+GOV.UK). This page has [definitions on the custom dimensions](https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/23855552/Analytics+on+GOV.UK#AnalyticsonGOV.UK-customDimensionsCustomdimensions) used in [Google BigQuery analytics tables](https://docs.google.com/document/d/1MPFvIkAc_0HhujOl-hXSfUimP2EWBWNq1IddWFhKN9k/edit?pli=1#heading=h.xxvwzmxv8f62).
+
+## The Aqua book for maintaining analytical quality assurance (AQA)
+
+Our analytical work can have far-reaching implications, including impacting individuals and their livelihoods. [The Aqua book provides high-level guidance on producing quality analysis for government](https://www.gov.uk/government/publications/the-aqua-book-guidance-on-producing-quality-analysis-for-government). This is termed analytical quality assurance (AQA). This book sets out how departments should ensure their work is fit-for-purpose through verification and validation.
+
+These checks apply to anything that can be loosely defined as a “model”. If your work takes an input, processes it, and produces an output, this comes under the scope of AQA. This includes but is not limited to visualisations, spreadsheets, machine learning models, and even back-of-napkin-type calculations.
+
+The Aqua book establishes four principles:
+
+### Proportionality of response
+
+The extent of the analytical quality assurance effort should be proportionate in response to the risks associated with the intended use of the analysis. These risks include financial, legal, operational and reputational impacts. In addition, analysis that is frequently used to support a decision-making process may require a more comprehensive analytical quality assurance response.
+
+### Assurance throughout development
+
+Quality assurance considerations should be taken into account throughout the life cycle of the analysis and not just at the end. Effective communication is crucial when understanding the problem, designing the analytical approach, conducting the analysis and relaying the outputs.
+
+### Verification and validation
+
+Analytical quality assurance is more than checking that the analysis is error-free and satisfies its specification (verification). It must also include checks that the analysis is appropriate, i.e. fit for the purpose for which it is being used (validation).
+
+### Analysis with RIGOUR
+
+Quality analysis needs to be the following:
+
+- repeatable (R)
+- independent (I)
+- grounded in reality (G)
+- objective (O)
+- have understood and managed uncertainty (U)
+- the results should address the initial question robustly (R)
+
+In particular, it is important to accept that uncertainty is inherent within the inputs and outputs of any piece of analysis. It is important to establish how much we can rely upon the analysis for a given problem.
+
+These principles must be considered when undertaking any work involving data/models. When setting up a project, use `govcookiecutter` to help concurrently set up all AQA documentation. Note this only sets up the documentation. You still need to perform the AQA itself.
+
+Note that AQA is not just about software quality assurance. It can also include dealing with ethical considerations, reasons for choosing the method/technique, and validating analytical assumptions and caveats.
+
+### Further information
+
+[Additional Aqua book resources are available](https://www.gov.uk/government/collections/aqua-book-resources), and the Government Analytical Function, Government Data Quality Hub, and other departments have also produced:
+
+- guides to ensure your [work is fit for purpose when working to very tight deadlines](https://www.gov.uk/government/publications/urgent-data-quality-assurance-guidance)
+- guides to ensure your [data is fit for purpose](https://www.gov.uk/government/publications/the-government-data-quality-framework)
+- a [curriculum around quality assurance, validation, and data linkage](https://www.gov.uk/guidance/af-learning-curriculum-technical#QualityAssuranceAF)
+
+## GOV.UK developer documentation
+
+See the [documentation on document types on GOV.UK](https://docs.publishing.service.gov.uk/document-types.html) for information on the various document types present on GOV.UK. This list may be incomplete.
+
+See the [documentation on content schemas](https://docs.publishing.service.gov.uk/content-schemas.html) for more information on schema used for different content items on the Content Store.
+
+This page is useful if you are working with the Content Store as it tells you what fields are available for different content document types again. This list may be incomplete.
+
+## Pre-existing code to reuse
+
+GOV.UK Data Labs has worked on many projects, and has developed code and features you can reuse.
+
+The following table has links to code that you can reuse.
+
+| Location | Notes |
+| :--- | :--- |
+| [2020-01-08 Possible Data Engineering problems to solve](https://docs.google.com/document/d/1fVdq3bfXZRAyL4f_6AiUyQ9gC0yO8mhsKOvy9TRewiY/) | Google Doc listing useful features, and data engineering-related thoughts. Mostly for Google BigQuery. |
+| [alphagov/modular_sql/src/tools](https://github.com/alphagov/modular_sql/tree/master/src/tools) <br> [alphagov/modular_sql/tests](https://github.com/alphagov/modular_sql/tree/master/tests)| Scripts and associated tests for logging, setting up Google BigQuery clients, parsing SQL scripts into Python, and loading YAML configuration files |
+
+## Code examples
+
+The following content has code examples for different data sources.
+
+### Google BigQuery code examples
+
+Google BigQuery code examples are available in the [`govuk-data-labs-onboarding` GitHub repo](https://github.com/alphagov/govuk-data-labs-onboarding/tree/main/src).
+
+### Content Store code examples
+
+Downloading the Content Store may take some time.
+
+If you need to use the Content Store in a project, you can instead use the:
+
+- [JavaScript files in the `govuk-intent-detector` GitHub repo](https://github.com/alphagov/govuk-intent-detector/tree/main/src/make_data)
+- [PyMongo Jupyter notebook in the define-content-schemas branch](https://github.com/alphagov/govuk-intent-detector/blob/define-content-schemas/notebooks/writing_aggregation_queries_for_content_store_with_pymongo.ipynb) of the `govuk-intent-detector` GitHub repo
+
+### GOV.UK mirror code examples
+
+Downloading the GOV.UK mirror may take some time.
+
+If you need to use the GOV.UK mirror in a project, you can instead use the [page term TF-IDF matrix notebooks in the `govuk-intent-detector` GitHub repo](https://github.com/alphagov/govuk-intent-detector/tree/main/notebooks/page_term_tfidf_matrix).
+
+## Learning and development resources
+
+<table>
+<tbody>
+<tr>
+<td><strong>Free?</strong></td>
+<td><strong>Materials</strong></td>
+<td><strong>Notes</strong></td>
+</tr>
+<tr>
+<td>No</td>
+<td><a href="https://www.acm.org/membership/membership-benefits" target="_blank" rel="noopener">O&rsquo;Reilly ebooks through ACM membership</a></td>
+<td>O&rsquo;Reilly Media publishes technology-oriented books with an associated app for reading their books on the go. Useful books and videos include:
+<ul>
+<li><a href="https://learning.oreilly.com/library/view/statistics-in-a/9781449361129/" target="_blank" rel="noopener">Statistics in a Nutshell</a></li>
+<li><a href="https://learning.oreilly.com/library/view/data-science-from/9781492041122/" target="_blank" rel="noopener">Data Science from Scratch</a></li>
+<li><a href="https://learning.oreilly.com/library/view/hands-on-machine-learning/9781492032632/" target="_blank" rel="noopener">Hands-On Machine Learning with Scikit-Learn, Keras, and Tensorflow</a></li>
+<li><a href="https://learning.oreilly.com/library/view/agile-data-science/9781491960103/" target="_blank" rel="noopener">Agile Data Science 2.0</a></li>
+<li><a href="https://learning.oreilly.com/library/view/deep-learning-for/9781492045519/" target="_blank" rel="noopener">Deep Learning for Coders with fastai and PyTorch</a></li>
+<li><a href="https://learning.oreilly.com/library/view/bayesian-statistics-the/9781098122492/" target="_blank" rel="noopener">Bayesian Statistics the Fun Way</a></li>
+<li><a href="https://learning.oreilly.com/videos/ab-testing-a/9781491934777/" target="_blank" rel="noopener">A/B Testing, A Data Science Perspective</a></li>
+</ul>
+</td>
+</tr>
+<tr>
+<td>No</td>
+<td><a href="https://www.pluralsight.com/" target="_blank" rel="noopener">Standard individual licence for Pluralsight</a></td>
+<td>Pluralsight provides online courses that lean towards software development and engineering. Some useful courses include:
+<ul>
+<li><a href="https://app.pluralsight.com/library/courses/using-unit-testing-python/table-of-contents" target="_blank" rel="noopener">Unit Testing with Python</a></li>
+<li><a href="https://app.pluralsight.com/paths/skills/data-analytics-on-google-cloud-platform" target="_blank" rel="noopener">From Data to Insights with Google Cloud</a></li>
+</ul>
+</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://course.spacy.io/en/" target="_blank" rel="noopener">Advanced NLP with spaCy</a></td>
+<td>Free online course by the creators of spaCy on natural language processing, including exercises, slides, videos, multiple choice questions, and interactive, browser-based coding practice.</td>
+</tr>
+<tr>
+<td>Depends</td>
+<td><a href="https://www.coursera.org/" target="_blank" rel="noopener">Coursera</a></td>
+<td>Coursera hosts a number of courses on data science.&nbsp;<a href="https://learner.coursera.help/hc/en-us/articles/209818613-Enrollment-options#heading-4" target="_blank" rel="noopener">You can &ldquo;audit&rdquo; courses for free</a>; but you cannot complete certain assignments or obtain a completion certificate. It&rsquo;s generally not worth paying for the courses. Good courses include:
+<ul>
+<li><a href="https://www.coursera.org/learn/machine-learning" target="_blank" rel="noopener">Stanford - Machine Learning</a>&nbsp;(Andrew Ng)</li>
+<li><a href="https://www.coursera.org/specializations/jhu-data-science" target="_blank" rel="noopener">John Hopkins University - Data Science Specialization</a></li>
+</ul>
+</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://www.fast.ai/" target="_blank" rel="noopener">fast.ai</a></td>
+<td>Online courses on deep learning using fast.ai, practical data ethics, computational linear algebra, and natural language processing</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://christophm.github.io/interpretable-ml-book/" target="_blank" rel="noopener">Interpretable Machine Learning</a></td>
+<td>Accessible book on interpretable machine learning, including interpretable machine learning models, as well as model-agnostic methods for interpretability.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="http://jalammar.github.io/illustrated-word2vec/" target="_blank" rel="noopener">The Illustrated Word2vec</a><a href="http://jalammar.github.io/" target="_blank" rel="noopener">Jay Alammar's GitHub Pages</a></td>
+<td>An illustrated guide to word2vec. The author, Jay Alammar, also has a whole host of other illustrated guides.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://matheusfacure.github.io/python-causality-handbook/landing-page.html" target="_blank" rel="noopener">Causal Inference for The Brave and True</a></td>
+<td>A light-hearted yet rigorous approach to learning impact estimation and sensitivity analysis.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://arxiv.org/abs/1803.09010" target="_blank" rel="noopener">Datasheets for Datasets</a></td>
+<td>A paper proposing how to document datasets.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://www.pluralsight.com/tech-blog/managing-python-environments/" target="_blank" rel="noopener">Managing Python Environments</a></td>
+<td>Short blog post by Pluralsight summarising Python.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://cjolowicz.github.io/posts/hypermodern-python-01-setup/" target="_blank" rel="noopener">Hypermodern Python</a></td>
+<td>A recent review on Python best practice for projects.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://mml-book.github.io/" target="_blank" rel="noopener">Mathematics for Machine Learning</a></td>
+<td>Mathematical skills book to be able to interpret other advanced machine learning books.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/huggingface/datasets" target="_blank" rel="noopener">huggingface/datasets</a></td>
+<td>The largest hub of ready-to-use natural language processing datasets for machine learning models with fast, easy-to-use and efficient data manipulation tools.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html" target="_blank" rel="noopener">ONS Best Practice and Impact - Quality Assurance of Code for Analysis and Research</a></td>
+<td>Cross Governmental guidance on best practice for analysis and research.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/ethen8181/machine-learning" target="_blank" rel="noopener">ethen8181/machine-learning</a></td>
+<td>Machine learning tutorials</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/ageron/handson-ml2" target="_blank" rel="noopener">ageron/handson-ml2</a></td>
+<td>Complementary code for the Hands-On Machine Learning with Scikit-Learn, Keras, and Tensorflow O&rsquo;Reilly book.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/awesomedata/awesome-public-datasets" target="_blank" rel="noopener">awesomedata/awesome-public-datasets</a></td>
+<td>A topic-centric list of high quality open datasets.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://madewithml.com/" target="_blank" rel="noopener">Made with ML</a></td>
+<td>Machine learning operations and engineering courses.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/ikatsov/tensor-house" target="_blank" rel="noopener">ikatsov/tensor-house</a></td>
+<td>A collection of reference machine learning and optimization models for enterprise operations, including marketing, pricing, and supply chain.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/jghoman/awesome-apache-airflow" target="_blank" rel="noopener">jghoman/awesome-apache-airflow</a></td>
+<td>Resources for Apache Airflow.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/aws/amazon-sagemaker-examples" target="_blank" rel="noopener">aws/amazon-sagemaker-examples</a></td>
+<td>AWS Sagemaker examples - these are automatically loaded into Sagemaker instances.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/Chris-Engelhardt/data_sci_guide" target="_blank" rel="noopener">Chris-Engelhardt/data_sci_guide</a></td>
+<td>A community-curated list of data science courses, including direct, free replacement courses for paid options.</td>
+</tr>
+<tr>
+<td>No</td>
+<td><a href="https://www.statlearning.com/" target="_blank" rel="noopener">Introduction to Statistical Learning: With Applications in R</a></td>
+<td>An accessible primer into machine learning - recommended read for newcomers to data science, and as a refresher.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/datastacktv/data-engineer-roadmap" target="_blank" rel="noopener">datastacktv/data-engineer-roadmap</a></td>
+<td>Roadmap for those wishing to study data engineering.</td>
+</tr>
+<tr>
+<td>Yes</td>
+<td><a href="https://github.com/alastairrushworth/free-data-science" target="_blank" rel="noopener">alastairrushworth/free-data-science</a></td>
+<td>Resources and learning materials across a broad range of popular data science topics and arranged thematically.</td>
+</tr>
+</tbody>
+</table>

--- a/source/manual/datalabs-setup-local-machine.html.md
+++ b/source/manual/datalabs-setup-local-machine.html.md
@@ -1,0 +1,42 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Set up your local machine
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+When you join the GOV.UK Data Labs team, you must set up your local machine and join Google groups.
+
+## Set up your local machine
+
+To set up your local machine, follow the [Get started on GOV.UK documentation](https://docs.publishing.service.gov.uk/manual/get-started.html).
+
+Once you have set up your local machine by following this documentation, you should have access to GitHub and AWS. If you are a data scientist, ask in the [GOV.UK Data Labs slack channel](https://gds.slack.com/archives/CHR4UQKU4) for someone to add you to the:
+
+- `ukgovdatascience` organisation in GitHub
+- `govuk-integration-datascience` AWS role, also known as the `govuk-datascienceusers` AWS IAM role
+
+## Join Google Groups
+
+You should join various Google Groups to be able to access group emails and calendars. To join any of the Google Groups linked below, select the link, and then select __Ask to join group__.
+
+All GOV.UK Data Labs members:
+
+- [govuk-members](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-members)
+- [GOV.UK Data Labs](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gov.uk-data-labs)
+
+Data scientists:
+
+- [GOV.UK Data Science](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-data-science)
+- [Data Science at GDS](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-data-science)
+- [gds-data-science-team](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/BUOD)
+
+All analysts:
+
+- [Cabinet Office Analysts](https://groups.google.com/a/cabinetoffice.gov.uk/g/analysts)
+
+Other useful Google Groups:
+
+- [cyber monthly report](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/cybersecurity-monthly-report) - a monthly newsletter from the GDS Cyber Security team, including GitHub repositories with vulnerabilities
+- [CO Coffee & Coding](https://groups.google.com/a/cabinetoffice.gov.uk/g/coffee-and-coding-group) - the Cabinet Office Coffee and Coding group

--- a/source/manual/datalabs-start-new-project.html.md
+++ b/source/manual/datalabs-start-new-project.html.md
@@ -11,7 +11,6 @@ When starting a new data science project, you should:
 - store your project in GitHub
 - set up your project using `govcookiecutter`
 - organise your workload using Trello
-- manage your machine's resources with AWS Sagemaker
 
 ## Store your projects in GitHub
 
@@ -64,7 +63,10 @@ You should use `govcookiecutter` to set up your data science project.
 
 If you use `govcookiecutter` to set up a data science project, `govcookiecutter` automatically covers most of these needs.
 
-See the [`govcookiecutter` documentation](https://github.com/ukgovdatascience/govcookiecutter) for more information.
+For more information, see the:
+
+- [`govcookiecutter` documentation](https://github.com/ukgovdatascience/govcookiecutter)
+- [July 2021 blog on govcookiecutter](https://dataingovernment.blog.gov.uk/2021/07/20/govcookiecutter-a-template-for-data-science-projects/)
 
 ## Organise your workload using Trello
 
@@ -100,65 +102,3 @@ Try to make your stories manageable, and doable within a sprint (usually two wee
 If a story is not well defined, split up that story into smaller stories to make it easier to complete them.
 
 If it is difficult to estimate how long a story should take, consider running that story as a spike. A spike is a set time interval to explore and report back on a task.
-
-## Manage your machine's resources with AWS Sagemaker
-
-You may find that you reach your local machine’s resource limit when running intensive tasks and/or when using large datasets, or that computations are taking a long time. You should use [AWS Sagemaker](https://eu-west-1.console.aws.amazon.com/sagemaker/home?region=eu-west-1#/landing) to manage these resource issues.
-
-The following documentation applies to on-demand notebook instances.
-
-AWS Sagemaker lets you create instances with different numbers of virtual CPUs and memory at a cost. See the [documentation on AWS Sagemaker pricing](https://aws.amazon.com/sagemaker/pricing/) for more information.
-
-### Access AWS Sagemaker
-
-Before you start, you must have [set up your AWS account](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access).
-
-1. [Sign in to AWS](https://console.aws.amazon.com/console/home)
-1. Change your role to `govuk-datascienceusers`.
-1. Enter “Sagemaker” into the search field and select __Amazon Sagemaker__.
-1. In the left hand navigation, select __Notebook__ and then __Notebook instances__.
-
-You have now accessed AWS Sagemaker. You can:
-
-- create a new instance
-- open or close an existing instance
-- edit an existing instance
-
-### Create a new instance
-
-1. Select __Create notebook instance__ on the __Notebook instances__ page.
-1. In the __Notebook instance setting__ section:
-     - enter a valid __Notebook instance name__
-     - choose an appropriate instance type depending on the amount of resources you require
-1. Select the __Additional configuration__ menu to see more options.
-1. The __Volume size in GB__ field defines the amount of storage available on your Sagemaker instance. Set this to a reasonable amount for storing data on your instance locally to the notebook. If you change this amount in future, you may lose any existing code and data on your instance.
-1. In the __Permissions and encryption__ section, set the __IAM role__ to __govuk-integration-data-science-role__.
-1. Select __Create notebook instance__.
-
-You are now ready to use your newly created instance.
-
-### Open an existing instance
-
-1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.
-1. In the __Actions__ column of the instance you want to open, select __Start__. AWS will then find the resources for your instance.
-1. When the __Status__ of your instance shows __InService__, select the __Open Jupyter__ or __Open JupyterLab__ as needed to open the Jupyter or JupyterLab instance.
-
-You have opened your instance.
-
-### Close an existing instance
-
-When you have finished with an instance, you should close that instance to minimise costs.
-
-1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.
-1. Select the radio button next to the name of the instance you want to close. To the right of the __Notebook instances__ title, the __Actions__ drop-down menu should become accessible.
-1. In this drop-down menu, select __Stop__, and wait for the instance status to change to __Stopped__.
-
-You have closed your instance.
-
-### Edit an existing AWS Sagemaker instance
-
-1. Double-click on the __Name__ of your instance you’d like to edit. You now should see the settings for this instance.
-1. Select __Edit__ for the __Notebook instance settings__ and change any of the available options.
-1. Once you’ve edited your instance, select __Update notebook instance__.
-
-You have edited your instance.

--- a/source/manual/datalabs-start-new-project.html.md
+++ b/source/manual/datalabs-start-new-project.html.md
@@ -1,0 +1,164 @@
+---
+owner_slack: "#govuk-data-labs"
+title: Start a new project
+section: Data Labs Team Manual
+layout: manual_layout
+parent: "/manual.html"
+---
+
+When starting a new data science project, you should:
+
+- store your project in GitHub
+- set up your project using `govcookiecutter`
+- organise your workload using Trello
+- manage your machine's resources with AWS Sagemaker
+
+## Store your projects in GitHub
+
+You must store all your projects in GitHub repositories (repos).
+
+See the [GOV.UK developer documentation on setting up your GitHub account](https://docs.publishing.service.gov.uk/manual/get-started.html#2-set-up-your-github-account) for information on how to get access to GitHub.
+
+You should follow best practice when storing projects in GitHub:
+
+- store GOV.UK projects in [`alphagov` organisation](https://github.com/alphagov) repos
+- store non-GOV.UK projects in [`ukgovdatascience` organisation](https://github.com/ukgovdatascience) repos
+- do not store repos under your GitHub username
+- set your repo to public where possible as the GOV.UK Data Labs team likes to code in the open
+- when naming your repo, use hyphens instead of underscores to separate words.
+- to make sure colleagues have access to repo if the repo owner leaves, grant the following GitHub teams access to your `alphagov` repositories:
+  - admin access: `gov-uk-production`
+  - write access: `gov-uk-data-scientists`
+- for `ukgovdatascience` repos, grant the following GitHub teams access:
+  - write access: `gdsdatascience`
+
+By default, GitHub organisation owners have admin access to all repos. If you cannot access a repo, speak to the owner for access.
+
+See the [GitHub documentation on access permissions](https://docs.github.com/en/get-started/learning-about-github/access-permissions-on-github) for more information.
+
+### Add branch protection rules
+
+You must add branch protection rules to the `main` branch of your repo to prevent unwanted actions to this branch. At a minimum, set that all pull requests require at least one approved review.
+
+1. Go to your GitHub repo.
+1. Select __Settings__ and then select __Branches__ in the left-hand navigation.
+1. In __Branch protection rules__, select __Add rule__.
+1. Enter "main" into the __Branch name pattern__ field.
+1. In __Protect matching branches__, select the __Require pull request reviews before merging__ checkbox. By default this requires one approving review.
+1. Change any other options as necessary.
+1. Select __Save changes__.
+
+## Set up your project using `govcookiecutter`
+
+You should use `govcookiecutter` to set up your data science project.
+
+[`govcookiecutter`](https://github.com/ukgovdatascience/govcookiecutter) is a template for data science projects in HM Government and the wider public sector.
+
+`govcookiecutter` was designed by the GDS Data Science team to:
+
+- make sure data science projects use Agile approaches to adhere to AQA standards
+- prevent data leakage by enforcing data version control and cleaning Jupyter notebook outputs
+- centralise documentation local to code so documentation is kept up to date and changes made are visible to reviewers
+- make sure secrets and credentials are usable locally, but kept out of version control
+- implement a consistent folder structure to reduce onboarding time
+
+If you use `govcookiecutter` to set up a data science project, `govcookiecutter` automatically covers most of these needs.
+
+See the [`govcookiecutter` documentation](https://github.com/ukgovdatascience/govcookiecutter) for more information.
+
+## Organise your workload using Trello
+
+GOV.UK Data Labs adopts [Agile ways of working](https://agilemanifesto.org/). We use Trello to maintain a team-wide [Kanban-style way of working](https://en.wikipedia.org/wiki/Kanban_(development)), although specific projects may adopt other methodologies such as [Scrum](https://scrumguides.org/index.html).
+
+To make sure all projects are visible to the team, you should write and update cards on Trello. GOV.UK Data Labs has two Trello boards:
+
+- the [Data Labs doing board](https://trello.com/b/FMptFIIw/data-labs-doing-board), a Trello board for all tasks in the current sprint
+- the [Data Labs planning board](https://trello.com/b/s6TGpjeA/data-labs-planning-board), a Trello board for all planned tasks for future sprints
+
+For new epics, create an epic using the __Epic template__ card and summarise the epic.
+
+For new and existing projects, create stories using the __Story template__ card.
+
+Stories should cover a specific task that has a valid acceptance criteria. Acceptance criteria are your “definition of done”. You should make the minimum developments to meet this criteria.
+
+Draft any further work over and above this acceptance criteria as new stories.
+
+### Label and estimate Trello cards
+
+For both epics and stories, make sure you label the Trello cards appropriately. If relevant, you should also try to label stories with a time estimate.
+
+Try to include time for colleagues to review your work. If stories are sufficiently small and discrete, reviewing should take a reasonable length of time.
+
+You should include time for colleagues to review because:
+
+- explicitly providing review time ensures reviewers have dedicated time for them
+- not planning sufficient review time may lead to poorer quality reviews due to non-story related pressures
+- any unused review time is never lost as reviewers can start other stories
+
+Try to make your stories manageable, and doable within a sprint (usually two weeks). This makes sure the story completion rate (otherwise known as velocity) is fast enough, and means that your stories are targeted to meet a need.
+
+If a story is not well defined, split up that story into smaller stories to make it easier to complete them.
+
+If it is difficult to estimate how long a story should take, consider running that story as a spike. A spike is a set time interval to explore and report back on a task.
+
+## Manage your machine's resources with AWS Sagemaker
+
+You may find that you reach your local machine’s resource limit when running intensive tasks and/or when using large datasets, or that computations are taking a long time. You should use [AWS Sagemaker](https://eu-west-1.console.aws.amazon.com/sagemaker/home?region=eu-west-1#/landing) to manage these resource issues.
+
+The following documentation applies to on-demand notebook instances.
+
+AWS Sagemaker lets you create instances with different numbers of virtual CPUs and memory at a cost. See the [documentation on AWS Sagemaker pricing](https://aws.amazon.com/sagemaker/pricing/) for more information.
+
+### Access AWS Sagemaker
+
+Before you start, you must have [set up your AWS account](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access).
+
+1. [Sign in to AWS](https://console.aws.amazon.com/console/home)
+1. Change your role to `govuk-datascienceusers`.
+1. Enter “Sagemaker” into the search field and select __Amazon Sagemaker__.
+1. In the left hand navigation, select __Notebook__ and then __Notebook instances__.
+
+You have now accessed AWS Sagemaker. You can:
+
+- create a new instance
+- open or close an existing instance
+- edit an existing instance
+
+### Create a new instance
+
+1. Select __Create notebook instance__ on the __Notebook instances__ page.
+1. In the __Notebook instance setting__ section:
+     - enter a valid __Notebook instance name__
+     - choose an appropriate instance type depending on the amount of resources you require
+1. Select the __Additional configuration__ menu to see more options.
+1. The __Volume size in GB__ field defines the amount of storage available on your Sagemaker instance. Set this to a reasonable amount for storing data on your instance locally to the notebook. If you change this amount in future, you may lose any existing code and data on your instance.
+1. In the __Permissions and encryption__ section, set the __IAM role__ to __govuk-integration-data-science-role__.
+1. Select __Create notebook instance__.
+
+You are now ready to use your newly created instance.
+
+### Open an existing instance
+
+1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.
+1. In the __Actions__ column of the instance you want to open, select __Start__. AWS will then find the resources for your instance.
+1. When the __Status__ of your instance shows __InService__, select the __Open Jupyter__ or __Open JupyterLab__ as needed to open the Jupyter or JupyterLab instance.
+
+You have opened your instance.
+
+### Close an existing instance
+
+When you have finished with an instance, you should close that instance to minimise costs.
+
+1. Go to the __Notebook instances__ page. You will see a table of existing AWS Sagemaker instances.
+1. Select the radio button next to the name of the instance you want to close. To the right of the __Notebook instances__ title, the __Actions__ drop-down menu should become accessible.
+1. In this drop-down menu, select __Stop__, and wait for the instance status to change to __Stopped__.
+
+You have closed your instance.
+
+### Edit an existing AWS Sagemaker instance
+
+1. Double-click on the __Name__ of your instance you’d like to edit. You now should see the settings for this instance.
+1. Select __Edit__ for the __Notebook instance settings__ and change any of the available options.
+1. Once you’ve edited your instance, select __Update notebook instance__.
+
+You have edited your instance.


### PR DESCRIPTION
## What

Create a data labs team manual section in the GOV.UK developer docs.

Add the documented onboarding process for new data science starters to the team manual once it is complete.

Content includes BigQuery, Content Store, Knowledge Graph, GOV.UK mirror, set up local machine, start new project, and reference information.


## Why

So new starters have a documented process to follow and refer to, and have immediate access to information needed to get them up and running in their role.

Trello card:
https://trello.com/c/OJQyfn1A/1046-create-a-data-labs-team-manual-and-include-the-onboarding-process