### PR TITLE
Mark asset_bom_removal-rails as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -9,6 +9,7 @@
   production_hosted_on: aws
 
 - github_repo_name: asset_bom_removal-rails
+  retired: true
   type: Gems
   team:
   sentry_url: false


### PR DESCRIPTION
It is [no longer used anywhere](https://github.com/search?q=org%3Aalphagov+asset_bom_removal-rails+-repo%3Aalphagov%2Fasset_bom_removal-rails+-repo%3Aalphagov%2Fgovuk-dependency-analysis&type=code).

Depends on https://github.com/alphagov/govuk-puppet/pull/11668.