### PR TITLE
Improve DNS deploy docs

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -56,14 +56,7 @@ USAGE:
    gds govuk dns [command options] [arguments...]
 
 OPTIONS:
-   --provider value, -p value            DNS provider to use
-   --zone value, -z value                DNS zone for
-   --action value, -a value              action to apply. e.g. plan
-   --github-username value, -u value     GitHub username used to log into Jenkins, can be set via env variable GITHUB_USERNAME [$GITHUB_USERNAME]
-   --role value, -r value                Name of the AWS role used to get credentials
-   --assume-role-ttl value, --art value  Expiration time for the assumed role. Most roles are configured to permit up to 60m. (default: "60m")
-   --skip-mfa, --sm                      Don't ask for MFA (default: false)
-   --help, -h                            show help (default: false)
+...
 ```
 
 For example, to have Jenkins run a terraform plan of changes to service.gov.uk against AWS, run:

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -14,7 +14,7 @@ By default, zones are hosted by AWS (Route 53) and Google Cloud Platform (Cloud 
 As of December 2022, there are 61 hosted zones. A list is retrievable from a terminal using:
 
 ```
-gds aws govuk-production-admin -- aws route53 list-hosted-zones | grep Name
+gds aws govuk-production-poweruser -- aws route53 list-hosted-zones | grep Name
 ```
 
 Some individual records within these zones are managed by other teams.

--- a/source/manual/google-cloud-platform-gcp.html.md
+++ b/source/manual/google-cloud-platform-gcp.html.md
@@ -42,7 +42,7 @@ The interesting services are:
 
 As with AWS, you can access GCP using the command line. The standard GCP command line interface is `gcloud`.
 
-You can install `gcloud` with `brew cask install google-cloud-sdk` or by following the instructions at [google's installation instructions][].
+You can install `gcloud` with `brew install --cask google-cloud-sdk` or by following the instructions at [google's installation instructions][].
 
 NOTE: By default `gcloud` doesn't put itself on your PATH, so there's an extra manual step to add it.
 Make sure you follow all of the instructions from [homebrew's google-cloud-sdk cask](https://formulae.brew.sh/cask/google-cloud-sdk)


### PR DESCRIPTION
Previously we didn't mention the gds cli automation we have that wraps triggering the Jenkins build. There's a minimum of four Jenkins builds required (plan aws, plan gcp, apply aws, apply gcp) to deploy a change, so this automation makes life immensely easier.

I've documented this, and made it clear it's the preferred option. I've also pulled out the manual steps into their own section, and simplified the deployment instructions (now that they're not interleaved with instructions about getting credentials).

I've also recommended the poweruser role instead of the admin role, as DNS changes don't touch IAM so they don't need admin.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
