### PR TITLE
Update process for editing Whitehall change notes

### DIFF
--- a/source/manual/howto-modify-change-note.html.md.erb
+++ b/source/manual/howto-modify-change-note.html.md.erb
@@ -10,17 +10,11 @@ Spelling mistakes can creep into [change notes](https://www.gov.uk/guidance/cont
 
 ## Whitehall
 
-To modify a change note in Whitehall, perform the following steps:
+To modify a change note in Whitehall, visit the following URL, replacing `<edition-id>` with the ID of the edition:
 
-1. Run a rake task to list the change notes for each edition, given the document's Content ID:
-
-   <%= RunRakeTask.links("whitehall", "change_note:list[content_id]") %>
-
-1. From the output of the previous rake task, get the ID for the edition whose change note needs updating, then run the following rake task to update this:
-
-   <%= RunRakeTask.links("whitehall", "change_note:amend['edition_id','new_change_note','your.email@digital.cabinet-office.gov.uk']") %>
-
-> This rake task will fail if you have never logged into Whitehall Publisher in the environment where you are running the task.
+```
+https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/<edition-id>/change_notes
+```
 
 ## Publishing API
 

--- a/source/manual/howto-remove-change-note.html.md
+++ b/source/manual/howto-remove-change-note.html.md
@@ -28,25 +28,11 @@ You first need to determine whether the request is referring to a `change_note` 
 
 ### Remove a Change Note from Whitehall
 
-Dry run:
+To delete a change note in Whitehall, visit the following URL, replacing `<edition-id>` with the ID of the edition:
 
-```bash
-$ bundle exec 'data_hygiene:remove_change_note:dry[content_id,locale,change note text]'
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27data_hygiene:remove_change_note:dry[CONTENT_ID,en,CHOSEN%20CHANGE%20NOTE%20TEXT]%27)
-
-This attempts to locate the selected change note for the content, and if found, report to the user the change note text that would have been removed.
-
-Real run:
-
-```bash
-$ bundle exec 'data_hygiene:remove_change_note:real[content_id,locale,change note text]'
+https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/<edition-id>/change_notes
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27data_hygiene:remove_change_note:real[CONTENT_ID,en,CHOSEN%20CHANGE%20NOTE%20TEXT]%27)
-
-This will downgrade the edition to a `minor change`, set the change note text to `nil` and the `major_change_published_at` to the previous major change. It then re-represents to the content store with the updated edition history.
 
 ### Remove an Editorial Remark from Whitehall
 


### PR DESCRIPTION
These were previously edited or deleted by developers using rake tasks.

In https://github.com/alphagov/whitehall/pull/7131, we have introduced a user interface, so need to update the documentation to reflect this.

[Trello card](https://trello.com/c/bMwFRQ3e)