### PR TITLE
Add WorldLocationNews to republishable content types

### DIFF
--- a/source/manual/republishing-content.html.md.erb
+++ b/source/manual/republishing-content.html.md.erb
@@ -58,6 +58,7 @@ To republish all instances of the following document types, run the following ra
 - TopicalEvent
 - TopicalEventAboutPage
 - WorldLocation
+- WorldLocationNews
 - WorldwideOrganisation
 
 <%= RunRakeTask.links("whitehall", "publishing_api:bulk_republish:document_type[DocumentClass]") %>


### PR DESCRIPTION
Now that [`WorldLocationNews` has been moved out of the `WorldLocation` model into a model of its own](https://github.com/alphagov/whitehall/pull/6722), we have removed the special rake task to publish this content type. This type of document can now be republished in the same way as all other document types.