### PR TITLE
Re-add reference to retired repo 'upgrade-ruby-version'

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1175,6 +1175,13 @@
   team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
 
+- repo_name: upgrade-ruby-version
+  type: Utilities
+  retired: true
+  description: |
+    Repo for raising PRs in bulk, to update ruby versions across GOV.UK. 
+    This was replaced by bulk-changer in January 2023.
+
 - repo_name: whitehall
   type: Publishing apps
   production_url: https://whitehall-admin.publishing.service.gov.uk


### PR DESCRIPTION
This was removed in #3830 but should have been kept but with a `retired: true`.
