### PR TITLE
Update Github production team name

### DIFF
--- a/source/manual/access-jenkins.html.md
+++ b/source/manual/access-jenkins.html.md
@@ -10,14 +10,14 @@ Our Jenkins installations ([deploy](https://deploy.integration.publishing.servic
 
 - For integration admin access, you need to be added to the [GOV.UK team][]
 - For [staging][] and [production][] [deploy access](manual/rules-for-getting-production-access.html#production-deploy-access), you need to be added to the [GOV.UK Production Deploy team][]
-- For [staging][] and [production][] [admin access](manual/rules-for-getting-production-access.html#production-admin-access), you need to be added to the [GOV.UK Production team][]
+- For [staging][] and [production][] [admin access](manual/rules-for-getting-production-access.html#production-admin-access), you need to be added to the [GOV.UK Production Admin team][]
 
 Without this you won't see any projects or you'll see a message that says you are unauthorised.
 
 Usually your tech lead or a member of senior tech can add you to the right team in GitHub. Try asking in the `#govuk-tech-leads` Slack channel if you're struggling to find someone.
 
 [GOV.UK team]: https://github.com/orgs/alphagov/teams/gov-uk
-[GOV.UK Production team]: https://github.com/orgs/alphagov/teams/gov-uk-production
+[GOV.UK Production Admin team]: https://github.com/orgs/alphagov/teams/gov-uk-production
 [GOV.UK Production Deploy team]: https://github.com/orgs/alphagov/teams/gov-uk-production-deploy
 [staging]: https://deploy.blue.staging.govuk.digital/
 [production]: https://deploy.blue.production.govuk.digital/

--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -55,7 +55,7 @@ Licensify is built and deployed using Jenkins. There are four relevant Jenkins i
 
 Access to Jenkins is controlled through GitHub teams. Users in the "GOV.UK" team have full access to the CI and
 Integration Jenkins instances, and read only access to the Staging and Production Jenkins instances. Users in the "
-GOV.UK Production" team have full access in all environments.
+GOV.UK Production Admin" team have full access in all environments.
 
 Usually, GOV.UK developers coordinate deployments through these Jenkins instances using
 [the Release app](https://release.publishing.service.gov.uk/applications). This shows which releases are deployed to

--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -8,7 +8,7 @@ section: GitHub
 
 Repositories in GOV.UK must:
 
-- Have the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production][govuk-production-team] teams as `Admin`
+- Have the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production Admin][govuk-production-team] teams as `Admin`
 - Have a good description
 - Link to relevant documentation
 - Have the [`govuk`][govuk-topic] topic
@@ -31,7 +31,7 @@ When your repo is tagged with `govuk`, it will be auto-configured by [govuk-saas
 
 When you create a new repo:
 
-- Give the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production][govuk-production-team] teams `Admin` access
+- Give the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production Admin][govuk-production-team] teams `Admin` access
 - Give the [GOV.UK][govuk-team] `Write` access
 - Tag it with the [`govuk`][govuk-topic] topic
 - [Kick off a build of the Jenkins job][jenkins-job] to automate the rest

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -54,7 +54,7 @@ Access should be granted at the discretion of the engineer's tech lead, once the
 - GOV.UK PaaS [Space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer) and `Org manager`
   access to all spaces in the [govuk_development](https://admin.cloud.service.gov.uk/organisations/f8718311-b9a4-49d3-b1c7-7c5345a74e35) and [data-gov-uk](https://admin.cloud.service.gov.uk/organisations/39c3d2c5-8809-4dcf-8cd6-a8f62923a295/users) organisations
 
-The steps above are outlined in the [GOV.UK Production template Trello card](https://trello.com/c/GIHPZi2o/382-production-access-for-2nd-line), which is normally given whilst on 2nd line.
+The steps above are outlined in the [GOV.UK Production Admin template Trello card](https://trello.com/c/GIHPZi2o/382-production-admin-access-for-2nd-line), which is normally given whilst on 2nd line.
 
 ## When you get Production Admin access
 


### PR DESCRIPTION
As covered in RFC 146 - Implement "Production Deploy Access" ,
we are renaming the production team name from "GOV.UK Production"
to "GOV.UK Production Admin". This should ensure there is no
ambiguity between this level of access and "Production Deploy" access.
Users with production access will be members of both groups.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5