### PR TITLE
Add links to healthcheck endpoints

### DIFF
--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
@@ -9,6 +9,14 @@ parent: "/manual.html"
 If there is a health check error showing for Content Data API, click
 on the alert to find out more details about what’s wrong.
 
+You can visit the [healthcheck endpoints](https://github.com/alphagov/content-data-api/blob/main/config/routes.rb)
+here:
+
+- https://content-data-api.publishing.service.gov.uk/healthcheck/metrics
+- https://content-data-api.publishing.service.gov.uk/healthcheck/search
+- https://content-data-api.publishing.service.gov.uk/healthcheck/live
+- https://content-data-api.publishing.service.gov.uk/healthcheck/ready
+
 ## What is the ETL process
 
 ETL stands for [Extract, Transform, Load][etl_definition].


### PR DESCRIPTION
It was too cumbersome for my liking, to figure out and navigate to the healthcheck endpoints.
Ideally this would be linked directly from the Icinga alert too, but adding to the docs is a good start.