### PR TITLE
Add byebug developer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,7 @@ gem "govuk_schemas"
 gem "faraday-http-cache"
 gem "faraday_middleware"
 gem "octokit"
+
+group :development do
+  gem "byebug"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       execjs (~> 2)
     backports (3.21.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -456,6 +457,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  byebug
   capybara
   dotenv
   faraday-http-cache


### PR DESCRIPTION
This should be included by default to make local development
easier.

That said, invoking byebug is surprisingly involved, as the Linter
will fail. It currently involves four lines of code:

```
require "byebug"
# rubocop:disable Lint/Debugger
byebug
# rubocop:enable Lint/Debugger
```

Hopefully that can be optimised in a future commit. For now, it's easier just to temporarily remove the linting task when introducing a byebug.