### PR TITLE
Remove conflicting information around HTTPS support

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -27,25 +27,11 @@ edit the relevant [transition configuration file].
 
 ## Checklist for transitioning a new site
 
-### 1) Ensure the department is aware of the technical limitation of HTTPS enabled sites
-
-Unless the domain being transitioned is a subdomain of one of our wildcard
-[SANs][], we [do not support HTTPS][https] for transitioned sites.
-
-[SANs]: https://en.wikipedia.org/wiki/Subject_Alternative_Name
-[https]: /manual/transition-architecture.html#https-support-for-transitioned-sites
-
-If a domain is not in our SAN but wants to keep HTTPS integrity, the best
-alternative is to set up redirects on their own server.
-
-The content team might ask a developer to offer the department some guidance
-around this.
-
-### 2) Add a site to the Transition app
+### 1) Add a site to the Transition app
 
 Follow the instructions in the [transition-config README][transition-config].
 
-### 3) Consider AKA domains
+### 2) Consider AKA domains
 
 If the department want to use the side-by-side browser to preview how their
 redirects will appear after transitioning they will need to set up AKA domains.
@@ -66,7 +52,7 @@ CNAME record for any new domains.
 
 [transition-hosts]: https://transition.publishing.service.gov.uk/hosts
 
-### 4) Get a list of old URLs
+### 3) Get a list of old URLs
 
 In order for us to redirect anything but the homepage, we need a list of URLs
 for the old site so that they can be mapped. In the past, this is something
@@ -92,7 +78,7 @@ $ anemone url-list 'transitioning-site.gov.uk'
 
 > **Note:** This will include 404s, 301s, etc.
 
-### 5) Clean up URLs
+### 4) Clean up URLs
 
 #### Strip paths and pattern
 
@@ -127,7 +113,7 @@ Some common examples of non-significant parameters:
 - analytics
 - search queries
 
-### 6) Add the old URLs as mappings
+### 5) Add the old URLs as mappings
 
 Ideally, any significant query string parameters should be identified and
 added to the site before adding the mappings. This is because URLs are
@@ -150,7 +136,7 @@ into [the allowlisted hosts in Transition][]. You'll need the `admin` permission
 
 [the allowlisted hosts in Transition]: https://transition.publishing.service.gov.uk/admin/whitelisted_hosts
 
-### 7) Get the organisation to do the mapping work
+### 6) Get the organisation to do the mapping work
 
 By default, the mappings will present an archive page to users visiting
 the old URL. The objective is to get users to somewhere that best serves
@@ -158,7 +144,7 @@ the need fulfilled by the old page. Usually this means redirecting them
 to the page on GOV.UK or elsewhere. It is really important that this is
 done by people who understand the users and content.
 
-### 8) Get the organisation to lower the TTL on the DNS records a day ahead
+### 7) Get the organisation to lower the TTL on the DNS records a day ahead
 
 In order to cleanly switch the domain from the old site, the TTL needs
 to be low enough that there isn't a significant period where some users
@@ -169,7 +155,7 @@ advance, and to be lowered to 300 seconds (5 minutes). It can be raised
 again once everyone is happy there is no need to switch back - normally
 the day after.
 
-### 9) Point the domain at us
+### 8) Point the domain at us
 
 Once the site has been imported successfully, the domain can be pointed
 at us by the organisation. For hostnames which can have a `CNAME`
@@ -185,7 +171,7 @@ You'll need to create a TLS certificate in Fastly for HTTPS domains, otherwise
 users will see a certificate error when being redirected from an external
 HTTPS URL to GOV.UK via Bouncer. Read how to [request a Fastly TLS certificate][]
 
-### 10) Get the organisation to monitor the traffic data in the Transition app
+### 9) Get the organisation to monitor the traffic data in the Transition app
 
 There are two things that need to be responded to:
 


### PR DESCRIPTION
Looks like this got missed from #2964.
The [link](https://docs.publishing.service.gov.uk/manual/transition-architecture.html#https-support-for-transitioned-sites) that supposedly confirms HTTPS is not supported currently deeplinks to a section stating:

> Bouncer in late 2020 began supporting HTTPS for transitioned sites, through a new feature in Fastly.