### PR TITLE
Add analytics documentation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+set -eu
+
+bundle check || bundle install
+NO_CONTRACTS=true bundle exec middleman build

--- a/config.rb
+++ b/config.rb
@@ -57,3 +57,23 @@ unless ENV["SKIP_PROXY_PAGES"] == "true"
     proxy resource[:path], resource[:template], resource[:frontmatter]
   end
 end
+
+# Configuration for Analytics pages
+ignore "analytics/templates/*"
+
+page "analytics/*", layout: :analytics_layout
+
+data.analytics.events.each do |event|
+  event_name = event["name"].downcase.gsub(" ", "_")
+  proxy "analytics/event_#{event_name}.html", "analytics/templates/event.html", locals: { event: }
+end
+
+data.analytics.attributes.each do |attribute|
+  attribute_name = attribute["name"].downcase.gsub(" ", "_")
+  proxy "analytics/attribute_#{attribute_name}.html", "analytics/templates/attribute.html", locals: { attribute: }
+end
+
+data.analytics.trackers.each do |tracker|
+  tracker_name = tracker["name"].downcase.gsub(" ", "_")
+  proxy "analytics/tracker_#{tracker_name}.html", "analytics/templates/tracker.html", locals: { tracker: }
+end

--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -1,0 +1,291 @@
+- name: action
+  description: Shows the kind of thing the user has done.
+  value:
+  example:
+  required: no
+  type: string
+  redact: false
+
+- name: browse_topic
+  description: Used in the page_view object to record the content section
+  value: content attribute of meta tag govuk:section
+  example: working at sea
+  required: no
+  type: string
+  redact: false
+
+- name: content_id
+  description:
+  value: content attribute of meta tag govuk:content-id
+  example: a6bb0fc8-753f-4732-aabc-ff727dcf1262
+  required: no
+  type: string
+  redact: false
+
+- name: document_type
+  description:
+  value: content attribute of meta tag govuk:format
+  example: detailed_guide
+  required: no
+  type: string
+  redact: false
+
+- name: dynamic
+  description: The existence of a referrer parameter indicates that the page has been dynamically updated via an AJAX request and therefore we can use it to set the dynamic property appropriately. This value is used by analysts to differentiate between fresh page loads and dynamic page updates.
+  value: true/false
+  required: no
+  type: string
+  redact: false
+
+- name: event
+  description: Needed by Google to contain a specific thing to cause a trigger to happen.
+  example: page_view, event_data
+  required: no
+  type: string
+  redact: false
+
+- name: event_name
+  description: Suggested by Google to contain a value that conforms to a schema they have proposed. This gives further information about the data being sent.
+  value: select_content
+  example:
+  required: yes
+  type: string
+  redact: false
+
+- name: external
+  description: Used for link tracking. True means the link points to a URL not on the current site.
+  example:
+  required: yes
+  type: string (true or false)
+  redact: false
+
+- name: first_published_at
+  description: date and time the page was first published
+  value: date part only of content attribute of meta tag govuk:first-published-at
+  example: "2012-09-05"
+  required: no
+  type: string
+  redact: false
+
+- name: history
+  description:
+  value: content attribute of meta tag govuk:content-has-history
+  example: true or false (defaults to false)
+  required: no
+  type: string
+  redact: false
+
+- name: index
+  description: Contains the index of a thing being clicked on, for example the nth accordion section, or the nth link in a list.
+  example:
+  required: no
+  type: string (1-indexed number)
+  redact: false
+
+- name: index_link
+  description: The index of the clicked link within the section
+  value:
+  example: 1
+  required: no
+  type: number
+  redact: false
+
+- name: index_section
+  description: The index of the section that was interacted with, for example the index of the section the clicked link is in
+  value:
+  example: 1
+  required: no
+  type: number
+  redact: false
+
+- name: index_section_count
+  description: The total number of sections in the thing being tracked, such as the header or sidebar
+  value:
+  example: 1
+  required: no
+  type: number
+  redact: false
+
+- name: index_total
+  description: Relates to index by showing the total number of things e.g. tabs or accordion sections.
+  example:
+  required: yes
+  type: string (number)
+  redact: false
+
+- name: language
+  description: the language the page is rendered in
+  value: lang attribute of the '#content' element
+  example: en
+  required: no
+  type: string
+  redact: false
+
+- name: link_domain
+  description: The protocol and domain of a link href attribute.
+  value:
+  example: https://www.nhs.uk
+  required: yes
+  type: string
+  redact: false
+
+- name: link_path_parts
+  description: An object containing a URL in 100 character parts, usually the href attribute of a link. This is stored like this to get around the 100 character limit on attribute values - many URLs are longer than this. Regardless of the length of the URL, the object will always contain 5 key/value pairs. If the URL is less than 500 characters, unused key/value pairs will be undefined. If the URL is longer than 500 characters, the extra characters will be lost.
+  value:
+  example: |
+    {1=>"/conditions/vaccinations/flu-influenza-vaccine/", 2=>"undefined", 3=>"undefined", 4=>"undefined", 5=>"undefined"}
+  required: yes
+  type: string
+  redact: true
+
+- name: location
+  description:
+  value: document.location
+  example: "https://www.gov.uk/find-a-job"
+  required: no
+  type: string
+  redact: true
+
+- name: method
+  description: How a link was clicked.
+  value:
+  example: primary click, secondary click, middle click, ctrl click, command/win click, shift click
+  required: yes
+  type: string
+  redact: false
+
+- name: publishing_app
+  description: application that published the content
+  value: content attribute of meta tag govuk:publishing-app
+  example: collections-publisher
+  required: no
+  type: string
+  redact: false
+
+- name: referrer
+  description: The page the user was on before coming to this page.
+  value: document.referrer
+  example: "https://www.gov.uk/"
+  required: no
+  type: string
+  redact: true
+
+- name: rendering_app
+  description: application that renders the page
+  value: content attribute of meta tag govuk:rendering-app
+  example: government-frontend
+  required: no
+  type: string
+  redact: false
+
+- name: schema_name
+  description:
+  value: content attribute of meta tag govuk:schema-name
+  example: detailed_guide
+  required: no
+  type: string
+  redact: false
+
+- name: section
+  alias: section_event_data
+  description: Used within the event_data object to identify where on the page an event occurred. Could be the area (header, footer) or a specific heading.
+  value:
+  example:
+  required: no
+  type: string
+  redact: false
+
+- name: status_code
+  description:
+  value: HTTP response status code
+  example: 200, 404
+  required: no
+  type: string
+  redact: false
+
+- name: taxonomy_all
+  description: An object containing the content attribute of the meta tag govuk:taxon_slugs in 100 character parts. This is stored like this to get around the 100 character limit on attribute values. Regardless of the length of the meta tag, the object will always contain 5 key/value pairs. If the values are less than 500 characters, unused key/value pairs will be undefined. If the values are longer than 500 characters, the extra characters will be lost.
+  value: content attribute of meta tag govuk:taxon_slugs
+  example: |
+    {"1"=>"finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-wo", "2"=>"rking-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-label", "3"=>"ling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific", "4"=>"-research-and-development,self-employed", "5"=>"undefined"}
+  required: no
+  type: string
+  redact: false
+
+- name: taxonomy_all_ids
+  description: An object containing the content attribute of the meta tag govuk:taxon_ids in 100 character parts. This is stored like this to get around the 100 character limit on attribute values. Regardless of the length of the meta tag, the object will always contain 5 key/value pairs. If the values are less than 500 characters, unused key/value pairs will be undefined. If the values are longer than 500 characters, the extra characters will be lost.
+  value: content attribute of meta tag govuk:taxon_ids
+  example: |
+    {"1"=>"ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a5", "2"=>"0d57be943f,23a712ff-23b3-4f5a-83f1-44ac679fe615,a1c6c263-e4ef-4b96-b82f-e070ff157367,e2559668-cf36-4", "3"=>"7fc-8a77-2e760e12a812", "4"=>"undefined", "5"=>"undefined"}
+  required: no
+  type: string
+  redact: false
+
+- name: taxonomy_level1
+  description:
+  value: content attribute of meta tag govuk:themes
+  example: crime-justice-and-law, life-circumstances
+  required: no
+  type: string
+  redact: false
+
+- name: taxonomy_main
+  description:
+  value: content attribute of meta tag govuk:taxon_slug
+  example: courts-sentencing-tribunals
+  required: no
+  type: string
+  redact: false
+
+- name: taxonomy_main_id
+  description:
+  value: content attribute of meta tag govuk:taxon_id
+  example: 357110bb-cbc5-4708-9711-1b26e6c63e86
+  required: no
+  type: string
+  redact: false
+
+- name: text
+  description: The text of the thing being tracked, for example the text of a link, button or tab. This can either be read directly from the element, passed from a data attribute, or generated automatically for elements where the text changes, for example the 'Show all sections' link in an accordion, which can also read 'Hide all sections'.
+  value: text of the element
+  required: no
+  type: string
+  redact: false
+
+- name: title
+  description:
+  value: document.title
+  example:
+  required: no
+  type: string
+  redact: true
+
+- name: type
+  description: Relates to the top level attribute of event_name but contains a value that we have defined.
+  example:
+  required: no
+  type: string
+  redact: false
+
+- name: updated_at
+  description: date the content was last updated
+  value: date part only of content attribute of meta tag govuk:updated-at
+  example: "2012-09-05"
+  required: no
+  type: string
+  redact: false
+
+- name: url
+  description: Used to communicate relevant location information, such as the URL of a tab that has been clicked or the href of the link where the user is going. Note that this can differ from the top level location attribute.
+  example:
+  required: no
+  type: string
+  redact: true
+
+- name: withdrawn
+  description:
+  value: content attribute of meta tag govuk:withdrawn
+  example: true or false (defaults to false)
+  required: no
+  type: string
+  redact: false

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1,0 +1,535 @@
+- name: accordion
+  events:
+    - name: Accordion section
+      description: When a section of the accordion is opened or closed.
+      example_url: https://www.gov.uk/coronavirus
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: select_content
+        - name: type
+          value: accordion
+        - name: text
+          value: text of selected accordion
+        - name: index
+          value:
+          - name: index_section
+          - name: index_link
+          - name: index_section_count
+        - name: index_total
+          value: number of sections in accordion (not including 'show all')
+        - name: action
+          value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
+    - name: Show all sections
+      description: When the 'Show all sections' control is used.
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: select_content
+        - name: type
+          value: accordion
+        - name: text
+          value: text of show all link when clicked e.g. "Show all sections"
+        - name: index
+          value: 0
+        - name: index_total
+          value: number of sections in the accordion (not including 'show all')
+        - name: action
+          value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
+
+- name: HTML attachments
+  events:
+    - name: link clicks (not implemented yet)
+      description: Triggered when a HTML attachment link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      example_url: https://www.gov.uk/government/publications/equality-act-guidance
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: html attachment
+        - name: url
+
+- name: breadcrumbs
+  events:
+    - name: link clicks
+      description: Triggered when a breadcrumb link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      example_url: https://www.gov.uk/learn-to-drive-a-car
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+          value: 'false'
+        - name: index
+          value:
+          - name: index_link
+            value: The position of the link within the breadcrumbs from left to right.
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: breadcrumbs
+        - name: url
+
+- name: feedback
+  events:
+    - name: Is this page useful? Yes
+      description:
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_submit
+        - name: section
+          value: Is this page useful?
+        - name: text
+          value: "Yes"
+        - name: type
+          value: feedback
+    - name: Is this page useful? No
+      description:
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_submit
+        - name: section
+          value: Is this page useful?
+        - name: text
+          value: "No"
+        - name: type
+          value: feedback
+    - name: Report a problem with this page
+      description:
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_submit
+        - name: section
+          value: Is this page useful?
+        - name: text
+          value: Report a problem with this page
+        - name: type
+          value: feedback
+    - name: Send me the survey
+      description:
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_submit
+        - name: section
+          value: Help us improve GOV.UK
+        - name: text
+          value: Send me the survey
+        - name: type
+          value: feedback
+    - name: Send
+      description:
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_submit
+        - name: section
+          value: Help us improve GOV.UK
+        - name: text
+          value: Send
+        - name: type
+          value: feedback
+
+- name: footer
+  events:
+    - name: link clicks
+      description: Triggered when a footer link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      example_url: https://www.gov.uk/
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+        - name: index
+          value:
+          - name: index_section
+            value: The section that this link is in. "Topics" are 1, "Government activity" are 2, "Meta links" (Help, Privacy etc.) are 3, The Open Government Licence link is 4, and the Crown Copyright link is 5.
+          - name: index_link
+            value: The position of the link within its section.
+          - name: index_section_count
+            value: 5
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: footer
+        - name: url
+        - name: section
+          value: One of "Topics", "Government Activity", "Support Links", "Licence", or "Copyright"
+
+- name: links
+  events:
+    - name: External links
+      description: When a link is followed to a page outside of www.gov.uk.
+      tracker: specialist_link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+          value: true
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: generic link
+        - name: url
+    - name: Download links
+      description: When a link is followed to an asset such as a PDF.
+      tracker: specialist_link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: file_download
+        - name: external
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: generic download
+        - name: url
+
+- name: page view
+  events:
+    - name: Page view
+      description: When a page loads.
+      tracker: page_view_tracker
+      data:
+      - name: event
+        value: page_view
+      - name: page_view
+        value:
+        - name: referrer
+        - name: location
+        - name: title
+        - name: status_code
+        - name: document_type
+        - name: publishing_app
+        - name: rendering_app
+        - name: schema_name
+        - name: content_id
+        - name: browse_topic
+        - name: taxonomy_main
+        - name: taxonomy_all
+        - name: taxonomy_main_id
+        - name: taxonomy_all_ids
+        - name: taxonomy_level1
+        - name: language
+        - name: history
+        - name: withdrawn
+        - name: first_published_at
+        - name: updated_at
+        - name: public_updated_at
+        - name: publishing_government
+        - name: political_status
+        - name: primary_publishing_organisation
+        - name: organisations
+        - name: world_locations
+        - name: dynamic
+
+- name: print page
+  events:
+    - name: print page
+      description: When a 'print this page' button is used
+      example_url: https://www.gov.uk/guidance/register-a-trust-as-a-trustee
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: print_page
+        - name: index
+        - name: index_total
+        - name: section
+        - name: type
+          value: print page
+
+- name: related navigation
+  description: Events gathered in the contextual sidebar, contextual footer and related navigation components.
+  events:
+    - name: Related Navigation
+      description: Clicks in the related navigation component
+      example_url: https://www.gov.uk/government/statistics/national-curriculum-assessments-key-stage-2-2016-provisional
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: related content
+        - name: index
+          value: 1.1
+        - name: section
+          value: Heading of section e.g. Related content, Collection
+        - name: text
+        - name: url
+          value: href attribute of link
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: external
+
+- name: share this page
+  events:
+    - name: follow us
+      description: Triggered when a 'follow us' social media link is used.
+      example_url: https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+          value: true
+        - name: index
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: follow us
+        - name: url
+    - name: share this page
+      description: Triggered when a 'share on' social media link is used.
+      example_url: https://www.gov.uk/government/news/new-protections-for-children-and-free-speech-added-to-internet-laws
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: share
+        - name: external
+          value: true
+        - name: index
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: share this page
+        - name: url
+
+- name: step by step navigation
+  events:
+    - name: Open/close step
+      description:
+      example_url: https://www.gov.uk/learn-to-drive-a-car
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: opened/closed
+        - name: event_name
+        - name: index
+        - name: index_total
+        - name: text
+        - name: type
+          value: "step by step"
+    - name: Show/hide all steps
+      description:
+      example_url: https://www.gov.uk/learn-to-drive-a-car
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: opened/closed
+        - name: event_name
+        - name: index
+          value: 0
+        - name: index_total
+        - name: text
+        - name: type
+          value: "step by step"
+    - name: link clicks
+      description: Triggered when a link within a step by step is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      example_url: https://www.gov.uk/learn-to-drive-a-car
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+        - name: index
+          value:
+          - name: index_section
+            value: The section that this link is in. The section in this case refers to the step number.
+          - name: index_link
+            value: The position of the link within this section.
+          - name: index_section_count
+            value: The total amount of links within this section.
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: step by step
+        - name: url
+        - name: section
+          value: The name of the step
+
+- name: super navigation header
+  events:
+    - name: Header menu bar buttons
+      description: When the Menu or Search button is expanded or collapsed.
+      example_url: https://www.gov.uk/
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: opened/closed
+        - name: event_name
+          value: select_content
+        - name: index
+          value:
+          - name: index_section
+          - name: index_link
+          - name: index_section_count
+        - name: index_total
+          value: 2
+        - name: section
+          value: Menu/Search
+        - name: type
+          value: header menu bar
+        - name: text
+          value: Menu/Search
+    - name: link clicks
+      description: Triggered when the GOVUK logo, a header "menu" section link, or a link under the search component is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      example_url: https://www.gov.uk/
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+        - name: index
+          value:
+          - name: index_section
+            value: The section that this link is in (Menu is 1, Search is 2)
+          - name: index_link
+            value: The position of the link within its section. GOVUK Logo has an index of 0.
+          - name: index_section_count
+            value: 2 (Menu and Search)
+        - name: index_total
+          value: Total links across all sections (currently 28)
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: header menu bar
+        - name: url
+        - name: section
+          value: The heading of the section the link is under, e.g. "Topics", "Government Activity"
+
+- name: tabs
+  events:
+    - name: Tab interaction
+      description: When a tab is selected.
+      example_url: https://www.gov.uk/renew-driving-licence
+      tracker: event_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+        - name: type
+          value: tabs
+        - name: url
+          value: tab identifier/url hash e.g. "#scotland"
+        - name: text
+          value: text of the selected tab
+        - name: index
+          value: index of the selected tab
+        - name: index_total
+          value: number of tabs in total

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -4,7 +4,7 @@ analytics:
 
 data:
   name: Data
