### PR TITLE
Add links for convenience to emergency banner page

### DIFF
--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -69,7 +69,13 @@ As a workaround, you need to re-run the clear CDN and Varnish cache Jenkins jobs
 1. Wait for 2 minutes after the Deploy Emergency Banner job has completed.
   This will allow the frontend application caches to [clear automatically after 60s][slimmer-cache].
 2. Run the "Clear varnish cache" Jenkins job
+   - [Clear varnish on Integration](https://deploy.blue.integration.govuk.digital/job/clear-varnish-cache/)
+   - [Clear varnish on  Staging](https://deploy.blue.staging.govuk.digital/job/clear-varnish-cache/)
+   - [⚠️ Clear varnish on Production ⚠️](https://deploy.blue.production.govuk.digital/job/clear-varnish-cache/)
 3. Run the "Clear CDN cache" Jenkins job
+   - [Clear CDN on Integration](https://deploy.blue.integration.govuk.digital/job/clear-cdn-cache/)
+   - [Clear CDN on  Staging](https://deploy.blue.staging.govuk.digital/job/clear-cdn-cache/)
+   - [⚠️ Clear CDN on Production ⚠️](https://deploy.blue.production.govuk.digital/job/clear-cdn-cache/)
 
 > **Note**
 >


### PR DESCRIPTION
[Trello](https://trello.com/c/BUSq6xQn/1270-emergency-banner-publishing-drill)

Whilst doing the regular emergency banner drill Dec 22nd, we commented
that there were not docs linked for convenience. Then thought we should
do something about that.

![image](https://user-images.githubusercontent.com/3694062/147119346-fd7c2c12-f8f5-4254-a63d-6e8e0a735b06.png)
