### PR TITLE
Document how to run the `update_project` Rake task

### DIFF
--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -242,6 +242,16 @@ Open a pull request to add your Rails app to the [GOV.UK developer documentation
 
 After you’ve added your Rails app to the GOV.UK developer documentation, run the [`update_project` rake task][sentry-update-project-rake-task] in [GOV.UK SaaS Config][govuk-saas-config] to update Sentry.
 
+From the `sentry` directory, run:
+
+```
+SENTRY_AUTH_TOKEN="token_value" bundle exec rake update_project[APP_NAME]
+```
+
+You'll need to [create a Sentry auth token](https://sentry.io/settings/account/api/auth-tokens/) first. Make sure it has the `project:write` scope. You can delete the token once you've successfully run the rake task.
+
+The rake task will create a 'project' for the app under the team name denoted by the app's `team` in the Developer Docs. If the team does not exist in Sentry yet, you can manually create it in the Sentry UI. If the Sentry team name does not match the Slack channel `team` name used in the Developer Docs, you can temporarily rename it so that it matches what the rake task expects, and then change it back later.
+
 ### Add your Rails app to Release app
 
 Add your Rails app to the [Release][release] app and select __Create__.


### PR DESCRIPTION
Note that Locations API is owned by `#govuk-platform-reliability-team`, which the rake task converts to `govuk-platform-reliability-team-team` for the purposes of creating the Sentry project. I had to manually create a team of that name, and then remove the extra `-team` from the team name once the Locations API project had been created.

I've documented this in case it is useful to future developers.

Trello: https://trello.com/c/gPRVvLXh/2848-set-up-remaining-infrastructure-for-locations-api-5