-  desc: Details of the data pushed to the dataLayer when tracking occurs, including event and attribute details.
+  desc: Details of our data schema, including event and attribute details.
   link_title: Browse data
   link: data.html
   subsections:

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -1,0 +1,45 @@
+analytics:
+  name: Google Analytics 4 Implementation record
+  desc: This site contains a record of the data implementation for Google Analytics 4 on GOV.UK Publishing. It has been built as an aid to developers on GOV.UK Publishing but is being made available for anyone who may find our approach useful.
+
+data:
+  name: Data
+  desc: Details of the data pushed to the dataLayer when tracking occurs, including event and attribute details.
+  link_title: Browse data
+  link: data.html
+  subsections:
+    - name: Events
+      link: events.html
+    - name: Attributes
+      link: attributes.html
+
+docs:
+  name: Documentation
+  desc: Relevant documentation including our approach.
+  link_title: Browse documentation
+  link: docs.html
+  subsections:
+    - name: Developer approach
+      link: approach.html
+    - name: Personally Identifiable Information
+      link: pii.html
+    - name: Trackers
+      link: trackers.html
+
+approach:
+  name: Developer approach
+
+pii:
+  name: Personally Identifiable Information
+
+trackers:
+  name: Trackers
+  desc: Trackers are distinct JavaScripts that collect GA4 data in specific ways. They work differently but produce and send data to GA4 in the same way.
+
+attributes:
+  name: Attributes
+  desc: Attributes are the key/value pairs of data inside events. Attributes are often used by more than one event.
+
+events:
+  name: Events
+  desc: Events are collections of data that are sent to Google Analytics when users do certain things, like opening an accordion or clicking certain links.

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -1,0 +1,19 @@
+- name: Event tracker
+  technical_name: event_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md
+  description: This script is intended for adding GA4 tracking to interactive elements such as buttons or details elements.
+
+- name: Link tracker
+  technical_name: link_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md
+  description: This script is intended for adding GA4 tracking to links.
+
+- name: Page view tracker
+  technical_name: page_view_tracker
+  url:
+  description: This script creates page view events on page load.
+
+- name: Specialist link tracker
+  technical_name: specialist_link_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md
+  description: This script automatically tracks clicks on links such as external links, download links, and mailto links.

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -41,6 +41,11 @@
         - name: Repositories
           url: /repos.html
           description: All the applications and other repositories we use to build GOV.UK.
