### PR TITLE
remove rate-limiting page from redirect list

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -216,7 +216,6 @@ redirects:
   /manual/mirror-fallback.html: /manual/fall-back-to-mirror.html
   /manual/nagios.html: /manual.html
   /manual/pact-broker.html: /manual/pact-testing.html
-  /manual/rate-limiting.html: /manual/rate-limiting.html
   /manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html: /apps/email-alert-api/receiving-emails-from-email-alert-api-in-integration-and-staging.html
   /manual/redirecting-content-in-the-router.html: /manual/redirect-routes.html
   /manual/releasing-software.html: /manual/development-pipeline.html


### PR DESCRIPTION
Whoops! Accidentally added the new page to the redirect list pointing to itself, so that it rendered empty but with a timed redirect. Removes that redirect.