### PR TITLE
Change Smokey's owner

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1070,7 +1070,7 @@
   production_hosted_on: aws
 
 - repo_name: smokey
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
This makes GOV.UK Platform Reliability team the owners of the Smokey repo, as that's been agreed. 