### PR TITLE
Expand on docker_management reboot reasons

### DIFF
--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -243,7 +243,9 @@ sudo reboot
 
 ### Rebooting docker-management
 
-It is safe to reboot while no other unattended reboot is underway:
+It is only safe to reboot while no other unattended reboot is underway. This is because it is used to manage locks for unattended reboots of other machines. If this machine is down, then multiple machines in high availability groups may choose to reboot themselves at the same time.
+
+To avoid this happening, we need to disable unattended reboots on all the other machines in the environment while we reboot this one:
 
 1. Set `govuk_unattended_reboot::enabled` to `false` in the [govuk-puppet common configuration](https://github.com/alphagov/govuk-puppet/blob/9c97f1cfe22334e472a48277f5131e0735b16a4e/hieradata_aws/common.yaml#L1166) - you can do this in a branch.
 1. Build the branch of govuk-puppet to Production


### PR DESCRIPTION
I was really tempted to just reboot this machine, and needed a bit more context about the warning.

The docker_management machine runs etcd which is used to provide a lock for other machines that wish to perform an unattended reboot. For that reason, we need to be a bit careful about rebooting it.

The etcd host is specified by the [etcd_endpoints](https://github.com/alphagov/govuk-puppet/blob/2a1b4084d8692707a8af72f4ed0f59f194705c86/hieradata_aws/common.yaml#L1532) configuration.

There is further context available in:
- [puppet-unattended_reboot Github repo](https://github.com/alphagov/puppet-unattended_reboot)
- [a presentation by Matt Bostock (@mattbostock)](https://www.dotconferences.com/2015/06/matt-bostock-coordinating-unattended-reboots-using-a-distributed-mutex)