### PR TITLE
Update RabbitMQ docs to add detail about the web control panel

### DIFF
--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -204,7 +204,7 @@ There are 3 RabbitMQ virtual machines in a cluster. You reboot one machine at a 
 
 1. Reboot the machine by running `sudo reboot`.
 
-When you have rebooted the machine, you should monitor alerts to see if there are any RabbitMQ-related alerts.
+When you have rebooted the machine, you should monitor alerts to see if there are any RabbitMQ-related alerts. You might also wish to monitor the cluster via the [RabbitMQ web control panel](/manual/rabbitmq.html#connecting-to-the-rabbitmq-web-control-panel) dashboard. This dashboard shows the current members of the cluster and means that you can avoid polling `sudo rabbitmqctl cluster_status` to determine when your restarted machine has rejoined the cluster.
 
 For more information on RabbitMQ-related alerts, see the [GOV.UK Puppet RabbitMQ `monitoring.pp` file](https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk_rabbitmq/manifests/monitoring.pp).
 

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -14,7 +14,10 @@ Protocol][AMQP] (AMQP).
 ## Connecting to the RabbitMQ web control panel
 
 Run `gds govuk connect rabbitmq -e integration aws/rabbitmq` and point your
-browser at <http://127.0.0.1:15672>.
+browser at <http://127.0.0.1:15672> (also available for `staging` and `production`).
+
+The username for connecting to the RabbitMQ web control panel is `root` and the password
+can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_rabbitmq::root_password]'` (from the `puppet_aws` directory).
 
 ## RabbitMQ metrics
 


### PR DESCRIPTION
This PR updates the docs on RabbitMQ to add details about the web control panel, specifically how it can be used during the process of rebooting instances of the cluster to aid with monitoring when those instances rejoin the cluster. The main RabbitMQ doc page is also updated to add the username and point to where to decrypt the password within the secrets repo.