### PR TITLE
Mark govuk_taxonomy_helpers as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -737,10 +737,12 @@
   dashboard_url: false
 
 - repo_name: govuk_taxonomy_helpers
-  team: "#navigation-and-presentation-govuk"
+  retired: true
   type: Utilities
-  sentry_url: false
-  dashboard_url: false
+  description: |
+    govuk_taxonomy_helpers was a gem that provided code for working with the
+    govuk-taxonomy. It was only used by Content Tagger and was retired as a gem
+    after the code was merged into Content Tagger.
 
 - repo_name: govuk_test
   team: "#govuk-platform-reliability-team"


### PR DESCRIPTION
This project was archived in October 2022, the functionality has been ported into content-tagger in https://github.com/alphagov/content-tagger/pull/1391