### PR TITLE
Revert "Mark tech-docs-monitor as retired"

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -455,6 +455,12 @@
   sentry_url: false
   dashboard_url: false
   deploy_url: false
+- github_repo_name: tech-docs-monitor
+  management_url: https://dashboard.heroku.com/apps/govuk-tech-docs-monitor
+  production_hosted_on: heroku
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
 - github_repo_name: govuk-pact-broker
   team: "#govuk-platform-health"
   production_hosted_on: paas
@@ -608,10 +614,3 @@
     calendars used to render the bank-holidays and
     when-do-the-clocks-change pages. Since May 2020 those pages are
     rendered by frontend.
-- github_repo_name: tech-docs-monitor
-  retired: true
-  type: Utilities
-  description: |
-    Was used to alert the page owner when a page needed reviewing, according to
-    its expiry date. It was seen as unhelpful noise - instead we started showing
-    the last commit date and a warning to the reader. 


### PR DESCRIPTION
Reverts alphagov/govuk-developer-docs#3334 because some other teams still use it, so we should include it on the list of apps