### PR TITLE
Update local frontend documentation

### DIFF
--- a/source/manual/local-frontend-development.html.md
+++ b/source/manual/local-frontend-development.html.md
@@ -88,7 +88,7 @@ PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.serv
 Modify it to the following and then run the startup script as normal. The first page may take a few minutes to appear.
 
 ```ruby
-PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-static.dev.gov.uk}
+PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-http://static.dev.gov.uk}
 ```
 
 ## Using a local components gem


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

Updates the documentation on [local frontend development](https://docs.publishing.service.gov.uk/manual/local-frontend-development.html#using-startup-scripts-and-govuk-docker). Recent changes mean that local modifications to the startup script to access a local static must be more specific.

(credit goes to @theseanything for finding the solution to this problem)

