### PR TITLE
Remove reference to ci-agent Icinga domain

### DIFF
--- a/source/manual/jenkins-ci.html.md
+++ b/source/manual/jenkins-ci.html.md
@@ -32,8 +32,6 @@ Components:
     the same services, this is managed with Puppet. Check the `govuk_ci::master::ci_agents` label keys in
     [Hiera](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml) for more information.
 - Supporting services:
-  - An [Icinga instance](https://ci-alert.integration.publishing.service.gov.uk) to monitor the
-    status of CI and the supporting infrastructure.
   - A [Deploy Jenkins instance](https://deploy.integration.publishing.service.gov.uk) to deploy Puppet
     in to the environment and run any other adhoc tasks.
   - [Graphite](https://ci-graphite.integration.publishing.service.gov.uk) and [Grafana](https://ci-grafana.integration.publishing.service.gov.uk)


### PR DESCRIPTION
This old CI icinga monitored the CI machines that used to run in Carrenza.
All of that was decommissioned a while back and CI was moved to AWS integration.
CI is now monitored by the same Icinga that monitors the rest of integration.