### PR TITLE
Update architecture diagram

### DIFF
--- a/source/manual/architecture.html.md
+++ b/source/manual/architecture.html.md
@@ -7,9 +7,15 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-<iframe src="https://www.draw.io/?lightbox=1&highlight=0000ff&layers=1&nav=1&title=Logical#Uhttps%3A%2F%2Fdrive.google.com%2Fa%2Fdigital.cabinet-office.gov.uk%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload" style="width:700pt;height:400pt; display: block; border:none"></iframe>
+[//]: # (1 - Visit https://app.diagrams.net/#G1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm)
+[//]: # (2 - File > Embed > IFrame...)
+[//]: # (3 - Uncheck Edit / Layers / Tags)
+[//]: # (4 - Create)
+[//]: # (5 - Copy the snippet and paste below, replacing the inline style attribute with class="architecture-diagram")
 
-[Open in Full Screen Mode](https://www.draw.io/?lightbox=1&highlight=0000ff&layers=1&nav=1&title=Logical#Uhttps%3A%2F%2Fdrive.google.com%2Fa%2Fdigital.cabinet-office.gov.uk%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload){:target="_blank"}
+<iframe frameborder="0" class="architecture-diagram" src="https://viewer.diagrams.net/?highlight=0000ff&nav=1&title=GOV.UK%20Logical%20architecture%20diagram#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload"></iframe>
+
+[Open in Full Screen Mode](https://viewer.diagrams.net/?tags=%7B%7D&highlight=0000ff&edit=https%3A%2F%2Fapp.diagrams.net%2F%23G1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm&layers=1&nav=1&title=GOV.UK%20Logical%20architecture%20diagram#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload)
 
 [Source diagram][src] in the [GOV.UK architecture folder][arch-folder].
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -93,9 +93,12 @@ ul.subdir__menu {
 }
 
 .architecture-diagram {
+  // https://github.com/alphagov/tech-docs-gem/blob/main/lib/assets/stylesheets/modules/_app-pane.scss#L2
+  $toc-width: 330px;
+
   height: 700px;
-  width: calc(100vw - 400px);
+  width: calc(100vw - #{$toc-width} - #{$govuk-gutter} * 2);
   @include govuk-media-query($until: tablet) {
-    width: calc(100vw - 60px);
+    width: calc(100vw - #{$govuk-gutter} * 2);
   }
 }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -91,3 +91,11 @@ ul.subdir__menu {
 .indented-list {
   margin: 0 0 0 20px;
 }
+
+.architecture-diagram {
+  height: 700px;
+  width: calc(100vw - 400px);
+  @include govuk-media-query($until: tablet) {
+    width: calc(100vw - 60px);
+  }
+}


### PR DESCRIPTION
The architecture diagram was looking a little out of date.

In particular:
- Mapit instead of locations-api
- manuals-frontend still there even though it's been retired
- info-frontend making calling out to performance platform (which has been retired)

I fixed these things in the source diagram, but that seems to have broken the original embedding code (draw.io has moved to diagrams.net, so I'm not surprised the embed broke).

This commit updates the embed, and attempts to size the diagram so it takes up more of the screen.

My CSS is a bit hacky, but the idea is "the whole view width, minus the sidebar and margins, appart from on mobile where it's the whole view width minus the margins". The 700px height is arbitrary. Seems to just about work.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
