### PR TITLE
Fix un-linkified URL in Publish Special Routes.

### DIFF
--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -10,4 +10,4 @@ old_paths:
 
 [Special Route Publisher](https://github.com/alphagov/special-route-publisher) is a tool for loading a set of routes (a map of URL path to a rendering app and content ID) from a YAML file into Publishing API.
 
-See https://github.com/alphagov/special-route-publisher#publishing-routes-on-eks for usage.
+See [Publishing routes on EKS](https://github.com/alphagov/special-route-publisher#publishing-routes-on-eks) for usage.


### PR DESCRIPTION
No idea why devdocs doesn't linkify URLs, but hey 🤷

While we're at it, make that a page a plain Markdown document instead of an ERB template, since it contains no Ruby.

Tested: renders as expected when running `bundle exec middleman server` locally.
