### PR TITLE
Add the govuk-provisioning repo, and mark it as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -543,6 +543,14 @@
   sentry_url: false
   dashboard_url: false
 
+- repo_name: govuk-provisioning
+  private_repo: true
+  retired: true
+  type: Utilities
+  team: "#govuk-platform-reliability-team"
+  description: |
+    This held infra-as-code for the old GOV.UK provider, which is no longer needed.
+
 - repo_name: govuk-puppet
   team: "#govuk-platform-reliability-team"
   type: Utilities


### PR DESCRIPTION
This adds the govuk-provisioning repo for completeness, even though it is now archived/retired. 

[Trello](https://trello.com/c/TgiVYqE6/)
