### PR TITLE
Rewrite policy around dependency management

### DIFF
--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -23,11 +23,13 @@ Where an exploitable security vulnerability has been identified and patched, we 
 
 If a vulnerability is only theoretical - for example, an issue in a library that is only used in your test suite and not user facing, then our normal dependency upgrade procedure applies. See next sections.
 
-### Stay within two major releases
+### Stay within two significant releases
 
 We should always stay within two major releases from the current major release of any given software. There is some industry precedent for this: providers such as Terraform [expect customers to stay within two major releases](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy) in order to receive optimal support.
 
-This is a rough guide. For example, if the latest version of something is version 9, and we're on version 6, we should update to at least version 7, even if version 6 hasn't reached EOL yet. The opposite is true too: if version 7 is EOL, we should update straight to version 8, even though version 7 is within two major versions of the latest.
+This is a rough guide.  Some projects, such as Ruby, don't necessarily follow [semver](https://semver.org/), and consider their minor versions to be significant upgrades. In these cases, you should stay within two minor releases of the latest.
+
+Another consideration is EOL. For example, if the latest version of something is version 9, and we're on version 7, but version 7 is EOL, we should update to version 8, despite version 7 being within two major versions of the latest.
 
 The two-major-releases rule allows some wiggle-room for keeping upgrade cadences manageable. Teams don't have to worry about upgrading to a new major version the moment it becomes available, but shouldn't allow themselves to fall too far behind. Teams can leverage tools such as [Dependabot](https://docs.publishing.service.gov.uk/manual/manage-ruby-dependencies.html) to automate much of the chore work.
 

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -7,13 +7,41 @@ section: Dependencies
 type: learn
 ---
 
-One of our core values is to use secure and up to date software. This document lays out the policy for keeping our Ruby on Rails software current.
+One of our core values is to use secure and up-to-date software. This document lays out the policy for keeping our software current.
 
-## Introduction
+## Guiding principles
 
-We run a lot of Rails applications. This means that we have dependencies on both Rails and Ruby versions.
+### Don't run EOL software
 
-### Upgrading Rails
+We should never be running [EOL (End-of-life) software](https://en.wikipedia.org/wiki/End-of-life_product).
+
+We should also ensure that we upgrade software in plenty of time before its EOL deadline. This is something we're hoping to keep track of by reviewing the [dependency management spreadsheet](https://docs.google.com/spreadsheets/d/137KZhjctJ8qTKYPnq2QNVkyoIC6ok7KA2G1vErNC6Oo/edit) on a regular basis.
+
+### Apply security patches quickly
+
+Where an exploitable security vulnerability has been identified and patched, we must work quickly in applying the security patches, dropping other priorities if necessary.
+
+If a vulnerability is only theoretical - for example, an issue in a library that is only used in your test suite and not user facing, then our normal dependency upgrade procedure applies. See next sections.
+
+### Stay within two major releases
+
+We should always stay within two major releases from the current major release of any given software.
+
+This is a rough guide. Providers such as Terraform [expect customers to stay within two major releases](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy) in order to receive optimal support.
+
+The two-major-releases rule allows some wiggle-room for keeping upgrade cadences manageable. Teams don't have to worry about upgrading to a new major version the moment it becomes available, but shouldn't allow themselves to fall too far behind. Teams can leverage tools such as [Dependabot](https://docs.publishing.service.gov.uk/manual/manage-ruby-dependencies.html) to automate much of the chore work.
+
+### Prioritise dependencies over subdependencies
+
+In a perfect world, all software would always be fully up to date. However, this comes with a big developer overhead.
+
+In [RFC-126](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-126-custom-configuration-for-dependabot.md), we agreed to configure Dependabot to only raise pull requests for important dependencies, so that we had a realistic chance of keeping on top of them all. We've prioritised security updates, internal dependencies and framework dependencies, and have configured Dependabot to only update top-level dependencies. We are less focussed on ensuring that dependencies of dependencies are kept up to date.
+
+## Exceptions
+
+Some dependencies have a stricter updates policy.
+
+### Rails
 
 It's very important that we're running a currently supported version of Rails for all applications, otherwise we aren't covered by security fixes. We should:
 
@@ -25,7 +53,7 @@ See [Upgrading Ruby on Rails][] for a guide on how to upgrade Rails.
 
 [Upgrading Ruby on Rails]: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
-### Upgrading Ruby
+### Ruby
 
 New versions of Ruby bring us improved performance and nicer syntax for certain things, but also can cause issues with the libraries etc. we use. We should:
 

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -25,9 +25,9 @@ If a vulnerability is only theoretical - for example, an issue in a library that
 
 ### Stay within two major releases
 
-We should always stay within two major releases from the current major release of any given software.
+We should always stay within two major releases from the current major release of any given software. There is some industry precedent for this: providers such as Terraform [expect customers to stay within two major releases](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy) in order to receive optimal support.
 
-This is a rough guide. Providers such as Terraform [expect customers to stay within two major releases](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy) in order to receive optimal support.
+This is a rough guide. For example, if the latest version of something is version 9, and we're on version 6, we should update to at least version 7, even if version 6 hasn't reached EOL yet. The opposite is true too: if version 7 is EOL, we should update straight to version 8, even though version 7 is within two major versions of the latest.
 
 The two-major-releases rule allows some wiggle-room for keeping upgrade cadences manageable. Teams don't have to worry about upgrading to a new major version the moment it becomes available, but shouldn't allow themselves to fall too far behind. Teams can leverage tools such as [Dependabot](https://docs.publishing.service.gov.uk/manual/manage-ruby-dependencies.html) to automate much of the chore work.
 


### PR DESCRIPTION
This follows a discussion between several members of Senior Tech and members of the Platform Reliability team.

[Trello](https://trello.com/c/TQj5sGXq/2881-update-govuk-policy-on-software-versions-and-dependency-management)