### PR TITLE
Shipping auth logs to Cyber's Splunk

### DIFF
--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -54,3 +54,17 @@ In the future this will be replaced.
 ## Fastly
 
 Fastly sends logs to S3 for the www, assets and bouncer services. These can be [queried through Athena](/manual/query-cdn-logs.html).
+
+Logs are also available in Splunk in the `govuk_cdn` index. Here's an [example query for POST requests](https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3Dgovuk_cdn%20http_method%3Dpost)
+
+## SSH logs
+
+We ship `/var/log/auth.log` to Splunk [via CloudWatch](https://github.com/alphagov/govuk-puppet/pull/11559) and CDIO Cyber's [centralised security logging service](https://github.com/alphagov/centralised-security-logging-service/blob/master/kinesis_processor%2Faccounts_loggroup_index.toml#L1430-L1440).
+
+There are different indices for each environment:
+
+- [govuk_production](https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_production%22)
+- [govuk_staging](https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_staging%22)
+- [govuk_integration](https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_integration%22)
+
+You can see the logs if your account has access to GOV.UK's Splunk. If you do not have access to Splunk, you can request access by raising a support ticket with IT and asking them to enable Splunk for your Google account with a note that you work on GOV.UK.


### PR DESCRIPTION
We have enabled log shipping to Splunk. These are some basic docs, which I expect to be expanded when we find useful things that can be done with them!

https://trello.com/c/3PEIdbKp/2861-ship-ssh-logs-from-jumpboxes-to-splunk-5