### PR TITLE
Pact documentation for GitHub Actions

### DIFF
--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -65,7 +65,7 @@ _If the app already had some Pact tests, follow [the steps for changing existing
   - CI won't be able to test them yet as they won't be pushed to the pact broker.
 
 1. Merge the consumer tests for the new app.
-  - This will cause the pact tests to be published to the pact broker, given the [project has been configured to do so](https://github.com/alphagov/gds-api-adapters/blob/bcc8e58eccf69dd37657d13156cbe11c07535844/.github/workflows/ci.yml#L37-L51).
+  - This will cause the [pact tests to be published to the pact broker](https://github.com/alphagov/gds-api-adapters/blob/bcc8e58eccf69dd37657d13156cbe11c07535844/.github/workflows/ci.yml#L37-L51).
 
 1. Merge a GitHub Action ([example](https://github.com/alphagov/asset-manager/blob/7311e5dae03496bde88b4eebf7104ea162603681/.github/workflows/pact-verify.yml)) into the provider app to verify the pact
   - This will verify the provider app fulfills the contract published by the consumer.
@@ -86,7 +86,7 @@ Follow these steps in order to change the provider and consumer in tandem.
   - `env PACT_CONSUMER_VERSION=branch-<branch-of-gds-api-adapters> bundle exec rake pact:verify`
 
 1. Merge the provider change
-  - The failing pact test should not block merging.
+  - We've configured failing Pact tests to not block merging, so you should still be able to merge.
 
 1. Re-run the consumer tests
   - These should pass now that the provider has been updated.


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

With GDS API Adapters moving to GitHub Actions, most of the CI specific documentation is out of date. This change updates it to reflect the changes incurred by GitHub Actions.

There are a couple of notable changes with GitHub Actions:

1) There is not the concept of a parameterised build that can change CI
   status, as per Jenkins, which means we can't do some delicate custom
   builds to get a green tick. GitHub Actions does have the workflow
   dispatch option, but this won't change a PR status. Therefore I've
   suggested running locally
2) Pact runs aren't required checks pre-merge which will allow a
   developer to merge in breaking pact changes.
3) We've switched from both consumer and provider having their own
   verify tasks to the provider having one that the consumer can call.