### PR TITLE
Fix links to component guides

### DIFF
--- a/source/manual/components.html.md
+++ b/source/manual/components.html.md
@@ -16,9 +16,10 @@ Components in applications are documented in component guides using the [govuk_p
 Find components in these guides:
 
 * [govuk_publishing_components component guide](https://components.publishing.service.gov.uk/component-guide)
-* [government-frontend component guide](https://government-frontend.herokuapp.com/component-guide/)
+* [government-frontend component guide](https://govuk-government-frontend.herokuapp.com/component-guide)
 * [collections component guide](https://govuk-collections.herokuapp.com/component-guide/)
-* [finder-frontend component guide](https://finder-frontend.herokuapp.com/component-guide/)
+* [finder-frontend component guide](https://govuk-finder-frontend.herokuapp.com/component-guide)
+* [frontend component guide](https://govuk-frontend.herokuapp.com/component-guide)
 
 ## Building components
 


### PR DESCRIPTION
Fix the links on [this page](https://docs.publishing.service.gov.uk/manual/components.html#component-guides) as some of them were out of date.