### PR TITLE
Mark govuk-lambda-app-deployment as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -495,6 +495,8 @@
 - repo_name: govuk-lambda-app-deployment
   type: Utilities
   team: "#govuk-platform-reliability-team"
+  retired: true
+  description: The lambda functions were migrated to govuk-aws.
 
 - repo_name: govuk-load-testing
   type: Utilities


### PR DESCRIPTION
The lambda fuctions from this repo were migrated to govuk-aws, except email_alert_notifications which is no longer used.

Trello card: https://trello.com/c/6hvNCAhx/2957-check-if-govuk-lambda-app-deployment-is-still-needed-and-retire-if-not