### PR TITLE
Adds requirement to include repo in list of repos

### DIFF
--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -13,6 +13,7 @@ Repositories in GOV.UK must:
 - Link to relevant documentation
 - Have the [`govuk`][govuk-topic] topic
 - Have a [good README](/manual/readmes.html)
+- Have an entry in [the list of repos](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml)
 
 Almost all repos should:
 
@@ -32,7 +33,7 @@ When your repo is tagged with `govuk`, it will be auto-configured by [govuk-saas
 When you create a new repo:
 
 - Give the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production Admin][govuk-production-team] teams `Admin` access
-- Give the [GOV.UK][govuk-team] `Write` access
+- Give the [GOV.UK team][govuk-team] `Write` access
 - Tag it with the [`govuk`][govuk-topic] topic
 - [Kick off a build of the Jenkins job][jenkins-job] to automate the rest
 


### PR DESCRIPTION
GOV.UK repos should be included in [the list of repos](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml) because other things rely on that list. 

