### PR TITLE
Update 'Get Started' document to give access to Release app

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -333,9 +333,18 @@ If you forget your `aws-vault` password, you must reset that password.
 [Signon](https://docs.publishing.service.gov.uk/apps/signon.html) is the application used to control access to the
 GOV.UK Publishing applications.
 
-Ask someone with production access (e.g. your tech lead or buddy) to [create an account for the integration
-Signon](https://signon.integration.publishing.service.gov.uk/users/invitation/new), with permission to access
-the applications that your team are likely to work on.
+Ask another developer to [create an account for the integration Signon](https://signon.integration.publishing.service.gov.uk/users/invitation/new),
+at 'Superadmin' level with permission to access the applications that your team are likely to work on.
+
+## 10. Get access to the Release app
+
+[Release](https://docs.publishing.service.gov.uk/apps/release.html) is the application we use to track deployments,
+work out which branch/tag is deployed to each environment and link to Jenkins to deploy code.
+
+Ask someone with production access (e.g. your tech lead or buddy) to [create an account for the production
+Signon](https://signon.publishing.service.gov.uk/users/invitation/new), at 'Normal' level with access to
+the 'Release' app only. No permissions should be given for other applications, until [production access](/manual/rules-for-getting-production-access.html)
+is granted.
 
 ## Supporting information
 


### PR DESCRIPTION
Developers without production access can be given access to the production release app, so we should document how they can gain access by being given a non-admin Signon account in production.