### PR TITLE
Update repo owners

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -389,7 +389,7 @@
   dashboard_url: false
 
 - repo_name: govuk-puppet
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
   deploy_url: https://github.com/alphagov/govuk-secrets/blob/main/puppet_aws/deploy.sh
   sentry_url: false


### PR DESCRIPTION
This updates repo ownership as recently agreed with teams, meaning all now have an owner.
It also adds the `govuk_test` repo which was missing, and tidies up a couple of other things (see commits)

[Trello](https://trello.com/c/hx9cd7e2/2887-assign-ownership-of-some-repos)