### PR TITLE
Add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.4
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{contains(env.AUTO_MERGE, steps.metadata.outputs.dependency-names) && contains(env.SEMVER, steps.metadata.outputs.update-type)}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          AUTO_MERGE: ("govuk_publishing_components")
+          SEMVER: ("version-update:semver-patch")


### PR DESCRIPTION
This workflow will auto-merge Dependabot PRs for selected internal dependencies if they're minor or patch version bumps.

https://trello.com/c/uwoMBinS/3015-create-proof-of-concept-for-auto-merging-internal-prs-5