### PR TITLE
Remove tech-docs-monitor

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -166,7 +166,6 @@ redirects:
   /apps/static.html: /repos/static.html
   /apps/support.html: /repos/support.html
   /apps/support-api.html: /repos/support-api.html
-  /apps/tech-docs-monitor.html: /repos/tech-docs-monitor.html
   /apps/transition.html: /repos/transition.html
   /apps/travel-advice-publisher.html: /repos/travel-advice-publisher.html
   /apps/whitehall.html: /repos/whitehall.html

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -574,11 +574,6 @@
   team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 
-- github_repo_name: tech-docs-monitor
-  management_url: https://dashboard.heroku.com/apps/govuk-tech-docs-monitor
-  production_hosted_on: heroku
-  type: Utilities
-
 - github_repo_name: transition
   type: Transition apps
   team: "#govuk-publishing-tech"


### PR DESCRIPTION
This is not a GOV.UK repo, so should not be imported as a GOV.UK
app in the GOV.UK docs.