### PR TITLE
Retire search performance explorer

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -745,6 +745,7 @@
   production_url: https://www.gov.uk/api/search.json
 
 - github_repo_name: search-performance-explorer
+  retired: true
   production_hosted_on: heroku
   production_url: https://search-performance-explorer.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/search-performance-explorer
@@ -752,6 +753,9 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+  description: |
+    Tools used to explore search performance and compare results
+    of A/B tests on GOV.UK search. Retired in April 2022
 
 - github_repo_name: service-manual-frontend
   team: "#find-and-view-tech"

--- a/source/manual/run-ab-test.html.md
+++ b/source/manual/run-ab-test.html.md
@@ -45,10 +45,6 @@ To deploy and activate an A/B test, you must [set up a personal API token](https
 1. Deploy the Fastly configuration to each environment using the [Deploy_CDN Jenkins job][deploy-cdn]. Use the same parameters as the previous step. You can test the deployment on staging by visiting <https://www.staging.publishing.service.gov.uk>. Changes should appear almost immediately as there is no caching of the CDN config.
 1. To activate or deactivate the test, or to change the B percentage, update your test in [the govuk-cdn-config repo][govuk-cdn-config] and deploy the dictionaries.
 
-If you're making a change to Search API, you may also want to test using
-the [search performance explorer](https://github.com/alphagov/search-performance-explorer/).
-To do this, [add your A/B test to the application](https://github.com/alphagov/search-performance-explorer/commit/01e3d21ceca96951425b5ddc87116f0756411691) and manually deploy the test to Heroku.
-
 [analytics-dimensions]: https://gov-uk.atlassian.net/wiki/display/GOVUK/Analytics+on+GOV.UK
 [dictionaries-readme]: https://github.com/alphagov/govuk-cdn-config#fastly-dictionaries
 [dictionary-config-example]: https://github.com/alphagov/govuk-cdn-config-secrets/commit/ba3ec923c0bb5bdf17bdaf02419ff4e049516fda


### PR DESCRIPTION
The Heroku-hosted search-performance-explorer app is being retired.

[trello](https://trello.com/c/TvBvDkuF/1218-retire-search-performance-explorer)