### PR TITLE
Remove duplicate whitehall-prototype entry

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1263,8 +1263,3 @@
 - repo_name: whitehall-prototype-2023
   type: Publishing apps
   team: "#govuk-publishing-experience-tech"
-  production_hosted_on: aws
-
-- repo_name: whitehall-prototype-2023
-  type: Publishing apps
-  team: "#govuk-publishing-experience-tech"


### PR DESCRIPTION
It is not an app, so I've left the repo entry.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
