### PR TITLE
Add govuk_schemas to applications list

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -441,6 +441,12 @@
   sentry_url: false
   dashboard_url: false
   deploy_url: https://github.com/alphagov/govuk-secrets/blob/main/puppet_aws/deploy.sh
+- github_repo_name: govuk_schemas
+  team: "#govuk-developers"
+  production_hosted_on: none
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 - github_repo_name: govuk-zendesk-display-screen
   management_url: https://dashboard.heroku.com/apps/govuk-zendesk-display-screen
   production_hosted_on: heroku


### PR DESCRIPTION
Following the convention established in 64127d3417788aba3c2c39a7e7c9ce1dbd458356,
we want to make sure that all active GOV.UK utilities are included
in the Developer Docs, to increase visibility and discoverability
of their documentation.