### PR TITLE
Update github-trello-poster.html.md

### DIFF
--- a/source/manual/github-trello-poster.html.md
+++ b/source/manual/github-trello-poster.html.md
@@ -11,11 +11,11 @@ This app uses GitHub webhooks to be notified when a pull request is opened or ch
 
 ## Background
 
-This app was created by Emma Beynon as a [20% time project](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-technology/junior-technologist/previous-20-projects/github-trello-poster).  It was built using Ruby and Sinatra and makes use of the Trello and GitHub APIs and GitHub webhooks.  It is hosted on Government PaaS.  You can find the GitHub repo [here](https://github.com/emmabeynon/github-trello-poster).
+This app was created by Emma Beynon as a [20% time project](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-technology/junior-technologist/previous-20-projects/github-trello-poster).  It was built using Ruby and Sinatra and makes use of the Trello and GitHub APIs and GitHub webhooks.  It is hosted on Heroku.  You can find the GitHub repo [here](https://github.com/alphagov/github-trello-poster).
 
 ## Credentials
 
-The credentials for the Trello account that posts to Trello cards and for PaaS can be found in [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/github-trello-poster).
+The credentials for the Trello account that posts to Trello cards can be found in [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/github-trello-poster).
 
 The app uses the `govuk-ci` user's GitHub Personal Access Token.
 
@@ -24,5 +24,5 @@ The app uses the `govuk-ci` user's GitHub Personal Access Token.
 It's a simple process:
 
 1. Add user `@pullrequestposter` to your team's Trello board.  It will need **read and write** access.
-2. Set up a webhook for your chosen repo, if it hasn't already been done.  For instructions, see the app's [GitHub repo](https://github.com/emmabeynon/github-trello-poster).  You can find the payload URL in [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/github-trello-poster).  Alternatively, copy how it's set up in a repo such as [Publishing API](https://github.com/alphagov/publishing-api/settings/hooks).
+2. Set up a webhook for your chosen repo, if it hasn't already been done.  For instructions, see the app's [GitHub repo](https://github.com/alphagov/github-trello-poster).  You can find the payload URL in [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/github-trello-poster).  Alternatively, copy how it's set up in a repo such as [Publishing API](https://github.com/alphagov/publishing-api/settings/hooks).
 3. That's it!  You should start seeing GitHub Trello Poster posting to your Trello cards once you start opening, modifying and closing pull requests.


### PR DESCRIPTION
This repo was forked and moved to Heroku.

https://trello.com/c/9q9d6O6s/3104-move-github-trello-poster-hosting-to-somewhere-supported-3

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
