### PR TITLE
Add instruction to rename Zendesk tickets

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -50,6 +50,9 @@ Below are some of the groups we often triage tickets to:
 * Security issues - `3rd Line--Cyber Security`
 * Spam - `2nd Line--User Support Escalation`
 
+If the ticket's subject is not descriptive of the problem (e.g. `Named contact`) then update this prior
+to triaging or working on the ticket.
+
 ## Passing to another government department or service team
 
 Sometimes a ticket relates to a service run by another government department. To transfer the ticket:


### PR DESCRIPTION
Some Zendesk tickets do not have a descriptive title (e.g. `Named contact` or `Technical support request`). This makes them difficult to recognise in a queue of tickets.

Adding an instruction to rename the ticket to something more descriptive in these cases.