### PR TITLE
Update slack channel ownership of CIOP apps.

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -4,7 +4,7 @@
 
 - repo_name: account-api
   type: APIs
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
 - repo_name: asset-manager
@@ -245,24 +245,24 @@
 
 - repo_name: email-alert-api
   type: APIs
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   metrics_dashboard_url: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api.json?refresh=10s&orgId=1
   production_hosted_on: eks
 
 - repo_name: email-alert-frontend
   type: Frontend apps
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
 - repo_name: email-alert-monitoring
   type: Utilities
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   sentry_url: false
   dashboard_url: false
 
 - repo_name: email-alert-service
   type: Services
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
 - repo_name: feedback
@@ -351,7 +351,7 @@
 
 - repo_name: govuk-account-architecture
   private_repo: true
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   type: Utilities
 
 - repo_name: govuk-app-deployment
@@ -770,7 +770,7 @@
     stored in the Publishing API, and available in the Content Store.
 
 - repo_name: govuk_personalisation
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   type: Gems
 
 - repo_name: govuk_publishing_components
@@ -821,7 +821,7 @@
 
 - repo_name: imminence
   type: APIs
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
 - repo_name: info-frontend
@@ -838,7 +838,7 @@
 - repo_name: licence-finder
   type: Frontend apps
   puppet_name: licencefinder
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
   argo_cd_apps:
     - licencefinder
@@ -874,12 +874,12 @@
 
 - repo_name: local-links-manager
   type: Publishing apps
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
 - repo_name: locations-api
   type: APIs
-  team: "#tech-interaction-and-personalisation"
+  team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
 - repo_name: lstm_segmentation


### PR DESCRIPTION
#tech-interaction-and-personalisation is now #tech-content-interactions-on-platform-govuk, update repo ownership so that docs are correct and Dependapanda will post to the correct slack channel.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
