### PR TITLE
Update dependencies owner for collections

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -105,7 +105,6 @@
 - repo_name: collections
   type: Frontend apps
   team: "#find-and-view-tech"
-  dependencies_team: "#govuk-corona-services-tech"
   component_guide_url: https://govuk-collections.herokuapp.com/component-guide
   production_hosted_on: aws
 
@@ -815,7 +814,6 @@
 - repo_name: local-links-manager
   type: Publishing apps
   team: "#find-and-view-tech"
-  dependencies_team: "#find-and-view-tech"
   production_hosted_on: aws
 
 - repo_name: locations-api


### PR DESCRIPTION
Changes the dependency owner to match the application owner. The coronavirus team doesn't exist anymore so the dependencies are not being monitored.