### PR TITLE
Remove Fabric from manual tools page

### DIFF
--- a/source/manual/tools.html.md
+++ b/source/manual/tools.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: 'Tools: Icinga, Grafana and Graphite, Kibana, Fabric and friends'
+title: 'Tools: Icinga, Grafana and Graphite, Kibana and friends'
 section: Monitoring
 type: learn
 layout: manual_layout
@@ -59,20 +59,6 @@ You can tweak the time range manually with the drop down at the top or by draggi
 Check out some of the [useful Kibana queries](kibana.html) to get an idea of what's possible.
 
 Logs are sent to Kibana using [Filebeat](logging.html#filebeat).
-
-## Fabric Scripts
-
-<https://github.com/alphagov/fabric-scripts/>
-
-The Fabric scripts are useful for running something on a set of machines. For instance, to restart all instances of the content store on backend boxes:
-
-`fab $environment class:backend app.reload:content-store`
-
-Check the `app.py` class for different methods you can use. To run more specific commands you can run the following (`sdo` for sudo):
-
-`fab $environment class:backend sdo:"service content-store reload"`
-
-For more information, check out the [Fabric scripts README](https://github.com/alphagov/fabric-scripts#readme).
 
 ## Prometheus, Grafana and AlertManager for COVID-19 Forms
 


### PR DESCRIPTION
[Trello](https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs)

Might be a place to come back to if we decide something like [pssh][1]
is cool and should be more widely used on GOV.UK

[1]: https://linux.die.net/man/1/pssh