### PR TITLE
Correct typo in the detaching ASG doc

### DIFF
--- a/source/manual/common-aws-tasks-for-2nd-line-support.html.md
+++ b/source/manual/common-aws-tasks-for-2nd-line-support.html.md
@@ -90,7 +90,7 @@ Log into the AWS console for the relevant environment:
   gds aws govuk-production-poweruser -l
   ```
 
-Refer to the AWS documentation on steps for on [how to detatch an instance from an ASG][]
+Refer to the AWS documentation on steps for on [how to detach an instance from an ASG][]
 
 If a machine is unhealthy, you may want to detach an instance from its Auto
 Scaling Group (ASG). Detaching the instance stops it receiving requests.


### PR DESCRIPTION
There is a typo on the "how to detach an instance from an ASG" link
which means the link isn't linking.

https://docs.publishing.service.gov.uk/manual/common-aws-tasks-for-2nd-line-support.html#detaching-an-instance-from-an-auto-scaling-group