+    - name: GOV.UK analytics
+      sites:
+        - name: Analytics
+          url: /analytics/analytics.html
+          description: This site contains a record of the data structure implemented for Google Analytics 4 by GOV.UK.
     - name: GOV.UK publishing
       sites:
         - name: Content schemas
@@ -49,4 +54,3 @@
         - name: Document types
           url: /document-types.html
           description: The kinds of documents that are published on GOV.UK using one of the schemas.
-

--- a/helpers/analytics_helpers.rb
+++ b/helpers/analytics_helpers.rb
@@ -1,0 +1,38 @@
+module AnalyticsHelpers
+  def urlize(string)
+    string.downcase.gsub(" ", "_").gsub("-", "_")
+  end
+
+  def build_event(data, attributes = [], output = {})
+    data.sort_by { |k, _v| k["name"] }.each do |item|
+      name = item["name"]
+      value = item["value"]
+      if value
+        case value
+        when String
+          output[name] = value
+        when Array
+          output[name] = build_event(value, attributes)
+        end
+      else
+        attribute = attributes.find { |x| x["name"] == name }
+        output[name] = attribute ? attribute["type"] : value
+      end
+    end
+    output
+  end
+
+  def to_html(hash, html = "")
+    html += "<ul class='govuk-list indented-list'>"
+    hash.each do |key, value|
+      case value
+      when String
+        html += "<li><a href='/analytics/attribute_#{urlize(key)}.html'>#{key}</a>: #{value}</li>"
+      when Hash
+        html += "<li>#{key}: #{to_html(value)}</li>"
+      end
+    end
+    html += "</ul>"
+    html
+  end
+end

