### PR TITLE
Update "who to ask" in getting added to GitHub

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -43,7 +43,7 @@ This command works for macOS or Linux.
 1. Ask your tech lead to add your GitHub username to the [user monitoring system][user-reviewer].
 
     If your tech lead is not available, ask in the [2nd line support Slack channel](https://gds.slack.com/archives/CADKZN519) for someone who has production access to add you.
-1. Ask your tech lead to add you to the [alphagov organisation][alphagov] and the [GOV.UK team][govuk-team] to get access to repos & CI.
+1. Ask in `#govuk-tech-leads` for someone to add you to the [alphagov organisation][alphagov] and the [GOV.UK team][govuk-team] to get access to repos & CI.
 
     Select __Accept__ in the GitHub email invitation when you receive this email. If your tech lead is not available, ask one of the [GDS GitHub owners](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-github-owners/members?pli=1).
 


### PR DESCRIPTION
Not many tech leads actually have the ability to add users to GitHub, so the most efficient
approach is just to ask in the tech leads channel and someone with the necessarily
privileges will action it.