### PR TITLE
Update guidance and tools for digital accessibility page

### DIFF
--- a/source/manual/guidance-and-tools-for-digital-accessibility.html.md
+++ b/source/manual/guidance-and-tools-for-digital-accessibility.html.md
@@ -7,4 +7,12 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-[Guidance and tools for digital accessibility](https://www.gov.uk/guidance/guidance-and-tools-for-digital-accessibility)
+[Review guidance and tools for digital accessibility](https://www.gov.uk/guidance/guidance-and-tools-for-digital-accessibility) on how to:
+
+- meet the Public Sector Bodies Accessibility Regulations
+- make your projects, programmes and infrastructure accessible and inclusive
+- design accessible services, content and communications
+- test with accessibility personas
+- get free accessibility training
+
+[Contact the GOV.UK Find and View team](https://app.slack.com/client/T8GT9416G/CL93VA6T1/thread/CAD79097T-1553596948.007500) for more specific support and [read further internal accessibility resources](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/we-are-gds/service-design-and-assurance-sda/accessibility/accessibility-resources).


### PR DESCRIPTION
**What**
https://trello.com/c/LO5gAQHO/996-add-introduction-copy-to-guidance-and-tools-for-digital-accessibilitypage-in-the-manual
Create and add some introductory text to this page https://docs.publishing.service.gov.uk/manual/guidance-and-tools-for-digital-accessibility.html.

**Why**

The manual (for developers) has recently been updated to link to the **Guidance and tools for digital accessibility** page. The page is a bit empty at the moment (essentially only the link to the guidance is included).