### PR TITLE
Allocate GOV.UK Publishing ownerships across teams 

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -869,7 +869,7 @@
 
 - repo_name: miller-columns-element
   type: Utilities
-  team: "#navigation-and-presentation-govuk"
+  team: "#govuk-publishing-experience-tech"
 
 - repo_name: multipage-frontend
   type: Frontend apps

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -5,7 +5,7 @@
 
 - repo_name: asset-manager
   type: APIs
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
 
 - repo_name: asset_bom_removal-rails
@@ -110,13 +110,13 @@
 
 - repo_name: collections-publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: contacts-admin
   type: Publishing apps
   puppet_name: contacts
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: contacts-frontend
@@ -138,18 +138,18 @@
 
 - repo_name: content-publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: content-store
   type: APIs
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
   production_url: https://www.gov.uk/api/content
 
 - repo_name: content-tagger
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: data-community-tech-docs
@@ -271,13 +271,13 @@
   production_hosted_on: aws
 
 - repo_name: gds-api-adapters
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
 
 - repo_name: gds-sso
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
   sentry_url: false
@@ -294,7 +294,7 @@
   production_hosted_on: aws
 
 - repo_name: govspeak
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
@@ -302,7 +302,7 @@
 - repo_name: govspeak-preview
   production_url: https://govspeak-preview.publishing.service.gov.uk
   management_url: https://dashboard.heroku.com/apps/govspeak-preview
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: heroku
   type: Utilities
   sentry_url: false
@@ -363,7 +363,7 @@
   type: Utilities
 
 - repo_name: govuk-content-api-docs
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Utilities
 
 - repo_name: govuk-content-metadata
@@ -374,7 +374,7 @@
 - repo_name: govuk-content-schemas
   production_url: https://govuk-content-store-examples.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/govuk-content-store-examples
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: heroku
   type: Utilities
   sentry_url: false
@@ -670,7 +670,7 @@
   dashboard_url: false
 
 - repo_name: govuk_admin_template
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   type: Gems
 
 - repo_name: govuk_app_config
@@ -699,7 +699,7 @@
   dashboard_url: false
 
 - repo_name: govuk_message_queue_consumer
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
@@ -725,7 +725,7 @@
   dashboard_url: false
 
 - repo_name: govuk_schemas
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
@@ -735,7 +735,7 @@
   type: Gems
 
 - repo_name: govuk_sidekiq
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
@@ -754,7 +754,7 @@
 
 - repo_name: hmrc-manuals-api
   type: APIs
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
 
 - repo_name: icinga_slack_webhook
@@ -808,7 +808,7 @@
 
 - repo_name: link-checker-api
   type: APIs
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
 
 - repo_name: local-links-manager
@@ -837,7 +837,7 @@
 
 - repo_name: manuals-publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: mapit
@@ -853,7 +853,7 @@
 
 - repo_name: maslow
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: metadata-api
@@ -879,13 +879,13 @@
     to government-frontend in March 2017.
 
 - repo_name: omniauth-gds
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
 
 - repo_name: optic14n
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Gems
   sentry_url: false
   dashboard_url: false
@@ -917,7 +917,7 @@
     responsible for sending their pages to search.
 
 - repo_name: paste-html-to-govspeak
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   type: Utilities
 
 - repo_name: plek
@@ -939,16 +939,16 @@
 
 - repo_name: publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: publishing-api
   type: APIs
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
 
 - repo_name: publishing-e2e-tests
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Utilities
   sentry_url: false
   dashboard_url: false
@@ -1039,16 +1039,16 @@
 
 - repo_name: service-manual-publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: short-url-manager
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: side-by-side-browser
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_url: https://govuk-side-by-side-browser.herokuapp.com/
   management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
   production_hosted_on: heroku
@@ -1057,14 +1057,14 @@
   dashboard_url: false
 
 - repo_name: sidekiq-monitoring
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   type: Utilities
   sentry_url: false
   dashboard_url: false
 
 - repo_name: signon
   type: Supporting apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
 
 - repo_name: slimmer
