### PR TITLE
Remove reference to the dummy content store

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -368,8 +368,6 @@
   type: Data science
 
 - repo_name: govuk-content-schemas
-  production_url: https://govuk-content-store-examples.herokuapp.com/
-  management_url: https://dashboard.heroku.com/apps/govuk-content-store-examples
   team: "#govuk-publishing-platform"
   production_hosted_on: heroku
   type: Utilities


### PR DESCRIPTION
We are retiring this application, so removing it from here.

[Trello](https://trello.com/c/z08hU3Ov/360-retire-the-dummy-content-store)