### PR TITLE
Dependabot-specific fix for auto-approving via access token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
 name: Dependabot auto-merge
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write


### PR DESCRIPTION
In #3819, I added a personal access token to auto-approve a given PR. However, [it didn't work](https://github.com/alphagov/govuk-developer-docs/actions/runs/3758439417/jobs/6386787033).

Turns out I'd missed https://github.com/hmarr/auto-approve-action#approving-dependabot-pull-requests:

> When a workflow is run in response to a Dependabot pull request
> using the pull_request event, the workflow won't have access to
> secrets. If you're trying to use a Personal Access Token but
> getting an error on Dependabot pull requests, this is probably
> why.
> Fortunately the fix is simple: use the pull_request_target event
> instead of pull_request. This runs the workflow in the context
> of the base branch of the pull request, which does have access
> to secrets.

Trello: https://trello.com/c/uwoMBinS/3015-create-proof-of-concept-for-auto-merging-internal-prs-5