--- a/source/analytics/analytics.html.md.erb
+++ b/source/analytics/analytics.html.md.erb
@@ -6,30 +6,40 @@
   <%= data.analytics.navigation.analytics.desc %>
 </p>
 
-<h2 class="govuk-heading-l">
-  <%= data.analytics.navigation.data.name %>
-</h2>
+<div class="govuk-grid-row govuk-!-margin-bottom-7">
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">
+      <%= data.analytics.navigation.data.name %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= data.analytics.navigation.data.desc %>
+    </p>
+
+    <p class="govuk-body">
+      <a href="<%= data.analytics.navigation.data.link %>" class="govuk-link">
+        <%= data.analytics.navigation.data.link_title %>
+      </a>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">
+      <%= data.analytics.navigation.docs.name %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= data.analytics.navigation.docs.desc %>
+    </p>
+
+    <p class="govuk-body">
+      <a href="<%= data.analytics.navigation.docs.link %>" class="govuk-link">
+        <%= data.analytics.navigation.docs.link_title %>
+      </a>
+    </p>
+  </div>
+</div>
 
 <p class="govuk-body">
-  <%= data.analytics.navigation.data.desc %>
-</p>
-
-<p class="govuk-body">
-  <a href="<%= data.analytics.navigation.data.link %>" class="govuk-link">
-    <%= data.analytics.navigation.data.link_title %>
-  </a>
-</p>
-
-<h2 class="govuk-heading-l">
-  <%= data.analytics.navigation.docs.name %>
-</h2>
-
-<p class="govuk-body">
-  <%= data.analytics.navigation.docs.desc %>
-</p>
-
-<p class="govuk-body">
-  <a href="<%= data.analytics.navigation.docs.link %>" class="govuk-link">
-    <%= data.analytics.navigation.docs.link_title %>
-  </a>
+  This documentation is part of the <a href="/" class="govuk-link">GOV.UK Developer docs</a>.
 </p>

