### PR TITLE
Analytics data update

### DIFF
--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -49,35 +49,26 @@
         - name: action
           value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
 
-- name: HTML attachments
+- name: banners
   events:
-    - name: link clicks (not implemented yet)
-      implemented: true
-      priority: high
-      description: Triggered when a HTML attachment link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
-      example_url: https://www.gov.uk/government/publications/equality-act-guidance
-      tracker: link_tracker
+    - name: banner shown
+      implemented: false
+      priority: medium
       data:
       - name: event
         value: event_data
-      - name: event_data
-        value:
-        - name: event_name
-          value: navigation
-        - name: external
-        - name: link_domain
-        - name: link_path_parts
-        - name: method
-        - name: text
-        - name: type
-          value: html attachment
-        - name: url
+    - name: link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
 
 - name: breadcrumbs
   events:
     - name: link clicks
       implemented: true
-      priority: high
+      priority: medium
       description: Triggered when a breadcrumb link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/learn-to-drive-a-car
       tracker: link_tracker
@@ -103,11 +94,74 @@
           value: breadcrumbs
         - name: url
 
+- name: browse
+  events:
+    - name: topic browse link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: page view topic page parameters
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: see more in this topic link click
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+
+- name: call out box
+  events:
+    - name: call out box link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
+- name: council lookup
+  events:
+    - name: council lookup
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
+- name: contents link
+  events:
+    - name: link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: back to contents link click
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+
+- name: details elements
+  events:
+    - name: details expanded/collapsed
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
 - name: feedback
   events:
     - name: Is this page useful? Yes
       implemented: true
-      priority: high
+      priority: medium
       description:
       tracker: event_tracker
       data:
@@ -125,7 +179,7 @@
           value: feedback
     - name: Is this page useful? No
       implemented: true
-      priority: high
+      priority: medium
       description:
       tracker: event_tracker
       data:
@@ -143,7 +197,7 @@
           value: feedback
     - name: Report a problem with this page
       implemented: true
-      priority: high
+      priority: medium
       description:
       tracker: event_tracker
       data:
@@ -161,7 +215,7 @@
           value: feedback
     - name: Send me the survey
       implemented: true
-      priority: high
+      priority: medium
       description:
       tracker: event_tracker
       data:
@@ -179,7 +233,7 @@
           value: feedback
     - name: Send
       implemented: true
-      priority: high
+      priority: medium
       description:
       tracker: event_tracker
       data:
@@ -200,7 +254,7 @@
   events:
     - name: link clicks
       implemented: true
-      priority: high
+      priority: medium
       description: Triggered when a footer link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       example_url: https://www.gov.uk/
       tracker: link_tracker
@@ -230,6 +284,90 @@
         - name: url
         - name: section
           value: One of "Topics", "Government Activity", "Support Links", "Licence", or "Copyright"
+
+- name: forms
+  events:
+    - name: form success alert
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+
+- name: get emails
+  events:
+    - name: get emails about this page link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: change how often you get emails
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: unsubscribe
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: unsubscribe from everything
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
+- name: homepage
+  events:
+    - name: Link clicks
+      implemented: true
+      priority: medium
+      description:
+      tracker:
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: homepage
+        - name: index
+          value:
+          - name: index_section
+          - name: index_link
+          - name: index_section_count
+        - name: index_total
+        - name: section
+
+- name: html attachments
+  events:
+    - name: link clicks (not implemented yet)
+      implemented: true
+      priority: high
+      description: Triggered when a HTML attachment link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      example_url: https://www.gov.uk/government/publications/equality-act-guidance
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: html attachment
+        - name: url
 
 - name: links
   events:
@@ -274,6 +412,57 @@
         - name: type
           value: generic download
         - name: url
+    - name: mailto links
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: attachment links
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
+- name: miscellaneous
+  events:
+    - name: javascript error
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: webchat
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: accessible format request
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: see all updates link click
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: view printable version of page
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: video
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
 
 - name: page view
   events:
