### PR TITLE
Document the move to Jenkins

### DIFF
--- a/source/manual/repository-mirroring.html.md
+++ b/source/manual/repository-mirroring.html.md
@@ -7,10 +7,6 @@ type: learn
 parent: "/manual.html"
 ---
 
-We mirror all GitHub repositories tagged with `govuk` to AWS CodeCommit every 2 hours using a [Concourse pipeline configured in alphagov/govuk-repo-mirror](https://github.com/alphagov/govuk-repo-mirror).
+We mirror all non-archived GitHub repositories tagged with `govuk` to AWS CodeCommit every 2 hours using a ['Mirror GitHub repositories' Jenkins job](https://deploy.integration.publishing.service.gov.uk/job/Mirror_Github_Repositories/). The job is [configured in govuk-puppet](https://github.com/alphagov/govuk-puppet/pull/11631/files) and the [govuk-repo-mirror repository](https://github.com/alphagov/govuk-repo-mirror).
 
-![](/manual/images/concourse-mirror-repos-pipeline.png)
-
-This backup allows us to continue deploying if GitHub is unavailable, and also gives us a private place to develop fixes for security vulnerabilities before they are deployed.
-
-If GitHub is unavailable, you can still [get access to Jenkins and deploy from AWS CodeCommit](github-unavailable.html).
+The backups allow us to continue [deploying if GitHub is unavailable](github-unavailable.html). They also give us a private place to develop fixes for security vulnerabilities before they are deployed.


### PR DESCRIPTION
The job no longer runs on Concourse.

NB I've linked to the govuk-puppet PR where the changes were made, rather than to any specific file in govuk-puppet, as there are several key files.

https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse