### PR TITLE
Add documentation on how to be a good buddy

### DIFF
--- a/source/manual/how-to-be-a-good-buddy.html.md
+++ b/source/manual/how-to-be-a-good-buddy.html.md
@@ -1,0 +1,40 @@
+---
+owner_slack: "#govuk-developers"
+title: How to be a good buddy
+section: Learning GOV.UK
+layout: manual_layout
+type: learn
+parent: "/manual.html"
+---
+
+When a new joiner starts on GOV.UK, it's good practice for the team they are joining to assign them a "buddy" to help them get started on GOV.UK, explain it's infrastructure and provide initial support.
+
+## What is a buddy?
+
+A buddy acts as a temporary guide for new joiners. It's an informal role and their responsibilities include:
+
+- explaining how our stack works
+- pointing the new joiner to useful docs/slack channels/general resources
+- being on hand to answer specific questions
+- generally making them feel welcome
+
+Ideally, a buddy will be in the same team and sit within the same function as the new joiner eg: a new frontend developer would have a frontend buddy.
+
+## How does a buddy differ from a line manager?
+
+Line managers aren't the same as buddies in that they…
+
+- might not always be on the same team or even the same programme
+- are focused more on personal stuff like objectives and working patterns
+- handle general admin and HR processes
+
+## Advice on being an effective buddy
+
+- Make sure that our new joiner documentation is up to date before they start
+- Schedule catchups with them in their first week or two, to talk through things like our stack and our tooling
+- Make them aware of our starter documentation such as our [getting started guide](/manual/get-started.html)
+- Check in semi-regularly to make it clear that you're available if they need help with anything
+- Let your team know that you're acting as a new joiner's buddy so your capacity might be reduced
+- Consider having a handover discussion after the first month to check how the new joiner found onboarding, then feed that feedback into our general onboarding process
+
+There's no official end date for being a buddy. It is up to you and the new joiner to continue checking in for as long as you both feel it's useful.


### PR DESCRIPTION
## What
Adds documentation on how to be a good "buddy" as part of a new joiner's onboarding process.

## Why
The buddy convention is something we follow stringently in the frontend community. Following a presentation I did to said community, it was proposed some documentation to the effect of that presentation could be added to these dev docs, potentially as a companion piece to our docs on the [responsibilities of a tech lead](https://docs.publishing.service.gov.uk/manual/tech-lead-responsibilities.html). This is an attempt to capture the contents of that presentation which went into recent positive examples of being a buddy and the differences between other roles like line manager to a new joiner.