### PR TITLE
Fix link syntax and convert to HTML comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,2 @@
-The documentation you're adding here is **publicly visible**.
-
-If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki][https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line] instead.
+<!-- The documentation you're adding here is **publicly visible**.
+If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->


### PR DESCRIPTION
Broken link syntax now fixed.
Also converted to HTML comment as these instructions are aimed at developers, not intended to be included in the PR description itself. It's too easy to open the PR with the text included.
