### PR TITLE
Add the connect to box by index trick to SSH docs

### DIFF
--- a/source/manual/howto-ssh-to-machines.html.md
+++ b/source/manual/howto-ssh-to-machines.html.md
@@ -18,6 +18,12 @@ $ gds govuk connect -e staging ssh cache
 
 This will automatically SSH into a random `cache` machine on AWS.
 
+You can connect to a consistent machine by its index:
+
+```sh
+$ gds govuk connect -e staging ssh cache:1
+```
+
 To see all classes, run:
 
 ```sh


### PR DESCRIPTION
@richardTowers  showed me this one recently, it was really useful
to stop hopping around between boxes randomly when I had to run a
command across each and didn't know the IP addresses in advance.

Was surprised this wasn't in the docs!