### PR TITLE
Deprecate arp cache flushing instructions

### DIFF
--- a/source/manual/flush-the-arp-cache.html.md
+++ b/source/manual/flush-the-arp-cache.html.md
@@ -6,7 +6,7 @@ layout: manual_layout
 section: 2nd line
 ---
 
-> These instructions should no longer be required. Please alert #govuk-platform-reliability if you have to use them.
+> These instructions should no longer be required. Please alert #govuk-platform-reliability-team if you have to use them.
 
 We're aware of a rare situation where our servers can find themselves with
 incorrect entries in their ARP cache (more detail below in [What is the ARP

--- a/source/manual/flush-the-arp-cache.html.md
+++ b/source/manual/flush-the-arp-cache.html.md
@@ -6,6 +6,8 @@ layout: manual_layout
 section: 2nd line
 ---
 
+> These instructions should no longer be required. Please alert #govuk-platform-reliability if you have to use them.
+
 We're aware of a rare situation where our servers can find themselves with
 incorrect entries in their ARP cache (more detail below in [What is the ARP
 cache?](#what-is-the-arp-cache) and [What is wrong with our ARP cache?](#what-is-wrong-with-our-arp-cache))


### PR DESCRIPTION
Since [upgrading the kernels on our machines](https://github.com/alphagov/govuk-puppet/pull/11696) we don't expect this to be required any more. We'd like to know if this isn't the case.