### PR TITLE
Retirement note for omniauth-gds

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -881,10 +881,11 @@
     to government-frontend in March 2017.
 
 - repo_name: omniauth-gds
-  team: "#govuk-publishing-platform"
   type: Gems
-  sentry_url: false
-  dashboard_url: false
+  retired: true
+  description: |
+    omniauth-gds was a gem providing an omniauth strategy for signon. It
+    was merged into the gds-sso gem.
 
 - repo_name: optic14n
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
This gem was retired October 2022 [1]

[1]: https://github.com/alphagov/omniauth-gds/pull/33