### PR TITLE
Update adding an organisation colour documentation

### DIFF
--- a/source/manual/howto-add-organisation-brand-colour.html.md
+++ b/source/manual/howto-add-organisation-brand-colour.html.md
@@ -7,42 +7,53 @@ parent: "/manual.html"
 related_repos: [whitehall, government-frontend]
 ---
 
-An organistion's brand colour is used to style their organisation page (such as
-dividing lines, icons and link text). For example
-see the [DCMS organisation page](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport).
+An organisation's brand colour is used to style their organisation page (such as dividing lines, icons and link text). For example see the [DCMS organisation page](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport).
 
-The colour is set as an option under a drop down field called "brand colour" when
-creating or editing an [organisation page in Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/organisations).
+The colour is set as an option under a drop down field called "brand colour" when creating or editing an [organisation page in Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/organisations).
 
-## 1. Add the brand colour in GOV.UK Frontend
+[Documentation in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/component_branding.md) explains how brand colours work in the code, for reference.
+
+## 1. Check the colour passes WCAG contrast requirements
+
+If an organisation's brand colour changes or a new one is required, check that it is of a high enough contrast against a white background to be accessible. Use a tool such as the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) to determine this.
+
+## 2. Add the brand colour in govuk_publishing_components
+
+If the brand colour is required urgently, follow this step to temporarily add it directly to `govuk_publishing_components`. Otherwise, skip to step 3.
+
+Add styles to `_brand-colours.scss` as shown in this example for [10 Downing Street](https://github.com/alphagov/govuk_publishing_components/blob/cefed3993d91f375a9990d703d49b41277acb189/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss#L58-L78). Copy and paste these lines and modify the organisation CSS class name and colour as required.
+
+You will then need to ready a [new release of the components gem](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/publishing-to-rubygems.md) for deployment.
+
+## 3. Add the brand colour in GOV.UK Frontend
 
 Set up a fork of `govuk-frontend`, then add the colour to the [_colours-organisations.scss file](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/settings/_colours-organisations.scss) and update the [CHANGELOG](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md).
 See [updating changelog](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/versioning.md#updating-changelog) and [example PR](https://github.com/alphagov/govuk-frontend/pull/1918) for more details.
 
-> **Note**
->
-> It may be some time before the next version of `govuk-frontend` is released,
-to get the changes out on time you can add the colour in `govuk_publishing_components`,
-see [this PR](https://github.com/alphagov/govuk_publishing_components/pull/1648)
-as an example.
+Note that it may be some time before a new version of `govuk-frontend` is released.
 
-## 2. Add the organisation as brand colour option in Whitehall
+## 4. Add the organisation as brand colour option in Whitehall
 
-Add a new entry for the organisation in [app/models/organisation_brand_colour.rb](https://github.com/alphagov/whitehall/blob/main/app/models/organisation_brand_colour.rb), which will show
-the organisation as an option under the [brand colour drop down field](https://github.com/alphagov/whitehall/blob/52aff8f61a29b3999054b5b5c94875a5534eaf9a/app/views/admin/organisations/_form.html.erb#L25) in Whitehall.
-The CSS class name should match the name used in `govuk-frontend`.
+Add a new entry for the organisation in [app/models/organisation_brand_colour.rb](https://github.com/alphagov/whitehall/blob/main/app/models/organisation_brand_colour.rb), which will show the organisation as an option under the [brand colour drop down field](https://github.com/alphagov/whitehall/blob/52aff8f61a29b3999054b5b5c94875a5534eaf9a/app/views/admin/organisations/_form.html.erb#L25) in Whitehall. The CSS class name should match the name used earlier.
 
-## Testing your changes locally
+## 5. Testing your changes
 
-1. [Install `govuk-frontend` with npm](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/running-locally.md)
-2. In `govuk_publishing_components`, update `package.json` to point to your local
-  `govuk-frontend` repo, then update the package, see [this doc](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/tasks.md) for more details
-3. In `collections`, update the Gemfile to point to your local version of
-  `govuk_publishing_components`
-4. In `whitehall`, you should see the organisation as an option under the `brand
-  colour` field (you will also need to update the `Status on GOV.UK` to `currently live`
-  to view the page)
-5. Run `./startup.sh —integration` in `collections` to view the organisation's page
+If you have modified `govuk_publishing_components`:
+
+1. Run `collections` with your local version of `govuk_publishing_components` (see [Local frontend development](https://docs.publishing.service.gov.uk/manual/local-frontend-development.html) if you need help).
+2. Go to an organisation page and use Chrome's developer tools to change the brand class of an element to match, check that the required colour is applied.
+3. Create a new release of `govuk_publishing_components` and get a branch of `collections` including this deployed to integration.
+
+If you have modified `govuk-frontend`:
+
+1. Check and approve the dependabot PR in `govuk_publishing_components` for the new version of `govuk-frontend`.
+2. Include a commit to remove any styles added in section 2 of this guide.
+3. Create a new release of `govuk_publishing_components` and get a branch of `collections` including this deployed to integration.
+
+Then:
+
+1. In integration `whitehall`, you should see the organisation as an option under the `brand colour` field (you will also need to update the `Status on GOV.UK` to `currently live` to view the page).
+2. Check the relevant organisation page has the new colour.
 
 > **Note**
 >


### PR DESCRIPTION
- was out of date
- extending to include a quick way of doing this, while hopefully still highlighting the correct way of doing this

Note that this change doesn't include a fix for the renamed rake task (e.g. `publishing_api:republish_organisation[slug]`) being wrong - apparently it doesn't work anymore. I don't know whether this needs to be changed or removed.

Runs but errors: 

```
17:28:37 warning: parser/current is loading parser/ruby31, which recognizes 3.1.3-compliant syntax, but you are running 3.1.2.
17:28:37 Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
17:28:37 rake aborted!
17:28:37 Don't know how to build task 'publishing_api:republish_organisation' (See the list of available tasks with `rake --tasks`)
17:28:37 Did you mean?  publishing_api:bulk_republish:by_organisation
17:28:37                publishing_api:republish:organisation_by_slug
17:28:37 /data/vhost/whitehall-admin/shared/bundle/ruby/3.1.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
```

Trello card: https://trello.com/c/8RuECJOM/1793-update-changing-org-colour-documentation
