### PR TITLE
Retire govuk schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Clone govuk-content-schemas
+      - name: Clone publishing api
         uses: actions/checkout@v2
         with:
-          repository: alphagov/govuk-content-schemas
+          repository: alphagov/publishing-api
           ref: deployed-to-production
-          path: tmp/govuk-content-schemas
+          path: tmp/publishing-api
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - run: bundle exec rake
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
+          GOVUK_CONTENT_SCHEMAS_PATH: tmp/publishing-api/content_schemas
 
   deploy:
     needs: test
@@ -41,12 +41,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Clone govuk-content-schemas
+      - name: Clone publishing api
         uses: actions/checkout@v2
         with:
-          repository: alphagov/govuk-content-schemas
+          repository: alphagov/publishing-api
           ref: deployed-to-production
-          path: tmp/govuk-content-schemas
+          path: tmp/publishing-api
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -54,7 +54,7 @@ jobs:
         run: bundle exec rake build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
+          GOVUK_CONTENT_SCHEMAS_PATH: tmp/publishing-api/content_schemas
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,8 +168,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
-    govuk_schemas (4.4.1)
-      json-schema (~> 2.8.0)
+    govuk_schemas (4.5.0)
+      json-schema (>= 2.8, < 3.1)
     govuk_tech_docs (3.2.1)
       autoprefixer-rails (~> 10.2)
       chronic (~> 0.10.2)

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ end
 namespace :assets do
   desc "Build the static site"
   task :precompile do
-    sh "rm -rf /tmp/govuk-content-schemas; git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas middleman build"
+    sh "rm -rf /tmp/govuk-content-schemas; git clone https://github.com/alphagov/publishing-api.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas/content_schemas middleman build"
   end
 end
 

--- a/app/content_schema.rb
+++ b/app/content_schema.rb
@@ -36,7 +36,7 @@ class ContentSchema
     end
 
     def link_to_github
-      "https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/#{schema_name}/frontend/schema.json"
+      "https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/#{schema_name}/frontend/schema.json"
     end
 
     def random_example
@@ -64,7 +64,7 @@ class ContentSchema
     end
 
     def link_to_github
-      "https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/#{schema_name}/publisher/schema.json"
+      "https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/#{schema_name}/publisher_v2/schema.json"
     end
 
     def random_example
@@ -92,7 +92,7 @@ class ContentSchema
     end
 
     def link_to_github
-      "https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/#{schema_name}/publisher/links.json"
+      "https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/#{schema_name}/publisher_v2/links.json"
     end
 
     def random_example

--- a/app/document_types.rb
+++ b/app/document_types.rb
@@ -1,6 +1,6 @@
 class DocumentTypes
   FACET_QUERY = "https://www.gov.uk/api/search.json?facet_content_store_document_type=500,examples:10,example_scope:global&count=0".freeze
-  DOCUMENT_TYPES_URL = "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/main/lib/govuk_content_schemas/allowed_document_types.yml".freeze
+  DOCUMENT_TYPES_URL = "https://raw.githubusercontent.com/alphagov/publishing-api/main/content_schemas/allowed_document_types.yml".freeze
 
   def self.pages
     known_from_search = facet_query.dig("facets", "content_store_document_type", "options").map do |o|

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -369,10 +369,10 @@
 
 - repo_name: govuk-content-schemas
   team: "#govuk-publishing-platform"
-  production_hosted_on: heroku
   type: Utilities
   sentry_url: false
   dashboard_url: false
+  retired: true
 
 - repo_name: govuk-content-similarity
   team: "#data-products"

--- a/source/content-schemas.html.md.erb
+++ b/source/content-schemas.html.md.erb
@@ -5,7 +5,7 @@ title: Content schemas
 
 The content schemas describe the underlying structure of a piece of content. This is different to the [document types][] which describe the different types of content on GOV.UK.
 
-The content schemas are defined in the [govuk-content-schemas repo][].
+The content schemas are defined in the [publishing api repo][].
 
 [document types]: /document-types.html
-[govuk-content-schemas repo]: https://github.com/alphagov/govuk-content-schemas
+[publishing api repo]: https://github.com/alphagov/publishing-api/tree/main/content_schemas

--- a/source/manual/add-a-new-document-type.html.md
+++ b/source/manual/add-a-new-document-type.html.md
@@ -12,25 +12,25 @@ The [document type][] describes what a page on GOV.UK looks like.
 
 ## Add the document type in the govuk-content-schema repo
 
