### PR TITLE
Update rabbitmq docs for amazonmq

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -42,7 +42,7 @@ redirects:
   /apis/publishing-api/model.html: /apps/publishing-api/model.html
   /apis/publishing-api/pact_testing.html: /apps/publishing-api/pact_testing.html
   /apis/publishing-api/publishing-application-examples.html: /apps/publishing-api/publishing-application-examples.html
-  /apis/publishing-api/rabbitmq.html: /apps/publishing-api/rabbitmq.html
+  /apis/publishing-api/rabbitmq.html: /apps/publishing-api/amazonmq.html
   /apis/search-api.html: /apps/search-api.html
   /apis/search-api/adding-new-fields.html: /apps/search-api/adding-new-fields.html
   /apis/search-api/content-api.html: /apps/search-api/content-api.html
@@ -142,6 +142,7 @@ redirects:
   /apps/policy-publisher.html: /repos/policy-publisher.html
   /apps/publisher.html: /repos/publisher.html
   /apps/publishing-api.html: /repos/publishing-api.html
+  /apps/publishing-api/rabbitmq.html: /apps/publishing-api/amazonmq.html
   /apps/release.html: /repos/release.html
   /apps/router.html: /repos/router.html
   /apps/router-api.html: /repos/router-api.html
@@ -179,6 +180,7 @@ redirects:
   /manual/alerts/gor.html: /manual/alerts/goreplay.html
   /manual/alerts/process-file-handle-count-exceedes.html: /manual/alerts/process-file-handle-count-exceeds.html
   /manual/alerts/publisher-app-health-check-not-ok.html: /manual/alerts/publisher-app-healthcheck-not-ok.html
+  /manual/alerts/rabbitmq-no-consumers-listening.html: /manual/alerts/amazonmq-no-consumers-listening.html
   /manual/alerts/rummager-index-size-change.html: /manual/alerts/search-api-index-size-change.html
   /manual/alerts/rummager-queue-latency.html: /manual/alerts/search-api-queue-latency.html
   /manual/alerts/whitehall-app-health-check-not-ok.html: /manual/alerts/whitehall-app-healthcheck-not-ok.html

--- a/source/manual/alerts/amazonmq-high-number-of-unprocessed-messages.html.md
+++ b/source/manual/alerts/amazonmq-high-number-of-unprocessed-messages.html.md
@@ -1,12 +1,12 @@
 ---
 owner_slack: "#govuk-2ndline-tech"
-title: 'RabbitMQ: High number of unprocessed messages'
+title: 'AmazonMQ: High number of unprocessed messages'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
 ---
 
-For information about how we use RabbitMQ, see [here][rabbitmq_doc].
+For information about how we use RabbitMQ on AmazonMQ, see [here][amazonmq_doc].
 
 We check that there is not a significant build up of messages compared to the
 normal amounts on certain queues. The queues this alert applies to are:
@@ -42,14 +42,15 @@ warning.
 
 For troubleshooting steps, see [here][troubleshooting_steps].
 
