### PR TITLE
Document how to set up custom Sentry alerts per-team

### DIFF
--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -56,12 +56,13 @@ all configuration is set up correctly.
 Apps are configured to talk to Sentry using the [govuk_app_config][] gem,
 which interfaces with Sentry via its [`GovukError` class][govukerror]. Apps
 call `GovukError.configure` - see [example][email-alert-api-example]. This
-[delegates][delegator-pattern] to the [sentry-raven][] gem under the hood,
-though the gem is now superseded by sentry-ruby, which we have
-[plans to migrate to][trello-migrate] in the future.
+uses the [delegator pattern][delegator-pattern] to proxy requests to the
+underlying Sentry gem, which is [sentry-ruby][] in govuk_app_config v4 and
+above, and [sentry-raven][] in govuk_app_config v3 and below.
 
 Unhandled exceptions are automatically logged to Sentry, but you can also
 [manually report something to Sentry using `GovukError.notify`][manually-report].
+This method takes an exception object, or a string.
 
 [docs-apps]: https://docs.publishing.service.gov.uk/apps.json
 [govuk-saas-config]: https://github.com/alphagov/govuk-saas-config/blob/5171b2803a7e211fff9536909b7d27c7fa5a4840/sentry/Rakefile#L1-L12

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -218,12 +218,24 @@ mechanism, ensuring that we would need two projects to be recording high-volume
 errors to risk breaching our account limit. These limits are configured on the
 [Rate Limits][sentry-configure-rate-limits] page.
 
-In addition, we've set up alerting so that any issue which records 100 or more
-errors in an hour period gets alerted to `#govuk-platform-health`. These alerts
-are configured in the [Alerts panel][].
+[sentry-configure-rate-limits]: https://sentry.io/settings/govuk/rate-limits/
+
+## Slack alerts
+
+You can configure Sentry to notify a Slack channel when a notable condition is
+satisfied. For example, the `#govuk-platform-health` channel gets notified when
+any issue records 100 or more errors in a 1 hour period.
+
+To set up an alert, visit the [Alerts panel][], select the project the alert
+should apply to (e.g. `app-whitehall`), and then click "Create Alert Rule". It is
+currently not possible to set up a 'global' alert to apply to all projects at
+once.
+
+We encourage teams to set up alerts for any projects they're responsible for, so
+that they can be alerted to new and high-volume issues and prioritise them.
+Multiple teams are allowed to set up alerts for the same projects.
 
 [Alerts panel]: https://sentry.io/organizations/govuk/alerts/rules/
-[sentry-configure-rate-limits]: https://sentry.io/settings/govuk/rate-limits/
 
 ## Sentry issue actions
 


### PR DESCRIPTION
Trello: https://trello.com/c/izP3qFWg/2516-document-how-teams-can-set-up-sentry-slack-alerts