### PR TITLE
Fix relative links

### DIFF
--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -7,7 +7,7 @@ section: 2nd line
 type: learn
 ---
 
-There are a number of areas that are important to drill on 2nd line and include some tasks you may not necessarily encounter in your mission team. We want to ensure developers have the opportunity to practise these tasks ahead of the real thing and in preparation of going [on call](https://docs.publishing.service.gov.uk/manual/on-call.html) if you are part of the out of hours rota.
+There are a number of areas that are important to drill on 2nd line and include some tasks you may not necessarily encounter in your mission team. We want to ensure developers have the opportunity to practise these tasks ahead of the real thing and in preparation of going [on call](/manual/on-call.html) if you are part of the out of hours rota.
 
 ## Drill detaching an instance
 
@@ -15,7 +15,7 @@ Follow the [Detaching an instance from an Auto Scaling Group](/manual/common-aws
 
 ## Drill publishing emergency banner
 
-Follow the [Deploy an emergency banner](https://docs.publishing.service.gov.uk/manual/emergency-publishing.html) on Staging.
+Follow the [Deploy an emergency banner](/manual/emergency-publishing.html) on Staging.
 
 You'll need to choose a non-serious and clearly fake news headline. For example:
 
@@ -108,7 +108,7 @@ Upon loading this dashboard it will ask for the `govuk-zendesk-display-screen` c
 
 ### Change a user's permissions in Signon
 
-Carry out a hypothetical walk through of [unsuspending a user](manual/manage-sign-on-accounts#unsuspending-a-user) and [resetting a user's 2FA](manual/manage-sign-on-accounts#resetting-a-users-2fa).
+Carry out a hypothetical walk through of [unsuspending a user](/manual/manage-sign-on-accounts#unsuspending-a-user) and [resetting a user's 2FA](/manual/manage-sign-on-accounts#resetting-a-users-2fa).
 
 ## Drill creating and changing redirects
 

--- a/source/manual/access-jenkins.html.md
+++ b/source/manual/access-jenkins.html.md
@@ -9,8 +9,8 @@ parent: "/manual.html"
 Our Jenkins installations ([deploy](https://deploy.integration.publishing.service.gov.uk/) and [CI](https://ci.integration.publishing.service.gov.uk/)) use GitHub for authentication and authorisation.
 
 - For integration admin access, you need to be added to the [GOV.UK team][]
-- For [staging][] and [production][] [deploy access](manual/rules-for-getting-production-access.html#production-deploy-access), you need to be added to the [GOV.UK Production Deploy team][]
-- For [staging][] and [production][] [admin access](manual/rules-for-getting-production-access.html#production-admin-access), you need to be added to the [GOV.UK Production Admin team][]
+- For [staging][] and [production][] [deploy access](/manual/rules-for-getting-production-access.html#production-deploy-access), you need to be added to the [GOV.UK Production Deploy team][]
+- For [staging][] and [production][] [admin access](/manual/rules-for-getting-production-access.html#production-admin-access), you need to be added to the [GOV.UK Production Admin team][]
 
 Without this you won't see any projects or you'll see a message that says you are unauthorised.
 

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -24,7 +24,7 @@ This document covers some of the requests that GOV.UK Technical 2nd Line support
 
 [Separate documentation][dgu-docs] exists for publishers.
 
-There's also [an architectural overview of data.gov.uk](manual/data-gov-uk-architecture) and [a deployment guide](manual/data-gov-uk-deployment).
+There's also [an architectural overview of data.gov.uk](/manual/data-gov-uk-architecture) and [a deployment guide](/manual/data-gov-uk-deployment).
 
 [ckanext-datagovuk][ckan-app] is the primary CKAN extension behind data.gov.uk.
 

--- a/source/manual/environments.html.md
+++ b/source/manual/environments.html.md
@@ -36,7 +36,7 @@ so that we're able to test things like the performance impact of changes.
 Staging is hosted on [AWS][govuk-in-aws].
 
 Access to Staging is restricted to office IPs, so you'll need to [be
-on the VPN](manual/get-started.html#4-connecting-to-the-gds-vpn).
+on the VPN](/manual/get-started.html#4-connecting-to-the-gds-vpn).
 AWS configuration can be found in
 [govuk-aws-data](https://github.com/alphagov/govuk-aws/blob/master/terraform/projects/infra-security-groups/cache.tf).
 

--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -478,7 +478,7 @@ eventual JSON you will manually put into the Fastly web UI:
 1. Add your new column name, type and description to the JSON below the
    comments ([example
    for the `govuk_www.cache_response` column][cache-response-json]).
-1. Raise a PR, get a review, merge and [deploy](manual/deploying-terraform.html).
+1. Raise a PR, get a review, merge and [deploy](/manual/deploying-terraform.html).
 
 The manual steps to make Fastly send the log data:
 

--- a/source/manual/removing-a-user-from-puppet.html.md
+++ b/source/manual/removing-a-user-from-puppet.html.md
@@ -41,7 +41,7 @@ the past where user had large files in that directory.
 Machines will eventually get recycled as they're scaled up or down, so these
 directories should naturally start to disappear over time. If there is a need
 to remove the directories more quickly, you can consider using some of the
-[commands here](manual/howto-run-ssh-commands-on-many-machines.html#useful-commands).
+[commands here](/manual/howto-run-ssh-commands-on-many-machines.html#useful-commands).
 
 Unfortunately it's [not possible to retrospectively reintroduce](https://github.com/alphagov/govuk-puppet/pull/10892#issuecomment-749678673)
 the user with a `ensure => absent` argument, as the user will already have


### PR DESCRIPTION
This fixes some broken relative links. 

Before, a link like `manual/get-started.html` resulted in the link https://docs.publishing.service.gov.uk/manual/manual/get-started.html which 404s. 

