### PR TITLE
Add pointer to set up contract tests for new apps

### DIFF
--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -172,6 +172,10 @@ You should:
 
 Add your Rails app to GOV.UK Docker so you can run the app locally. See an [example GOV.UK Docker pull request](https://github.com/alphagov/govuk-docker/pull/465).
 
+### Set up contract tests for your app
+
+If your app provides an internal API, it should have [contract tests](https://docs.publishing.service.gov.uk/manual/pact-testing.html).
+
 ## Set up a GitHub repo for your Rails app
 
 When you’ve finished developing your Rails app, you can [set up a GitHub repo for your Rails app][auto-config].


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This was missed for the new Locations API app.

Note that the link won't work until [^1] is merged.

[^1]: https://github.com/alphagov/govuk-developer-docs/pull/3498