### PR TITLE
Retire side-by-side-browser

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1061,13 +1061,13 @@
   production_hosted_on: aws
 
 - repo_name: side-by-side-browser
-  team: "#govuk-publishing-platform"
-  production_url: https://govuk-side-by-side-browser.herokuapp.com/
-  management_url: https://dashboard.heroku.com/apps/govuk-side-by-side-browser
-  production_hosted_on: heroku
   type: Transition apps
-  sentry_url: false
-  dashboard_url: false
+  retired: true
+  description: |
+    This used to be a supporting tool for transition which was used to allow
+    browsing a preview of a transitioned host with the current host. It
+    was retired in November 2022 to reflect the reduced need for transition
+    functionality.
 
 - repo_name: sidekiq-monitoring
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
Trello: https://trello.com/c/rv3f6V9H/378-retire-side-by-side-browser

This application is being retired. It has been non-operational for an unclear amount of time due to being hosted on a personal Heroku account. Due to this strange hosting it has never been a full part of the GOV.UK stack.

We decided that, since to the very infrequent usage of transition, it was a better option to retire the app that try to resurrect it.