### PR TITLE
Update DNS docs to notify senior tech and CDDO

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -128,6 +128,7 @@ access.
 
 You should also make sure that the following groups of people are aware before
 requesting any changes:
+
 - 2nd line (via email)
 - GOV.UK's Head of Tech and the lead technologists
 - The CDDO domains team (the lead technologists can contact them)

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -126,6 +126,12 @@ list. Speak to a senior technologist member of GOV.UK or someone in
 GOV.UK Replatforming if you need to make a change and don't have
 access.
 
+You should also make sure that the following groups of people are aware before
+requesting any changes:
+- 2nd line (via email)
+- GOV.UK's Head of Tech and the lead technologists
+- The CDDO domains team (the lead technologists can contact them)
+
 2nd line should be notified of any planned changes via email.
 
 - `gov.uk.` is a top-level domain so it cannot contain a CNAME record

--- a/source/manual/renew-a-tls-certificate.html.md
+++ b/source/manual/renew-a-tls-certificate.html.md
@@ -16,6 +16,11 @@ certificate.
 Note that the www.gov.uk certificate is not visible anywhere in the Fastly user
 interface. It is managed entirely through Fastly support.
 
+Renewing the certificate may require a TXT record on the `gov.uk` top level
+domain. This is because the certificate contains a Subject Alternate Name (SAN)
+of `DNS: gov.uk`. This TXT record needs to be requested through JISC following
+the process for [DNS for the gov.uk top level domain](/manual/dns.html#dns-for-the-gov-uk-top-level-domain).
+
 Credentials for the Fastly Zendesk support site are in the [2nd line password store](https://github.com/alphagov/govuk-secrets/blob/master/pass/2ndline/fastly).
 
 ## Renewing wildcard certificates


### PR DESCRIPTION
CDDO colleagues monitor the DNS records for gov.uk, and they would like
us to notify them before making changes so they know to ignore the
alarms we set off.

We also need to tell the GOV.UK lead technologists because they're the
people who'll get a call from JISC to confirm. And also it's generally
good for them to know what's going on.