### PR TITLE
Update ruby upgrade docs to reflect the current process

### DIFF
--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -58,7 +58,12 @@ and then on the respective machine that your app will run on (e.g. `backend`).
 ### Update Ruby version in the relevant repos
 
 We use [upgrade-ruby-version][] to automatically raise pull requests in GOV.UK repositories which use Ruby.
-See an [example PR](https://github.com/alphagov/upgrade-ruby-version/pull/1) for how to specify the repos and versions.
+
+It's advised not to use your personal GitHub account to create the access token required by the script, as another developer will need to approve the PRs. You can use [govuk-ci GitHub account](https://github.com/govuk-ci). The login credentials for the account can be fetched from [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/main/pass) with:
+
+```
+PASSWORD_STORE_DIR=~/govuk/govuk-secrets/pass/2ndline pass github/govuk-ci
+```
 
 Once the PRs are raised, you should test the changes before merge, as follows:
 


### PR DESCRIPTION
## Context

The PRs used to be generated by the Platform Reliability team. This will no longer be the case and now the teams are solely responsible for upgrading ruby versions in the apps/repos they own. 

## What and why
Running the script with access token from a personal account would unnecessarily increase the burden on team's devs. The person who raised the PR would not be able to approve it. 

The PRs would also be posted to the slack channel by the Seal. Since upgrading to the latest ruby version doesn't tend to be the priority, the PRs are likely to hang around for long time and add noise to the Slack channels.

It removes the example PR because it got out of date and the setup instructions are now well described in the README.

Related PR: https://github.com/alphagov/upgrade-ruby-version/pull/8