### PR TITLE
Add `data/repos.yml` entry for `govuk-ask-export`

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -295,7 +295,7 @@
 - repo_name: gds_zendesk
   team: "#govuk-platform-reliability-team"
   type: Gems
-  
+
 - repo_name: github-trello-poster
   team: "#govuk-platform-reliability-team"
   management_url: https://dashboard.heroku.com/apps/govuk-github-trello-poster
@@ -347,6 +347,12 @@
   description: Capistrano deployment scripts for applications running on GOV.UK.
   sentry_url: false
   dashboard_url: false
+
+- repo_name: govuk-ask-export
+  team: "#user-experience-measurement-govuk"
+  type: Utilities
+  description: |
+    A tool for exporting the user responses and metadata from Smart Survey which is used for the [https://www.gov.uk/ask](https://www.gov.uk/ask) service.
 
 - repo_name: govuk-aws
   team: "#govuk-platform-reliability-team"


### PR DESCRIPTION
Part of [Work through list of missing repos tagged as govuk](https://github.com/alphagov/govuk-developer-docs/pull/3913).

`govuk-ask-export` is owned by the User Experience Measurement (UXM) team.

[Trello](https://trello.com/c/iJj8Qyjr/401-add-govuk-ask-export-to-data-reposyml)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
