### PR TITLE
Add emergency banner docs for EKS

### DIFF
--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -32,11 +32,13 @@ Contact numbers for those people are in the [legacy Ops manual](https://docs.goo
 
 The GOV.UK on-call escalations contact will supply you with:
 
-- The emergency banner type or campaign class (one of `notable-death`,
-  `national-emergency` or `local-emergency`)
+- The [emergency banner type or campaign class](#types-of-emergency-banners). Must be one of the following:
+  - `notable-death`
+  - `national-emergency`
+  - `local-emergency`
 - Text for the heading.
 - (Optional) Text for the 'short description', which is a sentence displayed under the heading. This is optional.
-- (Optional) A URL for users to find more information (it might not be provided at first).
+- (Optional) A URL for users to find more information (it might not be provided at first). Use a relative URL if the link on the www.gov.uk domain.
 - (Optional) Link text that will be displayed for the more information URL (this will default to "More information" if you do not supply it).
 
 ### 2. Deploy the banner using Jenkins
@@ -50,7 +52,7 @@ The data for the emergency banner is stored in Redis. Jenkins is used to set the
 
 1. Click `Build with Parameters`.
 
-1. Fill in the appropriate variables using the form presented by Jenkins. Use a relative URL (i.e. without the www.gov.uk prefix) if a link is required.
+1. Fill in the appropriate variables using the form presented by Jenkins.
 
 1. Click `Build`.
 
@@ -189,12 +191,6 @@ If you need to manually run the rake tasks to set the Redis keys, you can do so:
    ```bash
    $ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:deploy[campaign_class,heading,short_description,link,link_text]
    ```
-
-The `campaign_class` is directly injected into the HTML as a `class` and must be one of
-
-- notable-death
-- national-emergency
-- local-emergency
 
 For example, if you are deploying an emergency banner for which you have the
 following information:

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -56,10 +56,6 @@ The data for the emergency banner is stored in Redis. Jenkins is used to set the
 
 ![Jenkins Deploy Emergency Banner](images/emergency_publishing/deploy_emergency_banner_job.png)
 
-> **Note**
->
-> The Jenkins job will also clear the Varnish caches and the CDN cache for [a predefined list of 10 URLs](https://github.com/alphagov/govuk-puppet/blob/8cca9aad2b68d6cb396a135f47524fafeca1c947/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb#L22-L34) (including the website root).
-
 ### 3. Test with cache bust strings
 
 Most GOV.UK pages have a cache TTL of 5 minutes. After deploying the emergency
@@ -109,8 +105,6 @@ Once all caches have had time to clear, check that the emergency banner is visib
 1. Click `Build now` in the left hand menu.
 
 ![Jenkins Remove Emergency Banner](images/emergency_publishing/remove_emergency_banner_job.png)
-
-Caches will clear automatically.
 
 ---
 
@@ -174,7 +168,7 @@ irb(main):001:0> Redis.new.hgetall("emergency_banner")
 
 ### Manually running the rake task to deploy the emergency banner
 
-If you need to manually run the rake tasks to set the Redis keys, you can do so (remember to follow the instructions above to clear application template caches, restart Whitehall and purge origin caches afterwards):
+If you need to manually run the rake tasks to set the Redis keys, you can do so:
 
 1. SSH into a `frontend` machine appropriate to the environment you are
    deploying the banner on. For example:

--- a/source/manual/emergency-publishing.html.md
+++ b/source/manual/emergency-publishing.html.md
@@ -209,12 +209,6 @@ $ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:deploy["n
 
 Note there are no spaces after the commas between parameters to the rake task.
 
-Quit your SSH session:
-
-```bash
-$ exit
-```
-
 ### Manually running the rake task to remove an emergency banner
 
 1. SSH into a frontend machine:
@@ -233,12 +227,6 @@ $ exit
 
    ```bash
    $ sudo -u deploy govuk_setenv static bundle exec rake emergency_banner:remove
-   ```
-
-1. Quit your SSH session
-
-   ```bash
-   $ exit
    ```
 
 ---


### PR DESCRIPTION
This adds the documentation with instructions on how to deploy the banner using Kubernetes. It also removes outdated information about cache clearing, as this no longer apart of the process of deploying banner since cache times were shortened to 5 mins.