### PR TITLE
Removes mention of RE GOV.UK team, and clarifies 2nd Line numbers

### DIFF
--- a/source/manual/welcome-to-2nd-line.html.md
+++ b/source/manual/welcome-to-2nd-line.html.md
@@ -9,7 +9,9 @@ type: learn
 
 If you’re new to 2nd line or have not worked with us for a while, here’s a brief introduction to what we do and how we work.
 
-Every Wednesday 3 people from GOV.UK - 2 developers and a shadow developer - join the team to work on 2nd line. An 'interruptible' reliability engineer from the [RE GOV.UK Infra team also sits with the team](/manual/raising-issues-with-reliability-engineering.html#header). You can check the [2nd line support rota](https://docs.google.com/spreadsheets/d/1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU/edit#gid=10) to find out when your shift is.
+Every Wednesday at least 2 people from GOV.UK - 2 developers and usually a shadow developer - join the team to work on 2nd line. [An 'interruptible' Site Reliability Engineer (SRE) is also available](/manual/raising-issues-with-reliability-engineering.html).
+
+You can check the [2nd line support rota](https://docs.google.com/spreadsheets/d/1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU/edit#gid=10) to find out when your shift is.
 
 Your main responsibility is to respond to alerts. You’ll be set up in [PagerDuty](https://governmentdigitalservice.pagerduty.com/schedules#?offset=5) so that you can be called if there are any urgent alerts during working hours.
 


### PR DESCRIPTION
A few changes to the 2nd Line welcome docs to:
-clarify that there won't *always* be a shadow
-remove mention of RE:GOV.UK team which no longer exists