### PR TITLE
Document Kibana "Short URLs"

### DIFF
--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -36,6 +36,8 @@ You can save and load queries using the buttons in the top right. You may want t
 
 ![Kibana saved searches](images/kibana_saved_searches.png)
 
+Every change to the query changes the URL in the browser. This URL is rather long and unfriendly, and often gets mangled by the Slack or Trello parser when trying to share it. Instead, you can generate a "short URL" by clicking the "Share" link in the top right, followed by "Short URL".
+
 ### All requests rendered by the content_items controller in government-frontend
 
 ```rb


### PR DESCRIPTION
This was new to me - I'd previously been pasting long URLs inside backticks to get around third party parsers. The short URL is much friendlier to share with colleagues.
