### PR TITLE
Fix incorrect repo links

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -129,12 +129,6 @@ class App
     app_data["dashboard_url"] || "https://grafana.production.govuk.digital/dashboard/file/#{app_name}.json"
   end
 
-  def publishing_e2e_tests_url
-    if ["Frontend apps", "Publishing apps"].include?(type)
-      "https://github.com/alphagov/publishing-e2e-tests/search?q=%22#{app_name.underscore}%3A+true%22+path%3A%2Fspec%2F"
-    end
-  end
-
   def api_docs_url
     app_data["api_docs_url"]
   end

--- a/app/app.rb
+++ b/app/app.rb
@@ -114,7 +114,7 @@ class App
   end
 
   def deploy_url
-    return if app_data["deploy_url"] == false || %w[none heroku].include?(production_hosted_on)
+    return if app_data["deploy_url"] == false || [nil, "none", "heroku"].include?(production_hosted_on)
 
     if production_hosted_on == "paas"
       app_data["deploy_url"]

--- a/app/app.rb
+++ b/app/app.rb
@@ -159,7 +159,9 @@ class App
   end
 
   def production_url
-    app_data["production_url"] || (type.in?(["Publishing app", "Admin app"]) ? "https://#{app_name}.publishing.service.gov.uk" : nil)
+    return if app_data["production_url"] == false
+
+    app_data["production_url"] || (type.in?(["Publishing apps", "Supporting apps"]) ? "https://#{app_name}.publishing.service.gov.uk" : nil)
   end
 
   def readme

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -18,6 +18,7 @@
   type: Supporting apps
   team: "#find-and-view-tech"
   production_hosted_on: aws
+  production_url: false
 
 - github_repo_name: blinkenjs
   app_name: govuk-secondline-blinken
@@ -31,6 +32,7 @@
   type: Transition apps
   team: "#find-and-view-tech"
   production_hosted_on: aws
+  production_url: false
 
 - github_repo_name: bulk-merger
   type: Utilities
@@ -90,6 +92,7 @@
   team: "#govuk-datagovuk"
   production_hosted_on: aws
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
+  production_url: https://ckan.publishing.service.gov.uk/
 
 - github_repo_name: collections
   type: Frontend apps
@@ -135,6 +138,7 @@
   type: APIs
   team: "#govuk-publishing-tech"
   production_hosted_on: aws
+  production_url: https://www.gov.uk/api/content
 
 - github_repo_name: content-tagger
   type: Publishing apps
@@ -142,7 +146,7 @@
   production_hosted_on: aws
 
 - github_repo_name: datagovuk-tech-docs
-  management_url: https://guidance.data.gov.uk/
+  production_url: https://guidance.data.gov.uk/
   production_hosted_on: paas
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
@@ -172,6 +176,7 @@
 
 - github_repo_name: datagovuk_reference
   team: "#govuk-datagovuk"
+  production_url: https://interval-server.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/interval-server
   production_hosted_on: heroku
   type: data.gov.uk apps
@@ -260,7 +265,8 @@
   dashboard_url: false
 
 - github_repo_name: govspeak-preview
-  management_url: https://govspeak-preview.publishing.service.gov.uk
+  production_url: https://govspeak-preview.publishing.service.gov.uk
+  management_url: https://dashboard.heroku.com/apps/govspeak-preview
   team: "#govuk-publishing-tech"
   production_hosted_on: heroku
   type: Utilities
@@ -309,6 +315,7 @@
 
 - github_repo_name: govuk-content-schemas
   app_name: govuk-content-store-examples
+  production_url: https://govuk-content-store-examples.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/govuk-content-store-examples
   team: "#govuk-publishing-tech"
   production_hosted_on: heroku
@@ -326,6 +333,7 @@
 
 - github_repo_name: govuk-dependencies
   team: "#govuk-platform-reliability-team"
+  production_url: https://govuk-dependencies.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/govuk-dependencies
   production_hosted_on: heroku
   type: Utilities
@@ -382,6 +390,7 @@
 
 - github_repo_name: govuk-pact-broker
   team: "#govuk-platform-reliability-team"
+  production_url: https://pact-broker.cloudapps.digital/
   production_hosted_on: paas
   type: Utilities
   sentry_url: false
