### PR TITLE
Add new RabbitMQ queues to alert docs

### DIFF
--- a/source/manual/alerts/rabbitmq-high-number-of-unprocessed-messages.html.md
+++ b/source/manual/alerts/rabbitmq-high-number-of-unprocessed-messages.html.md
@@ -10,17 +10,23 @@ For information about how we use RabbitMQ, see [here][rabbitmq_doc].
 
 We check that there is not a significant build up of messages compared to the
 normal amounts on certain queues. The queues this alert applies to are:
-[email_alert_service][email_service_config],
-[email_unpublishing][email_unpublishing_config] and
-[cache_clearing_service-\*][cache_config] (low, medium and high). The plugin
-which implements this alert is [here][plugin].
+
+* [`email_alert_service`][email_service_config]
+* [`email_unpublishing`][email_unpublishing_config]
+* [`subscriber_list_details_update_major`][email_subscriber_list_major_config]
+* [`subscriber_list_details_update_minor`][email_subscriber_list_minor_config]
+* [`cache_clearing_service-*`][cache_config] (low, medium and high)
+
+The plugin which implements this alert is [here][plugin].
 
 The Icinga check is performed by connecting to RabbitMQ's admin API and
 triggering if the number of messages on the queues listed above crosses certain
 thresholds.
 
-For `email_alert_service` and `email_unpublishing` queues the [message
-thresholds][email_thresholds] are: 25 for critical and 5 for warning.
+For the `email_alert_service`,  `email_unpublishing`,
+`subscriber_list_details_update_major` and `subscriber_list_details_update_minor`
+queues the [message thresholds][email_thresholds] are:
+25 for critical and 5 for warning.
 
 For `cache_clearing_service-*` queues the [message
 thresholds][cache_clearing_thresholds] are: 100,000 for critical and 80,000 for
@@ -38,6 +44,8 @@ For troubleshooting steps, see [here][troubleshooting_steps].
 
 [email_service_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L54-L60
 [email_unpublishing_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L70-L76
+[email_subscriber_list_major_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L101-L107
+[email_subscriber_list_minor_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L92-L98
 [cache_config]: https://github.com/alphagov/govuk-puppet/blob/616cae598f91406e29ed2e4fc287c71b690c55b0/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp#L107-L132
 [troubleshooting_steps]: https://docs.publishing.service.gov.uk/manual/alerts/rabbitmq-no-consumers-listening.html#troubleshooting
 [no_consumers_listening]: https://docs.publishing.service.gov.uk/manual/alerts/rabbitmq-no-consumers-listening.html


### PR DESCRIPTION
We added new queues to the email-alert-service to update subscriber
list details when the page they alert for is updated. [[1]]

There are alerts that might go off for these queues that will link to
this document, so we need to add links to the queue config here.

Also refactor the list of queues into a bulleted list - now there are 
five items the comma separated list was a bit clunky.

<img width="713" alt="image" src="https://user-images.githubusercontent.com/6362602/153175923-7ceb87a1-ffa7-4845-a305-7894547f5630.png">

[Trello](https://trello.com/c/qdE5KvZu/1233-update-docs-for-message-processor-alerts)

[1]: https://github.com/alphagov/email-alert-service/pull/493