### PR TITLE
Mark 'Locations API' as a deployed app

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -477,9 +477,7 @@
 - github_repo_name: locations-api
   type: APIs
   team: "#govuk-platform-reliability-team"
-  sentry_url: false
-  dashboard_url: false
-  deploy_url: false
+  production_hosted_on: aws
 
 - github_repo_name: manuals-frontend
   type: Frontend apps


### PR DESCRIPTION
This will mean Locations API appears on https://docs.publishing.service.gov.uk/apps.json, which will allow us to add it to Sentry.

Trello: https://trello.com/c/gPRVvLXh/2848-set-up-remaining-infrastructure-for-locations-api-5