### PR TITLE
Proposal on consistent approach for running GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,15 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout
+        default: main
+        type: string
   schedule:
     # Deploy hourly between 9am and 7pm on weekdays
     - cron: "0 9-19 * * 1-5"
@@ -12,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Clone publishing api
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This has been produced following the discussiona in: https://github.com/alphagov/govuk-developer-docs/pull/3950 and https://github.com/alphagov/govuk-developer-docs/pull/3816

This is to try resolve a consistency issue we have in GOV.UK where we have an agreed approach to using GitHub Actions documented which doesn't reflect the configurations used across GOV.UK.

Since we agreed the approach of running CI GitHub Action on `[push, pull_request]` and adopted it has become clear that this is not unanimously popular and, due to the appearance of duplicate jobs, can imply misconfiguration.

The motivation to document a new approach is to try form consensus on an approach that can be good enough for most cases and cover common concerns. This can then reduce the time we spend debating how to configure individual projects.

Aspects I've wanted to cover in this are:

- Stay broadly consistent with approach replatforming popularised since that is what is predominantly in use
- Remove the appearance of duplicate runs by default in pull requests
- Allow CI for external contributors (our [current process for dealing with them][1] seems more of a legacy Jenkins concern)
- Offer an approach for running CI without opening a PR, as that seems to be a common point of contention (it's a key part of some workflows, yet not a concern for others).

A risk of this approach is that the use of workflow_dispatch is somewhat ignored and thus unreliable. This doesn't seem a huge concern to me as I imagine this would be fixed if it's used frequently or be a sign that it can be removed.

[1]: https://docs.publishing.service.gov.uk/manual/merge-pr.html#a-change-from-an-external-contributor

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
