### PR TITLE
Add 'Pentests' document

### DIFF
--- a/source/manual/pentests.html.md
+++ b/source/manual/pentests.html.md
@@ -1,0 +1,11 @@
+---
+owner_slack: "#govuk-developers"
+title: Pentests
+section: Security
+layout: manual_layout
+parent: "/manual.html"
+---
+
+GOV.UK periodically runs penetration tests (otherwise known as 'pentests' or 'IT healthchecks') on its infrastructure, to identify security issues. Read more at [govuk-ithc-documentation][].
+
+[govuk-ithc-documentation]: https://github.com/alphagov/govuk-ithc-documentation


### PR DESCRIPTION
I'm always forgetting the name of the repo where we've documented our pentest procedures. This placeholder page contains some keyword stuffing to make it easier for developers to find in future.