### PR TITLE
Fix hanging GitHub PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     - cron: "0 9-19 * * 1-5"
 jobs:
   test:
-    name: Run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: Run tests
+          check-name: test
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Dependabot metadata


### PR DESCRIPTION
PRs have started being 'stuck' on a 'test' GitHub Action that is seemingly never triggered:

![screenshot](https://user-images.githubusercontent.com/5111927/208898669-9fd25182-7dc6-4ad0-af61-f92e1bd186a1.png)

This appears to be because the CI action with a key of `test` was recently given a `name` of "Run tests" (see
a869cc3b0bb987c778697943c7a841198bd16ce0), and a custom name doesn't seem to be compatible by the 'required status checks' configuration in govuk-saas-config:

https://github.com/alphagov/govuk-saas-config/blob/8cfb23db6a200214411fc1de150d3c8582950588/github/lib/configure_repo.rb#L106

There's no need for the custom name (other than making things a bit more explicit / readable), so we'll remove the custom name and revert to the action using the key name as its name.