### PR TITLE
Fix broken link on `/apps` page.

### DIFF
--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -12,8 +12,8 @@ Each application should be owned by a team. [What application ownership means in
 Apps can be loosely grouped into different types, including:
 
 - **APIs** provide functionality to other apps. For example, an app can publish content via Publishing API.
-- **Frontend apps** render content to GOV.UK users. For example, a [HMRC manual page][hmrc-manual] is rendered by an application called [government-frontend][government-frontend]. Use the [chrome extension][extension] to find out which application is rendering any given page, and [read more about the frontend architecture on GOV.UK](/manual/frontend-architecture.html).
-- **Publishing apps** are used by editors to publish content to GOV.UK. For example, [specialist-publisher][specialist-publisher] publishes [specialist documents][specialist documents]. The apps are secured by behind a [single signon system][signon].
+- **Frontend apps** render content to GOV.UK users. For example, a [HMRC manual page][hmrc-manual] is rendered by an application called [government-frontend]. Use the [chrome extension] to find out which application is rendering any given page, and [read more about the frontend architecture on GOV.UK](/manual/frontend-architecture.html).
+- **Publishing apps** are used by editors to publish content to GOV.UK. For example, [specialist-publisher] publishes [specialist documents]. The apps are secured by behind a [single signon system][signon].
 
 ## Apps by type
 
@@ -53,11 +53,12 @@ In Google Spreadsheets, use the following formula to import all of the data:
 
 [application-ownership-meaning]: /manual/ownership-meaning.html
 [rails]: http://rubyonrails.org/
-[extension]: https://github.com/alphagov/govuk-browser-extension
+[chrome extension]: https://github.com/alphagov/govuk-browser-extension
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet
 [govuk-app-deployment]: https://github.com/alphagov/govuk-app-deployment
 [slimmer]: https://github.com/alphagov/slimmer
 [gds-sso]: https://github.com/alphagov/gds-sso
+[government-frontend]: https://github.com/alphagov/government-frontend
 [hmrc-manual]: https://www.gov.uk/hmrc-internal-manuals/vat-clothing/vclothing1100
 [specialist documents]: https://www.gov.uk/cma-cases/legal-services-market-study
 [manuals-frontend]: /repos/manuals-frontend.html


### PR DESCRIPTION
The link `government-frontend` was broken and being rendered as `[government-frontend][government-frontend]` because there was no corresponding reference.

Also clean up reference-style links which had unnecessarily duplicated link text and reference.