### PR TITLE
Add policy on Ruby versions for Rubygems

### DIFF
--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -61,6 +61,7 @@ New versions of Ruby bring us improved performance and nicer syntax for certain 
 
 - Be running on the current major version
 - Maintain our applications at the current or next-to-current minor version
+- Maintain our gems to support all currently supported Ruby versions (see [Ruby version compatibility for gems](/manual/publishing-a-ruby-gem.html#ruby-version-compatibility))
 
 See [Add a new Ruby version][] for a guide on how to install a new version of Ruby.
 

--- a/source/manual/publishing-a-ruby-gem.html.md
+++ b/source/manual/publishing-a-ruby-gem.html.md
@@ -47,6 +47,35 @@ The default Jenkins build script will automatically detect the presence of a
 [Jenkinsfile for govuk_app_config](https://github.com/alphagov/govuk_app_config/blob/master/Jenkinsfile)
 for an example.
 
+## Ruby version compatibility
+
+Our policy is that our Ruby gems are compatible with all [currently supported
+minor versions of Ruby][supported-rubies]. For example, in November 2022, There
+are supported Ruby releases of 2.7, 3.0 and 3.1, thus we expect gems to be
+compatible with each of those and be tested against them (there is
+[documentation][testing-gems] on the approach to test them).
+
+We specify the minimum Ruby version supported in the [gemspec file][gemspec-ruby-version]
+and expect the `.ruby-version` to match that version. For example, if Ruby 2.7
+is the oldest supported minor version we expect gems to require Ruby 2.7 or
+greater and the `.ruby-version` file to reference the most recent Ruby 2.7
+release (which in November 2022 is 2.7.6).
+
+When new minor versions of Ruby are released (typically each Christmas) we
+update gems to test against the new version. For example, when Ruby 3.2
+is released our gem test matrices should be expanded to test against Ruby 3.2.
+
+When Ruby versions reach end-of-life (typically April) we update gems
+to drop support for that Ruby version and update the `.ruby-version` files to
+the next supported version. For example, when Ruby 2.7 reaches end of life, we drop 2.7
+from the test matrices and we update the `.ruby-version` file to be the most
+recent release of the 3.0 branch (which in November 2022 is 3.0.4).
+
+[supported-rubies]: https://www.ruby-lang.org/en/downloads/branches/
+[testing-gems]: /manual/test-and-build-a-project-with-github-actions.html#a-ruby-gem
+[gemspec-ruby-version]: https://guides.rubygems.org/specification-reference/#required_ruby_version
+[minimum-ruby-gem]: https://github.com/alphagov/govuk_sidekiq/blob/12183f8781f2755e185e6a14a722e6f3892bda4a/govuk_sidekiq.gemspec#L19
+
 ### Manually publishing gems from the CLI
 
 Sometimes you may be required to publish a gem outside of Jenkins, if you need

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -57,7 +57,7 @@ and then on the respective machine that your app will run on (e.g. `backend`).
 
 ### Update Ruby version in the relevant repos
 
-We use [upgrade-ruby-version][] to automatically raise pull requests in GOV.UK repositories which use Ruby.
+We use [upgrade-ruby-version][] to automatically raise pull requests in GOV.UK repositories to update Ruby applications. Please note, we manage the [Ruby version in gems](/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) differently to applications.
 
 It's advised not to use your personal GitHub account to create the access token required by the script, as another developer will need to approve the PRs. You can use [govuk-ci GitHub account](https://github.com/govuk-ci). The login credentials for the account can be fetched from [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/main/pass) with:
 


### PR DESCRIPTION
This adds documentation on the approach we take for managing Ruby versions with gems, this is added as documentation is this is not widely known. I've also added some links to documentation that may be used when updating Ruby to hopefully bring this to peoples attention (thanks for the suggestions Murilo, Ollie and Jonathan).

With our Ruby apps we aim to run them, in dev, CI and production on the newest Ruby version available. However with a Rubygem we aim for it to be compatible across the range of supported Ruby versions - this allows our apps to upgrade Ruby versions when the teams are ready and is friendly to anyone outside GDS who also uses the gems.

When supporting a number of Ruby versions it is better to run on the lowest version by default in development. This is because it immediately prevents using features that aren't available in all of the supported Rubies and it stops the linter trying to make suggestions to utilise those new features.