### PR TITLE
Update Logit Team Permission Instructions

### DIFF
--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -51,9 +51,12 @@ This will normally be your Tech Lead.
 
 ### Adding users to GOV.UK Stacks
 
-1. Go to "People", and click "Manage".
-2. Click "Teams", then "Assign members" on the "GOV.UK" team.
-3. Add the new members of the team, and click "Update team members".
+If you cannot see the user in the user list, they need to first attempt to login via SSO to Logit.  Only once they have attempted to login to Logit will their account be visible for you to then assign them to a team.
+
+1. Go to the main "Dashboard"
+2. Click "Manage Teams", then "Team Settings" and then click the appropriate team.
+3. Scroll down until you see a list of users and for the particular user give them "Member" access
+4. Click "Apply Changes"
 
 ### Updating Logstash configuration
 


### PR DESCRIPTION
The instructions where out of date due to changes in the Logit UI.  This
updates the instructions and gives details on how to resolve the problem
of a user not appearing.