### PR TITLE
Add link to GCP mirror bucket

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -49,13 +49,14 @@ follow these steps:
    - Log into the [GCP console](https://console.cloud.google.com/).
    - Go to the `GOVUK Production` project under the `DIGITAL.CABINET-OFFICE.GOV.UK`
      organisation.
-   - Select `Cloud Storage -> Browser`, go to the `govuk-production-mirror`
-     bucket.
+   - Select `Cloud Storage -> Browser`, go to the [`govuk-production-mirror`
+     bucket][govuk-production-mirror-gcp].
    - Navigate to the file, then delete it.
 
 [whitehall-rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:whitehall_delete[]
 [rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete[]
 [clear-cache]: https://docs.publishing.service.gov.uk/manual/purge-cache.html#assets
+[govuk-production-mirror-gcp]: https://console.cloud.google.com/storage/browser/govuk-production-mirror;tab=objects?forceOnBucketsSortingFiltering=false&project=govuk-production
 
 ## Redirecting an asset
 


### PR DESCRIPTION
Adds a link to the Google Cloud Platform bucket where assets are mirrored.

This should make it easier to locate this bucket in an unfamiliar user interface.