### PR TITLE
Remove seal from get started

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -83,7 +83,7 @@ If you have a YubiKey, you will use `gpg-agent` in place of `ssh-agent`, which r
 
 1. Set up a [GitHub] account. You can use your existing personal account.
 1. [Associate your GitHub account with your GDS email address][associate-email-github], this can be in addition to your personal email address.
-1. Ask your tech lead to add your GitHub username to the [user monitoring system][user-reviewer] and [seal].
+1. Ask your tech lead to add your GitHub username to the [user monitoring system][user-reviewer].
 
     If your tech lead is not available, ask in the [Technical 2nd Line Slack channel](https://gds.slack.com/archives/CADKZN519) for someone who has production access to add you.
 1. Email <govuk-github-owners@digital.cabinet-office.gov.uk> to request to be added to the [alphagov organisation][alphagov] and the [GOV.UK team][govuk-team] to get access to repos and CI environment, add your tech lead a CC of the email. Please explain in the email which team you are working on and in what role; include a link to the pull request created in the previous step.
@@ -106,7 +106,6 @@ If you have a YubiKey, you will use `gpg-agent` in place of `ssh-agent`, which r
 [register-ssh-key]: https://help.github.com/articles/connecting-to-github-with-ssh/
 [add-ssh-key]: https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account
 [user-reviewer]: https://github.com/alphagov/govuk-user-reviewer
-[seal]: https://github.com/alphagov/seal
 
 ## 4. Install GDS command line tools
 

--- a/source/manual/tech-lead-responsibilities.html.md
+++ b/source/manual/tech-lead-responsibilities.html.md
@@ -28,11 +28,8 @@ Anybody on the team should feel comfortable picking up any card, even if they do
 
 For existing teams, tech leads should on-board new developers to the team. You should meet with developers new to the team to introduce the team’s work and overall goals. Discuss the new developer’s objectives so you can help ensure there is suitable work for them and generally help settle them in to be productive team members.
 
-Ensure the developer is in the correct team in the [seal][].
-
 If the developer is new to GOV.UK, then it’s worth taking them through the [overview slides][].
 
-[seal]: https://github.com/alphagov/seal/blob/main/config/alphagov.yml
 [overview slides]: https://docs.google.com/presentation/d/1nAE65Og04JYNAc0VjYaUYLqNLuUOM9r3Mvo0PGFy_Zk/edit
 
 ## Managing leavers


### PR DESCRIPTION
The seal no longer contains individual team members so no longer needs to be update for new starters.

Also removed from the tech leads responsibility section.
