### PR TITLE
Add owner for govuk_publishing_components

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -497,7 +497,7 @@
     stored in the Publishing API, and available in the Content Store.
 
 - repo_name: govuk_publishing_components
-  team:
+  team: "#govuk-frontenders"
   type: Gems
   production_url: https://components.publishing.service.gov.uk
   sentry_url: false


### PR DESCRIPTION
A repo was missed in [the previous PR](https://github.com/alphagov/govuk-developer-docs/pull/3518)

[Trello](https://trello.com/c/hx9cd7e2/2887-assign-ownership-of-some-repos)