### PR TITLE
Add guidance for low disk space/inodes on the ci-master machine

### DIFF
--- a/source/manual/alerts/low-available-disk-inodes.html.md
+++ b/source/manual/alerts/low-available-disk-inodes.html.md
@@ -30,13 +30,27 @@ with a row for each filesystem currently mounted.
 ### Low available disk inodes (Jenkins)
 
 If Jenkins is running out of inodes (rather than disk space) then it may be
-possible to free some by clearing out old workspaces:
+possible to free some by clearing out old workspaces (on the `ci-agent` machines), or failed jobs (on the `ci-master` machine):
+
+#### Clearing old workspaces
 
 ```sh
 $ sudo find /var/lib/jenkins/workspace/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \;
 ```
 
 This will find any directories that are older than 1 day and delete them.
+
+#### Clearing failed jobs
+
+```sh
+$ sudo find /var/lib/jenkins/jobs/ -mindepth 3 -maxdepth 3 -type d -mtime +30 | grep -v -P "main|master" | xargs -I {} sudo rm -rf {}
+```
+
+This will find any job branches that are older than 30 days (except for main and master, which it might be prudent to keep) and delete them. If you want to know how many folders will be affected, you can see with:
+
+```sh
+$ sudo find /var/lib/jenkins/jobs/ -mindepth 3 -maxdepth 3 -type d -mtime +30 | grep -v -P "main|master" | wc -l
+```
 
 ### Low available disk space on Jenkins
 

--- a/source/manual/alerts/low-available-disk-inodes.html.md
+++ b/source/manual/alerts/low-available-disk-inodes.html.md
@@ -6,6 +6,8 @@ layout: manual_layout
 section: Icinga alerts
 ---
 
+See also: [low available disk space](low-available-disk-space.html)
+
 This alerts means that a machine's filesystem has too many files or directories.
 
 An inode is a data structure used on unix filesystems to store metadata about files and dirs. On a given filesystem the number of inodes is limited, so a machine may run out if it creates too many files -- even if there's plenty of disk space left. The solution is therefore to remove unused files or dirs.


### PR DESCRIPTION
Current docs only cover the ci-agent machines, and the ci-master needs a slightly different form of help (until we can fix the problem where failed jobs aren't cleaned up automatically by Jenkins).