### PR TITLE
Remove references to run Rake tasks on Jenkins

### DIFF
--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -69,11 +69,13 @@ investigate was the email sent. Some avenues to explore are:
 
 ## Resending travel advice emails
 
-If you need to force the sending of a travel advice email alert, there
-is a rake task in Travel Advice Publisher, which you can run using
-[this Jenkins job][resend travel advice job] where the edition ID of the
-travel advice content item can be found in the URL of the country's edit
-page in Travel Advice Publisher and looks like `fedc13e231ccd7d63e1abf65`.
+If you need to force the sending of a travel advice email alert, run the
+`email_alerts:trigger[PUT_EDITION_ID_HERE]` rake task in Travel Advice
+Publisher.
+
+The edition ID of the travel advice content item can be found in the
+URL of the country's edit page in Travel Advice Publisher and looks like
+`fedc13e231ccd7d63e1abf65`.
 
 [medical safety alerts]: https://www.gov.uk/drug-device-alerts
 [travel advice updates]: https://www.gov.uk/foreign-travel-advice
@@ -92,4 +94,3 @@ page in Travel Advice Publisher and looks like `fedc13e231ccd7d63e1abf65`.
 [view_emails task]: https://github.com/alphagov/email-alert-api/blob/main/docs/support-tasks.md#view-subscribers-recent-emails
 [Kibana logs]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/goto/43fc79ee47ac49f248e0f29a174be240
 [Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h
-[resend travel advice job]: https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=email_alerts:trigger%5BPUT_EDITION_ID_HERE%5D

--- a/source/manual/alerts/publisher-scheduled-publishing.html.md
+++ b/source/manual/alerts/publisher-scheduled-publishing.html.md
@@ -12,8 +12,4 @@ the number currently in the Sidekiq queue.
 
 This can happen in Staging and Integration as a result of the data
 sync from Production. Run Publisher's `editions:requeue_scheduled_for_publishing`
-rake task to re-queue all scheduled editions:
-
-- [Run in Integration Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=editions:requeue_scheduled_for_publishing)
-
-- [Run in Staging Jenkins](https://deploy.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=editions:requeue_scheduled_for_publishing)
+rake task to re-queue all scheduled editions in Integration and Staging.

--- a/source/manual/documents-are-published-but-links-arent-updated.html.md
+++ b/source/manual/documents-are-published-but-links-arent-updated.html.md
@@ -12,9 +12,7 @@ this is a problem [by monitoring Publishing API sidekiq queue][sidekiq-queue]
 and seeing if the `downstream_low` queue is high.
 
 To get things processed faster you can run the following Rake task on the
-Publishing API in Jenkins,
-[`represent_downstream:high_priority:content_id['some-content-id some-other-content-id']`][jenkins-task],
+Publishing API `represent_downstream:high_priority:content_id['some-content-id some-other-content-id']`,
 which will re-represent them downstream via the high priority queue.
 
 [sidekiq-queue]: https://docs.publishing.service.gov.uk/manual/sidekiq.html#sidekiq-web-aka-sidekiq-monitoring
-[jenkins-task]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[%27some-content-id%20some-other-content-id%27]

--- a/source/manual/documents-arent-live-after-publishing.html.md
+++ b/source/manual/documents-arent-live-after-publishing.html.md
@@ -18,8 +18,6 @@ Publishing API that will check where the content is currently available.
 $ bundle exec rake data_hygiene:document_status_check[content_id,locale]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=data_hygiene:document_status_check[content_id,locale])
-
 ## If documents aren't in the Publishing API
 
 This likely means that the publishing app itself failed to send the document
@@ -33,23 +31,17 @@ interface. If that doesn't work, there are some other things you can try:
 $ bundle exec rake publishing_api:republish_document[slug]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_document[slug])
-
 ### Publisher
 
 ```bash
 $ bundle exec rake publishing_api:republish_edition[slug]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[slug])
-
 ### Travel Advice Publisher
 
 ```bash
 $ bundle exec rake publishing_api:republish_edition[country_slug]
 ```
-
-[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[country_slug])
 
 ### Specialist Publisher
 
@@ -66,8 +58,6 @@ content item to the Content Store.
 $ bundle exec rake represent_downstream:high_priority:content_id[content_id]
 ```
 
