### PR TITLE
Mark 'datagovuk_publish_queue_monitor' as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -184,11 +184,9 @@
   production_hosted_on: paas
 
 - repo_name: datagovuk_publish_queue_monitor
-  production_hosted_on: paas
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
-  sentry_url: false
-  dashboard_url: false
+  retired: true
 
 - repo_name: datagovuk_reference
   team: "#govuk-datagovuk"


### PR DESCRIPTION
It has not been used for a long time, and is broken in all
environments. We've now archived the repo. The environments will
die when PaaS is decommissioned, if we don't do anything ourselves
sooner.