### PR TITLE
Add links to the deployment documentation

### DIFF
--- a/source/manual/deployments.html.md
+++ b/source/manual/deployments.html.md
@@ -20,7 +20,7 @@ The [Release app](https://release.publishing.service.gov.uk/applications) shows 
 
 You can manually deploy an application by triggering the "Deploy" GitHub Action workflow for that application’s repository.
 
-This can be done in GitHub’s web interface:
+This can be done in [GitHub’s web interface](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow):
 
 1. Go to the "Actions" page in the application repository
 1. Select the "Deploy" workflow from the list of workflows on the left hand side
@@ -28,7 +28,7 @@ This can be done in GitHub’s web interface:
 1. Input the git reference and environment (ignore the "Use workflow from" option)
 1. Click "Run workflow"
 
-Or using GitHub’s CLI:
+Or using [GitHub’s CLI](https://cli.github.com/manual/gh_workflow_run):
 
 ```bash
 gh workflow run -R "alphagov/${REPO}" deploy.yml -F environment=${ENVIRONMENT} -F gitRef=${GIT_REF}
@@ -38,20 +38,20 @@ gh workflow run -R "alphagov/${REPO}" deploy.yml -F environment=${ENVIRONMENT} -
 
 This is an example deploying an application to integration:
 
-1. Developer merges a PR into main branch and it passes CI
-1. Triggers the "Deploy" workflow in GitHub Actions
-    1. Builds and pushes an image to AWS Elastic Container Registery (ECR) in production
-    1. Sends a webhook to Argo Workflows in production
-1. Triggers the "deploy-image" workflow in Argo Workflows in production
-    1. Updates the image tag reference for integration in govuk-helm-charts with a new commit
+1. Developer merges a PR into main branch and it passes [CI](https://github.com/alphagov/whitehall/actions/workflows/ci.yml)
+1. Triggers the ["Deploy" workflow](https://github.com/alphagov/whitehall/actions/workflows/deploy.yml) in GitHub Actions
+    1. Builds and pushes an image to [AWS Elastic Container Registery (ECR)](https://aws.amazon.com/ecr/) in production
+    1. Sends a webhook to [Argo Workflows in production](https://argo-workflows.eks.production.govuk.digital/workflows/apps)
+1. Triggers the ["deploy-image" workflow](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/argo-services/templates/workflows/deploy-image/workflow.yaml) in [Argo Workflows in production](https://argo-workflows.eks.production.govuk.digital/workflows/apps)
+    1. Updates the image tag reference for integration in [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/image-tags) with a new commit
     1. Adds a "deployed-to-<environment>" tag on the image in ECR
     1. Notifies the Release application of the deployment
-1. Argo CD in integration polls govuk-helm-charts and detects updated image tag reference
-    1. Triggers sync of the `app-config` ([app-of-apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern)) application in Argo CD
-    1. Updates the Helm values for the deployed app's Argo CD application resource
+1. [Argo CD in integration](https://argo.eks.integration.govuk.digital/applications) polls [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts) and detects updated image tag reference
+    1. Triggers sync of the [`app-config`](https://argo.eks.integration.govuk.digital/applications/cluster-services/app-config) ([app-of-apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern)) application in Argo CD
+    1. Updates the Helm values for the deployed [app's Argo CD application resource](https://argo.eks.integration.govuk.digital/applications/cluster-services/whitehall-admin)
     1. Updates the Kubernetes deployment resource with the new image tag
-1. Kubernetes does a rolling update of the pods
-1. Argo CD triggers the "post-sync" workflow in Argo Workflows (in integration)
+1. Kubernetes does a [rolling update of the pods](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/)
+1. Argo CD triggers the ["post-sync" workflow](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/argo-services/templates/workflows/post-sync/workflow.yaml) in [Argo Workflows in integration](https://argo-workflows.eks.integration.govuk.digital/workflows/apps)
     1. Runs smoke tests for the app
     1. Checks if deployment should be promoted
     1. If so, sends a webhook to Argo Workflows (in production) to trigger deploy-image for the next environment


### PR DESCRIPTION
This adds links to help readers understand further whether process occur and are defined.
