### PR TITLE
Ignore GitHub API token file (as per the README)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 Staticfile.auth
 coverage
 tmp
+
+# Ignore GitHub API token
+*token.txt


### PR DESCRIPTION
I've left the precise name of the file flexible. I doubt we will
have any other top-level files ending in "...token.txt".