### PR TITLE
Fix absolute URL parsing

### DIFF
--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe ExternalDoc do
         it "converts links relative to the `docs` folder and applies the same business logic as before" do
           expect(html).to have_link("inline link", href: "/apps/lipsum/inline-link.html")
         end
+
+        it "converts links relative to the 'root' to absolute GitHub URLs" do
+          expect(html).to have_link("Link relative to root", href: "https://github.com/alphagov/lipsum/blob/main/public/json_examples/requests/foo.json")
+        end
       end
 
       it "rewrites relative images" do


### PR DESCRIPTION
We already had a [test](https://github.com/alphagov/govuk-developer-docs/blob/6fb3785cfb4386154c89c49598b7ba5913da6e58/spec/app/external_doc_spec.rb#L72-L74) for converting absolute URLs to the correct github.com representation of that URL. But our tests failed to cover the scenario whereby we're parsing a URL within the context of being inside the `docs/` subfolder.

A document with a link to `/config/schema/field_definitions.json` would have the link incorrectly parsed to
`https://github.com/alphagov/search-api/blob/main/docs/config/schema/field_definitions.json`. It should actually be
`https://github.com/alphagov/search-api/blob/main/config/schema/field_definitions.json`.

Fixes #3320.

Zendesk: https://govuk.zendesk.com/agent/tickets/4788958