### PR TITLE
Rename blinkenjs to govuk-secondline-blinken

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -21,13 +21,6 @@
   production_hosted_on: aws
   production_url: false
 
-- repo_name: blinkenjs
-  management_url: https://dashboard.heroku.com/apps/govuk-secondline-blinken
-  production_hosted_on: heroku
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
-
 - repo_name: bouncer
   type: Transition apps
   team: "#find-and-view-tech"
@@ -411,6 +404,14 @@
 
 - repo_name: govuk-saas-config
   team:
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- repo_name: govuk-secondline-blinken
+  app_name: govuk-secondline-blinken
+  management_url: https://dashboard.heroku.com/apps/govuk-secondline-blinken
+  production_hosted_on: heroku
   type: Utilities
   sentry_url: false
   dashboard_url: false

--- a/source/manual/2nd-line.html.md
+++ b/source/manual/2nd-line.html.md
@@ -57,6 +57,6 @@ Follow these Slack channels while working on Technical 2nd Line:
 
 [Technical 2nd Line dashboard]: https://alphagov.github.io/frame-splits/index.html?title=2nd+Line+Dashboard&layout=2x1-responsive&url%5B%5D=https%3A%2F%2Fgovuk-secondline-blinken.herokuapp.com%2Fblinken.html&url%5B%5D=https%3A%2F%2Fgrafana.production.govuk.digital%2Fdashboard%2Ffile%2F2ndline_health.json&url%5B%5D=https%3A%2F%2Fgovuk-zendesk-display-screen.herokuapp.com&url%5B%5D=
 [GOV.UK Technical 2nd Line Trello board]: https://trello.com/b/M7UzqXpk/govuk-2nd-line
-[install our Chrome extension]: https://github.com/alphagov/blinkenjs#chrome-extension
+[install our Chrome extension]: https://github.com/alphagov/govuk-secondline-blinken#chrome-extension
 [PagerDuty]: https://governmentdigitalservice.pagerduty.com
 [Zendesk]: https://govuk.zendesk.com

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -87,8 +87,8 @@ This screen shows a summary of the critical and warning alerts for our environme
 in colour-coded boxes (red for critical errors, yellow for warnings, purple for
 unknown errors and green for no issues). It automatically refreshes once a minute.
 
-This is powered by [blinkenjs][] which is [deployed to Heroku][govuk-secondline-blinken-heroku]. You must be in the
+This is powered by [govuk-secondline-blinken][] which is [deployed to Heroku][govuk-secondline-blinken-heroku]. You must be in the
 office or on the VPN to access the Icinga instances it gets its data from.
 
-[blinkenjs]: https://github.com/alphagov/blinkenjs
+[govuk-secondline-blinken]: https://github.com/alphagov/govuk-secondline-blinken
 [govuk-secondline-blinken-heroku]: https://govuk-secondline-blinken.herokuapp.com/blinken.html


### PR DESCRIPTION
This was identified as needing renaming, in
https://github.com/alphagov/govuk-developer-docs/pull/3509/commits/75956e5bc70cd0a4dc573c03e200dfd47e4e8784.