### PR TITLE
Replace machine generated grafana dashboard IDs with human readable versions

### DIFF
--- a/source/manual/alerts/RouterErrorRatioTooHigh.html.md
+++ b/source/manual/alerts/RouterErrorRatioTooHigh.html.md
@@ -8,7 +8,7 @@ section: Pagerduty alerts
 
 You can find the router request error rates on this dashboard:
 
-- [5xx Router Requests][router-5x https://grafana.eks.production.govuk.digital/d/uBEWkijnz/router-request-rates-errors-durations?orgId=1 x-request-rates-grafana]
+- [5xx Router Requests][router-5x https://grafana.eks.production.govuk.digital/d/router-requests/router-request-rates-errors-durations?orgId=1 x-request-rates-grafana]
 
 You can also view the 500+503 error rates across all applications on this dashboard:
 
@@ -29,7 +29,7 @@ Use [this][app-5xx-error-rates-grafana] dashboard to check which applications ha
 - If an application has been recently updated and is returning errors it may require a rollback using the app's deploy github action https://github.com/alphagov/<appname>/actions/workflows/deploy.yml
 - If your application is currently dealing with a sudden increase in load it could be that you need to scale your application. You can check the following [documentation][scale-app] in order to do this.
 
-[router-5xx-request-rates-grafana]: https://grafana.eks.integration.govuk.digital/d/uBEWkijnz/router-request-rates-errors-durations?orgId=1&var-namespace=apps&var-backend_app=All&var-quantile=0.99&var-error_status=500&var-error_status=503&var-error_status=504
-[app-5xx-error-rates-grafana]: https://grafana.eks.prodution.govuk.digital/d/000000111/app-request-rates-errors-durations?orgId=1&refresh=1m&var-namespace=apps&var-app=All&var-quantile=All&var-error_status=500&var-error_status=503
+[router-5xx-request-rates-grafana]: https://grafana.eks.integration.govuk.digital/d/router-requests/router-request-rates-errors-durations?orgId=1&var-namespace=apps&var-backend_app=All&var-quantile=0.99&var-error_status=500&var-error_status=503&var-error_status=504
+[app-5xx-error-rates-grafana]: https://grafana.eks.prodution.govuk.digital/d/app-requests/app-request-rates-errors-durations?orgId=1&refresh=1m&var-namespace=apps&var-app=All&var-quantile=All&var-error_status=500&var-error_status=503
 [prod-kibana]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover
 [scale-app]: https://govuk-k8s-user-docs.publishing.service.gov.uk/manage-app/scale-app/#scaling-your-app

--- a/source/manual/content-data-architecture.html.md
+++ b/source/manual/content-data-architecture.html.md
@@ -118,8 +118,8 @@ An overview of the process is as follows:
 [gds-sso]: https://github.com/alphagov/gds-sso
 [Kubernetes CronJob]: https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-production.yaml#L541-L543
 [Lifecycle configuration]: https://s3.console.aws.amazon.com/s3/management/govuk-production-content-data-csvs/lifecycle/view?region=eu-west-1&id=all
-[Sidekiq worker]: https://grafana.eks.production.govuk.digital/d/2Yy8PzmVk/sidekiq-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=content-data-admin-worker&from=1681272545106&to=1681294145106
-[Sidekiq jobs]: https://grafana.eks.production.govuk.digital/d/2Yy8PzmVk/sidekiq-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=content-data-api-worker
+[Sidekiq worker]: https://grafana.eks.production.govuk.digital/d/sidekiq-queues/sidekiq-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=content-data-admin-worker&from=1681272545106&to=1681294145106
+[Sidekiq jobs]: https://grafana.eks.production.govuk.digital/d/sidekiq-queues/sidekiq-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=content-data-api-worker
 [Signon]: https://signon.publishing.service.gov.uk
 [Support API]: https://github.com/alphagov/support-api
 [Support app]: https://github.com/alphagov/support

--- a/source/manual/kubernetes-infrastructure.html.md
+++ b/source/manual/kubernetes-infrastructure.html.md
@@ -66,7 +66,7 @@ The Smokey cronjob keeps the last 3 successes and the last 3 failures.
 ## Dashboards, alerting and Icinga
 
 - The Technical 2nd Line Dashboard will be kept up to date as we improve our dashboards. It's worth bookmarking <https://govuk-2ndline-dashboard.herokuapp.com/>
-- The detailed Sidekiq dashboard is not yet available for EKS (the [old one](https://sidekiq-monitoring.integration.govuk.digital/publishing-api/queues) still looks at EC2) but you can see queue lengths and age-of-oldest-job on the [Sidekiq Grafana dashboard](https://grafana.eks.production.govuk.digital/d/2Yy8PzmVk).
+- The detailed Sidekiq dashboard is not yet available for EKS (the [old one](https://sidekiq-monitoring.integration.govuk.digital/publishing-api/queues) still looks at EC2) but you can see queue lengths and age-of-oldest-job on the [Sidekiq Grafana dashboard](https://grafana.eks.production.govuk.digital/d/sidekiq-queues).
 - Dashboards are on <https://grafana.eks.production.govuk.digital/> and no longer require VPN. Don’t get confused by the [old Grafana](https://grafana.production.govuk.digital/), which will show mostly empty graphs about the old EC2 setup.
 - Most Icinga alerts are irrelevant now, **except for**:
     - “scheduled publications in Whitehall not queued” / “overdue publications in Whitehall”


### PR DESCRIPTION
https://github.com/alphagov/govuk-helm-charts/pull/1102

https://trello.com/c/GO8lk2ql/1159-human-readable-ids-for-grafana-dashboards

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