@@ -319,7 +508,7 @@
   events:
     - name: print page
       implemented: true
-      priority: high
+      priority: low
       description: When a 'print this page' button is used
       example_url: https://www.gov.uk/guidance/register-a-trust-as-a-trustee
       tracker: event_tracker
@@ -366,11 +555,74 @@
         - name: method
         - name: external
 
+- name: scroll tracking
+  events:
+    - name: scroll tracking
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
+- name: see all link
+  events:
+    - name: see all link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
+- name: search
+  events:
+    - name: search results
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: search boxes
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: ecommerce product list views and clicks
+      implemented: true
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: filters open/closed
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: facet tag removed
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+    - name: filter click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: organisations link click
+      implemented: false
+      priority: low
+      data:
+      - name: event
+        value: event_data
+
 - name: share this page
   events:
     - name: follow us
       implemented: true
-      priority: high
+      priority: low
       description: Triggered when a 'follow us' social media link is used.
       example_url: https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport
       tracker: link_tracker
@@ -394,7 +646,7 @@
         - name: url
     - name: share this page
       implemented: true
-      priority: high
+      priority: low
       description: Triggered when a 'share on' social media link is used.
       example_url: https://www.gov.uk/government/news/new-protections-for-children-and-free-speech-added-to-internet-laws
       tracker: link_tracker
@@ -416,6 +668,108 @@
         - name: type
           value: share this page
         - name: url
+
+- name: simple smart answers
+  events:
+    - name: completed
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: results link click
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: start again link click
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: question
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: change answer
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: start again
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: form error
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: start button
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+
+- name: smart answers
+  events:
+    - name: completed
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: results link click
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: start again link click
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: question
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: change answer
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: start again
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: form error
+      implemented: true
+      priority: high
+      data:
+      - name: event
+        value: event_data
+    - name: results ecommerce list views and click
+      implemented: true
+      priority: medium
+      data:
+      - name: event
+        value: event_data
 
 - name: step by step navigation
   events:
@@ -490,6 +844,15 @@
         - name: url
         - name: section
           value: The name of the step
+
+- name: super breadcrumb
+  events:
+    - name: link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
 
 - name: super navigation header
   events:

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -1,6 +1,6 @@
 analytics:
-  name: Google Analytics 4 Implementation record
-  desc: This site contains a record of the data implementation for Google Analytics 4 on GOV.UK Publishing. It has been built as an aid to developers on GOV.UK Publishing but is being made available for anyone who may find our approach useful.
+  name: Google Analytics 4 implementation record
+  desc: This site contains a record of the data implementation for Google Analytics 4 (GA4) on GOV.UK Publishing. It was built to aid developers on GOV.UK Publishing but available to anyone who may find our approach useful.
 
 data:
   name: Data
@@ -15,13 +15,13 @@ data:
 
 docs:
   name: Documentation
-  desc: Relevant documentation including our approach.
+  desc: Documentation relevant to GOV.UK's dataLayer approach.
   link_title: Browse documentation
   link: docs.html
   subsections:
-    - name: Developer approach
+    - name: Development approach
       link: approach.html
-    - name: Personally Identifiable Information
+    - name: Personally identifiable information
       link: pii.html
     - name: Trackers
       link: trackers.html
@@ -32,19 +32,26 @@ progress:
   link: progress.html
 
 approach:
-  name: Developer approach
+  name: Development approach
 
 pii:
   name: Personally Identifiable Information
 
 trackers:
   name: Trackers
-  desc: Trackers are distinct JavaScripts that collect GA4 data in specific ways. They work differently but produce and send data to GA4 in the same way.
+  desc: Trackers are distinct JavaScripts that collect GA4 data in specific ways. Each works differently but produces and sends data to GA4 in the same way.
 
 attributes:
   name: Attributes