@@ -489,6 +498,7 @@
 - github_repo_name: govuk_publishing_components
   team:
   type: Gems
+  production_url: https://components.publishing.service.gov.uk
   sentry_url: false
   dashboard_url: false
 
@@ -698,6 +708,7 @@
   type: Supporting apps
   team: "#find-and-view-tech"
   production_hosted_on: aws
+  production_url: false
 
 - github_repo_name: router-api
   type: APIs
@@ -731,9 +742,12 @@
   type: APIs
   team: "#find-and-view-tech"
   production_hosted_on: aws
+  production_url: https://www.gov.uk/api/search.json
 
 - github_repo_name: search-performance-explorer
   production_hosted_on: heroku
+  production_url: https://search-performance-explorer.herokuapp.com/
+  management_url: https://dashboard.heroku.com/apps/search-performance-explorer
   team: "#find-and-view-tech"
   type: Utilities
   sentry_url: false
@@ -755,6 +769,7 @@
   production_hosted_on: aws
 
 - github_repo_name: side-by-side-browser
+  production_url: https://govuk-side-by-side-browser.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
   production_hosted_on: heroku
   type: Transition apps

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -213,7 +213,7 @@
   production_hosted_on: aws
 
 - github_repo_name: email-alert-monitoring
-  type: Utlities
+  type: Utilities
   team: "#govuk-accounts-tech"
   sentry_url: false
   dashboard_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -383,7 +383,7 @@
   dashboard_url: false
 
 - github_repo_name: govuk-load-testing
-  type: Supporting apps
+  type: Utilities
   team: "#govuk-platform-reliability-team"
   sentry_url: false
   dashboard_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -368,8 +368,8 @@
 
 - github_repo_name: govuk-jenkinslib
   team: "#govuk-platform-reliability-team"
-  production_hosted_on: aws
   type: Utilities
+  description: Groovy library for common GOV.UK Jenkins CI tasks
   sentry_url: false
   dashboard_url: false
 

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -11,6 +11,8 @@
 - github_repo_name: asset_bom_removal-rails
   type: Gems
   team:
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: authenticating-proxy
   type: Supporting apps
@@ -22,6 +24,8 @@
   management_url: https://dashboard.heroku.com/apps/govuk-secondline-blinken
   production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: bouncer
   type: Transition apps
@@ -32,6 +36,8 @@
   type: Utilities
   team:
   description: For bulk merging Pull Requests for GOV.UK repos.
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: business-support-api
   retired: true
@@ -75,6 +81,8 @@
 - github_repo_name: ckan-functional-tests
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: ckanext-datagovuk
   puppet_name: ckan
@@ -138,6 +146,8 @@
   production_hosted_on: paas
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: datagovuk_find
   type: data.gov.uk apps
@@ -157,12 +167,16 @@
   production_hosted_on: paas
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: datagovuk_reference
   team: "#govuk-datagovuk"
   management_url: https://dashboard.heroku.com/apps/interval-server
   production_hosted_on: heroku
   type: data.gov.uk apps
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: design-principles
   type: Frontend apps
@@ -179,6 +193,8 @@
   team: "#govuk-data-labs"
   type: Data science
   description: Prototype to show content with eligibility based on a user's circumstances
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: email-alert-api
   type: APIs
@@ -194,6 +210,8 @@
 - github_repo_name: email-alert-monitoring
   type: Utlities
   team: "#govuk-accounts-tech"
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: email-alert-service
   type: Services
@@ -219,11 +237,15 @@
 - github_repo_name: gds-api-adapters
   team: "#govuk-developers"
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: gds-sso
   team:
   type: Gems
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: government-frontend
   type: Frontend apps
@@ -234,6 +256,8 @@
 - github_repo_name: govspeak
   team: "#govuk-publishing-tech"
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govspeak-preview
   management_url: https://govspeak-preview.publishing.service.gov.uk
@@ -248,28 +272,40 @@
   type: Data science
   description: Project containing numerous report generators to monitor accessibility
     on GOV.UK.
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-app-deployment
   team:
   type: Utilities
   description: Capistrano deployment scripts for applications running on GOV.UK.
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-aws
   team: "#govuk-platform-reliability-team"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-aws-data
   private_repo: true
   team: "#govuk-platform-reliability-team"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-browser-extension
   team: "#govuk-developers"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-cdn-config
   team: "#govuk-platform-reliability-team"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-content-schemas
   app_name: govuk-content-store-examples
