### PR TITLE
Rename Licence to License

### DIFF
--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -55,9 +55,9 @@ A list of links to key files in docs/.
 
 You can also just link to the docs/ directory itself.
 
-## Licence
+## License
 
-Link to your LICENCE file.
+Link to your LICENSE file.
 ```
 
 Examples READMEs that follow the above structure:
@@ -78,6 +78,6 @@ Use the GitHub link field to link to the developer docs page for the repository,
 
 Use GitHub's [CONTRIBUTING.md](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) guidelines for this. Always link to the [GOV.UK pull request style guide](https://github.com/alphagov/styleguides/blob/master/pull-requests.md).
 
-## LICENCE
+## LICENSE
 
 Follow [GitHub convention](https://help.github.com/articles/open-source-licensing/#where-does-the-license-live-on-my-repository).


### PR DESCRIPTION
Whilst they're interchangeable, this is the idiomatic choice. [LICENSE is already the most popular choice](https://github.com/search?l=&q=org:alphagov+filename:%22LICENSE%22&type=code), with around 10x more occurrences than [LICENCE](https://github.com/search?q=org:alphagov+filename:%22LICENCE%22&type=code).

It is also the name used by GitHub: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#where-does-the-license-live-on-my-repository

Trello: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-license