### PR TITLE
Transfer Smart Answers ownership from I&P to UXM

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -323,7 +323,7 @@
   type: Data science
   description: Project containing numerous report generators to monitor accessibility
     on GOV.UK. It was retired in November 2022 after Data Products found no evidence
-    of it being used for many months, and moved the data source needed to CPTO's 
+    of it being used for many months, and moved the data source needed to CPTO's
     GCloud account.
   sentry_url: false
   dashboard_url: false
@@ -1111,7 +1111,7 @@
 
 - repo_name: smart-answers
   type: Frontend apps
-  team: "#tech-interaction-and-personalisation"
+  team: "#user-experience-measurement-govuk"
   puppet_name: smartanswers
   production_hosted_on: aws
 
@@ -1183,7 +1183,7 @@
   type: Utilities
   retired: true
   description: |
-    Repo for raising PRs in bulk, to update ruby versions across GOV.UK. 
+    Repo for raising PRs in bulk, to update ruby versions across GOV.UK.
     This was replaced by bulk-changer in January 2023.
 
 - repo_name: whitehall


### PR DESCRIPTION
Smart Answers ownership is moving from I&P to user experience measurement, so mark it as so and redirect Seal / Dependapanda messages to their channel

https://trello.com/c/r0ChcHsm/1807-update-dev-docs-to-hand-over-smart-answers-to-uxm

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