-  desc: Attributes are the key/value pairs of data inside events. Attributes are often used by more than one event.
+  desc: |
+    Attributes are the key value pairs of data inside events. Attributes are often used by more than one event.
+
+    Events use the following attributes:
 
 events:
   name: Events
-  desc: Events are collections of data that are sent to Google Analytics when users do certain things, like opening an accordion or clicking certain links.
+  desc: |
+    Events are collections of data that are sent to a GA4 property when users do certain things, like opening an accordion or clicking a link. 
+
+    We use the following events:
+

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -2,18 +2,22 @@
   technical_name: event_tracker
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md
   description: This script is intended for adding GA4 tracking to interactive elements such as buttons or details elements.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
 
 - name: Link tracker
   technical_name: link_tracker
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md
   description: This script is intended for adding GA4 tracking to links.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
 
 - name: Page view tracker
   technical_name: page_view_tracker
   url:
   description: This script creates page view events on page load.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
 
 - name: Specialist link tracker
   technical_name: specialist_link_tracker
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md
   description: This script automatically tracks clicks on links such as external links, download links, and mailto links.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js

--- a/helpers/analytics_helpers.rb
+++ b/helpers/analytics_helpers.rb
@@ -27,7 +27,7 @@ module AnalyticsHelpers
     hash.each do |key, value|
       case value
       when String
-        html += "<li><a href='/analytics/attribute_#{urlize(key)}.html'>#{key}</a>: #{value}</li>"
+        html += "<li><a href='/analytics/attribute_#{urlize(key)}.html' class='govuk-link'>#{key}</a>: #{value}</li>"
       when Hash
         html += "<li>#{key}: #{to_html(value)}</li>"
       end

--- a/source/analytics/approach.html.md.erb
+++ b/source/analytics/approach.html.md.erb
@@ -2,12 +2,20 @@
   <%= data.analytics.navigation.approach.name %>
 </h1>
 
-<p class="govuk-body">This is our high level approach to implementing tracking across our applications.</p>
+<p class="govuk-body">This is our high-level approach to implementing tracking across our applications.</p>
 
-<p class="govuk-body">For elements that are consistent from page to page (such as the header, footer and breadcrumbs) tracking within these elements should be enabled by default.</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    For elements that are consistent from page to page (such as the header, footer and breadcrumbs) tracking should be enabled by default.
+  </li>
 
-<p class="govuk-body">For elements within the content of a page, tracking should be controllable. We want the flexibility to disable tracking in the unforeseen event of some kind of tracking collision/duplication. Tracking should be disabled on <a href="https://components.publishing.service.gov.uk/component-guide" class="govuk-link">components</a> by default and enabled with a 'ga4_tracking: true' option.</p>
+  <li>
+    For elements within the content of a page, tracking should be controllable. Specifically, tracking should be disabled on <a href="https://components.publishing.service.gov.uk/component-guide" class="govuk-link">components</a> by default and then enabled with the 'ga4_tracking: true' option. This provides the flexibility to disable tracking in the unforeseen event of some kind of tracking collision or duplication.
+  </li>
 
-<p class="govuk-body">For elements that are inside content coming from a publishing interface, such as <a href="https://components.publishing.service.gov.uk/component-guide/govspeak" class="govuk-link">govspeak</a> elements, we will decide on a case by case basis. The most likely approach is that tracking would be enabled by default (otherwise publishers would need an option to enable tracking on their content, and the conversation would get much more complex).</p>
+  <li>
+    For elements that are inside content coming from a publishing interface, such as <a href="https://components.publishing.service.gov.uk/component-guide/govspeak" class="govuk-link">govspeak</a> elements, tracking should be decided on a case by case basis. The most likely approach would be to enable tracking by default. This removes the need to provide publishers with an option to enable tracking on their content, which could get much more complex.
+  </li>
+</ul>
 
