### PR TITLE
Add `data/repos.yml` entry for `public-asset-checker`

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -976,6 +976,12 @@
     policy pages were replaced by Topic pages through the work on the
     GOV.UK Topic Taxonomy, removing the need for Policy Publisher.
 
+- repo_name: public-asset-checker
+  team: "#user-experience-measurement-govuk"
+  type: Utilities
+  description: |
+    Checks publicly hosted asset files against a known baseline and notifies the owning team if any require attention.
+
 - repo_name: publisher
   type: Publishing apps
   team: "#govuk-publishing-experience-tech"


### PR DESCRIPTION
Part of [Work through list of missing repos tagged as govuk](#3913).

public-asset-checker is owned by the User Experience Measurement (UXM) team.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

[Trello](https://trello.com/c/g7eHKMPo/402-add-public-asset-checker-to-data-reposyml)