### PR TITLE
Allow the GITHUB_TOKEN write permission on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write 
     steps:
       - name: Set commit message up front
         id: commit_message_writer


### PR DESCRIPTION
As of 1st February 2022, the org-wide setting for GitHub Actions
has been hardened such that the GITHUB_TOKEN generated for each
action run has just 'read' permission, and not 'read/write' as
it was previously.

As such, deployments to the Developer Docs have started failing
with the following error message:

```
Push the commit or tag
  /usr/bin/git push origin gh-pages
  remote: Permission to alphagov/govuk-developer-docs.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/alphagov/govuk-developer-docs.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

The solution is to [edit the permissions for GITHUB_TOKEN for the
'deploy' GitHub Action](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).
Allowing the 'write' permission on 'contents' allows the token
to push tags: https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents