### PR TITLE
Replace references to fab for how to switch off an app guidance

### DIFF
--- a/source/manual/switch-app-off-temporarily.html.md
+++ b/source/manual/switch-app-off-temporarily.html.md
@@ -8,16 +8,29 @@ parent: "/manual.html"
 
 In the event of a security incident an app may need to be switched off until it can be patched.
 
-1. You'll need to identify on which machine class the application runs on.
+Before you begin you will need to identify:
 
-1. Puppet must be disabled on the machines to prevent it automatically restarting the app:
+- which machine class the application runs on
+- how many machines of that class there are
 
-   ```sh
-   $ fab $environment node_type:frontend puppet.disable:"Reason for disabling Puppet"
+See the [SSH into machines docs for more information](/manual/howto-ssh-to-machines.html#usage)
+
+1. SSH into the first machine:
+
+   ```bash
+   gds govuk connect -e production ssh <machine_class>:<box_number>
    ```
 
-1. Stop the application service on the relevant machines:
+2. Disable puppet on the machine to prevent it automatically restarting the app (provide a better reason if you can):
 
-   ```sh
-   $ fab $environment node_type:frontend app.stop:frontend
    ```
+      sudo govuk_puppet --test --disable "Disabling puppet to prevent app restarting (by $USER)"
+   ```
+
+3. Stop the application service on the relevant machine
+
+   ```
+      sudo <app_name> stop
+   ```
+
+4. Repeat for other machines in the class until all have been disabled.


### PR DESCRIPTION
[Trello](https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs)

Fabric was previously the route to do this across multiple machines in a
class. With fabric gone, the commands will need to be more manual