### PR TITLE
Remove as repo is archived

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -319,11 +319,6 @@
   team: "#interaction-and-personalisation-govuk"
   type: Utilities
 
-- repo_name: govuk-account-scaling-docs
-  private_repo: true
-  team: "#interaction-and-personalisation-govuk"
-  type: Utilities
-
 - repo_name: govuk-app-deployment
   team: "#govuk-platform-reliability-team"
   type: Utilities


### PR DESCRIPTION
The repo only contained a very brief README (one sentence) and the main / only link to further docs was broken.

[Archived repo](https://github.com/alphagov/govuk-account-scaling-docs)