### PR TITLE
Add capistrano_rsync_with_remote_cache to list of known repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -91,6 +91,10 @@
     when-do-the-clocks-change pages. Since May 2020 those pages are
     rendered by frontend.
 
+- repo_name: capistrano_rsync_with_remote_cache
+  type: Utilities
+  team: "#govuk-platform-reliability-team"
+
 - repo_name: ckan-functional-tests
   type: data.gov.uk apps
   team: "#govuk-datagovuk"


### PR DESCRIPTION
We [use this in govuk-secrets](https://github.com/alphagov/govuk-secrets/blob/ee9bcb5e60f7b77f5e91b317630539ff9b045e47/Gemfile#L12-L14).

Platform Reliability is the most appropriate owner for this.
