### PR TITLE
Update modify change history doc

### DIFF
--- a/source/manual/howto-modify-change-note.html.md
+++ b/source/manual/howto-modify-change-note.html.md
@@ -8,31 +8,9 @@ parent: "/manual.html"
 
 Spelling mistakes can creep into [change notes](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes), and we are often asked to correct them. The instructions below cover doing this task in the Publishing API and in Whitehall - if your change note lives in Whitehall and is updated in the Publishing API it could be overwritten later.
 
-## Publishing API
-
-Connect to the Publishing API console:
-
-```
-govuk-connect app-console -e production publishing_api/publishing-api
-```
-
-Then find your document and update its content. You should see the
-`note` and `updated_at` values change.
-
-```
-$ d = Document.find_by_content_id("4dc38774-e687-4bff-aa68-6e08c66e98f9")
-=> #<ChangeNote id: 397621, note: "Bar", public_timestamp: "2020-06-16 11:02:22", edition_id: 5146461, created_at: "2020-06-16 10:22:34", updated_at: "2020-06-16 11:02:22">
-
-$ d.live.change_note.update(note: "Foo")
-=> true
-
-$ d
-=> #<ChangeNote id: 397621, note: "Foo", public_timestamp: "2020-06-16 11:02:22", edition_id: 5146461, created_at: "2020-06-16 10:22:34", updated_at: "2020-06-16 15:24:53">
-```
-
 ## Whitehall
 
-The following commands show you how to find the document, get the correct edition within it, and update it. To complete this you will need the document ID, a string to search for to identify the right change log entry (search is fuzzy, be precise to get the right one), and the string you want to replace the current change log.
+The following commands show you how to find the document, get the correct edition within it, and update it. To complete this you will need the document ID, a string to search for to identify the right change log entry (search is fuzzy, be precise to get the right one), and the string you want to replace the current change note text.
 
 Connect to the Whitehall console (test your change on Integration first):
 
@@ -64,16 +42,114 @@ Output should show the change notes. Select the relevant one:
 edition = fuzzy_match.find("A_STRING_FROM_YOUR_CHANGE_NOTE", must_match_at_least_one_word: true)
 ```
 
-Output shows the relevant edition that needs the change note update. Update it:
+Check the returned edition and change note to ensure it's the correct one:
 
 ```
-edition.update(change_note: "YOUR_DESIRED_CHANGE_NOTE_STRING")
+edition.change_note
+edition.major_change_published_at
 ```
 
-The response to this is "false" but the update has taken place. You can confirm this if you want to by typing "edition" to review it. Save the changes:
+Update it (without validation checks):
 
 ```
-edition.save!(validate: false)
+edition.update_attribute(:change_note, "YOUR_DESIRED_CHANGE_NOTE_STRING")
 ```
 
 Republish the document using a [Whitehall Rake task](https://docs.publishing.service.gov.uk/manual/republishing-content.html)
+
+## Publishing API
+
+Publishing API handles change notes in two different ways. To update the change history of a document, you'll either need to update an individual [ChangeNote] or update the `change_history` in the [details JSON] of the published edition.
+
+**Note**
+> Updating change notes in Publishing API should only be done when unable to from the publishing app (to avoid Publishing API being overwritten).
+
+First step is to connect to the Publishing API console:
+
+```
+govuk-connect app-console -e production publishing_api/publishing-api
+```
+
+Find the document:
+
+```
+document = Document.find_by_content_id("YOUR_CONTENT_ID_HERE")
+```
+
+Find the documents live edition:
+
+```
+live_edition = document.editions.live.last
+```
+
+Check edition's details hash for `change_history`. If this is empty then follow method 1, if not, follow method 2:
+
+```
+live_edition.details[:change_history]
+```
+
+### Method 1 (empty change_history)
+
+Fetch the change notes for the document:
+
+```
+change_notes = ChangeNote.joins(:edition).where(editions: { document: document }).order(:public_timestamp)
+```
+
+Select the relevant change note manually, or by searching for the note text:
+
+```
+change_note = change_notes.find_by("note LIKE ?", "%SUBSTRING OR FULL CHANGE NOTE TEXT%")
+```
+
+Update change note:
+
+```
+change_note.update(note, "NEW NOTE")
+```
+
+Finally, [send the document downstream] using the content id.
+
+### Method 2 (present change_history)
+
+Fetch details for edition:
+
+```
+details = live_edition.details
+```
+
+Ouput change history:
+
+```
+details[:change_history]
+```
+
+Select relevant change note manually, or by seaching for the node text:
+
+```
+change_note_index = details[:change_history].find_index { |change_note| change_note[:note] =~ /SUBSTRING OR FULL CHANGE NOTE TEXT/ }
+```
+
+Check the returned change not is correct:
+
+```
+details[:change_history][change_note_index]
+```
+
+Update change note:
+
+```
+details[:change_history][change_note_index][:note] = "New note"
+```
+
+Update edition:
+
+```
+edition.update(details: details)
+```
+
+Finally, [send the document downstream] using the content id.
+
+[ChangeNote]: https://github.com/alphagov/publishing-api/blob/main/app/models/change_note.rb
+[details JSON]: https://github.com/alphagov/publishing-api/blob/d6707237ee31090b2bb04015ba71d476f462448a/db/schema.rb#L85
+[send the document downstream]: https://docs.publishing.service.gov.uk/repos/publishing-api/admin-tasks.html#representing-data-downstream


### PR DESCRIPTION
This commit:

* Adds both ways to update a change note in Publishing API. Previously,
only one method was documented and didn't actually include the last
step which is to send the document downstream.

* Updates Whitehall guidance to check change note as FuzzyMatch can
sometimes return the wrong note if searching by substring.

We could / should probably turn this documentation into rake tasks at
some point.

Trello:
https://trello.com/c/Xrz8kzbW/1043-documentation-update-for-modifying-a-change-note