### PR TITLE
Clarify that patch versions of Rails can be merged without manual steps

### DIFF
--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -51,7 +51,8 @@ It's very important that we're running a currently supported version of Rails fo
 - Maintain our applications at the latest current bugfix release for the minor version we're on (expressed in Gemfile syntax as: ~> X.Y.Z)
 - Keep abreast of breaking changes for the next major version (eg 5.y.z), and have a plan to migrate our apps before the current version is deprecated
 
-See [Upgrading Ruby on Rails][] for a guide on how to upgrade Rails.
+Upgrading Rails requires carefully following the manual steps at [Upgrading Ruby on Rails][], for major and minor version increases.
+For patch increases, no manual steps are required and it is fine to merge the update provided the tests pass.
 
 [Upgrading Ruby on Rails]: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 


### PR DESCRIPTION
The [guidance](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) itself says:

> Rails version numbers are in the form Major.Minor.Patch. Major and Minor versions are allowed to make changes to the public API, so this may cause errors in your application. Patch versions only include bug fixes, and don’t change any public API.

Developers tend to merge patch versions freely anyway, but this always felt ambiguous against this guidance, so let's update the guidance to make it clear that it's fine.
