### PR TITLE
Update references to Platform Health

### DIFF
--- a/data/applications.yml
+++ b/data/applications.yml
@@ -94,8 +94,8 @@
   production_hosted_on: aws
 - github_repo_name: locations-api
   type: APIs
-  team: "#govuk-platform-health"
-  dependencies_team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
+  dependencies_team: "#govuk-platform-reliability-team"
   production_hosted_on: none
   sentry_url: false
   dashboard_url: false
@@ -119,7 +119,7 @@
   production_hosted_on: aws
 - github_repo_name: support-api
   type: APIs
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 - github_repo_name: hmrc-manuals-api
   type: APIs
@@ -127,7 +127,7 @@
   production_hosted_on: aws
 - github_repo_name: mapit
   type: APIs
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   api_docs_url: https://mapit.mysociety.org/docs/
   production_hosted_on: aws
 
@@ -150,11 +150,11 @@
 
 - github_repo_name: content-data-api
   type: Supporting apps
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 - github_repo_name: content-data-admin
   type: Supporting apps
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 - github_repo_name: search-admin
   type: Supporting apps
@@ -166,7 +166,7 @@
   production_hosted_on: aws
 - github_repo_name: support
   type: Supporting apps
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 - github_repo_name: authenticating-proxy
   type: Supporting apps
@@ -175,7 +175,7 @@
   production_hosted_on: aws
 - github_repo_name: release
   type: Supporting apps
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 - github_repo_name: router
   type: Supporting apps
@@ -183,7 +183,7 @@
   production_hosted_on: aws
 - github_repo_name: govuk-load-testing
   type: Supporting apps
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: none
 
 # frontend
@@ -416,7 +416,7 @@
 # Utilities - supporting applications/tooling
 
 - github_repo_name: seal
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   management_url: https://dashboard.heroku.com/apps/moody-seal
   production_hosted_on: heroku
   type: Utilities
@@ -443,7 +443,7 @@
   sentry_url: false
   dashboard_url: false
 - github_repo_name: govuk-dependencies
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   management_url: https://dashboard.heroku.com/apps/govuk-dependencies
   production_hosted_on: heroku
   type: Utilities
@@ -495,7 +495,7 @@
   sentry_url: false
   dashboard_url: false
 - github_repo_name: govuk-pact-broker
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: paas
   type: Utilities
   sentry_url: false
@@ -507,7 +507,7 @@
   sentry_url: false
   dashboard_url: false
 - github_repo_name: govuk-jenkinslib
-  team: "#govuk-platform-health"
+  team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
   type: Utilities
   sentry_url: false

--- a/source/manual/2nd-line.html.md
+++ b/source/manual/2nd-line.html.md
@@ -24,7 +24,7 @@ We have a [2nd line dashboard][] showing a high level overview of the state of t
 
 We use Icinga to monitor our platform and alert us when things go wrong. Many alerts have corresponding  documentation in these developer docs, detailing how to respond.
 
-You should record critical alerts that aren't easily solved to the [GOV.UK 2nd line Trello board][] to help inform Platform Health and the GOV.UK SREs. 2nd line should investigate these alerts when there is downtime; you do not necessarily have to fix them.
+You should record critical alerts that aren't easily solved to the [GOV.UK 2nd line Trello board][] to help inform the 2nd line tech lead(s) and the GOV.UK SREs. 2nd line should investigate these alerts when there is downtime; you do not necessarily have to fix them.
 
 [Read more about Icinga](/manual/icinga.html).
 

--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-platform-reliability-team"
 title: content-data-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout

--- a/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
+++ b/source/manual/alerts/fetch-analytics-data-for-search-failed.html.md
@@ -65,5 +65,5 @@ bundle exec rake search:unlock SEARCH_INDEX=all
 Then see the ["fix out-of-date search indices"](/manual/fix-out-of-date-search-indices.html)
 docs.
 
-If the job is failing often, make sure the team currently responsible for search
-are aware of the problem (or Platform Health).
+If the job is failing often, make sure the [team currently responsible for search](/apps/search-analytics.html)
+are aware of the problem.

--- a/source/manual/alerts/high-nginx-5xx-rate.html.md
+++ b/source/manual/alerts/high-nginx-5xx-rate.html.md
@@ -17,7 +17,7 @@ Change the hostname to view different apps.
 The alert should link to a graphite graph - often certain applications
 such as Whitehall can have spikes - if you can determine this is a spike
 it is best to acknowledge the alert and let a team that is working on the app
-know (or alert Platform Health).
+know (or alert Platform Reliability).
 
 ## Scaling up
 

--- a/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
+++ b/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: "Publisher: Unprocessed fact-check emails"
 section: Icinga alerts
 subsection: Email alerts

