### PR TITLE
Remove references to govuk-dependencies

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -109,7 +109,6 @@ redirects:
   /apps/govuk-accessibility-reports.html: /repos/govuk-accessibility-reports.html
   /apps/govuk-content-store-examples.html: /repos/govuk-content-store-examples.html
   /apps/govuk-delivery.html: /repos/govuk-delivery.html
-  /apps/govuk-dependencies.html: /repos/govuk-dependencies.html
   /apps/govuk-display-screen.html: /repos/govuk-display-screen.html
   /apps/govuk-docker.html: /repos/govuk-docker.html
   /apps/govuk-jenkinslib.html: /repos/govuk-jenkinslib.html

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -399,15 +399,6 @@
     translation of Whitehall feed URLs into Govdelivery topics. Retired in favour
     of email-alert-api in September 2017.
 
-- repo_name: govuk-dependencies
-  team: "#govuk-platform-reliability-team"
-  production_url: https://govuk-dependencies.herokuapp.com/
-  management_url: https://dashboard.heroku.com/apps/govuk-dependencies
-  production_hosted_on: heroku
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
-
 - repo_name: govuk-dependency-checker
   team: "#govuk-platform-reliability-team"
   type: Utilities

--- a/source/manual/manage-ruby-dependencies.html.md
+++ b/source/manual/manage-ruby-dependencies.html.md
@@ -52,7 +52,7 @@ Go to your project in GitHub and click on "Insights", then "Dependency graph", t
 
 #### Audit Dependabot PRs
 
-We have the [govuk-dependencies app][app] to monitor outstanding Dependabot PRs on govuk repos.
+We have the [seal][app] to monitor outstanding Dependabot PRs on GDS repos.
 
 ### Security
 
@@ -64,4 +64,4 @@ There are 2 safeguards to prevent unauthorised code changes. Firstly, Dependabot
 [current]: /manual/keeping-software-current.html
 [Dependabot]: https://dependabot.com
 [admin]: https://app.dependabot.com/accounts/alphagov/repos
-[app]: /repos/govuk-dependencies.html
+[app]: /repos/seal.html


### PR DESCRIPTION
We have started using the Seal repo to alert of us Dependabot PRs and have archived the govuk-dependencies repo.

https://trello.com/c/Vl80xssv/3046-archive-govuk-dependencies