--- a/source/analytics/analytics.html.md.erb
+++ b/source/analytics/analytics.html.md.erb
@@ -1,0 +1,35 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.analytics.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.analytics.desc %>
+</p>
+
+<h2 class="govuk-heading-l">
+  <%= data.analytics.navigation.data.name %>
+</h2>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.data.desc %>
+</p>
+
+<p class="govuk-body">
+  <a href="<%= data.analytics.navigation.data.link %>" class="govuk-link">
+    <%= data.analytics.navigation.data.link_title %>
+  </a>
+</p>
+
+<h2 class="govuk-heading-l">
+  <%= data.analytics.navigation.docs.name %>
+</h2>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.docs.desc %>
+</p>
+
+<p class="govuk-body">
+  <a href="<%= data.analytics.navigation.docs.link %>" class="govuk-link">
+    <%= data.analytics.navigation.docs.link_title %>
+  </a>
+</p>

--- a/source/analytics/approach.html.md.erb
+++ b/source/analytics/approach.html.md.erb
@@ -1,0 +1,13 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.approach.name %>
+</h1>
+
+<p class="govuk-body">This is our high level approach to implementing tracking across our applications.</p>
+
+<p class="govuk-body">For elements that are consistent from page to page (such as the header, footer and breadcrumbs) tracking within these elements should be enabled by default.</p>
+
+<p class="govuk-body">For elements within the content of a page, tracking should be controllable. We want the flexibility to disable tracking in the unforeseen event of some kind of tracking collision/duplication. Tracking should be disabled on <a href="https://components.publishing.service.gov.uk/component-guide" class="govuk-link">components</a> by default and enabled with a 'ga4_tracking: true' option.</p>
+
+<p class="govuk-body">For elements that are inside content coming from a publishing interface, such as <a href="https://components.publishing.service.gov.uk/component-guide/govspeak" class="govuk-link">govspeak</a> elements, we will decide on a case by case basis. The most likely approach is that tracking would be enabled by default (otherwise publishers would need an option to enable tracking on their content, and the conversation would get much more complex).</p>
+
+<p class="govuk-body">Tracking should be handled internally by components unless external data is required i.e. if something unique must be passed from the application to the component to track it correctly because we want to make enabling tracking as simple as possible.</p>

--- a/source/analytics/attributes.html.md.erb
+++ b/source/analytics/attributes.html.md.erb
@@ -1,0 +1,17 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.attributes.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.attributes.desc %>
+</p>
+
+<ul class="govuk-list">
+  <% data.analytics.attributes.each do |attribute| %>
+    <li>
+      <a href="attribute_<%= urlize(attribute['name']) %>.html" class="govuk-link">
+        <%= attribute.name %>
+      </a>
+    </li>
+  <% end %>
+</ul>

--- a/source/analytics/attributes.html.md.erb
+++ b/source/analytics/attributes.html.md.erb
@@ -6,8 +6,9 @@
   <%= data.analytics.navigation.attributes.desc %>
 </p>
 
-<ul class="govuk-list">
-  <% data.analytics.attributes.each do |attribute| %>
+<ul class="govuk-list govuk-list--bullet">
+  <% attributes = data.analytics.attributes.sort_by { |e| e[:name] } %>
+  <% attributes.each do |attribute| %>
     <li>
       <a href="attribute_<%= urlize(attribute['name']) %>.html" class="govuk-link">
         <%= attribute.name %>

--- a/source/analytics/data.html.md.erb
+++ b/source/analytics/data.html.md.erb
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.data.name %>
+</h1>
+
+<p class="govuk-body">This section contains details of the data structure that GOV.UK uses for recording analytics.</p>
+
+<p class="govuk-body">Specifically, this is the data that GOV.UK pushes to the dataLayer when events occur, triggered by JavaScript event listeners. These pages do not currently contain information about what happens to the data next, as it is collected by Google Tag Manager and sent to Google Analytics.</p>
+
+<ul class="govuk-list">
+  <% data.analytics.navigation.data.subsections.each do |item| %>
+    <li>
+      <a href="<%= item.link %>" class="govuk-link"><%= item.name %></a>
+    </li>
+  <% end %>
+</ul>

--- a/source/analytics/data.html.md.erb
+++ b/source/analytics/data.html.md.erb
@@ -6,7 +6,7 @@
 
 <p class="govuk-body">Specifically, this is the data that GOV.UK pushes to the dataLayer when events occur, triggered by JavaScript event listeners. These pages do not currently contain information about what happens to the data next, as it is collected by Google Tag Manager and sent to Google Analytics.</p>
 
-<ul class="govuk-list">
+<ul class="govuk-list govuk-list--bullet">
   <% data.analytics.navigation.data.subsections.each do |item| %>
     <li>
       <a href="<%= item.link %>" class="govuk-link"><%= item.name %></a>

--- a/source/analytics/docs.html.md.erb
+++ b/source/analytics/docs.html.md.erb
@@ -2,15 +2,9 @@
   <%= data.analytics.navigation.docs.name %>
 </h1>
 
-<p class="govuk-body">This section contains documentation relevant to GOV.UK's dataLayer approach. Our main source of documentation is <a href="https://github.com/alphagov/govuk_publishing_components" class="govuk-link">govuk_publishing_components</a>, where <a href="https://github.com/alphagov/govuk_publishing_components/tree/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4" class="govuk-link">our analytics code</a> is located.</p>
+<p class="govuk-body">This section contains documentation relevant to GOV.UK's dataLayer approach. Our main source of documentation is <a href="https://github.com/alphagov/govuk_publishing_components" class="govuk-link">govuk_publishing_components</a>, where <a href="https://github.com/alphagov/govuk_publishing_components/tree/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4" class="govuk-link">our analytics code</a> is located. You can read an <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">overview of our GA4 code here</a>.</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>
-    <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">GA4 code overview</a>
-  </li>
-</ul>
-
-<ul class="govuk-list">
   <% data.analytics.navigation.docs.subsections.each do |item| %>
     <li>
       <a href="<%= item.link %>" class="govuk-link"><%= item.name %></a>