-<p class="govuk-body">Tracking should be handled internally by components unless external data is required i.e. if something unique must be passed from the application to the component to track it correctly because we want to make enabling tracking as simple as possible.</p>
+<p class="govuk-body">Enabling tracking should be as simple as possible. For this reason, tracking should be handled internally by components unless external data is required, that is, unless something unique must be passed from the application to the component to track it correctly.</p>

--- a/source/analytics/data.html.md.erb
+++ b/source/analytics/data.html.md.erb
@@ -2,9 +2,9 @@
   <%= data.analytics.navigation.data.name %>
 </h1>
 
-<p class="govuk-body">This section contains details of the data structure that GOV.UK uses for recording analytics.</p>
+<p class="govuk-body">This section contains details of the data structure that GOV.UK uses to record analytics.</p>
 
-<p class="govuk-body">Specifically, this is the data that GOV.UK pushes to the dataLayer when events occur, triggered by JavaScript event listeners. These pages do not currently contain information about what happens to the data next, as it is collected by Google Tag Manager and sent to Google Analytics.</p>
+<p class="govuk-body">Specifically, this is the data that GOV.UK pushes to the dataLayer when events, triggered by JavaScript event listeners occur.</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <% data.analytics.navigation.data.subsections.each do |item| %>
@@ -13,3 +13,5 @@
     </li>
   <% end %>
 </ul>
+
+<p class="govuk-body">These pages do not currently contain information about what happens to the data next: it is collected by Google Tag Manager and sent to Google Analytics.</p>

--- a/source/analytics/docs.html.md.erb
+++ b/source/analytics/docs.html.md.erb
@@ -2,7 +2,7 @@
   <%= data.analytics.navigation.docs.name %>
 </h1>
 
-<p class="govuk-body">This section contains documentation relevant to GOV.UK's dataLayer approach. Our main source of documentation is <a href="https://github.com/alphagov/govuk_publishing_components" class="govuk-link">govuk_publishing_components</a>, where <a href="https://github.com/alphagov/govuk_publishing_components/tree/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4" class="govuk-link">our analytics code</a> is located. You can read an <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">overview of our GA4 code here</a>.</p>
+<p class="govuk-body">This section contains documentation relevant to GOV.UK's dataLayer approach.</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <% data.analytics.navigation.docs.subsections.each do |item| %>
@@ -11,3 +11,5 @@
     </li>
   <% end %>
 </ul>
+
+<p class="govuk-body">Our main documentation source is <a href="https://github.com/alphagov/govuk_publishing_components" class="govuk-link">govuk_publishing_components</a>. This is where <a href="https://github.com/alphagov/govuk_publishing_components/tree/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4" class="govuk-link">our analytics code</a> is located. Read our <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">overview of our GA4 code</a> for more information.</p>

--- a/source/analytics/pii.html.md.erb
+++ b/source/analytics/pii.html.md.erb
@@ -2,7 +2,7 @@
   <%= data.analytics.navigation.pii.name %>
 </h1>
 
-<p class="govuk-body">Any data collected by GA4 must be free of Personally Identifiable Information (PII). This includes, but is not limited to:</p>
+<p class="govuk-body">Any data collected by GA4 must be free of Personally identifiable information (PII). This includes, but is not limited to:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Email addresses</li>
@@ -10,6 +10,6 @@
   <li>Postcodes</li>
 </ul>
 
-<p class="govuk-body">If an attribute is listed with 'PII' next to it, the value of that attribute should be processed to remove PII.</p>
+<p class="govuk-body">Each attribute page indicates if an attribute value is PII (Redact=true) and should be processed to redact the PII.</p>
 
-<p class="govuk-body">Further information can be found here: <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/pii-remover.md" class="govuk-link">PII documentation</a>.</p>
+<p class="govuk-body">Read our <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/pii-remover.md" class="govuk-link">PII documentation</a> for more information on how we redact PII.</p>

--- a/source/analytics/templates/attribute.html.erb
+++ b/source/analytics/templates/attribute.html.erb
@@ -11,7 +11,7 @@
       </dt>
       <dd class="govuk-summary-list__value">
         <% if name == 'Redact' %>
