### PR TITLE
Add `bulk-changer` repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -34,6 +34,13 @@
   production_hosted_on: aws
   production_url: false
 
+- repo_name: bulk-changer
+  type: Utilities
+  team: "#govuk-platform-reliability-team"
+  description: Command-line tools for bulk raising PRs across GOV.UK repos.
+  sentry_url: false
+  dashboard_url: false
+
 - repo_name: bulk-merger
   type: Utilities
   team: "#govuk-platform-reliability-team"


### PR DESCRIPTION
Spun out of https://trello.com/c/AqLwVouU/2981-automatically-include-pr-template-in-dependabot-pr-descriptions-5.

Adds the new [`bulk-changer`](https://github.com/alphagov/bulk-changer) repo to `data/repos.yml`.