### PR TITLE
Document that Production Admin role grants access to Tools env

### DIFF
--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -15,15 +15,13 @@ If GitHub is unavailable, we lose:
 * Access to our primary code repository
 * The ability to authenticate with Jenkins, as it makes use of GitHub groups
 
-We [mirror all GitHub repositories](repository-mirroring.html) tagged with `govuk` to AWS CodeCommit every 2 hours. In the event of GitHub being down, we can deploy from AWS CodeCommit repos. This requires help from a GOV.UK AWS admin.
+We [mirror all GitHub repositories](repository-mirroring.html) tagged with `govuk` to AWS CodeCommit every 2 hours. In the event of GitHub being down, we can deploy from AWS CodeCommit repos.
 
 ### Deploying from AWS CodeCommit
 
 Use the normal deployment Jenkins job but check the box to deploy from AWS CodeCommit.
 
 #### Making changes to code in AWS CodeCommit before deployment
-
-GOV.UK AWS admin users can give access to developers who need to make changes to the code before deployment.
 
 1. In the root of the local repo, run the following commands to install the AWS
    credential helper and add CodeCommit as a remote:
@@ -71,7 +69,7 @@ See the [Jenkins documentation](https://jenkins.io/doc/book/system-administratio
 
 ### Deploying the code change
 
-1. Review the pull request on AWS CodeCommit through the [AWS Console](https://eu-west-2.console.aws.amazon.com/codesuite/codecommit/repositories?region=eu-west-2) (access to GOV.UK repos must be granted by a GDS AWS administrator).
+1. Review the pull request on AWS CodeCommit through the [AWS Console](https://eu-west-2.console.aws.amazon.com/codesuite/codecommit/repositories?region=eu-west-2)
 
 1. Create a release tag manually in git. This should follow the standard format
    `release_X`. Tag the branch directly instead of merging it.

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -57,7 +57,7 @@ Access should be granted at the discretion of the engineer's tech lead, once the
 - Permission to read & write to the [password store](https://github.com/alphagov/govuk-secrets/tree/main/pass) in govuk-secrets store using [GPG](https://github.com/alphagov/govuk-secrets/blob/master/pass/2ndline/.gpg-id)
 - Access to [Production Deploy Jenkins](https://deploy.blue.production.govuk.digital/) and [Staging Deploy Jenkins](https://deploy.blue.staging.govuk.digital/) to deploy applications via the [GOV.UK Production GitHub team](https://github.com/orgs/alphagov/teams/gov-uk-production)
 - [SSH access](https://docs.publishing.service.gov.uk/manual/howto-ssh-to-machines.html) to production and staging servers via [govuk-puppet](https://github.com/alphagov/govuk-puppet)
-- AWS [PowerUser Access](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/production/common.tfvars) via the `role_poweruser_user_arns` role
+- Privileged AWS Access in [Production](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/production/common.tfvars), [Staging](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/staging/common.tfvars) and [Tools](https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/tools/common.tfvars) environments (via the `role_admin_user_arns` role)
 - [Google Cloud Platform (GCP)](/manual/google-cloud-platform-gcp.html) access to role to manage [static mirrors](/manual/fall-back-to-mirror.html) and DNS
 - Signon "Super Admin" access in production
 - `engineer` and "Access all services" permissions in Fastly


### PR DESCRIPTION
We should now grant admin access to the Tools environment at the same time as granting said access to Production/Staging.