-          <%= link_to attribute.send(name.downcase), "pii.html" %>
+          <%= link_to attribute.send(name.downcase), "pii.html", class: "govuk-link" %>
         <% else %>
           <%= attribute.send(name.downcase) %>
         <% end %>
@@ -30,12 +30,12 @@
             <% if events_attribute.value.is_a?(Array) %>
               <% events_attribute.value.each do |sub_attribute| %>
                 <% if sub_attribute.name == attribute.name %>
-                  <%= link_to event.name, "event_#{urlize(event.name)}.html" %> (<%= events.name %>)<br/>
+                  <%= link_to event.name, "event_#{urlize(event.name)}.html", class: "govuk-link" %> (<%= events.name %>)<br/>
                 <% end %>
               <% end %>
             <% else %>
               <% if events_attribute.name == attribute.name %>
-                <%= link_to event.name, "event_#{urlize(event.name)}.html" %> (<%= events.name %>)<br/>
+                <%= link_to event.name, "event_#{urlize(event.name)}.html", class: "govuk-link" %> (<%= events.name %>)<br/>
               <% end %>
             <% end %>
           <% end %>

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">
+<h1 class="govuk-heading-l analytics-heading">
   <span class="govuk-caption-l">Event</span>
   <%= event.name %>
 </h1>
@@ -9,17 +9,19 @@
 
 <% event.events.each do |page_event| %>
   <div class="event">
-    <h2 class="govuk-heading-m">
+    <h2 class="govuk-heading-m analytics-heading">
       <%= page_event.name %>
     </h2>
 
-    <strong class="govuk-tag <%= tag_colours[page_event.priority] %>">
-      <%= page_event.priority %>
-    </strong>
+    <p class="govuk-body">
+      <strong class="govuk-tag <%= tag_colours[page_event.priority] %>">
+        <%= page_event.priority %>
+      </strong>
 
-    <% unless page_event.implemented %>
-      <strong class="govuk-tag">Not yet implemented</strong>
-    <% end %>
+      <% unless page_event.implemented %>
+        <strong class="govuk-tag">Not yet implemented</strong>
+      <% end %>
+    </p>
 
     <% if page_event.description %>
       <p class="govuk-body">
@@ -29,14 +31,14 @@
     <ul class="govuk-list govuk-list--bullet">
       <% if page_event.example_url %>
         <li>
-          Example of <%= link_to page_event.name, page_event.example_url %>
+          Example of <%= link_to page_event.name, page_event.example_url, class: "govuk-link" %>
         </li>
       <% end %>
       <% if page_event.tracker %>
         <% data.analytics.trackers.each do |tracker| %>
           <% if tracker.technical_name == page_event.tracker %>
             <li>
-              Tracked by <%= link_to page_event.tracker, "tracker_#{page_event.tracker}.html" %>
+              Tracked by <%= link_to page_event.tracker, "tracker_#{page_event.tracker}.html", class: "govuk-link" %>
             </li>
           <% end %>
         <% end %>

--- a/source/analytics/templates/tracker.html.erb
+++ b/source/analytics/templates/tracker.html.erb
@@ -14,7 +14,7 @@
         Technical documentation
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= link_to tracker.technical_name, "#{tracker.url}" %>
+        <%= link_to tracker.technical_name, "#{tracker.url}", class: "govuk-link" %>
       </dd>
     </div>
   <% end %>
@@ -24,7 +24,7 @@
         Tracker code
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= link_to "#{tracker.technical_name} code", "#{tracker.code}" %>
+        <%= link_to "#{tracker.technical_name} code", "#{tracker.code}", class: "govuk-link" %>
       </dd>
     </div>
   <% end %>
@@ -36,7 +36,7 @@
       <% data.analytics.events.each do |event| %>
         <% event.events.each do |events| %>
           <% if events.tracker == tracker.technical_name %>
