### PR TITLE
Remove redundant whitehall healthcheck doc

### DIFF
--- a/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md
@@ -1,9 +1,0 @@
----
-owner_slack: "#govuk-2ndline-tech"
-title: Whitehall app healthcheck not ok
-parent: "/manual.html"
-layout: manual_layout
-section: Icinga alerts
----
-
-See: [how healthcheck alerts work on GOV.UK](app-healthcheck-not-ok.html)


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This is no longer linked to from alerts [^1].

[^1]: https://github.com/alphagov/govuk-puppet/pull/11688