### PR TITLE
Remove references to fabric

### DIFF
--- a/source/manual/alerts/rabbitmq-dead-nodes.html.md
+++ b/source/manual/alerts/rabbitmq-dead-nodes.html.md
@@ -7,7 +7,7 @@ section: Icinga alerts
 ---
 
 
-This can happen if one of the machines in the cluster is killed by AWS and replaced with a new machine. In this scenario, the cluster is still working, but leaving the dead node will cause problems in future e.g. when we try to [reboot the machines to install updates](https://github.com/alphagov/fabric-scripts/blob/a14686667d27790f0978146634b1e4d281552b8c/rabbitmq.py#L57). The check can be found [here][alert_check].
+This can happen if one of the machines in the cluster is killed by AWS and replaced with a new machine. In this scenario, the cluster is still working, but leaving the dead node will cause problems in future. The check can be found [here][alert_check].
 
 First, check which node is dead:
 
@@ -28,7 +28,7 @@ gds govuk connect -e production ssh aws/rabbitmq "sudo rabbitmqctl forget_cluste
 ```
 
 [rabbitmq_doc]: https://docs.publishing.service.gov.uk/manual/rabbitmq.html
-[alert_check]: https://github.com/alphagov/govuk-puppet/blob/ae1be54779ae6912fe693cc66394e6e61afccd9b/modules/govuk_rabbitmq/templates/check_rabbitmq_dead_nodes.cfg.erb
+[alert_check]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk_rabbitmq/templates/check_rabbitmq_dead_nodes.cfg.erb
 [restart_an_application]: https://docs.publishing.service.gov.uk/manual/restart-application.html
 
 ## Unhealthy nodes

--- a/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
+++ b/source/manual/alerts/rabbitmq-no-consumers-listening.html.md
@@ -15,12 +15,12 @@ the alert.
 
 For information about how we use RabbitMQ, see [here][rabbitmq_doc].
 
-### `No consumers listening to queue`
+### No consumers listening to queue
 
 This check reports a critical error when **no** consumers are listening to the
 queue, meaning messages entering the queue will never be processed.
 
-### `No activity for X seconds: idle times are [X, Y, Z]`
+### No activity for X seconds: idle times are [X, Y, Z]
 
 This checks whether the RabbitMQ consumers for a queue have been active in the
 last 5 minutes. Consumers in an `idle` state are listening to the queue but are
@@ -74,12 +74,8 @@ messages then this could indicate an issue with the consumer.
 
 ### Troubleshooting steps
 
-1. You could try restarting the consumer applications. After restarting, check
-   to see if the problem is solved. E.g for email-alert-service, run:
-
-```bash
-$ fab $environment class:email_alert_api app.restart:email-alert-service
-```
+1. You could try restarting the application [on all the machines of the relevant class](https://docs.publishing.service.gov.uk/manual/howto-run-ssh-commands-on-many-machines).
+   For example, to restart the email-alert-service application, you'd SSH into each `email_alert_api` machine and [restart the app](/manual/restart-application.html). After restarting, check to see if the problem is solved.
 
 2. If the issue has not resolved, we should check in the consumers application
    logs to see if any errors are being thrown.

--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -153,7 +153,6 @@ support (assuming everything is working).
 
 [So, you're having an incident]: /manual/incident-what-to-do.html
 [docs]: https://github.com/alphagov/govuk-developer-docs/
-[fabric]: https://github.com/alphagov/fabric-scripts/
 [govuk-secrets]: https://github.com/alphagov/govuk-secrets/
 [vcloud]: connect-to-vcloud-director.html
 [payment claim form]: https://forms.gle/yvPoANwrsHz8SrL4A

--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -40,8 +40,8 @@ the past where user had large files in that directory.
 
 Machines will eventually get recycled as they're scaled up or down, so these
 directories should naturally start to disappear over time. If there is a need
-to remove the directories more quickly, you can consider
-[running commands on multiple machines](/manual/howto-run-ssh-commands-on-many-machines.html).
+to remove the directories more quickly, you can consider using some of the
+[commands here](manual/howto-run-ssh-commands-on-many-machines.html#useful-commands).
 
 Unfortunately it's [not possible to retrospectively reintroduce](https://github.com/alphagov/govuk-puppet/pull/10892#issuecomment-749678673)
 the user with a `ensure => absent` argument, as the user will already have


### PR DESCRIPTION
### **What**

Fabric is an old tool that can no longer be used by [GOV.UK](http://gov.uk/) Devs. We should therefore remove all references to it from our docs and replace them with alternative commands

### **Why**

Fabric used to let us apply an ssh command across lots of machines. However in recent years the tool has become difficult for many devs to install.

It relies on an old deprecated form of python, and its dependencies cannot be installed today in a way that function.

It has still been referred to as a command in numerous places in [GOV.UK](http://gov.uk/) developer documentation, causing confusion for 2ndline shifts which are unable to use the tool.

This PR therefore seeks to remove said references. 

Trello: https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs