### PR TITLE
Add Locations API

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -121,6 +121,14 @@
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
+- github_repo_name: locations-api
+  type: APIs
+  team: "#govuk-platform-health"
+  dependencies_team: "#govuk-platform-health"
+  production_hosted_on: none
+  sentry_url: false
+  dashboard_url: false
+  deploy_url: false
 - github_repo_name: publishing-api
   type: APIs
   team: "#govuk-platform-health"


### PR DESCRIPTION
This is a new application that will interface between GOV.UK's frontend apps and external location APIs (e.g. Ordnance Survey).

The application is not currently deployable, so some attributes will need updating as part of later work.

[Trello card](https://trello.com/c/yGHQYoWC)