### PR TITLE
Update fastly cache time to 5 minutes from 30

### DIFF
--- a/source/manual/architecture-shallow-dive.html.md
+++ b/source/manual/architecture-shallow-dive.html.md
@@ -42,7 +42,7 @@ Router sends the request to [Frontend](https://github.com/alphagov/frontend). Fr
 
 Frontend produces the homepage as an HTML response and sends that response back to Router.
 
-Router sends the response to Fastly, which caches the response for 30 minutes. This means that Fastly can handle any subsequent requests for the homepage during this time, without needing to query Origin at all.
+Router sends the response to Fastly, which caches the response for 5 minutes. This means that Fastly can handle any subsequent requests for the homepage during this time, without needing to query Origin at all.
 
 Finally, Fastly sends the response back to the user.
 


### PR DESCRIPTION
## What 

Update the cache time for fastly to be 5 minutes, reasons for this are outlined in this [RFC](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md)

## Reference 

https://trello.com/c/OaUhq6uI/722-replatform-emergency-banner