### PR TITLE
Remove quote marks in headings

### DIFF
--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -6,7 +6,7 @@ layout: manual_layout
 section: Icinga alerts
 ---
 
-## 'overdue publications in Whitehall'
+## Overdue publications in Whitehall
 
 This alert means that there are scheduled editions which have passed their
 publication due date but haven't been published by the scheduled publishing
@@ -52,7 +52,7 @@ These documents cannot be published and will cause a
 The situation is likely to be re-created the next day by the above process on
 the same documents/editions.
 
-## 'scheduled publications in Whitehall not queued'
+## Scheduled publications in Whitehall not queued
 
 This alert means that the number of editions in the database which are
 scheduled to be published in the future is different from the number currently


### PR DESCRIPTION
These are being coverted into ASCII characters and is breaking the
anchor link to these sections. We also don't include quote marks
for our other alerts that are documented.