### PR TITLE
Add `data/repos.yml` entry for `govuk-google-analytics`

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -484,6 +484,14 @@
   team: "#data-products"
   type: Data science
 
+- repo_name: govuk-google-analytics
+  team: "#user-experience-measurement-govuk"
+  type: Utilities
+  description: |
+    Documentation and tools for GOV.UK and others that describes
+    the approach taken when converting from Universal Analytics (UA)
+    to Google Analytics 4 (GA4).
+
 - repo_name: govuk-helm-charts
   type: Utilities
   team: "#govuk-replatforming"


### PR DESCRIPTION
Part of [Work through list of missing repos tagged as govuk](#3913).

govuk-google-analytics is owned by the User Experience Measurement (UXM) team.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

[Trello](https://trello.com/c/gmY02y8h/403-add-govuk-google-analytics-to-data-reposyml)