### PR TITLE
Update ownership and URL for govspeak-preview app

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -236,7 +236,7 @@
   type: Gems
 
 - github_repo_name: govspeak-preview
-  team:
+  team: "#govuk-publishing-tech"
   type: Utilities
 
 - github_repo_name: govuk-accessibility-reports

--- a/source/manual/howto-find-hardcoded-markup-govspeak.html.md
+++ b/source/manual/howto-find-hardcoded-markup-govspeak.html.md
@@ -58,7 +58,7 @@ Edition.where.not(content_store: nil).find_each { |e| puts "https://gov.uk#{e.ba
 Edition.where.not(content_store: nil).find_each { |e| puts "https://gov.uk#{e.base_path}" if e.details.to_s =~ /class=\\"button/ }
 ```
 
-[Govspeak]: http://govspeak-preview.herokuapp.com/
+[Govspeak]: https://govspeak-preview.publishing.service.gov.uk
 [Getting Started]: /manual/get-started.html
 [publishing-api]: https://github.com/alphagov/publishing-api
 [Find instances of a keyword on GOV.UK]: https://gov-uk.atlassian.net/wiki/spaces/CC/pages/1314488405/Find+instances+of+a+keyword+on+GOV.UK


### PR DESCRIPTION
- Updates the owner of govspeak-preview to be the GOV.UK Publishing Service team
- Changes the URL to match the change in https://github.com/alphagov/govuk-dns-config/pull/788

[Trello card](https://trello.com/c/al645JXy/230-change-url-of-govspeak-and-govspeak-preview-application-to-show-they-are-a-govuk-service)