### PR TITLE
This repo was archived

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1154,10 +1154,6 @@
   team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
-- repo_name: upgrade-ruby-version
-  team: "#govuk-platform-reliability-team"
-  type: Utilities
-
 - repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk


### PR DESCRIPTION
https://trello.com/c/LB4NJ3z5/3055-retire-upgrade-ruby-version-repo