### PR TITLE
Document GOV.UK mirrors responses for search and non-existent pages

### DIFF
--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -20,7 +20,7 @@ If Fastly goes down, we would manually [switch to AWS CloudFront](https://docs.p
 
 ## GOV.UK mirror locations and access
 
-The GOV.UK mirror is hosted in an [Amazon Web Services (AWS) S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html). The bucket contains copies of GOV.UK HTML files. The mirror is static, meaning dynamic pages such as search pages will not work.
+The GOV.UK mirror is hosted in an [Amazon Web Services (AWS) S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html). The bucket contains copies of GOV.UK HTML files. The mirror is static, meaning dynamic pages such as search pages will not work. S3 will return 403 Forbidden response for non-existent pages instead of 404, because we don't allow the ListBucket permission. This also affects requests for features such as Search, which are not covered by the mirrors.
 
 The term "GOV.UK mirror" actually refers to 3 separate mirrors:
 


### PR DESCRIPTION
It's worth mentioning how those pages are handled by the mirrors in the docs as
it might not be expected to get a 403 response for an originally 404 page. 

This behaviour is currently documented in [Smokey tests](https://github.com/alphagov/smokey/blob/aaa0522666d49db116b939276f0e0969357e3ed4/features/mirror.feature#L23-L30) which were identified as
redundant in the [Smokey audit](https://docs.google.com/spreadsheets/d/1i2k4WexywoJurdFddOxiNICN-Elv1D5Mb2sdaCjF1t0/edit#gid=0&fvid=1582574436) and will be removed.