@@ -277,6 +313,8 @@
   team: "#govuk-publishing-tech"
   production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-delivery
   retired: true
@@ -291,29 +329,41 @@
   management_url: https://dashboard.heroku.com/apps/govuk-dependencies
   production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-deploy-lag-badger
   team: "#govuk-platform-reliability-team"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-display-screen
   management_url: https://dashboard.heroku.com/apps/govuk-display-screen
   production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-dns
   team: "#govuk-platform-reliability-team"
   type: Utilities
   description: Tasks for managing DNS records
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-docker
   team: "#govuk-developers"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-jenkinslib
   team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-knowledge-graph
   private_repo: true
@@ -321,64 +371,90 @@
   type: Data science
   description: Experiment with setting up an extended property graph of GOV.UK organisations
     and associated content.
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-load-testing
   type: Supporting apps
   team: "#govuk-platform-reliability-team"
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-pact-broker
   team: "#govuk-platform-reliability-team"
   production_hosted_on: paas
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-puppet
   team: "#govuk-developers"
   type: Utilities
   deploy_url: https://github.com/alphagov/govuk-secrets/blob/main/puppet_aws/deploy.sh
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-related-links-recommender
   team: "#govuk-data-labs"
   type: Data science
   description: Machine learning model to recommend related content
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-saas-config
   team:
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-secrets
   private_repo: true
   team: "#govuk-platform-reliability-team"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-user-intent-survey-explorer
   private_repo: true
   team: "#govuk-data-labs"
   type: Data science
   description: Prototype to help explorer user intent survey data
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-user-journey-models
   private_repo: true
   team: "#govuk-data-labs"
   type: Data science
   description: Classifying successful and unsuccessful user journeys on GOV.UK
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-user-reviewer
   private_repo: true
   team:
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk-zendesk-display-screen
   management_url: https://dashboard.heroku.com/apps/govuk-zendesk-display-screen
   production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_ab_testing
   team: "#govuk-developers"
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_app_config
   team: "#govuk-developers"
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_content_api
   retired: true
@@ -392,10 +468,14 @@
 - github_repo_name: govuk_document_types
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_message_queue_consumer
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_need_api
   retired: true
@@ -409,18 +489,26 @@
 - github_repo_name: govuk_publishing_components
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_schemas
   team: "#govuk-developers"
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_sidekiq
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: govuk_taxonomy_helpers
   team:
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: hmrc-manuals-api
   type: APIs
@@ -525,10 +613,14 @@
 - github_repo_name: omniauth-gds
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: optic14n
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: organisations-publisher
   type: Publishing apps
@@ -555,6 +647,8 @@
 - github_repo_name: plek
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: policy-publisher
   retired: true
@@ -580,14 +674,20 @@
 - github_repo_name: publishing-e2e-tests
   team: "#govuk-publishing-tech"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: rack-logstasher
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: rails_translation_manager
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: release
   type: Supporting apps
@@ -607,12 +707,16 @@
 - github_repo_name: rubocop-govuk
   team:
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: seal
   team: "#govuk-platform-reliability-team"
   management_url: https://dashboard.heroku.com/apps/moody-seal
   production_hosted_on: heroku
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: search-admin
   type: Supporting apps
@@ -632,6 +736,8 @@
   production_hosted_on: heroku
   team: "#find-and-view-tech"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: service-manual-frontend
   team: "#find-and-view-tech"
@@ -652,10 +758,14 @@
   management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
   production_hosted_on: heroku
   type: Transition apps
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: sidekiq-monitoring
   team:
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: signon
   type: Supporting apps
@@ -665,6 +775,8 @@
 - github_repo_name: slimmer
   team: "#govuk-developers"
   type: Gems
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: smart-answers
   type: Frontend apps
@@ -675,10 +787,14 @@
 - github_repo_name: smokey
   team: "#govuk-developers"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: special-route-publisher
   team: "#govuk-publishing-tech"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: specialist-frontend
   type: Frontend apps
@@ -711,10 +827,13 @@
   type: Transition apps
   team: "#govuk-publishing-tech"
   production_hosted_on: aws
