### PR TITLE
Update redirect issue guidance relating to Whitehall priority queue

### DIFF
--- a/source/manual/howto-change-slug-and-create-redirect.html.md
+++ b/source/manual/howto-change-slug-and-create-redirect.html.md
@@ -95,7 +95,7 @@ slug and the new slug as arguments.
 If you run a task and find the redirect has worked but the new location returns
 a 404, it's likely because the republish command is languishing in the
 low-priority queue ([check queue volumes in Grafana][grafana-queue-volumes]).
-Whitehall appears to put the redirect in the high priority queue, so there can
+Whitehall appears to put the redirect in the low-priority queue, so there can
 be a delay between the redirect being applied and the content being republished.
 
 This should resolve itself over time, but if you need to process the content


### PR DESCRIPTION
## What
Update the guidance for fixing the 404 issue to state that Whitehall appears to publish the in the low-priortity queue.

## Why
When following the guidance on 2nd line, the documentation suggested that Whitehall puts the redirect in the high priority queue, and to resolve the issue you would need to move it to the high priority queue, which is a bit confusing.