### PR TITLE
Simplify 'Deploy Terraform' docs

### DIFF
--- a/source/manual/deploying-terraform.html.md
+++ b/source/manual/deploying-terraform.html.md
@@ -27,81 +27,11 @@ poweruser role.
 
 ### 2. Install `gds-cli`
 
-[`gds-cli`][gds-cli] is the [preferred way](/manual/get-started.html) of obtaining
-AWS credentials.
+[`gds-cli`](https://github.com/alphagov/gds-cli) is the [preferred way](/manual/get-started.html) of obtaining AWS credentials.
 
-As of version `v2.15.0` of `gds-cli`, you can use it to deploy terraform via Jenkins.
-
-### 3. Get GitHub Credentials
-
-You need to obtain your GitHub credentials by creating a read-only GitHub personal access token. This [GitHub personal access token](https://github.com/settings/tokens) should be
-created with the `read:org` scope only.
-
-> Take care to store and handle the token securely. If you accidentally share your token,
-  [revoke it immediately](https://github.com/settings/tokens) and follow the
-  [instructions for reporting a potential data security incident][security-incidents].
-
-## Deploying Terraform
+## Deploy Terraform via Jenkins
 
 **Always `plan` first, check that the output is what you expect, then `apply`.**
-
-There are 3 ways of deploying terraform:
-
-1. [`gds-cli`][gds-cli] as of version `v2.15.0`
-2. `deploy.rb` script in [govuk-aws][deploy-rb] repository
-3. via the [dedicated Jenkins job](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS)
-
-It is recommended that you use the gds-cli option before exploring the other 2.
-
-### 1. gds-cli
-
-To deploy terraform using [`gds-cli`][gds-cli], you should run:
-
-```sh
-GITHUB_USERNAME=<github_username> GITHUB_TOKEN=<github_token> \
-gds govuk terraform -e <environment> -p <project> -s <stack> -a <action> -r <aws_role>
-```
-
-Where:
-
-1. `<github_username>` is the name of your GitHub account
-1. `<github_token>` is the GitHub token that you created as described [above](#3-get-github-credentials)
-1. `<environment>` is the govuk environment you want to deploy to. E.g. `integration`,`staging`
-1. `<project>` is the terraform project that you want to deploy. E.g. `app-gatling`, `infra-security`
-1. `<stack>` is the govuk stack you want to deploy to. E.g. `blue` (which is usually for `app-` projects), `govuk` (which is usually for `infra-` projects)
-1. `<action>` is the terraform action you want to perform. E.g. `plan`, `apply`
-1. `<aws_role>` is the govuk aws role you want to use for terraforming. E.g. `govuk-integration-admin`
-
-After you deploy, you can visit the [`deploy` Jenkins job][deploy-jenkins] to see the job running or queued.
-
-### 2. `deploy.rb` script in govuk-aws
-
-The Ruby script [`tools/deploy.rb`][deploy-rb] in the `govuk-aws` repository takes care of requesting temporary
-AWS credentials with an assumed role and queuing the deployment Jenkins job.
-
-You can use it by running:
-
-```sh
-GITHUB_USERNAME=<your GitHub username> \
-  GITHUB_TOKEN=<your GitHub personal access token> \
-  gds aws <your role e.g. govuk-integration-admin> -- \
-  ~/govuk/govuk-aws/tools/deploy.rb blue app-backend integration plan
-```
-
-You will need to change the arguments to the `deploy.rb` script. E.g.
-
-- `app-backend` should be the name of the project you want to deploy
-- `blue` is for `app-` projects, `govuk` is for `infra-` projects usually
-- `integration` is the starting point, then `staging`, etc.
-
-Once the script has run, visit the [`deploy` Jenkins job][deploy-jenkins] to see the job running or queued.
-
-[gds-cli]: https://github.com/alphagov/gds-cli
-[deploy-rb]: https://github.com/alphagov/govuk-aws/blob/master/tools/deploy.rb
-[deploy-jenkins]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS
-[security-incidents]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/security/security-incidents
-
-### 3. Jenkins
 
 Before you begin, run the following command using `gds-cli`:
 
@@ -111,16 +41,31 @@ gds aws govuk-integration-admin -e
 
 This will allow you to retrieve several AWS access keys that the Jenkins job requires to run.
 
-In the Jenkins job, click "Build with Parameters" and enter the following for each field:
+In the ['Deploy_Terraform_GOVUK_AWS' Jenkins job](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS), click "Build with Parameters" and enter the following for each field:
 
 - AWS_ACCESS_KEY_ID: can be retrieved from the above command
 - AWS_SECRET_ACCESS_KEY: can be retrieved from the above command
 - AWS_SESSION_TOKEN: can be retrieved from the above command
-- COMMAND: see `<action>` in gds-cli method above
-- ENVIRONMENT: see `<environment>` in gds-cli method above
-- STACKNAME: see `<stack>` in gds-cli method above
-- PROJECT: see `<project>` in gds-cli method above
+- COMMAND: the terraform action you want to perform. E.g. `plan`, `apply`
+- ENVIRONMENT: the govuk environment you want to deploy to. E.g. `integration`,`staging`
+- STACKNAME: the govuk stack you want to deploy to. E.g. `blue` (which is usually for `app-` projects), `govuk` (which is usually for `infra-` projects)
+- PROJECT: the terraform project that you want to deploy. E.g. `app-gatling`, `infra-security`
 
 All other fields can be left as they are.
 
 Click "build" and terraform should deploy as expected. Remember to deploy to staging and/or production as required.
+
+### Other ways of invoking Jenkins
+
+As of version `v2.15.0` of `gds-cli`, you can use it to deploy terraform via Jenkins. Run `gds govuk terraform --help` for details.
+
+Alternatively, you can invoke this [script in the govuk-aws repository](https://github.com/alphagov/govuk-aws/blob/master/tools/deploy.rb):
+
+```sh
+GITHUB_USERNAME=<your GitHub username> \
+  GITHUB_TOKEN=<your GitHub personal access token> \
+  gds aws <your role e.g. govuk-integration-admin> -- \
+  ~/govuk/govuk-aws/tools/deploy.rb <stackname> <project> integration plan
+```
+
+Both of these alternatives take care of requesting temporary AWS credentials with an assumed role and queue the deployment Jenkins job. However, they don't allow you to specify a branch of govuk-aws / govuk-aws-data, so using Jenkins directly is often preferred.


### PR DESCRIPTION
The previous docs described in detail how to use the gds-cli and
deploy.rb script to deploy Terraform, but both of these methods
simply trigger the same parameterised Jenkins build under the
hood. There's no particular advantage to this abstraction layer,
and furthermore, no way of triggering a build of a branch of
changes, which can only be done by configuring the job in Jenkins
manually. As this is quite a common use case for the job, it
makes sense to put the Jenkins instructions first, and to highlight
this as the primary means of deploying Terraform.

With this as the preferred approach, we no longer need to
document how to get a GitHub token (it isn't required by the job),
and we don't need to repeat the definition of each parameter either.

I've kept a short section at the end of the doc to make a reference
to these alternative means of triggering the jobs, for sake of
completion.