+  production_url: https://transition.publishing.service.gov.uk
 
 - github_repo_name: transition-config
   type: Transition apps
   team: "#govuk-publishing-tech"
+  sentry_url: false
+  dashboard_url: false
 
 - github_repo_name: travel-advice-publisher
   type: Publishing apps

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -723,7 +723,7 @@
 
 - github_repo_name: seal
   team: "#govuk-platform-reliability-team"
-  management_url: https://dashboard.heroku.com/apps/moody-seal
+  management_url: https://dashboard.heroku.com/apps/govuk-seal
   production_hosted_on: heroku
   type: Utilities
   sentry_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -125,7 +125,7 @@
   production_hosted_on: aws
 
 - github_repo_name: content-data-api
-  type: Supporting apps
+  type: APIs
   team: "#govuk-platform-reliability-team"
   production_hosted_on: aws
 

--- a/source/partials/application/_links.html.erb
+++ b/source/partials/application/_links.html.erb
@@ -1,37 +1,21 @@
+<%
+
+links = [
+  (link_to("Sentry (error tracking)", application.sentry_url, class: "govuk-link") if application.sentry_url),
+  (link_to("Manage application", application.management_url, class: "govuk-link") if application.management_url),
+  (link_to("Puppet configuration", application.puppet_url, class: "govuk-link") if application.puppet_url),
+  (link_to("Deploy scripts", application.deploy_url, class: "govuk-link") if application.deploy_url),
+  (link_to("Deployment dashboard", application.dashboard_url, class: "govuk-link") if application.dashboard_url),
+  (link_to("API docs", application.api_docs_url, class: "govuk-link") if application.api_docs_url),
+  (link_to("Component guide", application.component_guide_url, class: "govuk-link") if application.component_guide_url),
+  (link_to("Metrics dashboard", application.metrics_dashboard_url, class: "govuk-link") if application.metrics_dashboard_url),
+  (link_to(application.production_url.gsub("https://", ""), application.production_url, class: "govuk-link") if application.production_url),
+]
+
+if links.any?
+%>
 <ul class="govuk-list">
-  <% if application.sentry_url %>
-    <li><%= link_to "Sentry (error tracking)", application.sentry_url, class: "govuk-link" %></li>
+  <% links.each do |link| %>
+    <li><%= link %></li>
   <% end %>
-
-  <% if application.management_url %>
-    <li><%= link_to "Manage application", application.management_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.puppet_url %>
-    <li><%= link_to "Puppet configuration", application.puppet_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.deploy_url %>
-    <li><%= link_to "Deploy scripts", application.deploy_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.dashboard_url %>
-    <li><%= link_to "Deployment dashboard", application.dashboard_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.api_docs_url %>
-    <li><%= link_to "API docs", application.api_docs_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.component_guide_url %>
-    <li><%= link_to "Component guide", application.component_guide_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.metrics_dashboard_url %>
-    <li><%= link_to "Metrics dashboard", application.metrics_dashboard_url, class: "govuk-link" %></li>
-  <% end %>
-
-  <% if application.production_url %>
-    <li><%= link_to application.production_url.gsub('https://', ''), application.production_url, class: "govuk-link" %></li>
-  <% end %>
-</ul>
+<% end %>

--- a/source/partials/application/_links.html.erb
+++ b/source/partials/application/_links.html.erb
@@ -19,10 +19,6 @@
     <li><%= link_to "Deployment dashboard", application.dashboard_url, class: "govuk-link" %></li>
   <% end %>
 
-  <% if application.publishing_e2e_tests_url %>
-    <li><%= link_to "Publishing E2E scenarios", application.publishing_e2e_tests_url, class: "govuk-link" %> (warning: not all apps have E2E tests)</li>
-  <% end %>
-
   <% if application.api_docs_url %>
     <li><%= link_to "API docs", application.api_docs_url, class: "govuk-link" %></li>
   <% end %>

--- a/source/partials/application/_links.html.erb
+++ b/source/partials/application/_links.html.erb
@@ -1,4 +1,4 @@
-<ul>
+<ul class="govuk-list">
   <% if application.sentry_url %>
     <li><%= link_to "Sentry (error tracking)", application.sentry_url, class: "govuk-link" %></li>
   <% end %>

