### PR TITLE
[BAU] Fix a Typo on 2nd Line Page

### DIFF
--- a/source/manual/2nd-line.html.md
+++ b/source/manual/2nd-line.html.md
@@ -124,7 +124,7 @@ When creating a new card please include:
 - Links to related Zendesk tickets and suggested reply to users
 - Any investigation you have done so far/steps you have taken as a workaround
 
-This will help inform developers, Technical 2nd Line tech lead(s), and the GOV.UK Sire Reliability Engineers (SREs) about known issues.
+This will help inform developers, Technical 2nd Line tech lead(s), and the GOV.UK Site Reliability Engineers (SREs) about known issues.
 
 ## Slack channels
 


### PR DESCRIPTION
## What?
My first commit to these docs - fixing a small typo. Because unfortunately, our SREs probably don't have Knighthoods.