### PR TITLE
Mark datagovuk_reference as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -189,13 +189,9 @@
   retired: true
 
 - repo_name: datagovuk_reference
-  team: "#govuk-datagovuk"
-  production_url: https://interval-server.herokuapp.com/
-  management_url: https://dashboard.heroku.com/apps/interval-server
-  production_hosted_on: heroku
   type: data.gov.uk apps
-  sentry_url: false
-  dashboard_url: false
+  team: "#govuk-datagovuk"
+  retired: true
 
 - repo_name: deprecated_columns
   type: Gems


### PR DESCRIPTION
The repo is now archived, and http://reference.data.gov.uk/ is unreachable.