### PR TITLE
Add aws-vault as a dependency of gds-cli

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -84,6 +84,7 @@ On GOV.UK we use the following command-line tools for AWS and SSH access:
     ```bash
     brew tap alphagov/gds
     brew install gds-cli govuk-connect
+    brew install --cask aws-vault
     ```
 
     The GDS CLI repository is private, so you must first [set up your GitHub account](#2-set-up-your-github-account).


### PR DESCRIPTION
gds-cli needs aws-vault, so if you're doing a fresh install you'll need to install that as well.