### PR TITLE
Clarify the clearance needed for prod access

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -25,6 +25,7 @@ These rules apply to developers, SREs, and technical architects in the GOV.UK pr
 
 - Temporary supervised access during two Technical 2nd Line shadow shifts (GOV.UK developers only)
 - Supervised access during the second shadow shift and probation has been passed
+- A minimum of BPSS (a blue building pass) security clearance
 - Permanent access once two shadow shifts have been completed
 
 "Supervised" means "we trust you, but just be extra careful," and the dev should


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-developer-docs/pull/2969/commits/4f2ffed8d5bcf109bde3e9ef48de8a5d86cabdf3

There was a bit of confusion about the minimum level of clearance required for production access.

This page only mentioned a "minimum of BPSS" for temporary access, but did not clarify if that was true for permanent access as well.