-[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[content_id])
-
 > WARNING: this task might publish draft content to the live content store. Use with caution.
 > See [this 'ongoing issues' card for more details](https://trello.com/c/bfAEuv4S/1576-consider-improving-documentation-on-the-consequences-of-running-representdownstream-rake-task-on-publishing-api).
 
@@ -82,8 +72,6 @@ routes for a Content Item directly.
 ```bash
 $ bundle exec rake routes:register[base_path]
 ```
-
-[Run this job in production Jenkins ⚠️](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-store&MACHINE_CLASS=content_store&RAKE_TASK=routes:register[base_path])
 
 ## If the document isn't live after all this
 

--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -16,7 +16,7 @@ Content in the `govuk` index is populated from the [Publishing API message queue
 Missing documents can be recovered by resending the content to the message queue, using
 the `represent_downstream:published_between` rake task.
 
-[Run this task in Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:published_between['2018-12-17T01:02:30,%202018-12-18T10:20:30']), but changing the two timestamps to cover the period of downtime.
+Run the `represent_downstream:published_between['2018-12-17T01:02:30,%202018-12-18T10:20:30']` rake task in Publishing API, but changing the two timestamps to cover the period of downtime.
 
 [Other replay options are available](https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake), for example replaying all traffic for a single publishing app or doctype.
 Be aware that these options will replay the entire Publisher API history for that app or doctype, and may take some time.
@@ -29,7 +29,7 @@ Be aware that these options will replay the entire Publisher API history for tha
 These indexes are populated by whitehall calling an HTTP API in Search API.
 Missing documents can be recovered by resending the content to Search API directly.
 
-[Run this task in Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=search:index:published_between['2018-12-17T01:02:30,%202018-12-18T10:20:30']), remembering to change the two timestamps.
+Run the `search:index:published_between['2018-12-17T01:02:30,%202018-12-18T10:20:30']` rake task in Whitehall, remembering to change the two timestamps.
 
 ## `metasearch` index
 
@@ -37,7 +37,7 @@ This index is used for best bets, which are published by Search Admin
 communicating with Search API directly (like how whitehall updates the
 `government` and `detailed` indices directly).
 
-[Run this task in Jenkins](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=search-admin&MACHINE_CLASS=backend&RAKE_TASK=reindex_best_bets) to resend all bets to Search API.
+Run the `reindex_best_bets` rake task in search admin to resend all bets to Search API.
 
 [restore-backups]: https://docs.publishing.service.gov.uk/manual/elasticsearch-dumps.html
 [queue]: https://github.com/alphagov/search-api/blob/main/docs/new-indexing-process.md

--- a/source/manual/help-with-publishing-content.html.md
+++ b/source/manual/help-with-publishing-content.html.md
@@ -43,9 +43,4 @@ necessary to help them to ensure it goes out as smoothly as possible.
   start here: [if documents aren't live after being published][live].
   If it looks as though the content was never published from
   Whitehall, there is a Rake task available which will publish overdue
-  documents. In Production, run [this Rake
-  task](https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing:overdue:publish).
-
-  ```bash
-  $ bundle exec rake publishing:overdue:publish
-  ```
+  documents. In Production on Whitehall run `publishing:overdue:publish`.

--- a/source/manual/howto-add-organisation-brand-colour.html.md
+++ b/source/manual/howto-add-organisation-brand-colour.html.md
@@ -59,4 +59,4 @@ Then:
 >
 > It may take some time for the colour to update on the page in `integration`.
 > You might be able to speed up the process by running the
-> [`publishing_api:republish_organisation[slug]`](https://deploy.integration.publishing.service.gov.uk//job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=publishing_api:republish_organisation[slug]) rake task in Whitehall.
+> `publishing_api:republish_organisation[slug]` rake task in Whitehall.

--- a/source/manual/howto-change-slug-and-create-redirect.html.md
+++ b/source/manual/howto-change-slug-and-create-redirect.html.md
@@ -18,76 +18,27 @@ These Rake Tasks also reindex the entity with its new slug and republish it to
 Publishing API, which automatically handles the redirect. They all take the old
 slug and the new slug as arguments.
 
-- Change slug and create redirect for a `Person`:
-  - in [integration][person-integration]
-  - in [staging][person-staging]
-  - in [⚠️ production ⚠️][person-production]
+To change slug and create redirect for a `Person` use `reslug:person[OLD_SLUG,NEW_SLUG]`.
 
-[person-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:person[OLD_SLUG,NEW_SLUG]
-[person-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:person[OLD_SLUG,NEW_SLUG]
-[person-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:person[OLD_SLUG,NEW_SLUG]
+To change slug and create redirect for a `Role` use `reslug:role[OLD_SLUG,NEW_SLUG]`.
 
-- Change slug and create redirect for a `Role`:
-  - in [integration][role-integration]
-  - in [staging][role-staging]
-  - in [⚠️ production ⚠️][role-production]
+To change slug and create redirect for a `Document`:
 
-  [role-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:role[OLD_SLUG,NEW_SLUG]
-  [role-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:role[OLD_SLUG,NEW_SLUG]
-  [role-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:role[OLD_SLUG,NEW_SLUG]
-
-- Change slug and create redirect for a `Document`:
-
-To update a documents slug, visit the following URL, replacing `<edition_id>` with the ID of any of a documents editions:
+Visit the following URL, replacing `<edition_id>` with the ID of any of a documents editions:
 
 ```
 https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/<edition_id>/edit_slug
 ```
 
-- Change slug and create redirect for a `PolicyGroup`:
-  - in [integration][policy_group-integration]
-  - in [staging][policy_group-staging]
-  - in [⚠️ production ⚠️][policy_group-production]
+To change slug and create redirect for a `PolicyGroup` use `reslug:policy_group[OLD_SLUG,NEW_SLUG]`.
 
-  [policy_group-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:policy_group[OLD_SLUG,NEW_SLUG]
-  [policy_group-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:policy_group[OLD_SLUG,NEW_SLUG]
-  [policy_group-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:policy_group[OLD_SLUG,NEW_SLUG]
+To change slug and create redirect for a `WorldLocation` use `reslug:world_location[OLD_SLUG,NEW_SLUG]`.
 
-- Change slug and create redirect for a `WorldLocation`:
-  - in [integration][world_location-integration]
-  - in [staging][world_location-staging]
-  - in [⚠️ production ⚠️][world_location-production]
+To change slug and create redirect for a `Organisation` use `reslug:organisation[OLD_SLUG,NEW_SLUG]`.
 
-  [world_location-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:world_location[OLD_SLUG,NEW_SLUG]
-  [world_location-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:world_location[OLD_SLUG,NEW_SLUG]
-  [world_location-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:world_location[OLD_SLUG,NEW_SLUG]
+To change slug and create redirect for a `WorldwideOrganisation` use `reslug:worldwide_organisation[OLD_SLUG,NEW_SLUG]`.
 
-- Change slug and create redirect for a `Organisation`:
-  - in [integration][organisation-integration]
-  - in [staging][organisation-staging]
-  - in [⚠️ production ⚠️][organisation-production]
-
-  [organisation-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:organisation[OLD_SLUG,NEW_SLUG]
-  [organisation-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:organisation[OLD_SLUG,NEW_SLUG]
-  [organisation-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:organisation[OLD_SLUG,NEW_SLUG]
-
-- Change slug and create redirect for a `WorldwideOrganisation`:
-  - in [integration][worldwide_organisation-integration]
-  - in [staging][worldwide_organisation-staging]
-  - in [⚠️ production ⚠️][worldwide_organisation-production]
-
-  [worldwide_organisation-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:worldwide_organisation[OLD_SLUG,NEW_SLUG]
-  [worldwide_organisation-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:worldwide_organisation[OLD_SLUG,NEW_SLUG]
-  [worldwide_organisation-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:worldwide_organisation[OLD_SLUG,NEW_SLUG]
-
-- Change slug and create redirect for a `StatisticsAnnoucement`:
-  - in [integration][statistics_annoucement-integration]
-  - in [staging][statistics_annoucement-staging]
-  - in [⚠️ production ⚠️][statistics_annoucement-production]
-
-  [statistics_annoucement-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:statistics_annoucement[OLD_SLUG,NEW_SLUG]
-  [statistics_annoucement-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:statistics_annoucement[OLD_SLUG,NEW_SLUG]
-  [statistics_annoucement-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=reslug:statistics_annoucement[OLD_SLUG,NEW_SLUG]
+To change slug and create redirect for a `StatisticsAnnoucement` use `reslug:statistics_annoucement[OLD_SLUG,NEW_SLUG]`.
 
 ### Issues
 
@@ -99,13 +50,6 @@ be a delay between the redirect being applied and the content being republished.
 
 This should resolve itself over time, but if you need to process the content
 change more quickly, run `represent_downstream:high_priority:content_id[CONTENT_ID]`
-to put it in the high priority queue:
-
-- in [integration][high-priority-queue-integration]
-- in [staging][high-priority-queue-staging]
-- in [⚠️ production ⚠️][high-priority-queue-production]
+to put it in the high priority queue,
 
 [grafana-queue-volumes]: https://grafana.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=publishing-api&var-Queues=All&from=now-30m&to=now
-[high-priority-queue-integration]: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[CONTENT_ID]
-[high-priority-queue-staging]: https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[CONTENT_ID]
-[high-priority-queue-production]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=represent_downstream:high_priority:content_id[CONTENT_ID]

--- a/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
+++ b/source/manual/howto-redirect-html-attachment-urls-from-whitehall.html.md
@@ -30,10 +30,8 @@ There are two interfaces for dry and real runs, to ensure the correct HtmlAttach
 ##### Dry run
 
 ```bash
-$ bundle exec 'publishing_api:redirect_html_attachments:by_content_id_dry_run[document_content_id,redirection_url]'
+$ bundle exec rake 'publishing_api:redirect_html_attachments:by_content_id_dry_run[document_content_id,redirection_url]'
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27publishing_api:redirect_html_attachments:by_content_id_dry_run[DOCUMENT_CONTENT_ID,REDIRECTION_URL]%27)
 
 > You need to find the `content_id` of the Document the attachment belongs to via Rails console if the Document has already been unpublished and redirected.
 > Remember to use the relative path for an internal URL. Example:
@@ -49,10 +47,8 @@ This attempts to locate the HtmlAttachments for the latest unpublished Edition o
 ##### Real run
 
 ```bash
-$ bundle exec 'publishing_api:redirect_html_attachments:by_content_id[document_content_id,redirection_url]'
+$ bundle exec rake 'publishing_api:redirect_html_attachments:by_content_id[document_content_id,redirection_url]'
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=whitehall&MACHINE_CLASS=whitehall_backend&RAKE_TASK=%27publishing_api:redirect_html_attachments:by_content_id[DOCUMENT_CONTENT_ID,REDIRECTION_URL]%27)
 
 This will actually request that the PublishingApi redirects the selected HtmlAttachments.
 

--- a/source/manual/howto-remove-change-note.html.md
+++ b/source/manual/howto-remove-change-note.html.md
@@ -54,19 +54,15 @@ https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/<edi
 Dry run:
 
 ```bash
-$ bundle exec 'data_hygiene:remove_change_note:dry[content_id,locale,change note text]'
+$ bundle exec rake 'data_hygiene:remove_change_note:dry[content_id,locale,change note text]'
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=%27data_hygiene:remove_change_note:dry[CONTENT_ID,en,CHOSEN%20CHANGE%20NOTE%20TEXT]%27)
 
 This attempts to locate the selected change note for the content, and if found, report to the user the change note object that would have been removed.
 
 Real run:
 
 ```bash
-$ bundle exec 'data_hygiene:remove_change_note:real[content_id,locale,change note text]'
+$ bundle exec rake 'data_hygiene:remove_change_note:real[content_id,locale,change note text]'
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=%27data_hygiene:remove_change_note:real[CONTENT_ID,en,CHOSEN%20CHANGE%20NOTE%20TEXT]%27)
 
 This will actually *delete* the selected change note and re-represent to the content store, also updating the edition history.

--- a/source/manual/howto-remove-invalid-about-page-drafts-from-world-organisations.html.md
+++ b/source/manual/howto-remove-invalid-about-page-drafts-from-world-organisations.html.md
@@ -20,8 +20,6 @@ Whilst these invalid drafts are present users are unable to make any further edi
 A rake task exists in Publishing API that will clear the invalid drafts.
 
 ```bash
-$ bundle exec 'data_hygiene:remove_invalid_worldorg_drafts'
+$ bundle exec rake 'data_hygiene:remove_invalid_worldorg_drafts'
 ```
-
-[Jenkins - integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?delay=0sec&TARGET_APPLICATION=publishing-api&MACHINE_CLASS=publishing_api&RAKE_TASK=data_hygiene:remove_invalid_worldorg_drafts)
 

--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -53,8 +53,6 @@ follow these steps:
      bucket][govuk-production-mirror-gcp].
    - Navigate to the file, then delete it.
 
-[whitehall-rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:whitehall_delete[]
-[rake-delete]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=asset-manager&MACHINE_CLASS=backend&RAKE_TASK=assets:delete[]
 [clear-cache]: https://docs.publishing.service.gov.uk/manual/purge-cache.html#assets
 [govuk-production-mirror-gcp]: https://console.cloud.google.com/storage/browser/govuk-production-mirror;tab=objects?forceOnBucketsSortingFiltering=false&project=govuk-production
 

--- a/source/manual/redirect-routes.html.md.erb
+++ b/source/manual/redirect-routes.html.md.erb
@@ -312,9 +312,9 @@ The deleted routes will take effect after a short delay (for Router instances to
 ## Redirects for HMRC manuals
 [hmrc-manuals-section]: #redirects-for-hmrc-manuals
 
-There are rake tasks for redirecting HMRC manuals and HMRC manual sections, which can be [found in the hmrc-manuals-api repo](https://github.com/alphagov/hmrc-manuals-api/tree/main/lib/tasks). These can be run via the `Run rake task` jenkins job.
+There are rake tasks for redirecting HMRC manuals and HMRC manual sections, which can be [found in the hmrc-manuals-api repo](https://github.com/alphagov/hmrc-manuals-api/tree/main/lib/tasks).
 
-[See example of redirecting a HMRC manual section to another section](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=hmrc-manuals-api&MACHINE_CLASS=backend&RAKE_TASK=redirect_hmrc_section[original-parent-manual-slug,original-section-slug,new-parent-manual-slug,new-section-slug])
+An example of redirecting a HMRC manual section to another section would be to run `redirect_hmrc_section[original-parent-manual-slug,original-section-slug,new-parent-manual-slug,new-section-slug]`
 
 ## Redirects from campaign sites
 [campaign-sites-section]: #redirects-from-campaign-sites

--- a/source/manual/related-links.html.md
+++ b/source/manual/related-links.html.md
@@ -72,11 +72,9 @@ Should we ever need to roll back any suggested related links, there are a number
 
 #### Links for individual pages
 
-To rollback suggested related links for an individual page (to show the original related links), use the [Run rake task job on Jenkins](https://deploy.publishing.service.gov.uk/job/run-rake-task/) with the following parameters set:
+To rollback suggested related links for an individual page (to show the original related links), use the following rake task for Publishing API:
 
-- `TARGET_APPLICATION: publishing-api`
-- `MACHINE_CLASS: publishing_api`
-- `RAKE_TASK: content:reset_related_links_for_pages['CONTENT_ID’]`, where `CONTENT_ID` is the content id of the page to remove suggested links from
+`content:reset_related_links_for_pages['CONTENT_ID’]`, where `CONTENT_ID` is the content id of the page to remove suggested links from.
 
 #### Links for certain document types
 

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -31,9 +31,9 @@ This will update www.gov.uk/foreign-travel-advice/`<country_slug>` to www.gov.uk
    * You will see the country has updated in the list in [Travel Advice Publisher](https://travel-advice-publisher.integration.publishing.service.gov.uk/admin)
 
 3. Run Rake tasks
-   * Run [country:rename[old_country_slug,new_country_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=country:rename[<old_country_slug>,<new_country_slug>]) to update the `TravelAdviceEdition`s.
-   * Run [publishing_api:republish_edition[new_country_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_edition[<new_country_slug>]) to update the PublishingApi.
-   * Run [publishing_api:republish_email_signups:country_edition[country-slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=travel-advice-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:republish_email_signups:country_edition[<country-slug>]) to update email subscriptions at `/foreign-travel-advice/<country_slug>/email-signup`
+   * Run `country:rename[old_country_slug,new_country_slug]` to update the `TravelAdviceEdition`s.
+   * Run `publishing_api:republish_edition[new_country_slug]` to update the Publishing API.
+   * Run `publishing_api:republish_email_signups:country_edition[country-slug]` to update email subscriptions at `/foreign-travel-advice/<country_slug>/email-signup`
 
 4. Update the search metadata
    * In the [UI](https://travel-advice-publisher.integration.publishing.service.gov.uk/admin), go to the country and create a new edition
@@ -73,10 +73,11 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 
 1. Create a [data migration](https://github.com/alphagov/whitehall/pull/4643/files) to update the `slug` and `name` fields of the `WorldLocation` table.
 
-2. Deploy the pull request
-   * After deploying, run the [Whitehall data migrations](https://deploy.integration.publishing.service.gov.uk/job/Run_Whitehall_Data_Migrations/) job
+2. Deploy the changes
 
-3. Update World Location News
+3. Run the `db:data:migrate` rake task in Whitehall
+
+4. Update World Location News
    * Go to the relevant country in [World Location News](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/world_locations). In the "Details" tab, edit the `Title`, `Mission statement` and relevant `Featured links`.
 
 ### 4. Update Smart-answers
@@ -115,9 +116,9 @@ Each subscriber list also has a "slug", which appears in the query params of the
 
 **WARNING: the slug is used as an ID for the last few pages of the signup journey (e.g. [here](https://github.com/alphagov/email-alert-frontend/blob/784009bfff734003e028e1c0ab36b61d1775a45f/app/controllers/content_item_signups_controller.rb#L33)). When you change the slug, any users currently trying to sign up on the pages will receive a 404.**
 
-1. Run the rake task [data_migration:find_subscriber_list_by_title[title]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=data_migration:find_subscriber_list_by_title[country_name])
+1. Run the rake task `data_migration:find_subscriber_list_by_title[title]`
   with the country name to see which subscription lists need to be updated
-2. Run the rake task [data_migration:update_subscriber_list_slug[slug,new_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=data_migration:update_subscriber_list_slug[country_slug,new_country_slug])
+2. Run the rake task `data_migration:update_subscriber_list_slug[slug,new_slug]`
   to update the subscription lists
 
 ### 6. Remove duplicate search results
@@ -130,11 +131,11 @@ Failing this, there is a [rake task](https://github.com/alphagov/search-api/blob
 
 1. Create and deploy pull requests for schemas in publishing api  ([example](https://github.com/alphagov/govuk-content-schemas/pull/1014)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1722/commits/79c10d173f8294fef25b07678a7e74213e78e424)) to support both countries temporarily (during the data migration). Note that the schema example PR given here is for the archived govuk-content-schemas repo - please update with a publishing api PR when this is available.
 
-2. Run the rake task [publishing_api:publish_finder[finder]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=specialist-publisher&MACHINE_CLASS=backend&RAKE_TASK=publishing_api:publish_finder[finder]) to republish the updated finders:
+2. Run the rake task `publishing_api:publish_finder[finder]` to republish the updated finders:
    * `export_health_certificates`
    * `international_development_funds`
 
-3. Run the rake task [rename_country:all[country_slug,new_country_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=specialist-publisher&MACHINE_CLASS=backend&RAKE_TASK=rename_country:all[country_slug,new_country_slug]) to republish all the relevant documents.
+3. Run the rake task `rename_country:all[country_slug,new_country_slug]` to republish all the relevant documents.
 
 4. Check the country filter options have updated and documents appear with the new country filter set. This could take a few minutes due to the time it takes to republish the finder and all its associated documents.
    * [Export Health Certificates](https://www-origin.integration.publishing.service.gov.uk/export-health-certificates?cachebust=123).
@@ -144,6 +145,6 @@ Failing this, there is a [rake task](https://github.com/alphagov/search-api/blob
 
 6. Re-publish the finders again, as above.
 
-7. Run the rake task [data_migration:update_subscriber_list_tag[field,country_slug,new_country_slug]](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=data_migration:update_subscriber_list_tag[field,country_slug,new_country_slug]]) to update the matching criteria for any subscriber lists in Email Alert API with keys of:
+7. Run the rake task `data_migration:update_subscriber_list_tag[field,country_slug,new_country_slug]` to update the matching criteria for any subscriber lists in Email Alert API with keys of:
    * `location`
    * `destination_country`

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -9,6 +9,18 @@ important: true
 
 Rake is a task runner for Ruby. There are several different methods of running a rake task:
 
+## Run a rake task on EKS
+
+To run a rake task in Kubernetes, execute the rake command inside the application container.
+
+For example:
+
+```sh
+kubectl -n apps exec deploy/publishing-api -- rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
+```
+
+The output of the command will be streamed to your terminal.
+
 ## Run a rake task on EC2
 
 There is a Jenkins job that can be used to run any rake task:
@@ -47,14 +59,3 @@ govuk_setenv publishing-api bundle exec \
 rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
 ```
 
-## Run a rake task on EKS
-
-To run a rake task in Kubernetes, execute the rake command inside the application container.
-
-For example:
-
-```sh
-kubectl -n apps exec deploy/publishing-api -- rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
-```
-
-The output of the command will be streamed to your terminal.


### PR DESCRIPTION
We should be running rake tasks on EKS now, and these links to Jenkins may be confusing.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
