### PR TITLE
Remove references to fabric scripts

### DIFF
--- a/source/manual/howto-block-arbitrary-urls.html.md
+++ b/source/manual/howto-block-arbitrary-urls.html.md
@@ -5,6 +5,7 @@ section: Security
 layout: manual_layout
 parent: "/manual.html"
 ---
+
 During a recent security incident it became necessary to block a GOV.UK
 section in order to prevent access to sensitive data.
 
@@ -20,13 +21,9 @@ In order to block `<LEAK_URL>` on `<INSTANCE_CLASS>` in `<GOVUK_ENVIRONMENT>`:
    - For external/independent applications, e.g. CKAN, you may need to consult the respective routing table to find out from which machine the content is served.
    - Another option to determine which machine class runs an app is to consult the [GOV.UK architecture overview](https://drive.google.com/a/digital.cabinet-office.gov.uk/file/d/1-O5XIIeDK-Mos_thA_hQODBQ6sYnToWs/view?usp=sharing).
 
-1. Disable Puppet on the respective `<INSTANCE_CLASS>`, e.g. via Fabric:
+1. [Disable Puppet on each machine](/manual/howto-run-ssh-commands-on-many-machines.html#disable-puppet) of the respective `<INSTANCE_CLASS>`
 
-   ```
-   fab <GOVUK_ENVIRONMENT> class:<INSTANCE_CLASS> do:'govuk_puppet --disable "RE:GOV.UK Temporary override nginx.conf in order to block <LEAK_URL>"'
-   ```
-
-1. Edit `/etc/nginx/nginx.conf` on the `<INSTANCE_CLASS>` to add a location block
+1. Edit `/etc/nginx/nginx.conf` on each machine of the `<INSTANCE_CLASS>` to add a location block
    to the server block, forcing to return `403 FORBIDDEN`, e.g.
 
    ```
@@ -39,24 +36,17 @@ In order to block `<LEAK_URL>` on `<INSTANCE_CLASS>` in `<GOVUK_ENVIRONMENT>`:
    ```
 
    Location blocks are not limited to absolute paths, but can also include regular expressions if prefixed by the `~` operator.
-   See the additonal external documentation [here][Digital ocean] and [here][Linode] for examples.
+   See the additional external documentation [here][Digital ocean] and [here][Linode] for examples.
    > Note:
    >
    > When using location blocks in general and regular expressions in particular
    > take extra care to not accidentally block unaffected pages as a side effect.
-1. Test the NGINX configuration, e.g. via Fabric
 
-   ```
-   fab <GOVUK_ENVIRONMENT> class:<INSTANCE_CLASS>  do:'sudo service nginx configtest'
-   ```
+1. Test the NGINX configuration by running `sudo service nginx configtest` [on each machine](/manual/howto-run-ssh-commands-on-many-machines.html#loop-over-the-machines)
 
    If the configuration test is successful, e.g. returns `out: nginx: configuration file /etc/nginx/nginx.conf test is successful`
 
-1. Reload the NGINX configuration, e.g. via Fabric
-
-   ```
-   fab <GOVUK_ENVIRONMENT> class:<INSTANCE_CLASS> do:'sudo service nginx restart'
-   ```
+1. Reload the NGINX configuration by running `sudo service nginx restart` [on each machine](/manual/howto-run-ssh-commands-on-many-machines.html#loop-over-the-machines)
 
 1. To make sure the change of configuration was successful, try to browse `https://www.gov.uk/<LEAK_URL>`
 
@@ -65,11 +55,8 @@ In order to block `<LEAK_URL>` on `<INSTANCE_CLASS>` in `<GOVUK_ENVIRONMENT>`:
    or introduce a separate NGINX configuration template for the app if more complex
    changes are required ([example PR](https://github.com/alphagov/govuk-puppet/pull/9485)).
    Alternatively, changes to the app may remove the offending content.
-1. Finally, re-enable Puppet on the `<INSTANCE_CLASS>`, e.g. via Fabric:
 
-   ```
-   fab <GOVUK_ENVIRONMENT> class:<INSTANCE_CLASS>  do:'govuk_puppet --enable'
-   ```
+1. Finally, [re-enable Puppet on each machine](/manual/howto-run-ssh-commands-on-many-machines.html#enable-puppet) of the `<INSTANCE_CLASS>`
 
 - [Digital ocean]: https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms
 - [Linode]: https://www.linode.com/docs/web-servers/nginx/how-to-configure-nginx/#location-blocks


### PR DESCRIPTION
Fabric is now deprecated.

https://trello.com/c/AGdifoDb/250-remove-fabric-and-replace-references-in-docs