### PR TITLE
Mark deprecated_columns as retired and remove owner team

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -199,7 +199,7 @@
 
 - repo_name: deprecated_columns
   type: Gems
-  team: "#navigation-and-presentation-govuk"
+  retired: true
 
 - repo_name: design-principles
   type: Frontend apps


### PR DESCRIPTION
The `deprecated_columns` gem has been [deprecated](https://github.com/alphagov/deprecated_columns/pull/15) and the repo has been archived. 

This simply marks it as retired in our list of repos (and there's no need to have it owned by a team). 