--- a/source/manual/alerts/search-reindex-failed.html.md.erb
+++ b/source/manual/alerts/search-reindex-failed.html.md.erb
@@ -12,7 +12,8 @@ to ensure the process works as expected when we need to run it in production.
 This task is manually run in production by the development team after they have
 made and changes to the Elasticsearch schema.
 
-If this process fails then please escalate to Platform Health for further investigation.
+If this process fails then please escalate to the [team currently responsible for search][search-api]
+for further investigation.
 
 This task can be run in Jenkins:
 

--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-platform-reliability-team"
 title: Ask for help
 parent: "/manual.html"
 layout: manual_layout
@@ -20,10 +20,9 @@ The GOV.UK developer community (#govuk-developers):
 - supports each other with issues deploying changes to GOV.UK
 - ensures missions are delivered technically in the best and most appropriate way
 
-The GOV.UK Platform Health team (#govuk-platform-health):
+The GOV.UK Platform Reliability team (#govuk-platform-reliability-team):
 
 - works on long term fixes to the platform
-- supports 2nd line by taking on bigger pieces of work that doesn't fit the weekly schedule
 - owns the infrastructure, although doesn't necessarily have the expertise to fix issues
 
 The GOV.UK Replatforming team (#govuk-replatforming):

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: 'Assets: how they work'
 section: Assets
 type: learn

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -236,7 +236,7 @@ Publishers upload their organograms as a Excel (XLS) file that contains macros. 
 
 ### Dataset Analytics requests
 
-It is possible to access analytics for datasets. If a user requests analytics for datasets, we can provide them with access to an analytics dashboard. Assign tickets like this to Martin Lugton or another member of the Platform Health product team.
+It is possible to access analytics for datasets. If a user requests analytics for datasets, we can provide them with access to an analytics dashboard. Assign tickets like this to Martin Lugton or to the `3rd Line--GOV.UK Product Requests` Zendesk queue.
 
 ## Differences in CKAN 2.9 vs 2.7/2.8
 

--- a/source/manual/data-gov-uk-architecture.html.md
+++ b/source/manual/data-gov-uk-architecture.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-datagovuk"
 title: Architecture of data.gov.uk
 section: data.gov.uk
 layout: manual_layout

--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-datagovuk"
 title: Common 2nd line support tasks for CKAN
 section: data.gov.uk
 layout: manual_layout

--- a/source/manual/load-testing.html.md.erb
+++ b/source/manual/load-testing.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-platform-reliability-team"
 title: Load Testing
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: Manage assets
 section: Assets
 layout: manual_layout

--- a/source/manual/mapit-caches.html.md
+++ b/source/manual/mapit-caches.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-platform-reliability-tech"
 title: Mapit Caches
 layout: manual_layout
 parent: "/manual.html"
@@ -35,4 +35,3 @@ Currently Django will only caches responses from the `/postcode` endpoints and n
 ## Bypassing the cache
 
 Cache keys are based on the URI of the request, therefore you can avoid the cache by adding a unique query string. For example `/postcode/sw71ne?nocache=<random>`.
-

--- a/source/manual/request-fastly-tls-certificate.html.md
+++ b/source/manual/request-fastly-tls-certificate.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: Request Fastly TLS certificate
 section: Transition
 layout: manual_layout

--- a/source/manual/scale-mapit.html.md
+++ b/source/manual/scale-mapit.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-platform-reliability-team"
 title: Scale Mapit
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -223,7 +223,7 @@ errors to risk breaching our account limit. These limits are configured on the
 ## Slack alerts
 
 You can configure Sentry to notify a Slack channel when a notable condition is
-satisfied. For example, the `#govuk-platform-health` channel gets notified when
+satisfied. For example, the `#govuk-platform-reliability-team` channel gets notified when
 any issue records 100 or more errors in a 1 hour period.
 
 To set up an alert, visit the [Alerts panel][], select the project the alert

--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: Transition a site to GOV.UK
 section: Transition
 layout: manual_layout

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: Transition architecture
 section: Transition
 type: learn

--- a/source/manual/whitehall-historical-accounts.html.md
+++ b/source/manual/whitehall-historical-accounts.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-health"
+owner_slack: "#govuk-publishing-tech"
 title: Add Historical Accounts
 section: Publishing
 layout: manual_layout


### PR DESCRIPTION
Our Slack channel has been renamed to #govuk-platform-reliability-team.
Some app ownership has also been updated to reflect https://docs.publishing.service.gov.uk/apps/by-team.html which has been recently updated.

https://trello.com/c/65t3VYTd/2818-update-references-to-platform-health-in-dev-docs-and-govuk-techlead-rota