### PR TITLE
Display alternative versions of page for EKS platform

### DIFF
--- a/app/manual.rb
+++ b/app/manual.rb
@@ -34,6 +34,7 @@ class Manual
     return [] if current_page.data.subsection.nil?
 
     sitemap.resources
+      .reject { |page| page.data.index == false }
       .select { |page| page.data.section == ICINGA_ALERTS }
       .select { |page| page.data.subsection == current_page.data.subsection }
       .sort_by { |page| page.data.title.downcase } - [current_page]
@@ -47,6 +48,7 @@ private
 
   def manual_pages
     sitemap.resources
+      .reject { |page| page.data.index == false }
       .reject { |page| page.data.section == ICINGA_ALERTS }
       .select { |page| page.path.start_with?("manual/") && page.path.end_with?(".html") && page.data.title }
       .sort_by { |page| [page.data.type || "how to", page.data.title.downcase] }

--- a/app/page_versions.rb
+++ b/app/page_versions.rb
@@ -1,0 +1,64 @@
+# PageVersions extension allows you to write alternative versions of a page and
+# have them hidden from site navigation features (such as search and page
+# lists).
+#
+# Page versions use a attribute in the frontmatter to specify the version. This
+# attribute is set using the version_attribute option. The default_version
+# option specifies what version of a page should appear in the site navigation
+# features (e.g. the default page version users open). The version_order option
+# specifies the order in which versions should be presented.
+
+class PageVersions < Middleman::Extension
+  expose_to_template :page_versions
+
+  option :version_attribute
+  option :default_version
+  option :version_order
+
+  def initialize(app, options_hash = {}, &block)
+    super
+
+    @attribute = options.version_attribute
+    @default_version = options.default_version
+    @version_order = options.version_order
+  end
+
+  # Add `index = false` tag to non-default pages so they don't appear in site
+  # navigation features.
+  def manipulate_resource_list(resources)
+    resources.each do |resource|
+      version = resource.data[@attribute]
+
+      if !version.nil? && version != @default_version
+        resource.data.index = false
+      end
+    end
+
+    resources
+  end
+
+  # Helper function for templates to generate navigation to alternative page
+  # versions. Alternative pages must have the same title.
+  def page_versions(current_page)
+    return nil if current_page.data[@attribute].nil?
+
+    resource_versions = @app.sitemap.resources.select do |resource|
+      resource.data.title == current_page.data.title
+    end
+
+    resource_versions.sort_by! do |r|
+      # Match order in version_order option and put non-specifed versions last.
+      @version_order.index(r.data[@attribute] || Float.INFINITY)
+    end
+
+    resource_versions.map do |version|
+      {
+        active: (current_page.path == version.path),
+        text: version.data[@attribute],
+        path: version.normalized_path,
+      }
+    end
+  end
+end
+
+::Middleman::Extensions.register(:page_versions, PageVersions)

--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,12 @@ require_relative "./app/requires"
 
 GovukTechDocs.configure(self)
 
+activate :page_versions do |opts|
+  opts.version_attribute = "platform"
+  opts.default_version = "EC2"
+  opts.version_order = %w[EC2 EKS]
+end
+
 set :markdown,
     renderer: DeveloperDocsRenderer.new(
       with_toc_data: true,

--- a/source/layouts/manual_layout.html.erb
+++ b/source/layouts/manual_layout.html.erb
@@ -13,11 +13,22 @@
   }) unless current_page.data.section == "Icinga alerts" %>
 <% end %>
 
+<% page_navigation = capture do %>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-two-thirds'>
+      <%= breadcrumb %>
+    </div>
+    <div class='govuk-grid-column-one-third'>
+      <%= partial 'partials/_page_version_selector' %>
+    </div>
+  </div>
+<% end %>
+
 <% last_updated_banner = capture do %>
   <%= partial 'partials/last_updated' %>
 <% end %>
 
-<% html = "#{breadcrumb} #{last_updated_banner} <h1 id='header'>#{current_page.data.title}</h1> #{yield}" %>
+<% html = "#{page_navigation} #{last_updated_banner} <h1 id='header'>#{current_page.data.title}</h1> #{yield}" %>
 
 <% content_for :page_description, Snippet.generate(html) %>
 

--- a/source/partials/_page_version_selector.html.erb
+++ b/source/partials/_page_version_selector.html.erb
@@ -1,0 +1,17 @@
+<% if page_versions(current_page) %>
+  <div class="page-version-selector-nav">
+    <ul class="page-version-selector-nav__list">
+      <% page_versions(current_page).each do |page_version| %>
+        <li class="page-version-selector-nav__list-item">
+          <% if page_version[:active] %>
+            <span><%= page_version[:text] %></span>
+          <% else %>
+            <%= link_to page_version[:text], "/" + page_version[:path],
+              class: "govuk-link page-version-selector-nav__link"
+            %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -87,3 +87,36 @@
 ul.subdir__menu {
   padding-left: 20px;
 }
+
+.page-version-selector-nav {
+    margin-top: 15px;
+    font-size: 14px;
+    line-height: 1.1428571429;
+    border-bottom:1px solid #b1b4b6
+}
+
+.page-version-selector-nav__list {
+    list-style: none;
+    margin: 0 -10px;
+    padding:0
+}
+
+.page-version-selector-nav__list:after {
+    content: "";
+    display: block;
+    clear:both
+}
+
+.page-version-selector-nav__list-item {
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-bottom: 10px;
+    border-right: 1px solid #b1b4b6;
+    height:16px
+}
+
+.page-version-selector-nav__list-item:last-child {
+    border-right: 0;
+    border-left:0
+}

