### PR TITLE
Remove references to blue-postgresql-primary

### DIFF
--- a/source/manual/alerts/app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/app-healthcheck-not-ok.html.md
@@ -54,7 +54,7 @@ This means the app is accepting requests, but taking too long to respond (over [
 This means the app is unable to connect to its database.
 
 - Check for [any RDS alerts](/manual/govuk-in-aws.html#postgresql-and-mysql).
-- Check the [AWS RDS dashboard][postgres dash] to see if we're experiencing resourcing issues.
+- Check the corresponding [AWS RDS dashboard][rds dash] to see if we're experiencing resourcing issues.
 - Check for network connectivity to the DB.
 
 ```
@@ -107,7 +107,7 @@ This means the time it takes for a [Sidekiq][] job to be processed is unusually 
 
 - Check the Sidekiq ['Queue Length'][Sidekiq dash] graph to see if we have a
   high number of jobs queued up.
-- Check the [Machine dashboard][machine metrics] or the [AWS RDS postgres dashboard][postgres dash] to see if we're experiencing resourcing issues.
+- Check the [Machine dashboard][machine metrics] or the [AWS RDS postgres dashboard][rds dash] to see if we're experiencing resourcing issues.
 - Are the workers reporting any problems or any issues being raised in [Sentry]?
 - Check [Kibana] for Sidekiq error logs (`application: <app> AND @type: sidekiq`).
 
@@ -116,4 +116,4 @@ This means the time it takes for a [Sidekiq][] job to be processed is unusually 
 [Sidekiq dash]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json
 [Kibana]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(columns:!('@message',host),index:'*-*',interval:auto,query:(query_string:(query:'@type:%20sidekiq%20AND%20application:%20email-alert-api')),sort:!('@timestamp',desc))
 [machine metrics]: https://grafana.blue.production.govuk.digital/dashboard/file/machine.json
-[postgres dash]: https://grafana.production.govuk.digital/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=blue-postgresql-primary&from=now-3h&to=now
+[rds dash]: https://grafana.production.govuk.digital/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&from=now-3h&to=now

--- a/source/manual/alerts/email-alert-api-high-queue-latency.html.md
+++ b/source/manual/alerts/email-alert-api-high-queue-latency.html.md
@@ -56,4 +56,4 @@ diagnostic steps you could take are:
 [Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h
 [Kibana]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(columns:!('@message',host),index:'*-*',interval:auto,query:(query_string:(query:'@type:%20sidekiq%20AND%20application:%20email-alert-api')),sort:!('@timestamp',desc))
 [machine metrics]: https://grafana.blue.production.govuk.digital/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=email_alert_api*&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All
-[postgres dash]: https://grafana.production.govuk.digital/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=blue-postgresql-primary&from=now-3h&to=now
+[postgres dash]: https://grafana.production.govuk.digital/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=email-alert-api-postgres&from=now-3h&to=now


### PR DESCRIPTION
Trello: https://trello.com/c/6fLV2SRM/103-review-documentation-for-references-to-old-database-architecture

We no longer have this RDS instance. I've replaced the specific link
(Email Alert API) as a direct one to the instance, for the generic one
I'm just not including a database variable so Grafana picks the first
one and the user of the graph can determine the appropriate one.