### PR TITLE
Mark govuk-deploy-lag-badger as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -450,6 +450,7 @@
   type: Utilities
 
 - repo_name: govuk-deploy-lag-badger
+  retired: true
   team: "#govuk-platform-reliability-team"
   type: Utilities
   sentry_url: false


### PR DESCRIPTION
It was retired in https://github.com/alphagov/govuk-deploy-lag-badger/pull/37

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