--- a/spec/app/manual_spec.rb
+++ b/spec/app/manual_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Manual do
   describe "#manual_pages_grouped_by_section" do
     it "returns the correct groups" do
       sitemap = double(resources: [
-        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo", type: nil)),
-        double(path: "manual/foo.html", data: double(title: "Foo", important: true, review_by: Date.today, section: "Foo", type: nil)),
-        double(path: "manual/bar.html", data: double(title: "Bar", important: true, review_by: Date.today, section: "Bar", type: nil)),
+        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo", type: nil, index: nil)),
+        double(path: "manual/foo.html", data: double(title: "Foo", important: true, review_by: Date.today, section: "Foo", type: nil, index: nil)),
+        double(path: "manual/bar.html", data: double(title: "Bar", important: true, review_by: Date.today, section: "Bar", type: nil, index: nil)),
       ])
 
       manual_pages_grouped_by_section = Manual.new(sitemap).manual_pages_grouped_by_section
@@ -15,13 +15,13 @@ RSpec.describe Manual do
 
   describe "#other_pages_from_section" do
     it "returns the correct groups" do
-      one = double(path: "manual/foo.html", data: double(title: "Foo", important: true, section: "A section", type: nil))
-      other = double(path: "manual/bar.html", data: double(title: "Bar", important: true, section: "A section", type: nil))
+      one = double(path: "manual/foo.html", data: double(title: "Foo", important: true, section: "A section", type: nil, index: nil))
+      other = double(path: "manual/bar.html", data: double(title: "Bar", important: true, section: "A section", type: nil, index: nil))
 
       sitemap = double(resources: [
         one,
         other,
-        double(path: "manual/baz.html", data: double(title: "Baz", section: "B section", type: nil)),
+        double(path: "manual/baz.html", data: double(title: "Baz", section: "B section", type: nil, index: nil)),
       ])
 
       other_pages_from_section = Manual.new(sitemap).other_pages_from_section(one)
@@ -33,7 +33,7 @@ RSpec.describe Manual do
   describe "#other_alerts_from_subsection" do
     it "returns other Icinga Alert pages that have the same subsection" do
       def stub_page(data_args)
-        double(path: "manual/#{SecureRandom.uuid}.html", data: double({ important: true, type: nil, subsection: nil }.merge(data_args)))
+        double(path: "manual/#{SecureRandom.uuid}.html", data: double({ important: true, type: nil, subsection: nil, index: nil }.merge(data_args)))
       end
 
       matching_subsection_and_alert = stub_page(title: "Foo", section: "Icinga alerts", subsection: "Emails")
@@ -57,9 +57,9 @@ RSpec.describe Manual do
   describe "#pages_for_repo" do
     it "returns the pages that are relevant to a repo" do
       sitemap = double(resources: [
-        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo", type: nil)),
-        double(path: "manual/foo.html", data: double(title: "Foo", related_repos: %w[publisher], section: "Foo", type: nil)),
-        double(path: "manual/bar.html", data: double(title: "Bar", related_repos: %w[collections], section: "Bar", type: nil)),
+        double(path: "foo.html", data: double(title: "Won't be included", important: true, review_by: Date.today, section: "Foo", type: nil, index: nil)),
+        double(path: "manual/foo.html", data: double(title: "Foo", related_repos: %w[publisher], section: "Foo", type: nil, index: nil)),
+        double(path: "manual/bar.html", data: double(title: "Bar", related_repos: %w[collections], section: "Bar", type: nil, index: nil)),
       ])
 
       pages_for_repo = Manual.new(sitemap).pages_for_repo("publisher")


### PR DESCRIPTION
This PR enables a new feature that allows us to write alternative versions of a page. This is useful for allowing us to maintain new documentation for the new EKS platform along side our existing docs. For example, we can have two versions of "how to deploy the emergency banner", one for EC2 and another for EKS. These alternative versions of page are hidden from site navigation features (such as search and manual lists), so only a single result is displayed per manual. Navigation to alternative pages are provided by a selector adjacent the breadcrumbs, and is only visible if an alternative version is available.

This is feature is provided through the use of a Middleman extension and additional partial - so should be trivial to remove if no longer required (i.e. post migration to the new platform.) 

For example of a page using this feature see PR #3885:

Search results showing a single result (instead of duplicates):

![image](https://user-images.githubusercontent.com/11051676/219379306-bd7d42b9-9d0e-493e-95e3-26c0fd1fd32b.png)

Manual lists showing a single link:

![image](https://user-images.githubusercontent.com/11051676/219379417-0045e32e-8ff7-466b-a579-46906b0dfce1.png)

Page version selector:

![image](https://user-images.githubusercontent.com/11051676/219379504-a6cf5f07-8399-4942-8a00-0f73cd13b35e.png)

Alternative page selected:

![image](https://user-images.githubusercontent.com/11051676/219379933-ef89400d-ac2f-4b22-9478-9cbe275b7cd2.png)

Page without multiple versions (No selector):

![image](https://user-images.githubusercontent.com/11051676/219379646-0eeb82f2-bb6c-442c-a37c-5d76cd0d0bad.png)

