### PR TITLE
Update ownership of router-api

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -115,7 +115,7 @@
   production_hosted_on: aws
 - github_repo_name: router-api
   type: APIs
-  team: "#govuk-platform-health"
+  team: "#govuk-find-and-view-accessibility-team"
   production_hosted_on: aws
 - github_repo_name: support-api
   type: APIs


### PR DESCRIPTION
Changes router-api ownership to the newly-formed Find and View team (missed in [previous PR](https://github.com/alphagov/govuk-developer-docs/pull/3332))

