### PR TITLE
Mark Bouncer as continuously deployed

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -302,6 +302,7 @@
 # Transition
 
 - github_repo_name: bouncer
+  continuously_deployed: true
   type: Transition apps
   team: "#govuk-platform-health"
   production_hosted_on: aws


### PR DESCRIPTION
Bouncer has been continuously deployed since December!
https://github.com/alphagov/govuk-puppet/pull/10858

Trello: https://trello.com/c/dXp9XIV1/2571-enable-continuous-deployment-for-bouncer-3