-[email_service_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L54-L60
-[email_unpublishing_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L70-L76
-[email_subscriber_list_major_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L101-L107
-[email_subscriber_list_minor_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L92-L98
-[cache_config]: https://github.com/alphagov/govuk-puppet/blob/616cae598f91406e29ed2e4fc287c71b690c55b0/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp#L107-L132
-[troubleshooting_steps]: https://docs.publishing.service.gov.uk/manual/alerts/rabbitmq-no-consumers-listening.html#troubleshooting
-[no_consumers_listening]: https://docs.publishing.service.gov.uk/manual/alerts/rabbitmq-no-consumers-listening.html
+[email_service_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L57-L63
+[email_unpublishing_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L81-L87
+[email_subscriber_list_major_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L73-L79
+[email_subscriber_list_minor_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#65-L71
+[cache_config]: https://github.com/alphagov/govuk-puppet/blob/616cae598f91406e29ed2e4fc287c71b690c55b0/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp#L112-L137
+[troubleshooting_steps]: https://docs.publishing.service.gov.uk/manual/alerts/amazonmq-no-consumers-listening.html#troubleshooting
+[no_consumers_listening]: https://docs.publishing.service.gov.uk/manual/alerts/amazonmq-no-consumers-listening.html
 [rabbitmq_doc]: https://docs.publishing.service.gov.uk/manual/rabbitmq.html
+[amazonmq_doc]: https://docs.publishing.service.gov.uk/manual/amazonmq.html
 [email_thresholds]: https://github.com/alphagov/govuk-puppet/blob/8267943e08c314e0a97742fc9443b889d4cf358a/hieradata_aws/common.yaml#L577-L578
 [cache_clearing_thresholds]: https://github.com/alphagov/govuk-puppet/blob/8267943e08c314e0a97742fc9443b889d4cf358a/hieradata_aws/common.yaml#L456-L457
 [plugin]: https://github.com/alphagov/govuk-puppet/blob/80cff45935481a180dc9bfe8e2ab0ac8a0d80344/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages

--- a/source/manual/alerts/amazonmq-no-consumers-listening.html.md
+++ b/source/manual/alerts/amazonmq-no-consumers-listening.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-2ndline-tech"
-title: 'RabbitMQ: No consumers listening to queue'
+title: 'AmazonMQ: No consumers listening to queue'
 parent: "/manual.html"
 layout: manual_layout
 section: Icinga alerts
@@ -8,7 +8,7 @@ section: Icinga alerts
 
 ## Check that there is at least one non-idle consumer for rabbitmq queue {queue_name}
 
-Icinga connects to RabbitMQ's admin API to check on the activity of the
+Icinga connects to AmazonMQ's RabbitMQ admin API to check on the activity of the
 consumers and that at least one consumer is running for a given RabbitMQ
 message queue. See [here][check_rabbitmq_plugin] for the plugin that implements
 the alert.
@@ -41,15 +41,9 @@ never idle for these queues.
 
 ## Troubleshooting
 
-### Check the RabbitMQ logs
+### Check the AmazonMQ Grafana dashboard
 
-Check the logs for the `rabbitmq` application which can be achieved logging
-into Kibana and searching for `application: rabbitmq`. Is there evidence of any
-errors?
-
-### Check the RabbitmQ Grafana dashboard
-
-This [Grafana dashboard][rabbitmq_grafana_dashboard] shows activity across
+This [Grafana dashboard][amazonmq_grafana_dashboard] shows activity across
 multiple exchanges and queues. The main exchange we expect to be monitoring is
 `published_documents` which handles broadcasting to services such as search and
 email-alert-service when content changes across GOV.UK.
@@ -80,10 +74,10 @@ messages then this could indicate an issue with the consumer.
 2. If the issue has not resolved, we should check in the consumers application
    logs to see if any errors are being thrown.
 
-[high_unprocessed_messages]: https://docs.publishing.service.gov.uk/manual/alerts/rabbitmq-high-number-of-unprocessed-messages.html
+[high_unprocessed_messages]: https://docs.publishing.service.gov.uk/manual/alerts/amazonmq-high-number-of-unprocessed-messages.html
 [email_alert_binding]: https://github.com/alphagov/email-alert-service/blob/4412a1b3b0f281733801e1631416ab02fac90e25/lib/tasks/message_queues.rake#L17
-[rabbitmq_doc]: https://docs.publishing.service.gov.uk/manual/rabbitmq.html
+[amazonmq_doc]: https://docs.publishing.service.gov.uk/manual/amazonmq.html
 [check_rabbitmq_plugin]: https://github.com/alphagov/govuk-puppet/blob/eb8a04a7883d4772fa7266c909c7f40563f8f7a0/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_consumers
 [heartbeat_messages]: https://github.com/alphagov/publishing-api/blob/d2552f681e772c9e4f5afb3a76605630fa4a588c/lib/tasks/heartbeat_messages.rake
-[rabbitmq_grafana_dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/rabbitmq.json?refresh=10s&orgId=1
+[amazonmq_grafana_dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/amazonmq.json?refresh=10s&orgId=1
 [heartbeat]: https://github.com/alphagov/publishing-api/blob/d2552f681e772c9e4f5afb3a76605630fa4a588c/lib/queue_publisher.rb#L43

--- a/source/manual/alerts/rebooting-machines.html.md
+++ b/source/manual/alerts/rebooting-machines.html.md
@@ -161,47 +161,6 @@ at the alerts.
 
 SSH into the machine and run `sudo reboot`. The Icinga alerts will be temporarily unavailable.
 
-### Rebooting `rabbitmq` machines
-
-There are 3 RabbitMQ virtual machines in a cluster. You reboot one machine at a time. You should only reboot the RabbitMQ machines in-hours.
-
-1. SSH into the machine and environment you want to reboot by running the following command:
-
-    ```
-    gds govuk connect ssh -e <ENVIRONMENT> <MACHINE>
-    ```
-
-    For example, to SSH into the `integration` environment of the `rabbitmq:1` machine:
-
-    ```
-    gds govuk connect ssh -e integration rabbitmq:1
-    ```
-
-1. Check that the RabbitMQ cluster is healthy by running `sudo rabbitmqctl cluster_status`.
-
-    This prints a list of expected machines and a list of currently running machines. If the 2 lists are the same then the cluster is healthy. The following output is an example of a healthy cluster:
-
-    ```
-    Cluster status of node 'rabbit@ip-10-12-6-130'
-    [{nodes,[{disc,['rabbit@ip-10-12-4-186','rabbit@ip-10-12-5-128',
-                'rabbit@ip-10-12-6-130']}]},
-     {running_nodes,['rabbit@ip-10-12-4-186','rabbit@ip-10-12-5-128',
-                 'rabbit@ip-10-12-6-130']},
-     {cluster_name,<<"rabbit@ip-10-12-6-130.eu-west-1.compute.internal">>},
-     {partitions,[]},
-     {alarms,[{'rabbit@ip-10-12-4-186',[]},
-              {'rabbit@ip-10-12-5-128',[]},
-              {'rabbit@ip-10-12-6-130',[]}]}]
-    ```
-
-1. Reboot the machine by running `sudo reboot`.
-
-When you have rebooted the machine, you should monitor alerts to see if there are any RabbitMQ-related alerts. You might also wish to monitor the cluster via the [RabbitMQ web control panel](/manual/rabbitmq.html#connecting-to-the-rabbitmq-web-control-panel) dashboard. This dashboard shows the current members of the cluster and means that you can avoid polling `sudo rabbitmqctl cluster_status` to determine when your restarted machine has rejoined the cluster.
-
-For more information on RabbitMQ-related alerts, see the [GOV.UK Puppet RabbitMQ `monitoring.pp` file](https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk_rabbitmq/manifests/monitoring.pp).
-
-There have been two incidents after rebooting RabbitMQ machines. For more information, see the [No non-idle RabbitMQ consumers](https://docs.google.com/document/d/19gCq7p7OggkG0pGNL8iAspfnwR1UrsZfDQnOYniQlvM/edit?pli=1#) and [Publishing API jobs became stuck](https://docs.google.com/document/d/1ia3OGn-v0bimW4P0vRtKUVeVVNh7VEiXjHqlc9jfeFY/edit#heading=h.p99426yo0rbv) incident reports.
-
 ### Rebooting `router_backend` machines
 
 Router backend machines are instances of MongoDB machines and can be rebooted

--- a/source/manual/amazonmq.html.md
+++ b/source/manual/amazonmq.html.md
@@ -14,7 +14,7 @@ Protocol][AMQP] (AMQP). Publishing's RabbitMQ cluster is provided by AWS' [Amazo
 ## Connecting to the AmazonMQ web control panel
 
 Run `gds govuk connect amazonmq -e integration` and point your
-browser at the URL it gives you - it will look like <http://127.0.0.1:45612>, but will have a random port number. You can connect to `staging` and `production` the same way, just replace `integration` above with the environment of your choice..
+browser at the URL it gives you - it will look like <http://127.0.0.1:45612>, but will have a random port number. You can connect to `staging` and `production` the same way, just replace `integration` above with the environment of your choice.
 
 The username for connecting to the RabbitMQ web control panel is `root` and the password
 can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_amazonmq::root_password]'` (from the `puppet_aws` directory).

--- a/source/manual/amazonmq.html.md
+++ b/source/manual/amazonmq.html.md
@@ -1,46 +1,49 @@
 ---
 owner_slack: "#govuk-publishing-platform"
-title: Manage RabbitMQ
+title: Manage AmazonMQ
 section: Infrastructure
 layout: manual_layout
 parent: "/manual.html"
 ---
 
 [RabbitMQ][RabbitMQ] is a message broker based on the [Advanced Message Queuing
-Protocol][AMQP] (AMQP).
+Protocol][AMQP] (AMQP). Publishing's RabbitMQ cluster is provided by AWS' [AmazonMQ][] service.
 
 [Learn more about RabbitMQ][rabbitmq_tutorial].
 
-## Connecting to the RabbitMQ web control panel
+## Connecting to the AmazonMQ web control panel
 
-Run `gds govuk connect rabbitmq -e integration aws/rabbitmq` and point your
-browser at <http://127.0.0.1:15672> (also available for `staging` and `production`).
+Run `gds govuk connect amazonmq -e integration` and point your
+browser at the URL it gives you - it will look like <http://127.0.0.1:45612>, but will have a random port number. You can connect to `staging` and `production` the same way, just replace `integration` above with the environment of your choice..
 
 The username for connecting to the RabbitMQ web control panel is `root` and the password
-can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_rabbitmq::root_password]'` (from the `puppet_aws` directory).
+can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_amazonmq::root_password]'` (from the `puppet_aws` directory).
 
-## RabbitMQ metrics
+## AmazonMQ metrics
 
-A [generic RabbitMQ dashboard][rabbitmq-dashboard] shows metrics for queues and exchanges.
+A [generic AmazonMQ dashboard][amazonmq-dashboard] shows metrics for queues and exchanges.
 
 ## How we run RabbitMQ
 
 ### Overview
 
+![A graph showing the message flow](images/rabbitmq_graph.png)
+
 **Producer**: an application that publishes messages to RabbitMQ. On GOV.UK this could
-be [seed-crawler](https://github.com/alphagov/govuk_seed_crawler).
+be [publishing-api](https://github.com/alphagov/publishing-api).
 
 **Exchanges** are AMQP entities where messages are sent. They take a message
 and route it into zero or more queues. The routing algorithm used depends on
-the exchange type and rules called _bindings_. Seed Crawler publishes a message
-for every line in the GOV.UK sitemap, to the exchange
-`govuk_crawler_exchange`.
+the exchange type and rules called _bindings_.  When a content change is made
+in a publishing application (e.g. Travel Advice Publisher), Publishing API
+[publishes a message][publishing_api_publishes_message] to our main exchange,
+`publishing_documents`.
 
 **Queues** are very similar to queues in other message and task-queueing
 systems: they store messages that are consumed by applications. An example of a
-queue is `govuk_crawler_queue` which is used by
-[govuk_crawler_worker][https://github.com/alphagov/govuk_crawler_worker] as a list
-of URLs to process. Queues are [created by consumer applications][create_queues].
+queue is `email_alert_service` which is used by
+[email-alert-service][email-alert-service] to forward publishing activity to
+email-alert-api. Queues are [created by consumer applications][create_queues].
 
 **Bindings** are rules that exchanges use (among other things) to route
 messages to queues. To instruct an exchange E to route messages to a queue Q, Q
@@ -74,19 +77,21 @@ messages. All our consumer applications use the
 RabbitMQ in a standardised way.
 
 You can see live examples of things like queues, exchanges, bindings etc by
-connecting to the RabbitMQ control panel.
+connecting to the RabbitMQ control panel (see above).
 
 ## Further reading
 
 * [RabbitMQ Tutorials](https://www.rabbitmq.com/getstarted.html)
+* [AmazonMQ documentation][AmazonMQ]
 * [Bunny](https://github.com/ruby-amqp/bunny) is the RabbitMQ client we use.
 * [The Bunny Guides](http://rubybunny.info/articles/guides.html) explain all
   AMQP concepts really well.
 
 [rabbitmq_tutorial]: https://www.rabbitmq.com/tutorials/tutorial-one-ruby.html
+[AmazonMQ]: https://aws.amazon.com/amazon-mq/
 [RabbitMQ]: https://www.rabbitmq.com/
 [AMQP]: https://www.rabbitmq.com/tutorials/amqp-concepts.html
-[rabbitmq-dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/rabbitmq.json?refresh=10s&orgId=1
+[amazonmq-dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/amazonmq.json?refresh=10s&orgId=1
 [rabbitmq_overview]: https://github.com/alphagov/govuk_message_queue_consumer#Nomenclature
 [create_queues]: https://github.com/alphagov/email-alert-service/blob/f8485df2f0916285ade33a9cb1e4a7e73c2491ad/lib/tasks/message_queues.rake#L9
 [publishing_api_publishes_message]: https://github.com/alphagov/publishing-api/blob/1d6bf06fcb74519b5c379f803ae1df65f93f74f7/lib/queue_publisher.rb#L26
@@ -97,4 +102,4 @@ connecting to the RabbitMQ control panel.
 [message_consumer]: https://github.com/alphagov/govuk_message_queue_consumer
 [email-alert-service]: https://github.com/alphagov/email-alert-service
 [major_message_processor]: https://github.com/alphagov/email-alert-service/blob/2ba8ecd982c2226158b528e5442b012639797d41/email_alert_service/models/major_change_message_processor.rb#L35P
-[binding_config]: https://github.com/alphagov/govuk-aws/blob/main/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl#L248
+[binding_config]: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp#L42-L48

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -313,6 +313,9 @@ we want to send an email to anyone subscribed to that content.
 
 We use [Sidekiq] to manage the background processing. When each Sidekiq
 process is evaluated, a message is put onto a [RabbitMQ] queue.
+
+The RabbitMQ cluster used by publishing-api is managed by AWS, via their [AmazonMQ] service.
+
 RabbitMQ is a message broker: when a message is broadcast to a RabbitMQ
 exchange, it forwards the message to its consumers. These consumers
 retrieve the content item and do something in response, such as:
@@ -328,6 +331,7 @@ in a downstream process.
 
 [content-store-router-api]: https://github.com/alphagov/content-store/blob/dd79a03d74f130650bc97d1c84aae557ccea58d3/app/models/content_item.rb#L33
 [message-queues-rake]: https://github.com/alphagov/email-alert-service/blob/main/lib/tasks/message_queues.rake
+[AmazonMQ]: https://aws.amazon.com/amazon-mq/
 [RabbitMQ]: https://www.rabbitmq.com/
 [Sidekiq]: /manual/sidekiq.html
 

--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -142,13 +142,14 @@ environments.
 For [key-value datastore][] access (such as queues or distributed caches)
 [Redis][] should be used. Typically a Redis datastore will not be shared
 between applications, for queue-based communication between applications we
-have precedent for using [RabbitMQ][] via the [Bunny][] gem.
+have precedent for using [RabbitMQ][] via the [Bunny][] gem, and AWS' [AmazonMQ][].
 
 For file storage local to an application [Amazon S3][] is the preferred choice,
 where this needs to be associated with a database [ActiveStorage][] should be
 used.
 
 [ActiveRecord]: https://guides.rubyonrails.org/active_record_basics.html
+[AmazonMQ]: https://aws.amazon.com/amazon-mq/
 [db/seeds.rb]: https://github.com/alphagov/content-publisher/blob/main/db/seeds.rb
 [key-value datastore]: https://en.wikipedia.org/wiki/Key-value_database
 [Redis]: https://redis.io/

--- a/source/manual/help-with-publishing-content.html.md
+++ b/source/manual/help-with-publishing-content.html.md
@@ -31,7 +31,7 @@ necessary to help them to ensure it goes out as smoothly as possible.
 
   If there are no alerts, it would suggest that the content change never made it
   to the Email Alert API. In which case, you should [check that Email Alert
-  Service is correctly consuming from RabbitMQ](alerts/rabbitmq-no-consumers-listening.html).
+  Service is correctly consuming from AmazonMQ](alerts/amazonmq-no-consumers-listening.html).
   If all looks fine, it may be necessary to [manually create a `ContentChange` in
   Email Alert API](https://github.com/alphagov/email-alert-api/blob/1aee9703bf303d43ba4ecb5f6fd771b757d52daf/app/services/notification_handler_service.rb#L24-L43).
 

--- a/source/manual/make-a-new-document-type-available-to-search.html.md
+++ b/source/manual/make-a-new-document-type-available-to-search.html.md
@@ -13,7 +13,7 @@ included in the GOV.UK sitemap, which tells external search engines about our
 content.
 
 The app responsible for search is [Search API][search-api]. Search API listens
-to RabbitMQ messages about published documents to know when to index documents.
+to AmazonMQ messages about published documents to know when to index documents.
 For the new document type to be indexed, you need to add it to a whitelist.
 
 ### 1. Decide what fields you want to make available to search


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

We've now migrated publishing-api's RabbitMQ usage onto AmazonMQ in all environments ([Trello card](https://trello.com/c/to4fHvoa/458-run-amazonmq-migration-process-on-production)). This means updating the developer docs in a few places to reflect the change.( [Trello card](https://trello.com/c/fIjdBjZb/468-update-developer-docs) )

I'm conscious that I've been very close to the technical details of this migration, and documentation is not my specialty - so I'm particularly interested in the opinion of those who haven't been. Does the addition of `/source/manual/amazonmq.html` make sense? Do the redirects and removals make sense? etc etc. All feedback most welcome.