### PR TITLE
Change the govuk-publishing to govuk-publishing-tech

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -16,25 +16,25 @@
 
 - github_repo_name: collections-publisher
   type: Publishing apps
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
   actors:
   - Publisher
 - github_repo_name: contacts-admin
   type: Publishing apps
   puppet_name: contacts
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: content-tagger
   type: Publishing apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
   actors:
   - Publisher
 - github_repo_name: content-publisher
   type: Publishing apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: local-links-manager
   type: Publishing apps
@@ -43,41 +43,41 @@
   production_hosted_on: aws
 - github_repo_name: manuals-publisher
   type: Publishing apps
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: maslow
   type: Publishing apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: publisher
   type: Publishing apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: service-manual-publisher
   type: Publishing apps
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: short-url-manager
   type: Publishing apps
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: specialist-publisher
   type: Publishing apps
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: travel-advice-publisher
   type: Publishing apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
   actors:
     - Publisher
@@ -91,7 +91,7 @@
   production_hosted_on: aws
 - github_repo_name: content-store
   type: APIs
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: email-alert-api
   type: APIs
@@ -104,7 +104,7 @@
   production_hosted_on: aws
 - github_repo_name: link-checker-api
   type: APIs
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: locations-api
   type: APIs
@@ -116,8 +116,8 @@
   deploy_url: false
 - github_repo_name: publishing-api
   type: APIs
-  team: "#govuk-publishing"
-  dependencies_team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
+  dependencies_team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: search-api
   type: APIs
@@ -125,7 +125,7 @@
   production_hosted_on: aws
 - github_repo_name: asset-manager
   type: APIs
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: router-api
   type: APIs
@@ -137,7 +137,7 @@
   production_hosted_on: aws
 - github_repo_name: hmrc-manuals-api
   type: APIs
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: mapit
   type: APIs
@@ -176,7 +176,7 @@
   production_hosted_on: aws
 - github_repo_name: signon
   type: Supporting apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: support
   type: Supporting apps
@@ -275,7 +275,7 @@
   production_hosted_on: aws
 - github_repo_name: transition
   type: Transition apps
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: aws
 - github_repo_name: side-by-side-browser
   management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
@@ -419,7 +419,7 @@
 - github_repo_name: govuk-content-schemas
   app_name: govuk-content-store-examples
   management_url: https://dashboard.heroku.com/apps/govuk-content-store-examples
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: heroku
   type: Utilities
   sentry_url: false
@@ -470,7 +470,7 @@
   sentry_url: false
   dashboard_url: false
 - github_repo_name: special-route-publisher
-  team: "#govuk-publishing"
+  team: "#govuk-publishing-tech"
   production_hosted_on: none
   type: Utilities
   sentry_url: false


### PR DESCRIPTION
Change the name of the team owning the publishing applications so they 
will appear in the correct slack channel when we receive dependency 
updates from the https://github.com/alphagov/govuk-dependencies application.

Trello card: https://trello.com/c/S6LHALdf/40-set-up-alerts-to-slack-for-dependencies-for-the-apps-we-own