### PR TITLE
Update docs that mention mapit where is no longer used

### DIFF
--- a/source/manual/licensing.html.md
+++ b/source/manual/licensing.html.md
@@ -25,7 +25,7 @@ The Licensing service consists of [three separately deployed applications](https
 
 Users use [Licence Finder](https://www.gov.uk/licence-finder) to locate licences on the GOV.UK frontend, but from a technical perspective this is separate from Licensify.
 
-Licence Finder sends users to a "Licence" page served by [Frontend](/repos/frontend.html). Users enter their postcode and Frontend uses [Mapit](/repos/mapit.html) to [find their local authority](https://github.com/alphagov/frontend/blob/8dbe0f0f6ca0f5a777a0d6ca77b858fe5adc2494/app/controllers/licence_controller.rb#L83). Frontend makes a request to a Licensify API to find out whether the licence is available on GOV.UK.
+Licence Finder sends users to a "Licence" page served by [Frontend](/repos/frontend.html). Users enter their postcode and Frontend uses [Locations API](/repos/locations-api.html) to [find their local authority](https://github.com/alphagov/frontend/blob/e8effb3f7edf4f12c0f71076bfb079e985522796/app/controllers/licence_controller.rb#L87). Frontend makes a request to a Licensify API to find out whether the licence is available on GOV.UK.
 
 ### Applying for a licence
 


### PR DESCRIPTION
Mapit is no longer used by Frontend.
We need to update the postcode-related mentions in the dev docs.

Trello card: https://trello.com/c/6TO6GDJM/2934-switch-frontend-to-use-locations-api-5