### PR TITLE
Stop building PRs twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   pull_request:
   schedule:
     # Deploy hourly between 9am and 7pm on weekdays


### PR DESCRIPTION
We trigger our CI on both push (to branches, irrespective of there being an associated PR) and on `pull_request` (which triggers on any push to a branch which has a PR open - not just when the PR is first opened).

Consequently, we run two CI builds for each push, which is unnecessary and can slow us down (as sometimes one build langushes behind the other quite noticeably).

There should be no disadvantage to disabling build-on-push to branches which have no associated PR, except that any lint failures won't be brought to light. In practice, many branches are created directly from the GitHub interface, and a PR created in the same transaction, so this would only affect developers who create docs branches locally. In such cases, developers can always run their linter locally too.