### PR TITLE
Add how to change the Heroku password

### DIFF
--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -10,5 +10,7 @@ We use Heroku to host some non-critical applications like the [monitoring screen
 
 The credentials for Heroku are in [govuk-secrets](https://github.com/alphagov/govuk-secrets/blob/master/pass/2ndline/heroku/heroku.gpg).
 
+If you need to reset the password for the Heroku account, the email will be sent to a Google Group called [govuk-role-platform-accounts-members](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-role-platform-accounts-members). Only a few members of senior tech have access to this group at the moment.
+
 [monitoring screens]: screens.html
 [review apps]: review-apps.html


### PR DESCRIPTION
There was a struggle to find out how to access the email account
attached to the Heroku account. This should point people in the right
direction.