### PR TITLE
Retire govuk-ithc-documentation

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -518,8 +518,8 @@
   type: Data science
 
 - repo_name: govuk-ithc-documentation
+  retired: true
   private_repo: true
-  team: "#govuk-platform-reliability-team"
   type: Utilities
 
 - repo_name: govuk-jenkinslib

--- a/source/manual/pentests.html.md
+++ b/source/manual/pentests.html.md
@@ -6,6 +6,6 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-GOV.UK periodically runs penetration tests (otherwise known as 'pentests' or 'IT healthchecks') on its infrastructure, to identify security issues. Read more at [govuk-ithc-documentation][].
+GOV.UK periodically runs penetration tests (otherwise known as 'pentests' or 'IT healthchecks') on its infrastructure, to identify security issues. Any relevant documentation lives in the respective app repo or, if sensitive, in the the ITHC Google doc linked from the [govuk-ithc-documentation][] repo.
 
 [govuk-ithc-documentation]: https://github.com/alphagov/govuk-ithc-documentation


### PR DESCRIPTION
The repo was archived https://github.com/alphagov/govuk-ithc-documentation/pull/185 and relevant documentation should live in the respective app repo. Sensitive information included in the private repos should live in the ITHC Google doc. 

This way is easier to keep information up to date.

https://trello.com/c/EJXbs0ae/3120-retire-govuk-ithc-documentation-repository-2