### PR TITLE
Remove deprecated repos and sections

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -7,7 +7,6 @@
     - name: Frontend apps
     - name: data.gov.uk apps
     - name: Licensing apps
-    - name: Specialist apps
 
 - name: Community
   sections:
@@ -55,7 +54,6 @@
         - govspeak
         - govuk_document_types
         - govuk_message_queue_consumer
-        - govuk_navigation_helpers
         - govuk_personalisation
         - govuk_publishing_components
         - govuk_sidekiq
@@ -68,7 +66,6 @@
         - govuk-rfcs
         - rubocop-govuk
         - publishing-e2e-tests
-        - styleguides
         - stylelint-config-gds
 
 - name: Infrastructure
@@ -90,12 +87,10 @@
     - name: Configuration
       repos:
         - govuk-puppet
-        - fabric-scripts
 
     - name: Monitoring
       repos:
         - email-alert-monitoring
-        - govuk-tagging-monitor
         - sidekiq-monitoring
         - govuk-saas-config
         - govuk_app_config
@@ -110,9 +105,6 @@
 
     - name: Deployment
       sites:
-        - name: alphagov-deployment
-          url: https://github.com/alphagov/alphagov-deployment
-          description: (Deprecated) Capistrano scripts for deploying GOV.UK apps
         - name: govuk-secrets
           url: https://github.com/alphagov/govuk-secrets
           description: Encrypted secrets for GOV.UK infrastucture

--- a/source/partials/_intro.html.md
+++ b/source/partials/_intro.html.md
@@ -1,9 +1,11 @@
 This is the technical documentation for the [GOV.UK][] team in the [Government
 Digital Service (GDS)][GDS]. For other projects built by GDS, see the [Service
-Toolkit][].
+Toolkit][]. For technical documentation applicable to GDS as a whole, see [The
+GDS Way][GDS Way].
 
 New to the GOV.UK team? Read how to [get started developing on GOV.UK](/manual/get-started.html) or [how to learn how GOV.UK works](/manual/learn-govuk.html).
 
 [GDS]: https://gds.blog.gov.uk/about/
+[GDS Way]: https://gds-way.cloudapps.digital/
 [GOV.UK]: https://www.gov.uk/
 [Service Toolkit]: https://www.gov.uk/service-toolkit


### PR DESCRIPTION
We linked to a number of Archived repositories, which doesn't seem very useful.
We also had an empty section for 'Specialist apps', which we should just remove.