### PR TITLE
Retire Service manual frontend

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -151,7 +151,6 @@ redirects:
   /apps/search-analytics.html: /repos/search-analytics.html
   /apps/search-api.html: /repos/search-api.html
   /apps/search-performance-explorer.html: /repos/search-performance-explorer.html
-  /apps/service-manual-frontend.html: /repos/service-manual-frontend.html
   /apps/service-manual-publisher.html: /repos/service-manual-publisher.html
   /apps/short-url-manager.html: /repos/short-url-manager.html
   /apps/side-by-side-browser.html: /repos/side-by-side-browser.html

--- a/data/rendering-apps.yml
+++ b/data/rendering-apps.yml
@@ -394,19 +394,19 @@
   - finder-frontend
 - :name: service_manual_guide
   :apps:
-  - service-manual-frontend
+  - government-frontend
 - :name: service_manual_homepage
   :apps:
-  - service-manual-frontend
+  - government-frontend
 - :name: service_manual_service_standard
   :apps:
-  - service-manual-frontend
+  - government-frontend
 - :name: service_manual_service_toolkit
   :apps:
-  - service-manual-frontend
+  - government-frontend
 - :name: service_manual_topic
   :apps:
-  - service-manual-frontend
+  - government-frontend
 - :name: service_sign_in
   :apps:
   - government-frontend

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1069,9 +1069,11 @@
     of A/B tests on GOV.UK search. Retired in April 2022
 
 - repo_name: service-manual-frontend
-  team: "#navigation-and-presentation-govuk"
   type: Frontend apps
-  production_hosted_on: aws
+  retired: true
+  description: |
+    service-manual-frontend was used to render service manual pages. Those were moved
+    to government-frontend in February 2023.
 
 - repo_name: service-manual-publisher
   type: Publishing apps


### PR DESCRIPTION
The rendering was moved to government-frontend
This updates the docs to reflect that.

https://trello.com/c/gICwB7Ej/1195-retire-service-manuals-frontend-app-m

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