--- a/source/partials/application/_links.html.erb
+++ b/source/partials/application/_links.html.erb
@@ -1,6 +1,7 @@
 <%
 
 links = [
+  (link_to(application.production_url.gsub("https://", ""), application.production_url, class: "govuk-link") if application.production_url),
   (link_to("Sentry (error tracking)", application.sentry_url, class: "govuk-link") if application.sentry_url),
   (link_to("Manage application", application.management_url, class: "govuk-link") if application.management_url),
   (link_to("Puppet configuration", application.puppet_url, class: "govuk-link") if application.puppet_url),
@@ -9,7 +10,6 @@ links = [
   (link_to("API docs", application.api_docs_url, class: "govuk-link") if application.api_docs_url),
   (link_to("Component guide", application.component_guide_url, class: "govuk-link") if application.component_guide_url),
   (link_to("Metrics dashboard", application.metrics_dashboard_url, class: "govuk-link") if application.metrics_dashboard_url),
-  (link_to(application.production_url.gsub("https://", ""), application.production_url, class: "govuk-link") if application.production_url),
 ]
 
 if links.any?

--- a/source/templates/application_template.html.md.erb
+++ b/source/templates/application_template.html.md.erb
@@ -37,10 +37,10 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/repo
       field: "Rake tasks",
       value: RunRakeTask.terse_links(application).html_safe,
     } : nil),
-    {
+    ((links = partial("partials/application/links")) && links.strip.present? ? {
       field: "Links",
-      value: partial("partials/application/links"),
-    },
+      value: links,
+    } : nil),
   ].reject(&:nil?),
 ).strip %>
 
@@ -49,7 +49,7 @@ source_url: https://github.com/alphagov/govuk-developer-docs/blob/main/data/repo
 <%= partial("partials/application/relevant_manual_pages") %>
 <% end %>
 
-<% 
+<%
   unless application.private_repo?
     imported_docs = GitHubRepoFetcher.instance.docs(application.github_repo_name)
     unless imported_docs.nil? || imported_docs.empty?

--- a/spec/app/app_spec.rb
+++ b/spec/app/app_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe App do
 
   describe "production_url" do
     it "has a good default" do
-      app = App.new("type" => "Publishing app", "github_repo_name" => "my-app")
+      app = App.new("type" => "Publishing apps", "github_repo_name" => "my-app")
 
       expect(app.production_url).to eql("https://my-app.publishing.service.gov.uk")
     end
 
     it "allows override" do
-      app = App.new("type" => "Publishing app", "production_url" => "something else")
+      app = App.new("type" => "Publishing apps", "production_url" => "something else")
 
       expect(app.production_url).to eql("something else")
     end


### PR DESCRIPTION
Following https://github.com/alphagov/govuk-developer-docs/pull/3478 I noticed there were a few issues with the links metadata for repos so I went down a bit of a 🐰 🕳️ to fix them.

This fixes a bunch of incorrect metadata and the presentation of a number of links. It's easiest review commit-by-commit where each granular change is explained

Some examples:

|Before|After|
|------------|------------|
|<img width="841" alt="Screenshot 2022-03-29 at 12 28 40" src="https://user-images.githubusercontent.com/282717/160601575-6f010ce0-5015-4202-93c6-009a0b4c5525.png">|<img width="792" alt="Screenshot 2022-03-29 at 12 29 35" src="https://user-images.githubusercontent.com/282717/160601681-06ee1930-d87f-4be7-bde8-d82e984727a3.png">|
|<img width="792" alt="Screenshot 2022-03-29 at 12 30 38" src="https://user-images.githubusercontent.com/282717/160601882-56889b62-cc77-4668-a4ce-d7f843ad73fd.png">|<img width="783" alt="Screenshot 2022-03-29 at 12 30 43" src="https://user-images.githubusercontent.com/282717/160601893-42f148fb-56cb-451d-a18d-80210d3b2bbf.png">|
|<img width="802" alt="Screenshot 2022-03-29 at 12 32 11" src="https://user-images.githubusercontent.com/282717/160602102-00a3989e-8598-42d9-bd80-5586c2892479.png">|<img width="788" alt="Screenshot 2022-03-29 at 12 32 17" src="https://user-images.githubusercontent.com/282717/160602119-2f241dff-c6c1-4caa-921c-7e1159e2f5ab.png">|