-You need to add the document type into the [allowed document types][] in [govuk-content-schemas][]. Once you have added the document type you should:
+You need to add the document type into the [allowed document types][] in [publishing api][]. Once you have added the document type you should:
 
 - Commit the change
 - Run `bundle exec rake` to generate the schemas again
 - Commit this update separately
 
-Examples of implementation:
+Examples of implementation (note that these examples are for the retired govuk-content-schemas repo: please add examples of adding to publishing api when these are available):
 
 - <https://github.com/alphagov/govuk-content-schemas/pull/652>
 - <https://github.com/alphagov/govuk-content-schemas/pull/630>
 
-[allowed document types]: https://github.com/alphagov/govuk-content-schemas/blob/main/lib/govuk_content_schemas/allowed_document_types.yml
-[govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
+[allowed document types]: https://github.com/alphagov/publishing-api/tree/main/content_schemas/allowed_document_types.yml
+[publishing api]: https://github.com/alphagov/publishing-api
 
 ## Add a new content schema
 
 If your document type needs a new content schema, see "[Adding a new schema][]".
 
-[Adding a new schema]: /repos/govuk-content-schemas/adding-a-new-schema.html
+[Adding a new schema]: /repos/publishing-api/content_schemas/adding-a-new-schema.html
 
 ## Make the new document type available to search
 

--- a/source/manual/add-translation-whitehall.html.md
+++ b/source/manual/add-translation-whitehall.html.md
@@ -71,14 +71,17 @@ In [Whitehall](https://github.com/alphagov/whitehall):
          it: Italiano
      ```
 
-### 3. Update GOV.UK Content Schemas
+### 3. Update content schemas in publishing api
+
+Please note that this example PR is for the retired govuk-content-schemas repo - please add examples
+of adding to publishing api when it is available:
 
 [Example PR](https://github.com/alphagov/govuk-content-schemas/pull/906)
 
-In [GOV.UK Content Schemas](https://github.com/alphagov/govuk-content-schemas):
+In [publishing api](https://github.com/alphagov/publishing-api):
 
-1. Edit `formats/shared/definitions/locale.jsonnet` to include the new locale in alphabetical order
-2. Run `rake` to generate all the schemas
+1. Edit `content_schemas/formats/shared/definitions/locale.jsonnet` to include the new locale in alphabetical order
+2. Run `rake build_schemas` to generate all the schemas
 
 ### 4. Update Content Store
 

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -277,7 +277,7 @@ retrieved via the "[Content API]", which lives in the content-store repo.
 Content is published to the Content Store via the [Publishing API], which
 stores all of the editions of the document, and performs validation checks
 whenever it receives a new edition. Every piece of content has a `schema_name`
-corresponding to a particular JSON schema defined in [govuk-content-schemas].
+corresponding to a particular JSON schema defined in the [content schemas in Publishing Api].
 Most backend apps have their own databases modelling documents in their own
 way; at the point of sending the document to Publishing API, they transform the
 document to a JSON payload conforming to the appropriate schema.
@@ -298,7 +298,7 @@ sending an edition downstream to the Content Store.
 
 [Content API]: /repos/content-store.html
 [content-store]: https://github.com/alphagov/content-store
-[govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
+[content schemas in Publishing Api]: https://github.com/alphagov/publishing-api/tree/main/content_schemas
 [Link expansion]: https://github.com/alphagov/publishing-api/blob/main/docs/link-expansion.md
 [Publishing API]: https://github.com/alphagov/publishing-api
 [rendering]: #rendering
@@ -365,7 +365,7 @@ tag content independently using [content-tagger].
 
 [content-tagger]: https://github.com/alphagov/content-tagger
 [dependency resolution]: https://github.com/alphagov/publishing-api/blob/main/docs/dependency-resolution.md
-[schema-organisations-example]: https://github.com/alphagov/govuk-content-schemas/blob/d9684140462e4a138668539c04829cd808636ed5/dist/formats/news_article/publisher_v2/schema.json#L70-L73
+[schema-organisations-example]: https://github.com/alphagov/publishing-api/blob/a8039d430e44c86c3f54a69569f07ad48a4fc912/content_schemas/dist/formats/news_article/publisher_v2/schema.json#L70-L73
 [taxonomies]: /manual/taxonomy.html
 
 ### Summary

--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -57,7 +57,7 @@ Ruby / Rails applications:
 - [govuk_sidekiq][] - Provides common configuration for using sidekiq with
   GOV.UK infrastructure
 - [govuk_schemas][] - Provides helper utilities for interfacing with
-  [govuk-content-schemas][]
+  [content schemas in Publishing Api][]
 - [govuk_test][] - Provides configuration and dependencies for headless browser
   testing
 - [plek][] - Utility tool to access determine base URLs for GOV.UK applications
@@ -81,7 +81,7 @@ introduced by these gems.
 [govuk_publishing_components]: https://github.com/alphagov/govuk_publishing_components
 [govuk_sidekiq]: https://github.com/alphagov/govuk_sidekiq
 [govuk_schemas]: https://github.com/alphagov/govuk_schemas
-[govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
+[content schemas in Publishing Api]: https://github.com/alphagov/publishing-api/tree/main/content_schemas
 [govuk_test]: https://github.com/alphagov/govuk_test
 [plek]: https://github.com/alphagov/plek
 [rubocop-govuk]: https://github.com/alphagov/rubocop-govuk

--- a/source/manual/intro-to-docker-advanced.html.md
+++ b/source/manual/intro-to-docker-advanced.html.md
@@ -40,7 +40,7 @@ Now we can run `make content-publisher` and the commands are run for us.
 
 ## Step 2: `/govuk`
 
-At the end of the last tutorial we got some, but not all, of the tests passing. The remaining failures should be due to a missing dependency: [govuk-content-schemas][]. The tests are looking for the shemas at `../govuk-content-schemas`, which doesn't exist inside our container, since we only mapped the `content-publisher` directory to `/app`.
+At the end of the last tutorial we got some, but not all, of the tests passing. The remaining failures should be due to a missing dependency: [content-schemas][]. The tests are looking for the shemas at `../publishing-api/content_schemas`, which doesn't exist inside our container, since we only mapped the `content-publisher` directory to `/app`.
 
 * Mount the whole of the `~/govuk` directory
 
@@ -388,7 +388,7 @@ bin/setup
 [Bundler]: https://bundler.io/
 [content-publisher]: https://github.com/alphagov/content-publisher
 [dnsmasq]: http://www.thekelleys.org.uk/dnsmasq/doc.html
-[govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
+[content-schemas]: https://github.com/alphagov/publishing-api/tree/main/content_schemas
 [govuk-docker]: https://github.com/alphagov/govuk-docker
 [makefile]: https://www.gnu.org/software/make/manual/html_node/Introduction.html
 [nginx-proxy]: https://github.com/jwilder/nginx-proxy

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -128,7 +128,7 @@ Failing this, there is a [rake task](https://github.com/alphagov/search-api/blob
 
 ### 7. Update Specialist Publisher
 
-1. Create and deploy pull requests for GOV.UK Content Schemas ([example](https://github.com/alphagov/govuk-content-schemas/pull/1014)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1722/commits/79c10d173f8294fef25b07678a7e74213e78e424)) to support both countries temporarily (during the data migration).
+1. Create and deploy pull requests for schemas in publishing api  ([example](https://github.com/alphagov/govuk-content-schemas/pull/1014)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1722/commits/79c10d173f8294fef25b07678a7e74213e78e424)) to support both countries temporarily (during the data migration). Note that the schema example PR given here is for the archived govuk-content-schemas repo - please update with a publishing api PR when this is available.
 
 2. Run the rake task [publishing_api:publish_finder[finder]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=specialist-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:publish_finder[finder]) to republish the updated finders:
    * `export_health_certificates`
@@ -140,7 +140,7 @@ Failing this, there is a [rake task](https://github.com/alphagov/search-api/blob
    * [Export Health Certificates](https://www-origin.integration.publishing.service.gov.uk/export-health-certificates?cachebust=123).
    * [International Development Funds](https://www-origin.integration.publishing.service.gov.uk/international-development-funding?cachebust=123).
 
-5. Create and deploy another pull request for GOV.UK Content Schemas ([example](https://github.com/alphagov/govuk-content-schemas/pull/1015)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1724)) to remove support for the old country.
+5. Create and deploy another pull request for content schemas in publishing api ([example](https://github.com/alphagov/govuk-content-schemas/pull/1015)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1724)) to remove support for the old country. Note that the schema example PR given here is for the archived govuk-content-schemas repo - please update with a publishing api PR when this is available.
 
 6. Re-publish the finders again, as above.
 

--- a/source/manual/test-and-build-a-project-on-jenkins-ci.html.md
+++ b/source/manual/test-and-build-a-project-on-jenkins-ci.html.md
@@ -60,10 +60,10 @@ with a Jenkinsfile, which should be your new branch. Any open branches need to b
 ### 5. Set up schema testing
 
 Many GOV.UK applications test against the
-[content schemas](https://github.com/alphagov/govuk-content-schemas/).
+[content schemas](https://github.com/alphagov/publishing-api/blob/main/content_schemas). contained in publishing api
 
-To test your application for each PR on govuk-content-schemas, add it to the [govuk-content-schemas
-Jenkinsfile](https://github.com/alphagov/govuk-content-schemas/blob/main/Jenkinsfile).
+To test your application for each PR against any changes to publishing api's content-schemas, add it to the [publishing-api
+Jenkinsfile](https://github.com/alphagov/publishing-api/blob/main/Jenkinsfile).
 
 ## Specifying which database to use
 

--- a/source/manual/test-and-build-a-project-with-github-actions.html.md
+++ b/source/manual/test-and-build-a-project-with-github-actions.html.md
@@ -219,16 +219,16 @@ jobs:
       RAILS_ENV: test
       REDIS_URL: redis://localhost:6379/0
       TEST_DATABASE_URL: postgresql://postgres@localhost/content-publisher
-      GOVUK_CONTENT_SCHEMAS_PATH: vendor/govuk-content-schemas
+      GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
     steps:
       - name: Clone project
         uses: actions/checkout@v2
-      - name: Clone GOV.UK Content Schemas
+      - name: Clone publishing api for content schemas
         uses: actions/checkout@v2
         with:
-          repository: alphagov/govuk-content-schemas
+          repository: alphagov/publishing-api
           ref: deployed-to-production
-          path: vendor/govuk-content-schemas
+          path: vendor/publishing-api
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/source/manual/world-taxonomy.html.md
+++ b/source/manual/world-taxonomy.html.md
@@ -61,7 +61,7 @@ The structure of the world taxonomy is dense and repetitive. This results in a p
 
 The [/world][] page is unconventional for GOV.UK as it is not represented by a content item and it is instead only represented in router while being [rendered by Whitehall][]. There is a content item at [/world/all][] which redirects to /world, however the data from this content item is not used to render /world.
 
-[world-location]: https://github.com/alphagov/govuk-content-schemas/blob/0c6097e6afa6c7679b97aa4331b5d1fdd75fcdc3/formats/world_location.jsonnet
+[world-location]: https://github.com/alphagov/publishing-api/blob/a8039d430e44c86c3f54a69569f07ad48a4fc912/content_schemas/formats/world_location.jsonnet
 [atom-feed]: https://www.gov.uk/world/yemen.atom
 [world-page]: https://www.gov.uk/world
 [portugal-info]: https://www.gov.uk/government/news/information-and-events-for-uk-nationals-living-in-portugal

--- a/spec/app/content_schema_spec.rb
+++ b/spec/app/content_schema_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ContentSchema do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").frontend_schema
 
-      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/generic/frontend/schema.json")
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/generic/frontend/schema.json")
     end
 
     it "it has a random example" do
@@ -24,7 +24,7 @@ RSpec.describe ContentSchema do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").publisher_content_schema
 
-      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/generic/publisher/schema.json")
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/generic/publisher_v2/schema.json")
     end
 
     it "it has a random example" do
@@ -45,7 +45,7 @@ RSpec.describe ContentSchema do
     it "it can link to GitHub" do
       schema = ContentSchema.new("generic").publisher_links_schema
 
-      expect(schema.link_to_github).to eql("https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/generic/publisher/links.json")
+      expect(schema.link_to_github).to eql("https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/generic/publisher_v2/links.json")
     end
   end
 end

--- a/spec/app/document_types_spec.rb
+++ b/spec/app/document_types_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DocumentTypes do
           },
         )
 
-      stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-content-schemas/main/lib/govuk_content_schemas/allowed_document_types.yml")
+      stub_request(:get, "https://raw.githubusercontent.com/alphagov/publishing-api/main/content_schemas/allowed_document_types.yml")
         .to_return(body: File.read("spec/fixtures/allowed-document-types-fixture.yml"))
 
       document_type = DocumentTypes.pages.first


### PR DESCRIPTION
This updates dev docs following the recent move of schemas into publishing api.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)