-            <%= link_to event.name, "event_#{urlize(event.name)}.html" %> (<%= events.name %>)<br/>
+            <%= link_to event.name, "event_#{urlize(event.name)}.html", class: "govuk-link" %> (<%= events.name %>)<br/>
           <% end %>
         <% end %>
       <% end %>

--- a/source/analytics/templates/tracker.html.erb
+++ b/source/analytics/templates/tracker.html.erb
@@ -8,16 +8,26 @@
 <% end %>
 
 <dl class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <% if tracker.url %>
+  <% if tracker.url %>
+    <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         Technical documentation
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= link_to tracker.technical_name, "tracker_#{tracker.url}.html" %>
+        <%= link_to tracker.technical_name, "#{tracker.url}" %>
       </dd>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
+  <% if tracker.code %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Tracker code
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= link_to "#{tracker.technical_name} code", "#{tracker.code}" %>
+      </dd>
+    </div>
+  <% end %>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Used by

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -51,7 +51,7 @@
   </header>
 
   <div class="govuk-width-container ">
-    <main class="govuk-main-wrapper " id="main-content" role="main">
+    <main class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
           <ul class="govuk-list">
@@ -98,7 +98,7 @@
             </li>
           </ul>
         </div>
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds" id="main-content" role="main">
           <%= yield %>
         </div>
       </div>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -92,6 +92,10 @@ ul.subdir__menu {
   margin: 0 0 0 20px;
 }
 
+.analytics-heading {
+  text-transform: capitalize;
+}
+
 .architecture-diagram {
   // https://github.com/alphagov/tech-docs-gem/blob/main/lib/assets/stylesheets/modules/_app-pane.scss#L2
   $toc-width: 330px;

--- a/spec/helpers/analytics_helpers_spec.rb
+++ b/spec/helpers/analytics_helpers_spec.rb
@@ -116,10 +116,10 @@ RSpec.describe AnalyticsHelpers do
       expected = <<~HTML.gsub(/^\s+/, "").gsub("\n", "")
         <ul class='govuk-list indented-list'>
           <li>
-            <a href='/analytics/attribute_event_name.html'>event_name</a>: select_content
+            <a href='/analytics/attribute_event_name.html' class='govuk-link'>event_name</a>: select_content
           </li>
           <li>
-            <a href='/analytics/attribute_type.html'>type</a>: accordion
+            <a href='/analytics/attribute_type.html' class='govuk-link'>type</a>: accordion
           </li>
         </ul>
       HTML
@@ -136,7 +136,7 @@ RSpec.describe AnalyticsHelpers do
         <ul class='govuk-list indented-list'>
           <li>event_data: <ul class='govuk-list indented-list'>
               <li>
-                <a href='/analytics/attribute_event_name.html'>event_name</a>: select_content
+                <a href='/analytics/attribute_event_name.html' class='govuk-link'>event_name</a>: select_content
               </li>
             </ul>
           </li>
@@ -160,11 +160,11 @@ RSpec.describe AnalyticsHelpers do
         <ul class='govuk-list indented-list'>
           <li>event_data: <ul class='govuk-list indented-list'>
               <li>
-                <a href='/analytics/attribute_event_name.html'>event_name</a>: select_content
+                <a href='/analytics/attribute_event_name.html' class='govuk-link'>event_name</a>: select_content
               </li>
               <li>index: <ul class='govuk-list indented-list'>
                   <li>
-                    <a href='/analytics/attribute_index_section.html'>index_section</a>: integer
+                    <a href='/analytics/attribute_index_section.html' class='govuk-link'>index_section</a>: integer
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

## What
Improvements to the analytics documentation (GA4 implementation record) including:

- broad text improvements
- all data for analytics events has been added, even if not implemented, to give us a better view of overall progress
- various visual and accessibility fixes

## Why
We're working towards a public release of this information.

Trello card: https://trello.com/c/JbLX3n2C/388-implementation-record-additions-and-improvements
