### PR TITLE
Handle private repos' lack of README gracefully

### DIFF
--- a/app/external_doc.rb
+++ b/app/external_doc.rb
@@ -33,6 +33,8 @@ class ExternalDoc
       MarkdownLinkFilter,
     ]
 
+    markdown = "" if markdown.nil?
+
     HTML::Pipeline
       .new(filters)
       .to_html(markdown.to_s.force_encoding("UTF-8"), context)

--- a/spec/app/external_doc_spec.rb
+++ b/spec/app/external_doc_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe ExternalDoc do
         expect(html).to have_selector("h3#data-gov-uk")
         expect(html).to have_selector("h3#patterns-style-guides")
       end
+
+      it "returns empty string if passed nil" do
+        expect(described_class.parse(nil)).to eq("")
+      end
     end
   end
 


### PR DESCRIPTION
Requests for the `github_readme` method of a private repo return
`nil`:
https://github.com/alphagov/govuk-developer-docs/blob/7427f6886c0676a483e837824fb7d53a19db6df7/app/app.rb#L208

This is useful as it lets us provide specific error messages:
https://github.com/alphagov/govuk-developer-docs/blob/c4b9aebacb3d2c6f2948a5d96ef1c288fc2cd47b/source/partials/application/_readme.html.erb#L9-L13

However, calling `ExternalDoc.parse(application.readme` in
https://github.com/alphagov/govuk-developer-docs/blob/c4b9aebacb3d2c6f2948a5d96ef1c288fc2cd47b/source/partials/application/_readme.html.erb#L15
meant we were passing `nil` to the HTML::Pipeline's `to_html`
method. Even though we're attempting to be defensive and cast it
with `.to_s`, this was raising a "Cannot modify frozen string"
exception.

Trello: https://trello.com/c/baN54ay1/2839-add-more-repos-to-the-list-in-developer-docs