### PR TITLE
Update frontend architecture

### DIFF
--- a/source/manual/analytics.html.md
+++ b/source/manual/analytics.html.md
@@ -5,7 +5,7 @@ section: Frontend
 layout: manual_layout
 type: learn
 parent: "/manual.html"
-related_applications: [govuk_frontend_toolkit static frontend government-frontend]
+related_applications: [static frontend government-frontend]
 ---
 
 GOV.UK uses Google Analytics to track user journeys through the site. The tracking

--- a/source/manual/cookie-consent-on-govuk.html.md
+++ b/source/manual/cookie-consent-on-govuk.html.md
@@ -121,7 +121,7 @@ Regardless of how your cookie is set, you need to do the following:
 
 [cookie settings page]: https://www.gov.uk/help/cookies
 [Cookie settings page in Frontend GitHub repo]: https://github.com/alphagov/frontend/blob/master/app/views/help/cookie_settings.html.erb
-[Page template which pulls in the cookie banner]: https://github.com/alphagov/static/blob/54706a6eddcf71e2d6cd36b3239798293530d4e6/app/views/layouts/govuk_template.html.erb#L50
-[Cookie banner component]: https://govuk-publishing-components.herokuapp.com/component-guide/cookie_banner
+[Page template which pulls in the cookie banner]: https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_layout_for_public.html.erb#L86
+[Cookie banner component]: https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_cookie_banner.html.erb
 [special route]: publish_special_routes.html
 [Cookie details page]: https://www.gov.uk/help/cookie-details

--- a/source/manual/frontend-architecture.html.md
+++ b/source/manual/frontend-architecture.html.md
@@ -21,10 +21,8 @@ _[Source](https://docs.google.com/drawings/d/1L7pqFrHB2IQCnr0w3ticqBuR4U12b8psZQ
 
 Applications that serve pages for the public (everything on www.gov.uk) use:
 
-- [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components), the preferred way to share HTML, CSS and JS
-- [Static](https://github.com/alphagov/static) and [Slimmer](https://github.com/alphagov/slimmer) for layouts
-- Static uses [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit) and [govuk_template](https://github.com/alphagov/govuk_template), two deprecated projects built by GDS (not GOV.UK)
-- [licence-finder](https://github.com/alphagov/licence-finder) is the only frontend application that still relies on [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit)
+- components and assets from [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components)
+- [layout_for_public](https://components.publishing.service.gov.uk/component-guide/layout_for_public) (via [static](https://github.com/alphagov/static) and [slimmer](https://github.com/alphagov/slimmer))
 
 Most admin applications use:
 
@@ -32,17 +30,15 @@ Most admin applications use:
 
 New admin applications and some legacy admin applications that have been updated use:
 
-- [layout_for_admin](https://govuk-publishing-components.herokuapp.com/component-guide/layout_for_admin) which is available as a component in [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components)
+- components and assets from [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components)
+- [layout_for_admin](https://govuk-publishing-components.herokuapp.com/component-guide/layout_for_admin)
 
 ## Long term vision
+
+![](https://docs.google.com/drawings/d/e/2PACX-1vS5rtPYUJBvl2Th3JaT7WQQHu4KTDuYMdOiHCzUgyifG9ewuEyim_fC5VjmH8gjZg33o8E7TOcWn0sN/pub?w=873&amp;h=475)
+_[Source](https://docs.google.com/drawings/d/1R5s5lHyeDmPFfqXn17Lz3Z2MXoxhJcuSnnmdN327z9g/edit)_
 
 We have 2 [long term goals](https://docs.google.com/presentation/d/1q51pPWl4uaVM2PxFRmPUNu0wJvYfC-lO7GPLsRvyxtQ/edit) for the frontend:
 
 - Use the same tech for the public and admin apps
 - Use as much of the [GOV.UK Design System](https://design-system.service.gov.uk/) as possible
-
-![](https://docs.google.com/drawings/d/e/2PACX-1vS5rtPYUJBvl2Th3JaT7WQQHu4KTDuYMdOiHCzUgyifG9ewuEyim_fC5VjmH8gjZg33o8E7TOcWn0sN/pub?w=873&amp;h=475)
-_[Source](https://docs.google.com/drawings/d/1R5s5lHyeDmPFfqXn17Lz3Z2MXoxhJcuSnnmdN327z9g/edit)_
-
-- Public and admin apps use [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components)
-- [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components) consumes the [GOV.UK Design System](https://design-system.service.gov.uk/)


### PR DESCRIPTION
### What

- Remove references to `govuk_frontend_toolkit` and `govuk_template`
- Update the referenced diagrams accordingly (not part of the PR, but see screen captures below)

### Why

We removed `static`'s dependencies on deprecated gems

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1234" alt="Screenshot 2022-02-08 at 12 13 05" src="https://user-images.githubusercontent.com/788096/152986774-aa19f397-e49f-473d-844b-f506e47e8fca.png">


</td><td valign="top">

<img width="1234" alt="Screenshot 2022-02-08 at 12 13 19" src="https://user-images.githubusercontent.com/788096/152986777-51014a09-42e6-47d8-8f74-2f004d7c9213.png">


</td></tr>
</table>
