### PR TITLE
Use fine grained access token to auto-approve qualifying PR

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Approve the PR
         if: ${{contains(env.AUTO_MERGE, steps.metadata.outputs.dependency-names) && contains(env.SEMVER, steps.metadata.outputs.update-type)}}
         uses: hmarr/auto-approve-action@v3.1.0
+        with:
+          github-token: ${{ secrets.APPROVE_PR_ACCESS_TOKEN }}
   dependabot:
     needs: auto_approval
     name: Auto merge qualifying Dependabot PR


### PR DESCRIPTION
The auto-merge spike is failing to merge because we have disabled the "Allow GitHub Actions bot to approve PR" at the org level. Whilst we're evaluating the spike, we'll use a personal access token instead as a workaround.

I've created a fine grained access token with permissions only to read/write PRs for the govuk-developer-docs repository. I've tested that it should work in theory, by creating an identical token but for a test repository, where we can see the 'approve PR' step attempting to use the token:
https://github.com/ChrisBAshton/test-auto-merge/actions/runs/3757933226/jobs/6385682455

In the test case, it failed because I was also the person who raised the PR (`Error: Unprocessable Entity: "Can not approve your own pull request"`). This will not be an issue in govuk-developer-docs, as the PR in question was raised by Dependabot.

Trello: https://trello.com/c/uwoMBinS/3015-create-proof-of-concept-for-auto-merging-internal-prs-5