--- a/source/analytics/docs.html.md.erb
+++ b/source/analytics/docs.html.md.erb
@@ -1,0 +1,19 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.docs.name %>
+</h1>
+
+<p class="govuk-body">This section contains documentation relevant to GOV.UK's dataLayer approach. Our main source of documentation is <a href="https://github.com/alphagov/govuk_publishing_components" class="govuk-link">govuk_publishing_components</a>, where <a href="https://github.com/alphagov/govuk_publishing_components/tree/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4" class="govuk-link">our analytics code</a> is located.</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">GA4 code overview</a>
+  </li>
+</ul>
+
+<ul class="govuk-list">
+  <% data.analytics.navigation.docs.subsections.each do |item| %>
+    <li>
+      <a href="<%= item.link %>" class="govuk-link"><%= item.name %></a>
+    </li>
+  <% end %>
+</ul>

--- a/source/analytics/events.html.md.erb
+++ b/source/analytics/events.html.md.erb
@@ -6,8 +6,9 @@
   <%= data.analytics.navigation.events.desc %>
 </p>
 
-<ul class="govuk-list">
-  <% data.analytics.events.each do |event| %>
+<ul class="govuk-list govuk-list--bullet">
+  <% events = data.analytics.events.sort_by { |e| e[:name] } %>
+  <% events.each do |event| %>
     <li>
       <a href="event_<%= urlize(event['name']) %>.html" class="govuk-link">
         <%= event.name %>

--- a/source/analytics/events.html.md.erb
+++ b/source/analytics/events.html.md.erb
@@ -1,0 +1,17 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.events.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.events.desc %>
+</p>
+
+<ul class="govuk-list">
+  <% data.analytics.events.each do |event| %>
+    <li>
+      <a href="event_<%= urlize(event['name']) %>.html" class="govuk-link">
+        <%= event.name %>
+      </a>
+    </li>
+  <% end %>
+</ul>

--- a/source/analytics/pii.html.md.erb
+++ b/source/analytics/pii.html.md.erb
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.pii.name %>
+</h1>
+
+<p class="govuk-body">Any data collected by GA4 must be free of Personally Identifiable Information (PII). This includes, but is not limited to:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Email addresses</li>
+  <li>Phone numbers</li>
+  <li>Postcodes</li>
+</ul>
+
+<p class="govuk-body">If an attribute is listed with 'PII' next to it, the value of that attribute should be processed to remove PII.</p>
+
+<p class="govuk-body">Further information can be found here: <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/pii-remover.md" class="govuk-link">PII documentation</a>.</p>

--- a/source/analytics/templates/attribute.html.erb
+++ b/source/analytics/templates/attribute.html.erb
@@ -35,7 +35,7 @@
               <% end %>
             <% else %>
               <% if events_attribute.name == attribute.name %>
-                <%= link_to event.name, "event_#{urlize(event.name)}.html" %>(<%= events.name %>)<br/>
+                <%= link_to event.name, "event_#{urlize(event.name)}.html" %> (<%= events.name %>)<br/>
               <% end %>
             <% end %>
           <% end %>

--- a/source/analytics/templates/attribute.html.erb
+++ b/source/analytics/templates/attribute.html.erb
@@ -1,0 +1,46 @@
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">Attribute</span>
+  <%= attribute.name %>
+</h1>
+
+<dl class="govuk-summary-list">
+  <% %w[Name Description Value Example Required Type Redact].each do |name| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= name %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if name == 'Redact' %>
+          <%= link_to attribute.send(name.downcase), "pii.html" %>
+        <% else %>
+          <%= attribute.send(name.downcase) %>
+        <% end %>
+      </dd>
+    </div>
+  <% end %>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Used by
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <% data.analytics.events.each do |event| %>
+        <% event.events.each do |events| %>
+          <% events.data.each do |events_attribute| %>
+            <% if events_attribute.value.is_a?(Array) %>
+              <% events_attribute.value.each do |sub_attribute| %>
+                <% if sub_attribute.name == attribute.name %>
+                  <%= link_to event.name, "event_#{urlize(event.name)}.html" %> (<%= events.name %>)<br/>
+                <% end %>
+              <% end %>
+            <% else %>
+              <% if events_attribute.name == attribute.name %>
+                <%= link_to event.name, "event_#{urlize(event.name)}.html" %>(<%= events.name %>)<br/>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </dd>
+  </div>
+</dl>

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -1,0 +1,43 @@
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">Event</span>
+  <%= event.name %>
+</h1>
+
+<% if event.description %>
+  <p class="govuk-body"><%= event.description %></p>
+<% end %>
+
+<% event.events.each do |page_event| %>
+  <div class="event">
+    <h2 class="govuk-heading-m">
+      <%= page_event.name %>
+    </h2>
+    <% if page_event.description %>
+      <p class="govuk-body">
+        <%= page_event.description %>
+      </p>
+    <% end %>
+    <ul class="govuk-list govuk-list--bullet">
+      <% if page_event.example_url %>
+        <li>
+          Example of <%= link_to page_event.name, page_event.example_url %>
+        </li>
+      <% end %>
+      <% if page_event.tracker %>
+        <% data.analytics.trackers.each do |tracker| %>
+          <% if tracker.technical_name == page_event.tracker %>
+            <li>
+              Tracked by <%= link_to page_event.tracker, "tracker_#{page_event.tracker}.html" %>
+            </li>
+          <% end %>
+        <% end %>
+      <% end %>
+    </ul>
+    <h3 class="govuk-heading-s">Data sent to the dataLayer</h3>
+
+    <% event_hash = build_event(page_event.data, data.analytics.attributes) %>
+    <div class="govuk-inset-text">
+      <%= to_html(event_hash) %>
+    </div>
+  </div>
+<% end %>

