### PR TITLE
Remove fab references - high 5xx

### DIFF
--- a/source/manual/alerts/high-nginx-5xx-rate.html.md
+++ b/source/manual/alerts/high-nginx-5xx-rate.html.md
@@ -27,10 +27,6 @@ if there are an unusually high number of requests to a particular machine
 class. If there are, you may want to consider
 [scaling up the number of machines available][scaling-up] to handle the requests.
 
-> **Note**
->
->  This is only possible in AWS.
-
 ## `UNKNOWN: INTERNAL ERROR`
 
 If the message is "UNKNOWN: INTERNAL ERROR: RuntimeError: no valid

--- a/source/manual/alerts/high-nginx-5xx-rate.html.md
+++ b/source/manual/alerts/high-nginx-5xx-rate.html.md
@@ -27,29 +27,6 @@ if there are an unusually high number of requests to a particular machine
 class. If there are, you may want to consider
 [scaling up the number of machines available][scaling-up] to handle the requests.
 
-## `UNKNOWN: INTERNAL ERROR`
-
-If the message is "UNKNOWN: INTERNAL ERROR: RuntimeError: no valid
-datapoints" or "UNKNOWN: INTERNAL ERROR: RuntimeError: no data returned
-for target", it probably means that statsd or collectd stopped
-submitting data for a period. Statsd metrics (those that begin with
-`stats.`) don't get created until the first event of a given type. For
-infrequently-used apps which rarely have errors, the `http_5xx` may
-never get created. You can force creation by creating a zero-value
-`http_500` counter:
-
-```
-fab $environment -H frontend-1.frontend statsd.create_counter:frontend-1_frontend.nginx_logs.static_publishing_service_gov_uk.http_500
-```
-
-Note that the `http_5xx` counters are created by carbon-aggregator, so
-they will automatically be created when a corresponding `http_500`
-counter gets created. You should *not* create a statsd counter for
-`http_5xx` as this will confuse carbon-aggregator.
-
-For collectd metrics (those without a leading `stats.` prefix), you
-probably just need to wait for the metric to get created.
-
 [nginx-5xx-grafana-aws]: https://grafana.blue.production.govuk.digital/dashboard/file/nginx_requests.json?refresh=1m&orgId=1&var-Machines=All&var-Hostname=All&var-Status=5xx
 [nginx-requests]: https://grafana.production.govuk.digital/dashboard/file/nginx_requests.json?refresh=1m&orgId=1&from=now-30m&to=now
 [scaling-up]: /manual/auto-scaling-groups.html#manually-scaling


### PR DESCRIPTION
[Trello](https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs)

I was setting out to just remove the reference to fab here, but the
archived fab repo seems to have had statsd commands purposely removed
from it before we archived the repo.

Quote from an [old PR](fabric_scripts#291):

> I don't think this has been used in a while, and I also think there
> are better approaches now of addressing the problem it's trying to
> solve.

> I think this was about getting rid of UNKNOWN Icinga checks, but it's
> better just to acknowledge the failing check, or change the Graphite
> query if the data just hasn't arrived yet.

If that's the case then likely better to just clear up this entire
section.

[fabric_scripts#291](https://github.com/alphagov/fabric-scripts/pull/291)
