### PR TITLE
Link to up-to-date usage for special-route-publisher.

### DIFF
--- a/source/manual/publish-special-routes.html.md.erb
+++ b/source/manual/publish-special-routes.html.md.erb
@@ -8,16 +8,6 @@ old_paths:
  - /manual/publish_special_routes.html
 ---
 
-The [Special Route Publisher](https://github.com/alphagov/special-route-publisher) is the home for all special routes that are currently published by a variety of apps to the Publishing API.
+[Special Route Publisher](https://github.com/alphagov/special-route-publisher) is a tool for loading a set of routes (a map of URL path to a rendering app and content ID) from a YAML file into Publishing API.
 
-All new special routes should be created in this tool, and existing special routes should be moved as necessary.
-
-There are two Jenkins jobs to publish special routes:
-
-## Publish a single special route
-
-<%= RunJenkinsJob.links("Publish_Single_Special_Route") %>
-
-## Publish all special routes
-
-<%= RunJenkinsJob.links("Publish_Special_Routes") %>
+See https://github.com/alphagov/special-route-publisher#publishing-routes-on-eks for usage.


### PR DESCRIPTION
No sense in duplicating the usage instructions.