--- a/source/analytics/templates/tracker.html.erb
+++ b/source/analytics/templates/tracker.html.erb
@@ -1,0 +1,35 @@
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">Tracker</span>
+  <%= tracker.name %>
+</h1>
+
+<% if tracker.description %>
+  <p class="govuk-body"><%= tracker.description %></p>
+<% end %>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <% if tracker.url %>
+      <dt class="govuk-summary-list__key">
+        Technical documentation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= link_to tracker.technical_name, "tracker_#{tracker.url}.html" %>
+      </dd>
+    <% end %>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Used by
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <% data.analytics.events.each do |event| %>
+        <% event.events.each do |events| %>
+          <% if events.tracker == tracker.technical_name %>
+            <%= link_to event.name, "event_#{urlize(event.name)}.html" %> (<%= events.name %>)<br/>
+          <% end %>
+        <% end %>
+      <% end %>
+    </dd>
+  </div>
+</dl>

--- a/source/analytics/trackers.html.md.erb
+++ b/source/analytics/trackers.html.md.erb
@@ -6,7 +6,7 @@
   <%= data.analytics.navigation.trackers.desc %>
 </p>
 
-<ul class="govuk-list">
+<ul class="govuk-list govuk-list--bullet">
   <% data.analytics.trackers.each do |tracker| %>
     <li>
       <a href="tracker_<%= urlize(tracker.name) %>.html" class="govuk-link">

--- a/source/analytics/trackers.html.md.erb
+++ b/source/analytics/trackers.html.md.erb
@@ -1,0 +1,17 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.trackers.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.trackers.desc %>
+</p>
+
+<ul class="govuk-list">
+  <% data.analytics.trackers.each do |tracker| %>
+    <li>
+      <a href="tracker_<%= urlize(tracker.name) %>.html" class="govuk-link">
+        <%= tracker.name %>
+      </a>
+    </li>
+  <% end %>
+</ul>

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+
+<head>
+  <meta charset="utf-8">
+  <title>GOV.UK Analytics</title>
+  <link rel="stylesheet" type="text/css" href="/stylesheets/screen.css"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0c0c">
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <% meta_tags.tags.each do |name, content| %>
+    <%= tag :meta, name: name, content: content %>
+  <% end %>
+
+  <% meta_tags.opengraph_tags.each do |property, content| %>
+    <%= tag :meta, property: property, content: content %>
+  <% end %>
+</head>
+
+<body class="govuk-template__body ">
+  <script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+
+  <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+  <header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container">
+      <div class="govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/analytics/analytics.html" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <button hidden class="govuk-header__menu-button app-navigation__menu-button js-app-navigation__toggler" aria-controls="app-navigation">
+          Menu
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="govuk-width-container ">
+    <main class="govuk-main-wrapper " id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <ul class="govuk-list">
+            <li>
+              <%= link_to "Analytics", "/analytics/analytics.html" %>
+            </li>
+          </ul>
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          <ul class="govuk-list">
+            <li>
+              <%= link_to data.analytics.navigation.data.name, data.analytics.navigation.data.link %>
+            </li>
+            <ul class="govuk-list govuk-list--bullet">
+              <% data.analytics.navigation.data.subsections.each do |subsection| %>
+                <li>
+                  <%= link_to subsection.name, subsection.link %>
+                </li>
+              <% end %>
+            </ul>
+          </ul>
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          <ul class="govuk-list">
+            <li>
+              <%= link_to data.analytics.navigation.docs.name, data.analytics.navigation.docs.link %>
+            </li>
+            <ul class="govuk-list govuk-list--bullet">
+              <% data.analytics.navigation.docs.subsections.each do |subsection| %>
+                <li>
+                  <%= link_to subsection.name, subsection.link %>
+                </li>
+              <% end %>
+            </ul>
+          </ul>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+          <%= yield %>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+          </svg>
+          <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+        </div>
+        <div class="govuk-footer__meta-item">
+          <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/javascripts/application.js"></script>
+  <script>
+    window.GOVUKFrontend.initAll()
+  </script>
+</body>
+</html>

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -41,9 +41,11 @@
             </span>
           </a>
         </div>
-        <button hidden class="govuk-header__menu-button app-navigation__menu-button js-app-navigation__toggler" aria-controls="app-navigation">
-          Menu
-        </button>
+        <div class="govuk-header__content">
+          <a href="/analytics/analytics.html" class="govuk-header__link govuk-header__service-name">
+            Implementation record
+          </a>
+        </div>        
       </div>
     </div>
   </header>
@@ -54,7 +56,7 @@
         <div class="govuk-grid-column-one-third">
           <ul class="govuk-list">
             <li>
-              <%= link_to "Analytics", "/analytics/analytics.html" %>
+              <%= link_to "Implementation record", "/analytics/analytics.html" %>
             </li>
           </ul>
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -87,3 +87,7 @@
 ul.subdir__menu {
   padding-left: 20px;
 }
+
+.indented-list {
+  margin: 0 0 0 20px;
+}

