### PR TITLE
Document how to archive a repo

### DIFF
--- a/source/manual/retiring-a-repo.html.md
+++ b/source/manual/retiring-a-repo.html.md
@@ -1,0 +1,23 @@
+---
+owner_slack: "#govuk-developers"
+title: Retire a repo
+section: Applications
+layout: manual_layout
+parent: "/manual.html"
+---
+
+## 1. Update README
+
+Add a note to the top of the README explaining that the repo has been retired and, if applicable, what it has been replaced by.
+
+## 2. Update the Developer Docs
+
+Mark the application as `retired` in [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs).
+
+## 3. Remove other references
+
+Do a [search on GitHub](https://github.com/search?q=org%3Aalphagov+panopticon&type=Code) to find any references to the repository and update or remove them.
+
+## 4. Archive the repo
+
+Go into the repository settings in GitHub, and [archive the repo](https://github.com/blog/2460-archiving-repositories).

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -73,48 +73,34 @@ Requests.
 
 [dns-changes]: https://docs.publishing.service.gov.uk/manual/dns.html#dns-for-the-publishingservicegovuk-domain
 
-## 9. Update docs
-
-Mark the application as `retired` in [govuk-developer-docs][dev-docs].
-
-[dev-docs]: https://github.com/alphagov/govuk-developer-docs
-
-## 10. Remove credentials
+## 9. Remove credentials
 
 Remove any hieradata credential entries for the app in [govuk-secrets][]
 (private repo).
 
 [govuk-secrets]: https://github.com/alphagov/govuk-secrets
 
-## 11. Drop database
+## 10. Drop database
 
 If Puppet hasn't done it (eg for MongoDB databases), drop the database.
 
-## 12. Remove jobs in CI
+## 11. Remove jobs in CI
 
 If tests were set up, go to [CI][ci] and choose "Delete Repository" for your
 project.
 
 [ci]: https://ci.integration.publishing.service.gov.uk/
 
-## 13. Remove other references
-
-Do a [code search on GitHub][search] to find any references to the application
-and update or remove them.
-
-[search]: https://github.com/search?q=org%3Aalphagov+panopticon&type=Code
-
-## 14. Unpublish routes
+## 12. Unpublish routes
 
 Some applications are responsible for publishing certain routes. If you're
 retiring a publishing application, make sure you check if any of its content
 items need to be unpublished and do it via the Publishing API.
 
-## 15. Remove from Sentry
+## 13. Remove from Sentry
 
 Since the application has been retired, it shouldn't be tracked in Sentry.
 
-## 16. Archive the repo
+## 14. Archive the repo
 
-Go into the repository settings in GitHub, and
-[archive the repo](https://github.com/blog/2460-archiving-repositories).
+Follow the steps at [Retire a repo](/manual/retiring-a-repo.html).

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -101,6 +101,10 @@ items need to be unpublished and do it via the Publishing API.
 
 Since the application has been retired, it shouldn't be tracked in Sentry.
 
-## 14. Archive the repo
+## 14. Remove from Heroku
+
+If relevant (e.g. if Heroku was used for previews).
+
+## 15. Archive the repo
 
 Follow the steps at [Retire a repo](/manual/retiring-a-repo.html).


### PR DESCRIPTION
There are a few more steps than simply clicking 'archive' in the repo settings. This commit documents those steps and removes the duplication from the "Retire an application" steps.
