### PR TITLE
Update dependencies owner for local-links-manager

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -807,7 +807,7 @@
 - repo_name: local-links-manager
   type: Publishing apps
   team: "#find-and-view-tech"
-  dependencies_team: "#govuk-corona-services-tech"
+  dependencies_team: "#find-and-view-tech"
   production_hosted_on: aws
 
 - repo_name: locations-api


### PR DESCRIPTION
# What's changed and why?
Changes the dependency owner to match the application owner, as the coronavirus team doesn't exist anymore, so the dependencies are not being monitored.