### PR TITLE
Revert "Remove old GitHub Pages commits to reduce repo size"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,3 @@ jobs:
           publish_dir: ./build
           cname: docs.publishing.service.gov.uk
           commit_message: ${{steps.commit_message_writer.outputs.commit_message}}
-          force_orphan: true


### PR DESCRIPTION
Reverts alphagov/govuk-developer-docs#3321

Unfortunately, the auto-deployment failed because force-pushes (required by the `force_orphan: true` option) aren't allowed. We could weaken branch protection on the `gh-pages` branch, but this greatly increases the attack vector, and is not something we feel comfortable doing.

This PR did however clear the 10,000+ commit history of the `gh-pages` branch, so the problem it was trying to solve is temporarily fixed. I'll raise a separate issue to look into this again in future.