### PR TITLE
Add govuk-rota-generator

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -625,6 +625,12 @@
   team: "#govuk-platform-reliability-team"
   type: Utilities
 
+- repo_name: govuk-rota-generator
+  team: "#govuk-platform-reliability-team"
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
 - repo_name: govuk-saas-config
   team: "#govuk-platform-reliability-team"
   type: Utilities


### PR DESCRIPTION
We used this for generating the rota for Q1 and intend to keep using it. We even [presented it in the Software Engineering show and tell](https://docs.google.com/presentation/d/14eBhW5MR7EgWn5BWKaBuwD56pZ27ChfevRNuNhyR1lU/edit). Time to make it official!

This repo _may_ be merged with [pay-pagerduty](https://github.com/alphagov/pay-pagerduty) at some point, under a new name. But until that happens, let's get it documented here.

NB `#govuk-2ndline-tech` might be a more accurate 'owner' for this utility, but following the precedent set by similar utilities like govuk-user-reviewer and govuk-zendesk-display-screen, this should fall under `#govuk-platform-reliability-team`.
