### PR TITLE
Make auto-merging workflow wait for tests to pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 9-19 * * 1-5"
 jobs:
   test:
+    name: Run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,9 +7,17 @@ permissions:
 
 jobs:
   dependabot:
+    name: Auto merge qualifying Dependabot PR
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: Run tests
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.3.4


### PR DESCRIPTION
Currently the auto-merging workflow doesn't work as it doesn't have permission to merge to the repo, because not all PR checks have passed at the time the workflow runs.

This change uses https://github.com/marketplace/actions/wait-on-check to fix this.

I've tested the approach on a personal repo, here: https://github.com/ChrisBAshton/test-auto-merge/pull/1

Trello: https://trello.com/c/uwoMBinS/3015-create-proof-of-concept-for-auto-merging-internal-prs-5