### PR TITLE
Fix the name of the redirect HTML attachment task

### DIFF
--- a/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
+++ b/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
@@ -30,16 +30,16 @@ There are two interfaces for dry and real runs, to ensure the correct HtmlAttach
 ##### Dry run
 
 ```bash
-$ bundle exec 'publishing_api:redirect_html_attachments:dry[document_content_id,redirection_url]'
+$ bundle exec 'publishing_api:redirect_html_attachments:by_content_id_dry_run[document_content_id,redirection_url]'
 ```
 
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27publishing_api:redirect_html_attachments:dry[DOCUMENT_CONTENT_ID,REDIRECTION_URL]%27)
+[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27publishing_api:redirect_html_attachments:by_content_id_dry_run[DOCUMENT_CONTENT_ID,REDIRECTION_URL]%27)
 
 > You need to find the `content_id` of the Document the attachment belongs to via Rails console if the Document has already been unpublished and redirected.
 > Remember to use the relative path for an internal URL. Example:
 
 ```
-publishing_api:redirect_html_attachments:dry[f8781a75-9fb7-409a-a37d-3a5877ad28fb,/government/collections/trading-with-the-eu-if-the-uk-leaves-without-a-deal]
+publishing_api:redirect_html_attachments:by_content_id_dry_run[f8781a75-9fb7-409a-a37d-3a5877ad28fb,/government/collections/trading-with-the-eu-if-the-uk-leaves-without-a-deal]
 ```
 
 > Note: Please make sure the REDIRECTION_URL starts with a `/`, otherwise the redirection will not work.
@@ -49,10 +49,10 @@ This attempts to locate the HtmlAttachments for the latest unpublished Edition o
 ##### Real run
 
 ```bash
-$ bundle exec 'publishing_api:redirect_html_attachments:real[document_content_id,redirection_url]'
+$ bundle exec 'publishing_api:redirect_html_attachments:by_content_id[document_content_id,redirection_url]'
 ```
 
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27publishing_api:redirect_html_attachments:real[DOCUMENT_CONTENT_ID,REDIRECTION_URL]%27)
+[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27publishing_api:redirect_html_attachments:by_content_id[DOCUMENT_CONTENT_ID,REDIRECTION_URL]%27)
 
 This will actually request that the PublishingApi redirects the selected HtmlAttachments.
 


### PR DESCRIPTION
The name of the rake task to redirect HTML attachments in Whitehall has
been changed in a refactor. This amends the docs to have the correct
names.