### PR TITLE
Make auto-merger wait on auto-approval of PR before merging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,8 +6,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
-    name: Auto merge qualifying Dependabot PR
+  auto_approval:
+    name: Auto approve qualifying PR
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
@@ -18,12 +18,22 @@ jobs:
           check-name: test
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
+      - name: Approve the PR
+        if: ${{contains(env.AUTO_MERGE, steps.metadata.outputs.dependency-names) && contains(env.SEMVER, steps.metadata.outputs.update-type)}}
+        uses: hmarr/auto-approve-action@v3.1.0
+  dependabot:
+    needs: auto_approval
+    name: Auto merge qualifying Dependabot PR
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.3.4
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
+        # TODO: figure out how to de-duplicate the conditional below
         if: ${{contains(env.AUTO_MERGE, steps.metadata.outputs.dependency-names) && contains(env.SEMVER, steps.metadata.outputs.update-type)}}
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
Currently, the auto-merger waits for CI to pass, before attempting to merge. However, the merge fails, as PRs require at least one approving review before merge.

We've already established the conditions under which an auto review is sufficient: a patch upgrade of govuk_publishing_components, where the associated CI checks pass. Therefore we already approve of the PR, we just need a mechanism to make that happen. We're using https://github.com/hmarr/auto-approve-action to use a GitHub Actions 'bot' to approve the PR.

I've tested this approach in:
https://github.com/ChrisBAshton/test-auto-merge/pull/2

Trello: https://trello.com/c/uwoMBinS/3015-create-proof-of-concept-for-auto-merging-internal-prs-5