### PR TITLE
Do not show continuous deployment information

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -12,7 +12,6 @@ class App
       dependencies_team: dependencies_team,
       puppet_name: puppet_name,
       production_hosted_on: production_hosted_on,
-      continuously_deployed: continuously_deployed?,
       links: {
         self: "https://docs.publishing.service.gov.uk/apps/#{app_name}.json",
         html_url: html_url,
@@ -45,10 +44,6 @@ class App
 
   def hosting_name
     Applications::HOSTERS.fetch(production_hosted_on)
-  end
-
-  def continuously_deployed?
-    app_data["continuously_deployed"] || false
   end
 
   def html_url

--- a/data/applications.yml
+++ b/data/applications.yml
@@ -1,13 +1,11 @@
 # GOV.UK Account
 - github_repo_name: govuk-account-manager-prototype
-  continuously_deployed: true
   type: GOV.UK Account
   team: "#govuk-accounts-tech"
   production_hosted_on: paas
   sentry_url: https://sentry.io/organizations/govuk/issues/?project=5370953
   dashboard_url: false
 - github_repo_name: govuk-attribute-service-prototype
-  continuously_deployed: true
   type: GOV.UK Account
   team: "#govuk-accounts-tech"
   production_hosted_on: paas
@@ -17,7 +15,6 @@
 # publishing apps
 
 - github_repo_name: collections-publisher
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-corona-services-tech"
@@ -36,40 +33,33 @@
   actors:
   - Publisher
 - github_repo_name: content-publisher
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: local-links-manager
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-corona-services-tech"
   production_hosted_on: aws
 - github_repo_name: manuals-publisher
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: maslow
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: publisher
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: service-manual-publisher
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: short-url-manager
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -80,12 +70,10 @@
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: travel-advice-publisher
-  continuously_deployed: true
   type: Publishing apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: whitehall
-  continuously_deployed: true
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
   team: "#govuk-platform-health"
@@ -98,7 +86,6 @@
 # api
 
 - github_repo_name: account-api
-  continuously_deployed: true
   type: APIs
   team: "#govuk-accounts-tech"
   production_hosted_on: aws
@@ -113,7 +100,6 @@
   metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: aws
 - github_repo_name: imminence
-  continuously_deployed: true
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -153,7 +139,6 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: hmrc-manuals-api
-  continuously_deployed: true
   type: APIs
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -166,12 +151,10 @@
 # Services
 
 - github_repo_name: cache-clearing-service
-  continuously_deployed: true
   type: Services
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: email-alert-service
-  continuously_deployed: true
   type: Services
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -183,12 +166,10 @@
 # Support
 
 - github_repo_name: content-data-api
-  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: content-data-admin
-  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -201,18 +182,15 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: support
-  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: authenticating-proxy
-  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: release
-  continuously_deployed: true
   type: Supporting apps
   team: "#govuk-platform-health"
   production_hosted_on: aws
@@ -228,7 +206,6 @@
 # frontend
 
 - github_repo_name: collections
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-corona-services-tech"
@@ -244,13 +221,11 @@
   team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: finder-frontend
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   component_guide_url: https://finder-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
 - github_repo_name: frontend
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -258,14 +233,12 @@
   actors:
   - Public
 - github_repo_name: government-frontend
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   component_guide_url: https://government-frontend.herokuapp.com/component-guide
   production_hosted_on: aws
 - github_repo_name: info-frontend
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
@@ -277,19 +250,16 @@
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: manuals-frontend
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   production_hosted_on: aws
 - github_repo_name: smart-answers
-  continuously_deployed: true
   type: Frontend apps
   team: "#govuk-platform-health"
   puppet_name: smartanswers
   production_hosted_on: aws
 - github_repo_name: service-manual-frontend
-  continuously_deployed: true
   team: "#govuk-platform-health"
   dependencies_team: "#govuk-platform-health"
   type: Frontend apps
@@ -303,7 +273,6 @@
 # Transition
 
 - github_repo_name: bouncer
-  continuously_deployed: true
   type: Transition apps
   team: "#govuk-platform-health"
   production_hosted_on: aws

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -29,10 +29,6 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/appl
       field: "Hosting",
       value: sanitize(partial("partials/application/hosting").strip),
     },
-    (application.hosting_name == "None" ? nil : {
-      field: "Continuously deployed?",
-      value: application.continuously_deployed? ? "Yes" : "No",
-    }),
     (application.can_run_rake_tasks_in_jenkins? ? {
       field: "Rake tasks",
       value: RunRakeTask.terse_links(application).html_safe,

--- a/spec/app/app_spec.rb
+++ b/spec/app/app_spec.rb
@@ -6,25 +6,13 @@ RSpec.describe App do
         "team" => "bar",
         "dependencies_team" => "baz",
         "production_hosted_on" => "aws",
-        "continuously_deployed" => false,
       }
       payload = App.new(app_details).api_payload
       expect(payload[:app_name]).to eq(app_details["github_repo_name"])
       expect(payload[:team]).to eq(app_details["team"])
       expect(payload[:dependencies_team]).to eq(app_details["dependencies_team"])
       expect(payload[:production_hosted_on]).to eq(app_details["production_hosted_on"])
-      expect(payload[:continuously_deployed]).to eq(false)
       expect(payload[:links]).to include(:self, :html_url, :repo_url, :sentry_url)
-    end
-  end
-
-  describe "continuously_deployed?" do
-    it "defaults to `false`" do
-      expect(App.new("github_repo_name" => "foo").continuously_deployed?).to eq(false)
-    end
-
-    it "returns `continuously_deployed` property if specified" do
-      expect(App.new("github_repo_name" => "foo", "continuously_deployed" => true).continuously_deployed?).to eq(true)
     end
   end
 


### PR DESCRIPTION
This is now tracked in the release app as of alphagov/release#880
