### PR TITLE
Remove mentions of manuals-frontend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,8 @@ task :verify_deployable_apps do
 
       kibana-gds
       sidekiq-monitoring
+
+      manuals-frontend
     ]
 
   missing_apps = (deployable_applications - (our_applications + intentionally_missing)).uniq

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -136,7 +136,6 @@ redirects:
   /apps/link-checker-api.html: /repos/link-checker-api.html
   /apps/local-links-manager.html: /repos/local-links-manager.html
   /apps/locations-api.html: /repos/locations-api.html
-  /apps/manuals-frontend.html: /repos/manuals-frontend.html
   /apps/manuals-publisher.html: /repos/manuals-publisher.html
   /apps/mapit.html: /repos/mapit.html
   /apps/maslow.html: /repos/maslow.html

--- a/data/rendering-apps.yml
+++ b/data/rendering-apps.yml
@@ -418,10 +418,10 @@
   - whitehall-frontend
 - :name: manual
   :apps:
-  - manuals-frontend
+  - government-frontend
 - :name: manual_section
   :apps:
-  - manuals-frontend
+  - government-frontend
 - :name: detailed_guidance
   :apps:
   - whitehall-frontend
@@ -430,10 +430,10 @@
   - government-frontend
 - :name: hmrc_manual
   :apps:
-  - manuals-frontend
+  - government-frontend
 - :name: hmrc_manual_section
   :apps:
-  - manuals-frontend
+  - government-frontend
 - :name: international_development_fund
   :apps:
   - government-frontend

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -829,9 +829,13 @@
   type: Data science
 
 - repo_name: manuals-frontend
+  retired: true
   type: Frontend apps
   team: "#find-and-view-tech"
   production_hosted_on: aws
+  description: |
+    Used to host manuals from manuals-publisher and hmrc-manuals-api
+    (now hosted by government-frontend)
 
 - repo_name: manuals-publisher
   type: Publishing apps

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -12,7 +12,7 @@ Each application should be owned by a team. [What application ownership means in
 Apps can be loosely grouped into different types, including:
 
 - **APIs** provide functionality to other apps. For example, an app can publish content via Publishing API.
-- **Frontend apps** render content to GOV.UK users. For example, a [HMRC manual page][hmrc-manual] is rendered by an application called [manuals-frontend][manuals-frontend]. Use the [chrome extension][extension] to find out which application is rendering any given page, and [read more about the frontend architecture on GOV.UK](/manual/frontend-architecture.html).
+- **Frontend apps** render content to GOV.UK users. For example, a [HMRC manual page][hmrc-manual] is rendered by an application called [government-frontend][government-frontend]. Use the [chrome extension][extension] to find out which application is rendering any given page, and [read more about the frontend architecture on GOV.UK](/manual/frontend-architecture.html).
 - **Publishing apps** are used by editors to publish content to GOV.UK. For example, [specialist-publisher][specialist-publisher] publishes [specialist documents][specialist documents]. The apps are secured by behind a [single signon system][signon].
 
 ## Apps by type


### PR DESCRIPTION
## WHAT
Remove reference to manuals-frontend, update docs for apps that use it to mention government-frontend instead.

## WHY
We'd like to migrate the rendering so we can retire manuals-frontend as on trello ticket.

### Trello
https://trello.com/c/CfH8SX6D/1130-manuals-update-developer-documents

## RELATED
https://github.com/alphagov/hmrc-manuals-api/pull/664
https://github.com/alphagov/manuals-publisher/pull/1844