### PR TITLE
Remove unnecessary $ prefix

### DIFF
--- a/source/manual/alerts/low-available-disk-space.html.md
+++ b/source/manual/alerts/low-available-disk-space.html.md
@@ -13,7 +13,7 @@ See also: [low available disk inodes](low-available-disk-inodes.html)
 You can try clearing out the APT cache:
 
 ```sh
-$ sudo apt-get clean
+sudo apt-get clean
 ```
 
 ## Low available disc space on /mnt/uploads for asset-master-1 and asset-slave-1
@@ -31,7 +31,7 @@ Running the following command from within the above folders (ie cd to
 with the parent folders being deleted:
 
 ```sh
-$ find -type d -ctime +1 -exec rm -rf {} +
+find -type d -ctime +1 -exec rm -rf {} +
 ```
 
 In the above example, we:


### PR DESCRIPTION
Where we only list one shell command, pointless having a $ prefix (and actively slows down the developer, as they can't triple-click and copy & paste, they'd need to remove the $ prefix first.