### PR TITLE
Remove query result location instruction

### DIFF
--- a/source/manual/query-cdn-logs.html.md
+++ b/source/manual/query-cdn-logs.html.md
@@ -38,10 +38,6 @@ integration and staging). To access,
 [Athena](https://eu-west-1.console.aws.amazon.com/athena) and select the
 `fastly_logs` database.
 
-You need to set a query result location before running queries in Athena. To do
-this go to the settings tab on the Athena query editor page and click manage.
-Set the query result location to `s3://govuk-athena-results/` and save.
-
 ## Querying
 
 Queries are written using an SQL dialect, [presto](https://prestodb.io/),


### PR DESCRIPTION
This step is no longer needed since
https://github.com/alphagov/govuk-aws/pull/1668.
We have now created a bucket and configured it for the primary workgroup so queries run without extra set-up.