### PR TITLE
Update with start commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Store the token in a `.env` file like this:
 ```
 GITHUB_TOKEN=somethingsomething
 ```
+Example start up commands:
+```
+govuk-docker-up env GITHUB_TOKEN=$(cat ~/github_token.txt)
+GITHUB_TOKEN=$(cat ~/github_token.txt) ./startup.sh
+```
 
 ### Testing the app
 


### PR DESCRIPTION
## What

Add some example start commands while running the app for the first time

## Why

Adding some context how to quickly get setup running the app - [prompted from work on this PR](https://github.com/alphagov/govuk-developer-docs/pull/3304)

## Anything else

While `startup.sh` is active, i'm aware we're slowly moving away from this we might want to remove this