### PR TITLE
Update govuk-alerts guidance to match new config

### DIFF
--- a/source/manual/notify-emergency-alerts.html.md
+++ b/source/manual/notify-emergency-alerts.html.md
@@ -15,9 +15,11 @@ As part of this service, GOV.UK delegate serving [www.gov.uk/alerts](https://www
 How does www.gov.uk/alerts work?
 --------------------------------
 
-We have a custom host in Fastly for /alerts which points at an AWS CloudFront CDN which is managed by the GOV.UK Notify team.
-One custom host is used by [Fastly's Integration configuration](https://manage.fastly.com/configure/services/4mENG6RJL8sxnvgPUMRDz2/versions/275/origins) and [Fastly's Staging configuration](https://manage.fastly.com/configure/services/13QQKEZBSrBFyfxYGzjHPZ/versions/854/origins).
-[Fastly's Production configuration](https://manage.fastly.com/configure/services/4b340CyOhAgINR9eKMH83h/versions/549/origins) has a different host.
+We have a custom host in Fastly for /alerts which points at an AWS CloudFront CDN which is managed by the GOV.UK Notify team. Each GOV.UK environment points at a different custom host:
+
+- [Fastly's Integration configuration](https://manage.fastly.com/configure/services/4mENG6RJL8sxnvgPUMRDz2/versions/275/origins) points at Notify's Preview environment;
+- [Fastly's Staging configuration](https://manage.fastly.com/configure/services/13QQKEZBSrBFyfxYGzjHPZ/versions/854/origins) points at Notify's Staging environment; and
+- [Fastly's Production configuration](https://manage.fastly.com/configure/services/4b340CyOhAgINR9eKMH83h/versions/549/origins) points at Notify's Production environment.
 
 Requests to /alerts (or to anything beginning with `/alerts/`) hit GOV.UK's CDN (Fastly), but no other bits of GOV.UK's infrastructure.
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179482902

Previously the Integration and Staging versions of GOV.UK Alerts
both pointed at the same backend (in Notify's Staging environment).
Now that Notify has a dedicated backend for GOV.UK Integration to
point to, this updates the guidance to reflect that.