### PR TITLE
How to enable use of the AWS SRT role

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you do not do this, you will need to create a GitHub auth token to avoid gett
 #### Skipping proxied pages from other repositories
 
 ```
-SKIP_PROXY_PAGES=true ./startup
+SKIP_PROXY_PAGES=true ./startup.sh
 ```
 
 Note that `middleman server` will still try to load these pages lazily on some pages (e.g. the docs homepage, or the applications list), so you'll either need to avoid these pages or use a GitHub auth token.

--- a/source/manual/alerts/ddosdetected.html.md
+++ b/source/manual/alerts/ddosdetected.html.md
@@ -6,7 +6,8 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-If there is a Distributed Denial of Service (DDoS) alert in Icinga this means that AWS have detected a probable DDoS attack on one or more of the AWS Shield Advanced
+If there is a Distributed Denial of Service (DDoS) alert in Icinga this means that
+AWS have detected a probable DDoS attack on one or more of the AWS Shield Advanced
 protected resources.
 
 If the alert is `UNKNOWN`, this means that the alert is not working properly.
@@ -22,3 +23,23 @@ If the alert is `CRITICAL`, you should take the following actions to investigate
 
 The alert will appear on the Icinga dashboard for 24 hours after it was first triggered
 due to the sparse metrics.
+
+## AWS Shield Response Team (SRT)
+
+We have pre-configured an [IAM role for the SRT team to use](https://github.com/alphagov/govuk-aws/pull/1550/files).
+
+It is currently not assigned to any resources, but when activated will allow
+the SRT to view our shielded resources and edit things such as Web Application
+Firewall (WAF) rules, Access Control Lists (webacls), Shield and CloudFront
+configurations.
+
+We should not enable the role unless we are [engaged with the team](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-edit-drt.html)
+as a result of an incident.
+
+To enable the role:
+
+1. Open the AWS console for the affected environment, eg `gds aws govuk-integration-poweruser -l`
+1. Navigate to the [Edit AWS Shield Response Team (SRT) access page](https://console.aws.amazon.com/wafv2/shieldv2#/drt_settings/edit)
+1. In the AWS Shield Response Team (SRT) access section, select the "Choose an existing role for the SRT to access my accounts." radio button.
+1. From the role name drop down, select "shield-response-team-access".
+1. Click Save to apply the changes.


### PR DESCRIPTION
This role has been created for AWS SRT to use if they are helping us investigate DDOS events. Rather than manually creating a new one via the console, we should use the one [created in govuk-aws](https://github.com/alphagov/govuk-aws/pull/1550).