### PR TITLE
Add 2nd line instructions for adding an HMRC manual

### DIFF
--- a/source/manual/add-an-hmrc-manual.html.md
+++ b/source/manual/add-an-hmrc-manual.html.md
@@ -1,0 +1,11 @@
+---
+owner_slack: "#govuk-2ndline-tech"
+title: Add an HMRC Manual
+parent: "/manual.html"
+layout: manual_layout
+section: 2nd line
+---
+
+HMRC publish their own manuals on GOV.UK using the HMRC Manuals API, but new manuals can only be added once we have manually allowed the slug for the manual. When a ticket comes in to Zendesk asking for an HMRC manual to be published, it just means that we need to [add a new slug], which they will provide.
+
+[add a new slug]: https://github.com/alphagov/hmrc-manuals-api#adding-a-new-slug


### PR DESCRIPTION
https://trello.com/c/5pJBXAQP/1784-documentation-for-hmrc-manuals-api-slug-add

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
