### PR TITLE
Make following the indices-fixing instructions easier

### DIFF
--- a/source/manual/alerts/publisher-scheduled-publishing.html.md
+++ b/source/manual/alerts/publisher-scheduled-publishing.html.md
@@ -11,13 +11,8 @@ which are scheduled to be published in the future is different from
 the number currently in the Sidekiq queue.
 
 This can happen in Staging and Integration as a result of the data
-sync from Production. Run this rake task to re-queue all scheduled
-editions:
-
-```sh
-$ cd /var/apps/publisher
-$ sudo -u deploy govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing
-```
+sync from Production. Run Publisher's `editions:requeue_scheduled_for_publishing`
+rake task to re-queue all scheduled editions:
 
 - [Run in Integration Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=editions:requeue_scheduled_for_publishing)
 

--- a/source/manual/alerts/search-reindex-failed.html.md.erb
+++ b/source/manual/alerts/search-reindex-failed.html.md.erb
@@ -14,11 +14,9 @@ made and changes to the Elasticsearch schema.
 
 If this process fails then please escalate to Platform Health for further investigation.
 
-This task can be manually run with the following command:
+This task can be run in Jenkins:
 
-```
-bundle exec rake search:migrate_schema SEARCH_INDEX=<index_alias_name>
-```
+<%= RunRakeTask.links("search-api", "search:migrate_schema SEARCH_INDEX=index_alias_name") %>
 
 [reindexing]: /manual/reindex-elasticsearch.html
 [search-api]: /apps/search-api.html

--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -15,21 +15,22 @@ and `unpublish` messages that have not been processed need to be resent.
 Content in the `govuk` index is populated from the [Publishing API message queue][queue].
 Missing documents can be recovered by resending the content to the message queue. In the
 Publishing API, run the following rake task (including the quotes) to replay traffic between
-two datestamps:
+two datestamps (after SSH'ing into the `publishing_api` machine):
 
 ```
+cd /var/apps/publishing-api && \
 govuk_setenv publishing-api bundle exec \
 rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
 ```
 
-You can also run this task from Jenkins.
+You can also [run this task from Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:published_between[2018-12-17T01:02:30,%202018-12-18T10:20:30]).
 
 [Other replay options are available](https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake), for example replaying all traffic for a single publishing app or doctype.
 Be aware that these options will replay the entire Publisher API history for that app or doctype, and may take some time.
 
 ## `government`/`detailed` indexes
 
-**This will not be neccessary after whitehall content has been moved to the
+**This will not be necessary after whitehall content has been moved to the
 `govuk` index.**
 
 These indexes are populated by whitehall calling an HTTP API in Search API.

--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -13,17 +13,10 @@ and `unpublish` messages that have not been processed need to be resent.
 ## `govuk` index
 
 Content in the `govuk` index is populated from the [Publishing API message queue][queue].
-Missing documents can be recovered by resending the content to the message queue. In the
-Publishing API, run the following rake task (including the quotes) to replay traffic between
-two datestamps (after SSH'ing into the `publishing_api` machine):
+Missing documents can be recovered by resending the content to the message queue, using
+the `represent_downstream:published_between` rake task.
 
-```
-cd /var/apps/publishing-api && \
-govuk_setenv publishing-api bundle exec \
-rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
-```
-
-You can also [run this task from Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:published_between[2018-12-17T01:02:30,%202018-12-18T10:20:30]).
+[Run this task in Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:published_between[2018-12-17T01:02:30,%202018-12-18T10:20:30]), but changing the two timestamps to cover the period of downtime.
 
 [Other replay options are available](https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake), for example replaying all traffic for a single publishing app or doctype.
 Be aware that these options will replay the entire Publisher API history for that app or doctype, and may take some time.

--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -27,30 +27,17 @@ Be aware that these options will replay the entire Publisher API history for tha
 `govuk` index.**
 
 These indexes are populated by whitehall calling an HTTP API in Search API.
-Missing documents can be recovered by resending the content to Search API directly. In
-Whitehall, run the following rake task (including the quotes) to replay traffic between
-two datestamps:
+Missing documents can be recovered by resending the content to Search API directly.
 
-```
-govuk_setenv whitehall bundle exec \
-rake 'search:index:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
-```
-
-You can also run this task from Jenkins.
+[Run this task in Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=search:index:published_between[2018-12-17T01:02:30,%202018-12-18T10:20:30]), remembering to change the two timestamps.
 
 ## `metasearch` index
 
 This index is used for best bets, which are published by Search Admin
 communicating with Search API directly (like how whitehall updates the
-`government` and `detailed` indices directly).  In Search Admin, run
-the following rake task to resend all bets to Search API:
+`government` and `detailed` indices directly).
 
-```
-govuk_setenv search-admin bundle exec \
-rake reindex_best_bets
-```
-
-You can also run this task from Jenkins.
+[Run this task in Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=search-admin&MACHINE_CLASS=backend&RAKE_TASK=reindex_best_bets) to resend all bets to Search API.
 
 [restore-backups]: https://docs.publishing.service.gov.uk/manual/elasticsearch-dumps.html
 [queue]: https://github.com/alphagov/search-api/blob/main/docs/new-indexing-process.md

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -19,3 +19,26 @@ There is a Jenkins job that can be used to run any rake task:
 Jenkins jobs are also linkable. For example:
 
 <https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-tagger&MACHINE_CLASS=backend-1.backend&RAKE_TASK=routes>
+
+## Run rake tasks from the command line
+
+It is possible to bypass Jenkins and run the rake tasks directly on the relevant app machines.
+
+First, SSH into the right machine class (e.g. `publishing_api`):
+
+```
+gds govuk connect ssh -e production publishing_api
+```
+
+Secondly, change directory so that the rake task is available:
+
+```
+cd /var/apps/publishing-api
+```
+
+Finally, run the rake task, e.g.:
+
+```
+govuk_setenv publishing-api bundle exec \
+rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
+```


### PR DESCRIPTION
- Link to Jenkins job with pre-filled parameters
- Reminder of which machine to SSH to
- Reminder of which directory to CD into before attempting to run rake task
- Fix typo