### PR TITLE
Update rendering app for topical events

### DIFF
--- a/data/rendering-apps.yml
+++ b/data/rendering-apps.yml
@@ -394,7 +394,7 @@
   - government-frontend
 - :name: topical_event
   :apps:
-  - whitehall-frontend
+  - collections
 - :name: topical_event_about_page
   :apps:
   - government-frontend


### PR DESCRIPTION
Rendering has now been moved from Whitehall to collections