### PR TITLE
Remove reference to upgrading mysql

### DIFF
--- a/source/manual/alerts/security-updates.html.md
+++ b/source/manual/alerts/security-updates.html.md
@@ -32,6 +32,3 @@ If the unattended upgrades log looks okay, check which security updates are outs
 ```bash
 apt-get upgrade -s | grep -i security
 ```
-
-You may find that the upgrades are on a [deny list in govuk-puppet](https://github.com/alphagov/govuk-puppet/commit/a0872cb1c9e6e7981863660b1500f3a2ede631fe)
-(for example, `mysql-server-5.5` which [needs upgrading manually](/manual/upgrading-mysql.html)).


### PR DESCRIPTION
## What
Remove references to manually upgrading mysql

## Why
The link is broken as the file was removed in the Pull Request below:

Review Upgrade MySQL in production - https://github.com/alphagov/govuk-developer-docs/pull/2767