### PR TITLE
Add progress page for analytics

### DIFF
--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1,6 +1,8 @@
 - name: accordion
   events:
     - name: Accordion section
+      implemented: true
+      priority: high
       description: When a section of the accordion is opened or closed.
       example_url: https://www.gov.uk/coronavirus
       tracker: event_tracker
@@ -25,6 +27,8 @@
         - name: action
           value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
     - name: Show all sections
+      implemented: true
+      priority: high
       description: When the 'Show all sections' control is used.
       tracker: event_tracker
       data:
@@ -48,6 +52,8 @@
 - name: HTML attachments
   events:
     - name: link clicks (not implemented yet)
+      implemented: true
+      priority: high
       description: Triggered when a HTML attachment link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/government/publications/equality-act-guidance
       tracker: link_tracker
@@ -70,6 +76,8 @@
 - name: breadcrumbs
   events:
     - name: link clicks
+      implemented: true
+      priority: high
       description: Triggered when a breadcrumb link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/learn-to-drive-a-car
       tracker: link_tracker
@@ -98,6 +106,8 @@
 - name: feedback
   events:
     - name: Is this page useful? Yes
+      implemented: true
+      priority: high
       description:
       tracker: event_tracker
       data:
@@ -114,6 +124,8 @@
         - name: type
           value: feedback
     - name: Is this page useful? No
+      implemented: true
+      priority: high
       description:
       tracker: event_tracker
       data:
@@ -130,6 +142,8 @@
         - name: type
           value: feedback
     - name: Report a problem with this page
+      implemented: true
+      priority: high
       description:
       tracker: event_tracker
       data:
@@ -146,6 +160,8 @@
         - name: type
           value: feedback
     - name: Send me the survey
+      implemented: true
+      priority: high
       description:
       tracker: event_tracker
       data:
@@ -162,6 +178,8 @@
         - name: type
           value: feedback
     - name: Send
+      implemented: true
+      priority: high
       description:
       tracker: event_tracker
       data:
@@ -181,6 +199,8 @@
 - name: footer
   events:
     - name: link clicks
+      implemented: true
+      priority: high
       description: Triggered when a footer link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/
       tracker: link_tracker
@@ -214,6 +234,8 @@
 - name: links
   events:
     - name: External links
+      implemented: true
+      priority: high
       description: When a link is followed to a page outside of www.gov.uk.
       tracker: specialist_link_tracker
       data:
@@ -233,6 +255,8 @@
           value: generic link
         - name: url
     - name: Download links
+      implemented: true
+      priority: high
       description: When a link is followed to an asset such as a PDF.
       tracker: specialist_link_tracker
       data:
@@ -254,6 +278,8 @@
 - name: page view
   events:
     - name: Page view
+      implemented: true
+      priority: high
       description: When a page loads.
       tracker: page_view_tracker
       data:
@@ -292,6 +318,8 @@
 - name: print page
   events:
     - name: print page
+      implemented: true
+      priority: high
       description: When a 'print this page' button is used
       example_url: https://www.gov.uk/guidance/register-a-trust-as-a-trustee
       tracker: event_tracker
@@ -312,6 +340,8 @@
   description: Events gathered in the contextual sidebar, contextual footer and related navigation components.
   events:
     - name: Related Navigation
+      implemented: true
+      priority: high
       description: Clicks in the related navigation component
       example_url: https://www.gov.uk/government/statistics/national-curriculum-assessments-key-stage-2-2016-provisional
       tracker: link_tracker
@@ -339,6 +369,8 @@
 - name: share this page
   events:
     - name: follow us
+      implemented: true
+      priority: high
       description: Triggered when a 'follow us' social media link is used.
       example_url: https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport
       tracker: link_tracker
@@ -361,6 +393,8 @@
           value: follow us
         - name: url
     - name: share this page
+      implemented: true
+      priority: high
       description: Triggered when a 'share on' social media link is used.
       example_url: https://www.gov.uk/government/news/new-protections-for-children-and-free-speech-added-to-internet-laws
       tracker: link_tracker
@@ -386,6 +420,8 @@
 - name: step by step navigation
   events:
     - name: Open/close step
+      implemented: true
+      priority: high
       description:
       example_url: https://www.gov.uk/learn-to-drive-a-car
       tracker: event_tracker
@@ -403,6 +439,8 @@
         - name: type
           value: "step by step"
     - name: Show/hide all steps
+      implemented: true
+      priority: high
       description:
       example_url: https://www.gov.uk/learn-to-drive-a-car
       tracker: event_tracker
@@ -421,6 +459,8 @@
         - name: type
           value: "step by step"
     - name: link clicks
+      implemented: true
+      priority: high
       description: Triggered when a link within a step by step is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/learn-to-drive-a-car
       tracker: link_tracker
@@ -454,6 +494,8 @@
 - name: super navigation header
   events:
     - name: Header menu bar buttons
+      implemented: true
+      priority: high
       description: When the Menu or Search button is expanded or collapsed.
       example_url: https://www.gov.uk/
       tracker: event_tracker
@@ -480,6 +522,8 @@
         - name: text
           value: Menu/Search
     - name: link clicks
+      implemented: true
+      priority: high
       description: Triggered when the GOVUK logo, a header "menu" section link, or a link under the search component is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/
       tracker: link_tracker
