### PR TITLE
Avoid duplicating CI runs on pull requests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-  pull_request:
   schedule:
     # Deploy hourly between 9am and 7pm on weekdays
     - cron: "0 9-19 * * 1-5"


### PR DESCRIPTION
The CI workflow for devdocs really hammers the GitHub API because of the way devdocs works currently — sometimes so much that it fails because of rate-limiting — so it's worth avoiding running duplicate jobs.

This is the simplest way to avoid duplicate workflow runs; the only downside is that we'll no longer automatically trigger on third-party pull requests — but our [process for handling external contributions](https://docs.publishing.service.gov.uk/manual/merge-pr.html#a-change-from-an-external-contributor) already covers that.

If we want to make it automatic for external contributions in future, that's entirely doable — just involves some slightly more fancy YAML (hence not doing it in this PR, because I'm already two yaks deep and I just want to stop the tests from flaking).