### PR TITLE
Revert "Stop building PRs twice"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 on:
+  push:
   pull_request:
   schedule:
     # Deploy hourly between 9am and 7pm on weekdays


### PR DESCRIPTION
Reverts alphagov/govuk-developer-docs#3816

This goes against our [agreed guidance on how CI workflows should run](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#when-the-ci-workflow-should-run), with the biggest issue being that a merge to `main` would not trigger a build and could be disguising an issue if the branch was not recently rebased.