### PR TITLE
Update owner of govuk-browser-extension

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -346,7 +346,7 @@
   dashboard_url: false
 
 - repo_name: govuk-browser-extension
-  team: "#govuk-developers"
+  team: "#govuk-publishing-experience-tech"
   type: Utilities
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
This is best placed in the publishing team, as it is most used by content people to navigate to and from the content they're working on in publishing tools.

