### PR TITLE
Add alphagov/whitehall-prototype-2023

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1221,3 +1221,7 @@
   production_url: https://whitehall-admin.publishing.service.gov.uk
   team: "#govuk-publishing-experience-tech"
   production_hosted_on: aws
+
+- repo_name: whitehall-prototype-2023
+  type: Publishing apps
+  team: "#govuk-publishing-experience-tech"


### PR DESCRIPTION
Add the repo `alphagov/whitehall-prototype-2023` to `repos.yml`

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
