### PR TITLE
Correct GDS GitHub Owners email link

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -45,7 +45,7 @@ This command works for macOS or Linux.
     If your tech lead is not available, ask in the [2nd line support Slack channel](https://gds.slack.com/archives/CADKZN519) for someone who has production access to add you.
 1. Ask in `#govuk-tech-leads` for someone to add you to the [alphagov organisation][alphagov] and the [GOV.UK team][govuk-team] to get access to repos & CI.
 
-    Select __Accept__ in the GitHub email invitation when you receive this email. If your tech lead is not available, ask one of the [GDS GitHub owners](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-github-owners/members?pli=1).
+    Select __Accept__ in the GitHub email invitation when you receive this email. If your tech lead is not available, ask one of the [GOV.UK GitHub owners](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-github-owners/members?pli=1).
 
 1. [Generate a new SSH key for your laptop and add it to the ssh-agent][generate-ssh-key] for your GitHub account.
 1. [Add the SSH key to your GitHub account][add-ssh-key].


### PR DESCRIPTION
It's better to use the GOV.UK group since it's more up-to-date and is GOV.UK specific.