### PR TITLE
Fix broken Github Team URL

### DIFF
--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -21,7 +21,7 @@ Almost all repos should:
 - Have [GitHub Trello Poster](/manual/github-trello-poster.html) enabled
 
 [govuk-ci-bots-team]: https://github.com/orgs/alphagov/teams/gov-uk-ci-bots
-[govuk-production-team]: https://github.com/orgs/alphagov/teams/gov-uk-production
+[govuk-production-team]: https://github.com/orgs/alphagov/teams/gov-uk-production-admin
 [govuk-production-deploy-team]: https://github.com/orgs/alphagov/teams/gov-uk-production-deploy
 [govuk-topic]: https://github.com/search?q=topic:govuk
 


### PR DESCRIPTION
The `GOV.UK Production Admin` team url has been renamed from `https://github.com/orgs/alphagov/teams/gov-uk-production` to `https://github.com/orgs/alphagov/teams/gov-uk-production-admin`.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
