### PR TITLE
Update world location news page document in rendering apps

### DIFF
--- a/data/rendering-apps.yml
+++ b/data/rendering-apps.yml
@@ -479,6 +479,6 @@
 - :name: topic
   :apps:
   - collections
-- :name: placeholder_world_location_news_page
+- :name: world_location_news
   :apps:
   - whitehall-frontend


### PR DESCRIPTION
The document type has changed to the non-placeholder version

[Trello](https://trello.com/c/5vpV1JUu/194-update-world-news-location-document-type)