### PR TITLE
Rewrite guidance about pact testing

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -215,6 +215,7 @@ redirects:
   /manual/migrate-testing-from-phantomjs-to-selenium-chrome.html: /manual.html
   /manual/mirror-fallback.html: /manual/fall-back-to-mirror.html
   /manual/nagios.html: /manual.html
+  /manual/pact-broker.html: /manual/pact-testing.html
   /manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html: /apps/email-alert-api/receiving-emails-from-email-alert-api-in-integration-and-staging.html
   /manual/redirecting-content-in-the-router.html: /manual/redirect-routes.html
   /manual/releasing-software.html: /manual/development-pipeline.html

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -15,6 +15,28 @@ parent: "/manual.html"
 
 GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 
+## Running Pact tests locally
+
+Example for Frontend (provider of `/bank-holidays.json`):
+
+```sh
+bundle exec rake pact:verify
+```
+
+You can also test against a specific branch of GDS API Adapters:
+
+```sh
+env PACT_CONSUMER_VERSION=branch-<branch-of-gds-api-adapters> bundle exec rake pact:verify
+```
+
+_Note: when a build runs for GDS API Adapters, [the generated JSON pact is pushed to the broker as `branch-<branch-name>`](https://github.com/alphagov/gds-api-adapters/blob/59cf7dbcf6b70a6d7ef68b3ed8b05b83cb40ecf2/Jenkinsfile#L7) using [the `pact:publish:branch` rake task](https://github.com/alphagov/gds-api-adapters/blob/59cf7dbcf6b70a6d7ef68b3ed8b05b83cb40ecf2/Rakefile#L26); this is why `PACT_CONSUMER_VERSION` needs to start with `branch-`._
+
+Alternatively, you can test against local changes to GDS API Adapters:
+
+```sh
+env PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json" bundle exec rake pact:verify
+```
+
 ## Adding new tests for an app
 
 This has to be done in several stages:
@@ -39,5 +61,4 @@ Due to the co-dependent nature of Pact providers and consumers, changes need to 
   - Its build should fail at the Pact test stage, because it is testing against the default branch of the provider.
 1. Run a parameterised build of the consumer, specifying the new branch name of the provider to test against.
   - The build should pass.
-  - It should also be possible to test this locally e.g. `bundle exec rake PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-collections_organisation_api.json" pact:verify`.
 1. Merge the consumer PR, followed by the provider PR.

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -17,18 +17,6 @@ GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We 
 
 ## About the app itself
 
-### Codebase
-
-Pact Broker is a ruby app that's provided as [a
-gem](https://github.com/bethesque/pact_broker) that needs to be wrapped in a
-small rack app. The resulting 'application' lives at
-<https://github.com/alphagov/govuk-pact-broker>.
-
-### Persistence
-
-Pact Broker stores its data in a PostgreSQL database. The location and creds for
-this are passed in the `DATABASE_URL` environment variable.
-
 ### Logging
 
 The app logs to `/var/log/pact_broker.log` and `/var/log/pact_broker.err.log`.

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -15,7 +15,7 @@ parent: "/manual.html"
 
 GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 
-## Writing Pact tests
+## Adding new tests for an app
 
 This has to be done in several stages:
 
@@ -29,7 +29,7 @@ This has to be done in several stages:
 1. Configure the consumer to test against the provider as part of its deployment pipeline, using the rake task defined above ([example](https://github.com/alphagov/gds-api-adapters/pull/1036)).
 1. Merge.
 
-### Updating Pact tests
+## Changing existing Pact tests
 
 Due to the co-dependent nature of Pact providers and consumers, changes need to be made in a particular order:
 

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -15,13 +15,6 @@ parent: "/manual.html"
 
 GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 
-## Accessing and logging on
-
-The application is open to the internet with no authentication for read
-requests. Write requests are restricted with HTTP basic auth. These credentials
-are exposed as environment variables to jobs on CI to enable them to publish
-pacts to the broker.
-
 ## About the app itself
 
 ### Codebase

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -9,9 +9,9 @@ parent: "/manual.html"
 
 [Pact](https://docs.pact.io/) is a tool we use for *contract testing*. Contract testing involves creating a set of tests that are shared between an API (the "provider") and its users ("consumers") using some kind of "broker". For example, the Publishing API has a "pact" or "contract" with GDS API Adapters:
 
-- the expected interactions are defined in [the publishing_api_test.rb in gds-api-adapters](https://github.com/alphagov/gds-api-adapters/blob/master/test/publishing_api_test.rb)
+- the expected interactions are defined in [imminence_api_pact_test.rb in GDS API Adapters](https://github.com/alphagov/gds-api-adapters/blob/master/test/imminence/imminence_api_pact_test.rb)
 - when these tests are run they output a JSON pactfile which is published to [our pact broker](https://github.com/alphagov/govuk-pact-broker) ([live site](https://pact-broker.cloudapps.digital/))
-- the build of publishing api will use this pactfile to test the publishing-api service
+- the build of Imminence will use this pactfile to test the Imminence service
 
 GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 
@@ -76,3 +76,7 @@ Follow these steps in order to change the provider and consumer in tandem.
 
 1. Re-run the build for the provider PR now the consumer is merged.
   - The build should pass so you can now merge the PR.
+
+## Special cases and tech debt
+
+Publishing API and Content Store have a direct pact, with [Publishing API acting as the consumer](https://github.com/alphagov/publishing-api/tree/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/pacts/content_store) and [Content Store acting as the provider](https://github.com/alphagov/content-store/blob/de729dfe12e6e9da4a27a52259f59b9051e4da27/spec/service_consumers/pact_helper.rb#L32). This can be confusing as [Publishing API is also a provider for GDS API Adapters](https://github.com/alphagov/publishing-api/blob/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/service_consumers/pact_helper.rb#L20). It's unclear if the direct pact was intentional. In future we should consider changing Publishing API to use GDS API Adapters to talk to Content Store and have an indirect pact like we do for all other apps.

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -39,17 +39,10 @@ env PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.
 
 ## Adding new tests for an app
 
-This has to be done in several stages:
+Write both parts at the same time so you can check they work together.
 
-1. Write the consumer tests ([example](https://github.com/alphagov/gds-api-adapters/pull/1035)).
-1. Write the provider pact ([example](https://github.com/alphagov/frontend/pull/2643)).
-  - You'll need to write these two in conjunction with each other.
-1. Merge both of the above PRs.
-1. Configure the provider to test against the default branch of the consumer as part of its deployment pipeline ([example](https://github.com/alphagov/frontend/pull/2644)).
-  - You'll need to expose this as a rake task that takes a branch argument (see the example PR above). This is needed in the next step.
-1. Merge.
-1. Configure the consumer to test against the provider as part of its deployment pipeline, using the rake task defined above ([example](https://github.com/alphagov/gds-api-adapters/pull/1036)).
-1. Merge.
+- [Consumer example](https://github.com/alphagov/gds-api-adapters/pull/1066)
+- [Provider example](https://github.com/alphagov/imminence/pull/644)
 
 ## Changing existing Pact tests
 

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -46,12 +46,16 @@ Write both parts at the same time so you can check they work together.
 
 ## Changing existing Pact tests
 
-Due to the co-dependent nature of Pact providers and consumers, changes need to be made in a particular order:
+Follow these steps in order to change the provider and consumer in tandem.
 
-1. Make the change to the API (your provider, e.g. Frontend), in a branch.
+1. Make the change to the API (your provider, e.g. Imminence), in a branch.
   - Its build should fail at the Pact test stage, because it is testing against the default branch of the consumer.
-1. Make the change to the pactfile in the consumer (e.g. gds-api-adapters), in a branch.
+
+1. Make the change to the pactfile in the consumer (e.g. GDS API Adapters), in a branch.
   - Its build should fail at the Pact test stage, because it is testing against the default branch of the provider.
+
 1. Run a parameterised build of the consumer, specifying the new branch name of the provider to test against.
-  - The build should pass.
-1. Merge the consumer PR, followed by the provider PR.
+  - The build should pass so you can now merge the PR, which will mean the change is on the default branch.
+
+1. Re-run the build for the provider PR now the consumer is merged.
+  - The build should pass so you can now merge the PR.

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -17,10 +17,6 @@ GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We 
 
 ## About the app itself
 
-### Logging
-
-The app logs to `/var/log/pact_broker.log` and `/var/log/pact_broker.err.log`.
-
 ### Pactfile versioning
 
 Out of the box, the Pact Broker allows uploading of pact files with semver

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -15,25 +15,6 @@ parent: "/manual.html"
 
 GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 
-## About the app itself
-
-### Pactfile versioning
-
-Out of the box, the Pact Broker allows uploading of pact files with semver
-style versions (eg 2.0.1). For our usage, we wanted to be able to upload pact
-files from various branches in addition the released versions so that our
-branch builds of consumers can verify their pactfiles with the producers.
-
-Pact Broker allows us to [implement our own versioning
-scheme](https://github.com/bethesque/pact_broker/wiki/Configuration#version-parser)
-by providing a custom version parser.  We've [used
-this](https://github.com/alphagov/govuk-pact-broker/blob/master/config.ru#L23-L50)
-to extend the versioning scheme to allow branch builds to be uploaded as well.
-In addition to numeric versions, our scheme allows for "master", and
-"branch-foo" versions to be uploaded. These will always be ordered after any
-numeric versions, so the 'latest' pactfile from the pact brokers POV will
-always be the highest numeric version.
-
 ## Writing Pact tests
 
 This has to be done in several stages:

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -37,12 +37,29 @@ Alternatively, you can test against local changes to GDS API Adapters:
 env PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json" bundle exec rake pact:verify
 ```
 
-## Adding new tests for an app
+## Adding tests for a new app
 
-Write both parts at the same time so you can check they work together.
+_If the app already had some Pact tests, follow [the steps for changing existing Pact tests](#changing-existing-pact-tests)._
 
-- [Consumer example](https://github.com/alphagov/gds-api-adapters/pull/1066)
-- [Provider example](https://github.com/alphagov/imminence/pull/644)
+1. Write the consumer and provider tests.
+  - [Consumer example](https://github.com/alphagov/gds-api-adapters/pull/1066).
+  - [Provider example](https://github.com/alphagov/imminence/pull/644).
+
+1. Check the consumer tests pass locally.
+  - CI won't do this for you yet because it doesn't know about the new app.
+
+1. Merge the consumer tests for the new app.
+  - Warning: the build will pass because it runs with the old Jenkinsfile.
+
+1. Check the main build of the consumer.
+  - [This will clone the default branch of the provider](https://github.com/alphagov/gds-api-adapters/blob/ddb49a487f5c8b5e28f74b81d98660fb2c02d98d/Jenkinsfile#L72) and [try to test it](https://github.com/alphagov/gds-api-adapters/blob/ddb49a487f5c8b5e28f74b81d98660fb2c02d98d/Jenkinsfile#L82).
+  - The build should fail until the provider part is merged.
+
+1. Merge tests for the provider.
+  - Re-run the build if you made the PR before merging the consumer one.
+
+1. Re-run the main build for the consumer.
+  - This will pass because the provider part now exists on the default branch.
 
 ## Changing existing Pact tests
 

--- a/source/manual/pact-broker.html.md
+++ b/source/manual/pact-broker.html.md
@@ -7,24 +7,13 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-[Pact](https://docs.pact.io/) is a tool for *consumer-driven contract testing*.
-It's a way of testing the integration between microservices without performing
-end-to-end testing.
+[Pact](https://docs.pact.io/) is a tool we use for *contract testing*. Contract testing involves creating a set of tests that are shared between an API (the "provider") and its users ("consumers") using some kind of "broker". For example, the Publishing API has a "pact" or "contract" with GDS API Adapters:
 
-"Consumer-driven" means that the consumer of a service sets expectations about
-behaviour it needs from the provider.
+- the expected interactions are defined in [the publishing_api_test.rb in gds-api-adapters](https://github.com/alphagov/gds-api-adapters/blob/master/test/publishing_api_test.rb)
+- when these tests are run they output a JSON pactfile which is published to [our pact broker](https://github.com/alphagov/govuk-pact-broker) ([live site](https://pact-broker.cloudapps.digital/))
+- the build of publishing api will use this pactfile to test the publishing-api service
 
-For example, [the publishing API is set up to run pact tests](https://github.com/alphagov/publishing-api/blob/main/docs/pact_testing.md).
-This means that any consumer of the publishing API can create contracts using the pact gem,
-and the publishing api deployment pipeline will check that consumers' contracts are still met by new builds.
-
-The [Pact Broker](https://docs.pact.io/getting_started/sharing_pacts) is
-a repository for all the contracts. The consumers publish to it, and the producers query from it when they run the tests.
-
-## Information you need to know
-
-* It runs on the Government PaaS at <https://pact-broker.cloudapps.digital/>
-* It is deployed from <https://github.com/alphagov/govuk-pact-broker>
+GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 
 ## Accessing and logging on
 

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -64,7 +64,7 @@ _If the app already had some Pact tests, follow [the steps for changing existing
   - CI won't do this for you yet because it doesn't know about the new app.
 
 1. Merge the consumer tests for the new app.
-  - Warning: the build will pass because it runs with the old Jenkinsfile.
+  - The build will pass because it runs with the old Jenkinsfile.
 
 1. Check the main build of the consumer.
   - [This will clone the default branch of the provider](https://github.com/alphagov/gds-api-adapters/blob/ddb49a487f5c8b5e28f74b81d98660fb2c02d98d/Jenkinsfile#L72) and [try to test it](https://github.com/alphagov/gds-api-adapters/blob/ddb49a487f5c8b5e28f74b81d98660fb2c02d98d/Jenkinsfile#L82).
@@ -87,10 +87,10 @@ Follow these steps in order to change the provider and consumer in tandem.
   - Its build should fail at the Pact test stage, because it is testing against the default branch of the provider.
 
 1. Run a parameterised build of the consumer, specifying the new branch name of the provider to test against.
-  - The build should pass so you can now merge the PR, which will mean the change is on the default branch.
+  - The build should pass so you can now merge the consumer PR, which will mean the change is on the default branch.
 
 1. Re-run the build for the provider PR now the consumer is merged.
-  - The build should pass so you can now merge the PR.
+  - The build should pass so you can now merge the provider PR.
 
 ## Special cases and tech debt
 

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -13,7 +13,7 @@ parent: "/manual.html"
 - when these tests are run they output a JSON pactfile which is published to [our pact broker](https://github.com/alphagov/govuk-pact-broker) ([live site](https://pact-broker.cloudapps.digital/))
 - the build of Imminence will setup a [test environment](https://github.com/alphagov/imminence/blob/9a4801da9d58be0af886d9095328894aac56917c/spec/service_consumers/pact_helper.rb) and use this pactfile to test the real API
 
-GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
+GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. The gem includes [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) for use in each app's own tests ([example](https://github.com/alphagov/contacts-admin/blob/e935fa54bf71c0063bb92faeaf8a27d1618e00ee/spec/interactors/admin/clone_contact_spec.rb#L11)). Using the stubs ensures each app stays in sync with GDS API Adapters, which can then do contract testing on their behalf.
 
 ## Running Pact tests locally
 

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -11,7 +11,7 @@ parent: "/manual.html"
 
 - the expected interactions are defined in [imminence_api_pact_test.rb in GDS API Adapters](https://github.com/alphagov/gds-api-adapters/blob/master/test/imminence/imminence_api_pact_test.rb)
 - when these tests are run they output a JSON pactfile which is published to [our pact broker](https://github.com/alphagov/govuk-pact-broker) ([live site](https://pact-broker.cloudapps.digital/))
-- the build of Imminence will use this pactfile to test the Imminence service
+- the build of Imminence will setup a [test environment](https://github.com/alphagov/imminence/blob/9a4801da9d58be0af886d9095328894aac56917c/spec/service_consumers/pact_helper.rb) and use this pactfile to test the real API
 
 GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We have [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) that are used to test GDS API Adapters with each app - ensuring they are in sync. GDS API Adapters can then do "proper contract testing" on behalf of all the apps that use it.
 

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -17,6 +17,21 @@ GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. We 
 
 ## Running Pact tests locally
 
+### For a consumer (GDS API Adapters)
+
+Pact tests are run alongside normal tests e.g.
+
+```sh
+bundle exec rake test 'TEST=test/imminence/*'
+```
+
+This will run [both sets of tests for Imminence](https://github.com/alphagov/gds-api-adapters/tree/a65fe9c46abe4db38ff2dd455821411d734133c2/test/imminence):
+
+- Normal unit tests using [the shared stubs](https://github.com/alphagov/gds-api-adapters/blob/a65fe9c46abe4db38ff2dd455821411d734133c2/lib/gds_api/test_helpers/imminence.rb).
+- [Pact tests, which define their own stubs](https://github.com/alphagov/gds-api-adapters/blob/a65fe9c46abe4db38ff2dd455821411d734133c2/test/imminence/imminence_api_pact_test.rb).
+
+### For a provider
+
 Example for Frontend (provider of `/bank-holidays.json`):
 
 ```sh
@@ -80,3 +95,5 @@ Follow these steps in order to change the provider and consumer in tandem.
 ## Special cases and tech debt
 
 Publishing API and Content Store have a direct pact, with [Publishing API acting as the consumer](https://github.com/alphagov/publishing-api/tree/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/pacts/content_store) and [Content Store acting as the provider](https://github.com/alphagov/content-store/blob/de729dfe12e6e9da4a27a52259f59b9051e4da27/spec/service_consumers/pact_helper.rb#L32). This can be confusing as [Publishing API is also a provider for GDS API Adapters](https://github.com/alphagov/publishing-api/blob/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/service_consumers/pact_helper.rb#L20). It's unclear if the direct pact was intentional. In future we should consider changing Publishing API to use GDS API Adapters to talk to Content Store and have an indirect pact like we do for all other apps.
+
+The tests are run in the same way as other consumers and providers (see above).

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Pact Broker
+title: Pact Testing
 section: Testing
 type: learn
 layout: manual_layout

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -92,8 +92,8 @@ Follow these steps in order to change the provider and consumer in tandem.
 1. Re-run the build for the provider PR now the consumer is merged.
   - The build should pass so you can now merge the provider PR.
 
-## Special cases and tech debt
+## Special cases
 
-Publishing API and Content Store have a direct pact, with [Publishing API acting as the consumer](https://github.com/alphagov/publishing-api/tree/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/pacts/content_store) and [Content Store acting as the provider](https://github.com/alphagov/content-store/blob/de729dfe12e6e9da4a27a52259f59b9051e4da27/spec/service_consumers/pact_helper.rb#L32). This can be confusing as [Publishing API is also a provider for GDS API Adapters](https://github.com/alphagov/publishing-api/blob/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/service_consumers/pact_helper.rb#L20). It's unclear if the direct pact was intentional. In future we should consider changing Publishing API to use GDS API Adapters to talk to Content Store and have an indirect pact like we do for all other apps.
+Publishing API and Content Store have a direct pact, with [Publishing API acting as the consumer](https://github.com/alphagov/publishing-api/tree/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/pacts/content_store) and [Content Store acting as the provider](https://github.com/alphagov/content-store/blob/de729dfe12e6e9da4a27a52259f59b9051e4da27/spec/service_consumers/pact_helper.rb#L32). This can be confusing as [Publishing API is also a provider for GDS API Adapters](https://github.com/alphagov/publishing-api/blob/dd8dd9232d3cbf33b8945fdd898ebe80d7dcfcf6/spec/service_consumers/pact_helper.rb#L20).
 
 The tests are run in the same way as other consumers and providers (see above).


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This rewrites the previous manual, which was a mixture of:

1. Description about the govuk-pact-broker app.
2. Guidance about actually writing Pact tests.

The rewrite moves the focus to (2), eventually renaming the 
manual from "Pact Broker" to "Pact Testing".

This wasn't the only guidance about Pact testing: Publishing 
API also has duplicate guidance[^1], so part of the change is 
to merge content from that in here so we can have a single, 
central document about how it's done across all apps.

Relates PRs:

- https://github.com/alphagov/govuk-pact-broker/pull/123
- https://github.com/alphagov/publishing-api/pull/2069

[^1]: https://github.com/alphagov/publishing-api/pull/2069