### PR TITLE
Retire webpacker aspiration for vaguer modern one

### DIFF
--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -183,13 +183,13 @@ with Yarn, providing default tasks and automating some workflows.
 
 ### Frontend assets
 
-GOV.UK applications use the Rails [asset pipeline][] for building assets. We
-aspire to migrate to [webpacker][] as the conventional approach when we have
-resolved [blocking issues][].
+GOV.UK applications use the Rails [asset pipeline][] for precompiling assets -
+we are currently prevented from broadly adopting a more modern approach,
+due to [asset pipeline coupling][] in our components gem, but do aspire to
+retire asset pipeline and encourage decoupling wherever possible.
 
 [asset pipeline]: https://guides.rubyonrails.org/asset_pipeline.html
-[webpacker]: https://github.com/rails/webpacker
-[blocking issues]: https://github.com/alphagov/govuk_publishing_components/issues/505
+[asset pipeline coupling]: https://github.com/alphagov/govuk_publishing_components/issues/505
 
 ### Sending emails
 


### PR DESCRIPTION
The content in this convention no-longer reflected reality. Rails has
moved away from Webpacker since Rails 7 and thusly, so has our
preference to use it.

We do however aspire to use modern Javascript, but which form we will
take is not clear. However whatever road we take, we will need to
resolve the asset pipeline coupling of GOV.UK Publishing Components,
which is the main limiter for newer apps.

This update tries to condense that into a single sentence.