### PR TITLE
Update leavers procedure

### DIFF
--- a/source/manual/encrypted-hiera-data.html.md
+++ b/source/manual/encrypted-hiera-data.html.md
@@ -192,6 +192,8 @@ credentials.
 
 1. Delete their public key from the [`gpg_public_keys` directory](https://github.com/alphagov/govuk-secrets/tree/main/gpg_public_keys) in govuk-secrets.
 
+1. Remove any other references to the user.
+
 1. Commit your changes and raise a pull request for review.
 
 > **WARNING**

--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -17,9 +17,7 @@ will remain on our servers forever more, [unless you perform a workaround](#what
    [example][absent-example].
 1. Once this has been raised as a PR and merged, deploy Puppet to all
    environments.
-1. Create a PR in [GOV.UK secrets][govuk-secrets] that:
-  - Removes the user from [production hieradata][production-hieradata]. Read [what to do when someone leaves][what-to-do-when-someone-leaves]
-  - Removes the user from [AWS production hieradata][aws-production-hieradata]. Read [what to do when someone leaves][what-to-do-when-someone-leaves]
+1. Create a PR in [GOV.UK secrets][govuk-secrets] that removes the user from [AWS production hieradata][aws-production-hieradata]. Follow the instructions in [what to do when someone leaves][what-to-do-when-someone-leaves]
 1. Create another PR for Puppet that:
   - Removes the user manifest file
   - Removes the user from [Integration users][integration-users]


### PR DESCRIPTION
Update the leavers procedure. The [current doc](https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html) lists two things to remove the user from (production hieradata and AWS hieradata) but it looks like we only have AWS hieradata now, so merging this into a single bullet point and removing the unnecessary one.

Also clarifies the [What to do when someone leaves](https://docs.publishing.service.gov.uk/manual/encrypted-hiera-data.html#what-to-do-when-someone-leaves) procedure to include a generic step to remove any other references to the user, which seems easier than listing them specifically and keeping that list up to date.
