### PR TITLE
Update docs to state GCP access is needed for DNS deploys

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -88,8 +88,7 @@ After you deploy, you can visit the [Jenkins job](https://deploy.blue.production
 > will require access to the GOV.UK AWS "production" account to roll changes for
 > both Amazon and Google.
 > - The order in which you deploy to providers is not important.
-> - You will not require credentials for Google Cloud. These credentials are stored
-> in Jenkins itself.
+> - You will need to be able to [use the Google Cloud (gcloud) CLI](/manual/google-cloud-platform-gcp.html#using-the-cli) to authenticate to Google Cloud. Everyone with permanent production access should have [access to GCP](/manual/google-cloud-platform-gcp.html#gcp-access).
 
 #### Google-based caveats
 


### PR DESCRIPTION
This was updated in https://github.com/alphagov/govuk-puppet/pull/11168
to avoid having to store google credentials with administrative
privileges in Jenkins.

The process now involves using the gcloud CLI to get a temporary access
token, and providing this to Jenkins via the API (as we do with AWS
tokens).