--- a/spec/helpers/analytics_helpers_spec.rb
+++ b/spec/helpers/analytics_helpers_spec.rb
@@ -1,0 +1,179 @@
+require "spec_helper"
+require_relative "../../helpers/analytics_helpers"
+
+RSpec.describe AnalyticsHelpers do
+  let(:helper) { Class.new { extend AnalyticsHelpers } }
+
+  describe "#urlize" do
+    it "returns a url safe version of the given string" do
+      expect(helper.urlize("An event-name")).to eq("an_event_name")
+    end
+  end
+
+  describe "#build_event" do
+    it "returns an ordered hash given an array of un-ordered hashes" do
+      input = [
+        { "name" => "type", "value" => "accordion" },
+        { "name" => "event_name", "value" => "select_content" },
+      ]
+
+      expected = {
+        "event_name" => "select_content",
+        "type" => "accordion",
+      }
+
+      expect(helper.build_event(input)).to eq(expected)
+    end
+
+    it "returns a nested ordered hash given an array of hashes with one having
+      a value that is an array" do
+      input = [
+        {
+          "name" => "event_data",
+          "value" => [
+            { "name" => "event_name", "value" => "select_content" },
+          ],
+        },
+      ]
+
+      expected = {
+        "event_data" => { "event_name" => "select_content" },
+      }
+
+      expect(helper.build_event(input)).to eq(expected)
+    end
+
+    it "returns a deeply nested ordered hash given an array of hashes with one
+      having a value that is an array and another where the value is also an array and requires attribute lookup" do
+      input = [
+        {
+          "name" => "event_data",
+          "value" => [
+            { "name" => "event_name", "value" => "select_content" },
+            {
+              "name" => "index",
+              "value" => [
+                { "name" => "index_section" },
+              ],
+            },
+          ],
+        },
+      ]
+
+      attributes = [
+        { "name" => "index_section", "type" => "integer" },
+      ]
+
+      expected = {
+        "event_data" => {
+          "event_name" => "select_content",
+          "index" => {
+            "index_section" => "integer",
+          },
+        },
+      }
+
+      expect(helper.build_event(input, attributes)).to eq(expected)
+    end
+
+    it "returns a deeply nested ordered hash given an array of hashes with one
+      having a value that is an array and another where the value is also an array and requires attribute lookup but without a matching value" do
+      input = [
+        {
+          "name" => "event_data",
+          "value" => [
+            { "name" => "event_name", "value" => "select_content" },
+            {
+              "name" => "index",
+              "value" => [
+                { "name" => "index_section" },
+              ],
+            },
+          ],
+        },
+      ]
+
+      expected = {
+        "event_data" => {
+          "event_name" => "select_content",
+          "index" => {
+            "index_section" => nil,
+          },
+        },
+      }
+
+      expect(helper.build_event(input)).to eq(expected)
+    end
+  end
+
+  describe "#to_html" do
+    it "returns an HTML list item set given a hash" do
+      input = {
+        "event_name" => "select_content",
+        "type" => "accordion",
+      }
+
+      expected = <<~HTML.gsub(/^\s+/, "").gsub("\n", "")
+        <ul class='govuk-list indented-list'>
+          <li>
+            <a href='/analytics/attribute_event_name.html'>event_name</a>: select_content
+          </li>
+          <li>
+            <a href='/analytics/attribute_type.html'>type</a>: accordion
+          </li>
+        </ul>
+      HTML
+
+      expect(helper.to_html(input)).to eq(expected)
+    end
+
+    it "returns a nested HTML list item set given a nested hash" do
+      input = {
+        "event_data" => { "event_name" => "select_content" },
+      }
+
+      expected = <<~HTML.gsub(/^\s+/, "").gsub("\n", "")
+        <ul class='govuk-list indented-list'>
+          <li>event_data: <ul class='govuk-list indented-list'>
+              <li>
+                <a href='/analytics/attribute_event_name.html'>event_name</a>: select_content
+              </li>
+            </ul>
+          </li>
+        </ul>
+      HTML
+
+      expect(helper.to_html(input)).to eq(expected)
+    end
+
+    it "returns a deeply nested HTML list item set given a deeply nested hash" do
+      input = {
+        "event_data" => {
+          "event_name" => "select_content",
+          "index" => {
+            "index_section" => "integer",
+          },
+        },
+      }
+
+      expected = <<~HTML.gsub(/^\s+/, "").gsub("\n", "")
+        <ul class='govuk-list indented-list'>
+          <li>event_data: <ul class='govuk-list indented-list'>
+              <li>
+                <a href='/analytics/attribute_event_name.html'>event_name</a>: select_content
+              </li>
+              <li>index: <ul class='govuk-list indented-list'>
+                  <li>
+                    <a href='/analytics/attribute_index_section.html'>index_section</a>: integer
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      HTML
+
+      expect(helper.to_html(input)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
This change converts the existing [GA4 Implementation record](https://alphagov.github.io/govuk-google-analytics/) to be a sub-section of the GOV.UK developer docs. 

The original repository was held in this [GitHub repo](https://github.com/alphagov/govuk-google-analytics), was written using [Jekyll](https://jekyllrb.com/), and was hosted via [GitHub Pages](https://pages.github.com). 

Why convert? There are 3 main reasons:

* The team and other interested parties have decided to  make the implementation record the public face of GOV.UK's GA4 documentation.

* We should not use the [GOV.UK](http://gov.uk/) crown, unless we are hosting on a .gov.uk domain.

* We want the deployment of this documentation to be as simple as possible, and as much content as possible to be contained in easily edited [Markdown](https://en.wikipedia.org/wiki/Markdown) files.

For these reasons, adding the implementation record to the existing GOV.UK developer docs, and making it a sub-section of that documentation is the preferred option.

As part of the conversion process, it was noted that the existing developer docs links append to each page by the [core layout](https://github.com/alphagov/tech-docs-gem/blob/main/lib/source/layouts/core.erb) for navigation and other purposes, would be likely to cause the user confusion. This is because they would be taken away from the analytics pages and back to the GOV.UK developer documentation. Having explored the options for overriding, or removing these links (including the creation of a [custom extension](https://github.com/grahamcharleslewis/analytics_config_switcher) for evaluation purposes) - it was decided that simplest and most pragmatic solution would be to simply supply a custom layout that does not extend from the [layouts in the tech-docs-gem](https://github.com/alphagov/tech-docs-gem/tree/main/lib/source/layouts). We have however, endeavoured to use as many elements from the original [core layout](https://github.com/alphagov/tech-docs-gem/blob/main/lib/source/layouts/core.erb) as possible (meta tags, styling etc). Inevitably, this will cause a slight maintenance overhead, but is seen as the least hackiest approach.

[Trello](https://trello.com/c/v7EXVpba/424-get-the-implementation-record-online)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
