### PR TITLE
Replace restart harvesting instructions referencing fab

### DIFF
--- a/source/manual/data-gov-uk-supporting-ckan.html.md
+++ b/source/manual/data-gov-uk-supporting-ckan.html.md
@@ -434,23 +434,39 @@ them. There are both 'gather' and 'fetch' jobs that may need restarting:
 'Gather' jobs retrieve the identifiers of the updated datasets and create jobs
 in the fetch queue. To restart, run:
 
-```
+```bash
 $ sudo initctl restart harvester_gather_consumer-procfile-worker
 ```
 
 'Fetch' jobs retrieve the datasets from the remote source and perform the relevant
 updates in CKAN. To restart, run:
 
-```
+```bash
 $ sudo initctl restart harvester_fetch_consumer-procfile-worker
 ```
 
-Alternatively, if the server has stopped, there is a Fabric script that will restart
-it for you. It will only restart if it detects the harvesting process is no longer
-running, so is safe to run immediately if you suspect the process has crashed:
+Alternatively, if the server has stopped, you can restart it with `initctl`.
+You must ensure it is safe to restart the process first, by checking if the harvest is still running.
+
+To check the status of both harvesters:
 
 ```bash
-$ fab aws_production class:ckan ckan.restart_harvester
+$ sudo initctl list | grep harvester_gather_consumer-procfile-worker_child | grep start
+$ sudo initctl list | grep harvester_fetch_consumer-procfile-worker_child | grep start
+```
+
+If either are not running you can restart the gather harvester using the following commands:
+
+```bash
+$ sudo initctl stop harvester_gather_consumer-procfile
+$ sudo initctl start harvester_gather_consumer-procfile
+```
+
+and fetch harvesters using the following commands:
+
+```bash
+$ sudo initctl stop harvester_fetch_consumer-procfile
+$ sudo initctl start harvester_fetch_consumer-procfile
 ```
 
 ### CKAN publisher on Staging environment responds with Nginx 504 timeout:


### PR DESCRIPTION
[Trello](https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs)

Fabric has been deprecated, we are replacing refrences with commands
that can be run directly on each box

![image](https://user-images.githubusercontent.com/3694062/156808113-ac365875-153d-4bbd-9f68-92d938ad220a.png)

