### PR TITLE
Document the retiring of govuk-dependencies

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -402,6 +402,15 @@
     translation of Whitehall feed URLs into Govdelivery topics. Retired in favour
     of email-alert-api in September 2017.
 
+- repo_name: govuk-dependencies
+  retired: true
+  team: "#govuk-platform-reliability-team"
+  type: Utilities
+  description: |
+    Retired in November 2022. This used to be a microsite showing us the outstanding open PRs made by Dependabot,
+    as well as being responsible for sending Slack alerts to GDS teams to remind them of open Dependabot PRs.
+    This functionality has now been merged into alphagov/seal.
+
 - repo_name: govuk-dependency-checker
   team: "#govuk-platform-reliability-team"
   type: Utilities


### PR DESCRIPTION
I searched for govuk-dependencies in the Developer Docs and could not find any reference to it - we should include retired repos in the repos.yml file but mark them as retired, rather than delete as happened in #3774.
