### PR TITLE
Add data.gov.uk Staging and Integration URLs

### DIFF
--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -39,11 +39,11 @@ fix it - open a PR to resolve the problem.
 
 ## Environments
 
-There are three environments for CKAN:
+There are three environments:
 
-- [Production][dgu-ckan]
-- [Staging](https://ckan.staging.publishing.service.gov.uk)
-- [Integration](https://ckan.integration.publishing.service.gov.uk)
+- [Production CKAN][dgu-ckan] which publishes to [data.gov.uk](https://www.data.gov.uk)
+- [Staging CKAN](https://ckan.staging.publishing.service.gov.uk) which publishes to https://find-data-beta-staging.cloudapps.digital/)
+- [Integration CKAN](https://ckan.integration.publishing.service.gov.uk) which publishes to https://find-data-beta-integration.cloudapps.digital/)
 
 ## Monitoring data.gov.uk
 


### PR DESCRIPTION
This adds the URLs for the staging and integration versions of data.gov.uk, to help with any testing or troubleshooting