### PR TITLE
Remove comma from example Gemfile

### DIFF
--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -49,7 +49,7 @@ You should:
 
     gem "rails", "6.0.3.4"
 
-    gem "bootsnap",
+    gem "bootsnap"
     gem "gds-api-adapters"
     gem "gds-sso"
     gem "govuk_app_config"


### PR DESCRIPTION
The comma appears to be a typo and should not be there.