### PR TITLE
Update rebooting instructions for jumpbox machines

### DIFF
--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -231,16 +231,6 @@ be unavailable during this period.
 Router backend machines are instances of MongoDB machines and can be rebooted
 as per the [MongoDB rebooting guidance](#rebooting-mongodb-machines).
 
-### Rebooting jumpbox machines
-
-These machines are safe to reboot during the day. During the night they
-are involved in a data sync processes and rebooting could cause the data
-sync to fail.
-
-```
-sudo reboot
-```
-
 ### Rebooting docker-management
 
 It is safe to reboot while no other unattended reboot is underway:


### PR DESCRIPTION
This class no is longer required for the synchronisation of DB
across environments since the deployment of govuk_env_sync.
Therefore it's fine to reboot those machines at any time and there
is no need for specific instructions anymore.