### PR TITLE
Include new warning in RuboCop header template

### DIFF
--- a/source/manual/configure-linting.html.md
+++ b/source/manual/configure-linting.html.md
@@ -34,6 +34,16 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
+
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************
 ```
 
 After running `bundle install` you can test the linting by running


### PR DESCRIPTION
https://trello.com/c/Cr2TnMtI/193-make-it-easier-to-agree-with-rubocop-govuk

This is so we maintain this convention [1] in new repos.

[1]: https://github.com/alphagov/content-publisher/pull/2411