@@ -1086,7 +1086,7 @@
   dashboard_url: false
 
 - repo_name: special-route-publisher
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   type: Utilities
   sentry_url: false
   dashboard_url: false
@@ -1100,7 +1100,7 @@
 
 - repo_name: specialist-publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: static
@@ -1128,19 +1128,19 @@
 
 - repo_name: transition
   type: Transition apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   production_hosted_on: aws
   production_url: https://transition.publishing.service.gov.uk
 
 - repo_name: transition-config
   type: Transition apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-platform"
   sentry_url: false
   dashboard_url: false
 
 - repo_name: travel-advice-publisher
   type: Publishing apps
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
 - repo_name: upgrade-ruby-version
@@ -1150,5 +1150,5 @@
 - repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk
-  team: "#govuk-publishing-tech"
+  team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws

--- a/source/manual/alerts/publisher-scheduled-publishing.html.md
+++ b/source/manual/alerts/publisher-scheduled-publishing.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline-tech"
+owner_slack: "#govuk-publishing-experience-tech"
 title: More items scheduled for publication than in queue for publisher
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
+++ b/source/manual/alerts/publisher-unprocessed-fact-check-emails.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-publishing-experience-tech"
 title: "Publisher: Unprocessed fact-check emails"
 section: Icinga alerts
 subsection: Email alerts

--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline-tech"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Whitehall scheduled publishing
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-developers"
 title: 'Assets: how they work'
 section: Assets
 type: learn

--- a/source/manual/change-base-path-in-specialist-publisher.html.md.erb
+++ b/source/manual/change-base-path-in-specialist-publisher.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Change a specialist document base path
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/documents-are-published-but-links-arent-updated.html.md
+++ b/source/manual/documents-are-published-but-links-arent-updated.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-publishing-platform"
 title: Debug published documents with incorrect links
 section: Publishing
 layout: manual_layout

--- a/source/manual/documents-arent-live-after-publishing.html.md
+++ b/source/manual/documents-arent-live-after-publishing.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-publishing-platform"
 title: If documents aren't live after being published
 section: Publishing
 layout: manual_layout

--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-publishing-platform"
 title: Manage assets
 section: Assets
 layout: manual_layout

--- a/source/manual/publish-special-routes.html.md.erb
+++ b/source/manual/publish-special-routes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Publish special routes
 section: Deployment
 layout: manual_layout

--- a/source/manual/publishing-e2e-tests.html.md
+++ b/source/manual/publishing-e2e-tests.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-publishing-platform"
 title: Work with the end to end publishing tests
 section: Testing
 layout: manual_layout

--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline-tech"
+owner_slack: "#govuk-publishing-platform"
 title: Manage RabbitMQ
 section: Infrastructure
 layout: manual_layout

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Rename a country
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/republishing-content.html.md.erb
+++ b/source/manual/republishing-content.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline-tech"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Republish content
 section: Publishing
 layout: manual_layout

--- a/source/manual/request-fastly-tls-certificate.html.md
+++ b/source/manual/request-fastly-tls-certificate.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-publishing-platform"
 title: Request Fastly TLS certificate
 section: Transition
 layout: manual_layout

--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-publishing-platform"
 title: Transition a site to GOV.UK
 section: Transition
 layout: manual_layout

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-publishing-platform"
 title: Transition architecture
 section: Transition
 type: learn

--- a/source/manual/whitehall-file-stuck-uploading.html.md
+++ b/source/manual/whitehall-file-stuck-uploading.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-2ndline-tech"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Whitehall Attachment Stuck in Uploading State
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/whitehall-historical-accounts.html.md
+++ b/source/manual/whitehall-historical-accounts.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-publishing-tech"
+owner_slack: "#govuk-publishing-experience-tech"
 title: Add Historical Accounts
 section: Publishing
 layout: manual_layout


### PR DESCRIPTION
Trello: https://trello.com/c/6ij2W9kf/131-split-combined-govuk-publishing-tech-alerts-for-each-team

This updates the references to #govuk-publishing-tech in this repo to split responsibilities to #govuk-publishing-experience-tech and #govuk-publishing-platform.

There is further info in the commits.