### PR TITLE
Add missing `search-api` Learn to Rank alert document

### DIFF
--- a/source/manual/alerts/search-api-learn-to-rank.html.md
+++ b/source/manual/alerts/search-api-learn-to-rank.html.md
@@ -1,0 +1,11 @@
+---
+owner_slack: "#govuk-2ndline-tech"
+title: Train and deploy LTR model for Search API
+parent: "/manual.html"
+layout: manual_layout
+section: Icinga alerts
+---
+
+[Search API](/repos/search-api.html) uses a machine learning tool called Learn to Rank (LTR) to improve search result relevance. This uses the TensorFlow Ranking module.
+
+On occassion the current ranking becomes out of date and the tool needs to be re-trained. There are [several rake tasks](/repos/search-api/learning-to-rank.html) to accomplish this.


### PR DESCRIPTION
The `View Extra Service Notes` link on Icinga for `Train and deploy LTR model for Search API` alert shows a 404 page when clicked.

This change adds a minimal page at the expected URL. This page serves only to point to the correct page at [https://docs.publishing.service.gov.uk/repos/search-api/learning-to-rank.html](https://docs.publishing.service.gov.uk/repos/search-api/learning-to-rank.html).