### PR TITLE
Update team ownership following retiring of Developer Tools group

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -358,7 +358,7 @@
   dashboard_url: false
 
 - repo_name: govuk-connect
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
 
 - repo_name: govuk-content-api-docs
@@ -434,7 +434,7 @@
   dashboard_url: false
 
 - repo_name: govuk-docker
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
   sentry_url: false
   dashboard_url: false
@@ -468,7 +468,7 @@
 
 - repo_name: govuk-ithc-documentation
   private_repo: true
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
 
 - repo_name: govuk-jenkinslib
@@ -571,7 +571,7 @@
 
 - repo_name: govuk-rota-announcer
   private_repo: true
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
 
 - repo_name: govuk-saas-config
@@ -635,7 +635,7 @@
 
 - repo_name: govuk-user-reviewer
   private_repo: true
-  team: "#govuk-developers"
+  team: "#govuk-platform-reliability-team"
   type: Utilities
   sentry_url: false
   dashboard_url: false
@@ -1081,7 +1081,7 @@
   production_hosted_on: aws
 
 - repo_name: slimmer
-  team: "#govuk-developers"
+  team: "#navigation-and-presentation-govuk"
   type: Gems
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
Proposed new owners:

* `govuk-connect`: Platform Reliability (it's "platform")
* `govuk-docker`: Platform Reliability (it's "platform")
* `govuk-ithc-documentation`: Platform Reliability (it's historically been a Platform Health/Reliability task to aid the pentesters in their testing, and we recently oversaw a Trello card for our security contractor to review the ITHC documentation)
* `govuk-rota-announcer`: Platform Reliability (we already own other Slack based apps, i.e. Dependapanda and Seal)
* `govuk-user-reviewer`: Platform Reliability (it drives a 2nd line alert, which Platform Health/Reliability have historically helped implement/refine)
* `slimmer`: Find & View (it injects the user-facing header/footer & GOV.UK Components. The team also owns static)
