### PR TITLE
Account docs cleanup

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -57,6 +57,7 @@
         - govuk_document_types
         - govuk_message_queue_consumer
         - govuk_navigation_helpers
+        - govuk_personalisation
         - govuk_publishing_components
         - govuk_sidekiq
         - govuk_taxonomy_helpers

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -1,7 +1,6 @@
 # These sections are magically populated from repos.yml
 - name: "Applications"
   sections:
-    - name: GOV.UK Account
     - name: Publishing apps
     - name: APIs
     - name: Services


### PR DESCRIPTION
[Trello](https://trello.com/b/TlvJ4j59/doing-accounts)

A bit of a clear up as we look to hand over some of our stuff.
- Increase visibility of the GOV.UK Personalisation Gem, folks can use that for future personalisation needs
- Remove a GOV.UK Account section, it was empty and probably should remain so.

See commit messages for further thinking.

## What it looks like
![image](https://user-images.githubusercontent.com/3694062/152023253-1c79e188-a8b5-4df9-89b4-a0c331b2c031.png)

![image](https://user-images.githubusercontent.com/3694062/152023312-8c1f9e24-cfdc-4507-80dc-7f4ccb61e7a3.png)
