### PR TITLE
Remove old GitHub Pages commits to reduce repo size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,4 @@ jobs:
           publish_dir: ./build
           cname: docs.publishing.service.gov.uk
           commit_message: ${{steps.commit_message_writer.outputs.commit_message}}
+          force_orphan: true


### PR DESCRIPTION
This repository uses GitHub Actions to automatically build and publish the docs to GitHub Pages.

Deploying to GitHub Pages involves pushing a commit of the built site to the `gh-pages` branch. We use the third-party GitHub Action `peaceiris/actions-gh-pages@v3` to handle this for us.

This commit sets the config option `force_orphan: true` on `peaceiris/actions-gh-pages@v3`, which will cause new commits to `gh-pages` to be orphaned.

Old build commits will therefore no longer belong to the `gh-pages` branch. This should result in future fetches and clones of the repo ignoring or garbage collecting those dangling commits.

Currently the `gh-pages` branch sits at around ~10k builds, so this change should enable a fairly significant size reduction for the repo.