### PR TITLE
Use main branch of Publishing API for schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: alphagov/publishing-api
-          ref: deployed-to-production
+          ref: main
           path: tmp/publishing-api
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The concept of the "deployed-to-production" branch no longer exists in GOV.UK infrastructure since we switched to a Kubernetes platform. Thus this branch is stale and no-longer represents the deployed version of Publishing API.

Switching this to "main" means that we will be using schemas from the version of Publishing API that is expected to be deployed - as Publishing API is continuously deployed.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
