### PR TITLE
Describe the process for rebooting docker-management machines

### DIFF
--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -243,7 +243,13 @@ sudo reboot
 
 ### Rebooting docker-management
 
-It is safe to reboot while no other unattended reboot is underway - see https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/class/docker_management.yaml
+It is safe to reboot while no other unattended reboot is underway:
+
+1. Set `govuk_unattended_reboot::enabled` to `false` in the [govuk-puppet common configuration](https://github.com/alphagov/govuk-puppet/blob/9c97f1cfe22334e472a48277f5131e0735b16a4e/hieradata_aws/common.yaml#L1166) - you can do this in a branch.
+1. Build the branch of govuk-puppet to Production
+1. Wait half an hour to allow all machines to pull from the puppetmaster
+1. Reboot the docker-management machine (`sudo reboot`)
+1. Deploy the previous release of govuk-puppet to Production
 
 ### Rebooting other machines
 


### PR DESCRIPTION
The previous instructions were open to ambiguity. For example,
I interpeted them as "disable the unattended reboots on the
docker_management machine class", but this made little sense as
we only had one such class on Production, so why would it be
necessary? It's only by digging into an old govuk-puppet [commit]
that it's clear that actually we need to disable unattended reboots
in ALL machines.

I've also removed the unhelpful link to
https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/class/docker_management.yaml,
as this doesn't provide any additional information that isn't
already in the doc.

[commit]: https://github.com/alphagov/govuk-puppet/commit/97ab27fc9a2d79305111280ee3f2a74a0d0f9e12