### PR TITLE
Update publishing govspeak/govspeak-preview ownership

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -232,7 +232,7 @@
   production_hosted_on: aws
 
 - github_repo_name: govspeak
-  team:
+  team: "#govuk-publishing-tech"
   type: Gems
 
 - github_repo_name: govspeak-preview

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -236,8 +236,12 @@
   type: Gems
 
 - github_repo_name: govspeak-preview
+  management_url: https://govspeak-preview.publishing.service.gov.uk
   team: "#govuk-publishing-tech"
+  production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-accessibility-reports
   team: "#govuk-data-labs"


### PR DESCRIPTION
This marks govspeak as an app owned by govuk-publishing, since publishing acquired as part of owning govspeak-preview (as per https://trello.com/c/al645JXy/230-change-url-of-govspeak-and-govspeak-preview-application-to-show-they-are-a-govuk-service)

This also updates the ownership data of govspeak preview so that that tool is represented as a hosted application rather than un-hosted utility.