@@ -514,6 +558,8 @@
 - name: tabs
   events:
     - name: Tab interaction
+      implemented: true
+      priority: high
       description: When a tab is selected.
       example_url: https://www.gov.uk/renew-driving-licence
       tracker: event_tracker

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -26,6 +26,11 @@ docs:
     - name: Trackers
       link: trackers.html
 
+progress:
+  name: Implementation progress
+  desc: Shows current percentage of implemented events by priority.
+  link: progress.html
+
 approach:
   name: Developer approach
 

--- a/helpers/analytics_helpers.rb
+++ b/helpers/analytics_helpers.rb
@@ -35,4 +35,19 @@ module AnalyticsHelpers
     html += "</ul>"
     html
   end
+
+  def tag_colours
+    {
+      "high" => "govuk-tag--red",
+      "medium" => "govuk-tag--yellow",
+      "low" => "govuk-tag--green",
+    }
+  end
+
+  def implementation_percentage(events)
+    implemented = events.select { |x| x["implemented"] == true }.count
+    percentage = ((implemented.to_f / events.count) * 100.00).round(2)
+    percentage = 0 if implemented.zero? || events.count.zero?
+    "#{implemented} of #{events.count} (#{percentage}%)"
+  end
 end

--- a/source/analytics/progress.html.md.erb
+++ b/source/analytics/progress.html.md.erb
@@ -1,0 +1,47 @@
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.progress.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.progress.desc %>
+</p>
+
+<% all_events = [] %>
+<% data.analytics.events.each do |event| %>
+  <% all_events += event.events %>
+<% end %>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Priority
+    </dt>
+    <dd class="govuk-summary-list__key">
+      Implemented
+    </dd>
+  </div>
+
+  <% tag_colours.keys.each do |priority| %>
+    <% events = all_events.select { |x| x["priority"] == priority } %>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <strong class="govuk-tag <%= tag_colours[priority] %>">
+          <%= priority.capitalize %>
+        </strong>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= implementation_percentage(events) %>
+      </dd>
+    </div>
+  <% end %>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Overall progress
+    </dt>
+    <dd class="govuk-summary-list__key">
+      <%= implementation_percentage(all_events) %>
+    </dd>
+  </div>
+</dl>

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -12,6 +12,15 @@
     <h2 class="govuk-heading-m">
       <%= page_event.name %>
     </h2>
+
+    <strong class="govuk-tag <%= tag_colours[page_event.priority] %>">
+      <%= page_event.priority %>
+    </strong>
+
+    <% unless page_event.implemented %>
+      <strong class="govuk-tag">Not yet implemented</strong>
+    <% end %>
+
     <% if page_event.description %>
       <p class="govuk-body">
         <%= page_event.description %>

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -89,6 +89,14 @@
               <% end %>
             </ul>
           </ul>
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          <ul class="govuk-list">
+            <li>
+              <%= link_to data.analytics.navigation.progress.name, data.analytics.navigation.progress.link, class: "govuk-link" %>
+            </li>
+          </ul>
         </div>
         <div class="govuk-grid-column-two-thirds">
           <%= yield %>

--- a/spec/helpers/analytics_helpers_spec.rb
+++ b/spec/helpers/analytics_helpers_spec.rb
@@ -176,4 +176,35 @@ RSpec.describe AnalyticsHelpers do
       expect(helper.to_html(input)).to eq(expected)
     end
   end
+
+  describe "#implementation_percentage" do
+    it "should be 0% when there are no events" do
+      expect(helper.implementation_percentage([])).to eq("0 of 0 (0%)")
+    end
+
+    it "should be 0% when none of the events are implemented" do
+      events = [
+        { "implemented" => false },
+      ]
+
+      expect(helper.implementation_percentage(events)).to eq("0 of 1 (0%)")
+    end
+
+    it "should be 100% when all the events are implemented" do
+      events = [
+        { "implemented" => true },
+      ]
+
+      expect(helper.implementation_percentage(events)).to eq("1 of 1 (100.0%)")
+    end
+
+    it "should be 50% when half of the events are implemented" do
+      events = [
+        { "implemented" => true },
+        { "implemented" => false },
+      ]
+
+      expect(helper.implementation_percentage(events)).to eq("1 of 2 (50.0%)")
+    end
+  end
 end


### PR DESCRIPTION
## What

This change:

- Adds a new progress page for our analytics implementation
- Adds a link to the analytics layout page to the new progress page
- Adds status tags to each trackable event
- Updates the events data YAML file to add `implemented` and `priority` status tags

## Why

We want to have a visual representation of the teams progress.

[Trello](https://trello.com/c/JbLX3n2C/388-implementation-record-additions-and-improvements)

## Screenshot - progress page

![screencapture-localhost-4567-analytics-progress-html-2023-05-05-09_51_52](https://user-images.githubusercontent.com/44037625/236417223-328d9db4-a327-466d-b01b-3d2fe86ded2f.png)

## Screenshot - event page

![screencapture-localhost-4567-analytics-event-accordion-html-2023-05-05-09_50_01](https://user-images.githubusercontent.com/44037625/236417222-b0f4c156-6928-43cb-b73b-d904315dea8c.png)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
