### PR TITLE
Update rendering apps for world location news

### DIFF
--- a/data/rendering-apps.yml
+++ b/data/rendering-apps.yml
@@ -482,3 +482,4 @@
 - :name: world_location_news
   :apps:
   - whitehall-frontend
+  - collections


### PR DESCRIPTION
Update rendering apps for world location news

Collections now renders english world location news pages, other locales still rendered by whitehall.