### PR TITLE
Remove reference to the Ops manual

### DIFF
--- a/source/manual/where-to-find-what.html.md
+++ b/source/manual/where-to-find-what.html.md
@@ -32,12 +32,6 @@ These presentations are repeated semi-regularly at the GOV.UK Tech Fortnightly m
 - The [Platform Operations wiki][plops] contains information about Technical 2nd Line and incident management
 - The [Product documentation][prod-docs] contains documentation about the features of the platform
 
-## Opsmanual (legacy)
-
-<https://docs.google.com/document/d/17XUuPaZ5FufyXH00S9qukl6Kf3JbJtAqwHR3eOBVBpI/edit>
-
-- Contains private information on operations, such as phone numbers and account IDs
-
 ## RFCs
 
 <https://github.com/alphagov/govuk-rfcs>


### PR DESCRIPTION
This is no longer being used. The relevant contact numbers we need are in the "GOV.UK - So, you're having an incident" Google doc.

Trello card - https://trello.com/c/PSHgTLC9/137-remove-link-to-legacy-ops-manual-from-developer-docs