### PR TITLE
Fix machine classes for Licensify

### DIFF
--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -45,7 +45,7 @@ environments is as follows:
 
 ## Accessing machines using SSH
 
-Follow the [instructions for connecting to a machine via SSH](/manual/howto-ssh-to-machines.html#connecting-with-plain-ssh). The machine classes you will need are `licensify_frontend` and `licensify_backend`. You will need to be on the VPN.
+Follow the [instructions for connecting to a machine via SSH](/manual/howto-ssh-to-machines.html#connecting-with-plain-ssh). The machine classes you will need are `licensing_frontend` and `licensing_backend`. You will need to be on the VPN.
 
 The files most relevant to the Licensify applications can be found in:
 


### PR DESCRIPTION
The classess are called `licensing_...` not `licensify_...`

Confirmed with:
```
$ ssh jumpbox.production.govuk.digital govuk_node_list -c licensify_frontend

$ ssh jumpbox.production.govuk.digital govuk_node_list -c licensing_frontend

ip-00-00-0-00.eu-west-0.compute.internal
ip-00-00-0-00.eu-west-0.compute.internal
```