### PR TITLE
Improve link and step by step documentation

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -135,7 +135,7 @@
   example: |
     {1=>"/conditions/vaccinations/flu-influenza-vaccine/", 2=>"undefined", 3=>"undefined", 4=>"undefined", 5=>"undefined"}
   required: yes
-  type: string
+  type: object
   redact: true
 
 - name: location

--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -76,10 +76,10 @@
   redact: false
 
 - name: index
-  description: Contains the index of a thing being clicked on, for example the nth accordion section, or the nth link in a list.
+  description: Contains an object with the indexes of a thing being interacted with on, for example the nth accordion section, or the nth link in a list.
   example:
   required: no
-  type: string (1-indexed number)
+  type: object
   redact: false
 
 - name: index_link

--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -56,7 +56,7 @@
   description: Used for link tracking. True means the link points to a URL not on the current site.
   example:
   required: yes
-  type: string (true or false)
+  type: string ("true" or "false")
   redact: false
 
 - name: first_published_at
@@ -76,7 +76,7 @@
   redact: false
 
 - name: index
-  description: Contains an object with the indexes of a thing being interacted with on, for example the nth accordion section, or the nth link in a list.
+  description: Contains an object with the indexes of a thing being interacted with, for example the nth accordion section, or the nth link in a list.
   example:
   required: no
   type: object
@@ -91,7 +91,7 @@
   redact: false
 
 - name: index_section
-  description: The index of the section that was interacted with, for example the index of the section the clicked link is in
+  description: The index of the section that was interacted with, for example the index of the section the clicked link is in. Sections are usually segmented by headings within a component.
   value:
   example: 1
   required: no
@@ -99,7 +99,7 @@
   redact: false
 
 - name: index_section_count
-  description: The total number of sections in the thing being tracked, such as the header or sidebar
+  description: The total number of sections in the thing being tracked, such as the header or sidebar. Sections are usually segmented by headings within a component.
   value:
   example: 1
   required: no

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -384,7 +384,7 @@
         - name: event_name
           value: navigation
         - name: external
-          value: string (true)
+          value: '"true"'
         - name: link_domain
         - name: link_path_parts
         - name: method
@@ -416,7 +416,7 @@
       implemented: true
       priority: low
       description: 'When a link points to an email address using mailto:'
-      tracker: specialist_link_tracker.
+      tracker: specialist_link_tracker
       data:
       - name: event
         value: event_data
@@ -425,7 +425,7 @@
         - name: event_name
           value: navigation
         - name: external
-          value: 'string (true)'
+          value: '"true"'
         - name: link_domain
         - name: link_path_parts
         - name: method
@@ -437,7 +437,7 @@
       implemented: false
       priority: medium
       description: 'Links on our guidance pages that contain file attachments, such as https://www.gov.uk/government/publications/equality-act-guidance'
-      tracker: specialist_link_tracker.
+      tracker: specialist_link_tracker
       data:
       - name: event
         value: event_data
@@ -820,11 +820,9 @@
         - name: index
           value:
           - name: index_section
-            value: The section that this step is in. The section in this case refers to the step number.
           - name: index_section_count
-            value: The total amount of steps within this step by step component.
         - name: text
-          value: (the opened/closed step's title)
+          value: title of the opened/closed step
         - name: type
           value: "step by step"
     - name: Show/hide all steps
@@ -867,11 +865,9 @@
         - name: index
           value:
           - name: index_section
-            value: The section that this link is in. The section in this case refers to the step number.
           - name: index_link
             value: The position of the link within this section.
         - name: index_total
-          value: The total amount of links within this section.
         - name: link_domain
         - name: link_path_parts
         - name: method

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -384,7 +384,7 @@
         - name: event_name
           value: navigation
         - name: external
-          value: true
+          value: string (true)
         - name: link_domain
         - name: link_path_parts
         - name: method
@@ -413,17 +413,47 @@
           value: generic download
         - name: url
     - name: mailto links
-      implemented: false
+      implemented: true
       priority: low
+      description: 'When a link points to an email address using mailto:'
+      tracker: specialist_link_tracker.
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+          value: 'string (true)'
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: email
+        - name: url
+          value: '[email] (PII redacted)'
     - name: attachment links
       implemented: false
       priority: medium
+      description: 'Links on our guidance pages that contain file attachments, such as https://www.gov.uk/government/publications/equality-act-guidance'
+      tracker: specialist_link_tracker.
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: text
+        - name: type
+          value: attachment
+        - name: url
 
 - name: miscellaneous
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -433,7 +433,6 @@
         - name: type
           value: email
         - name: url
-          value: '[email] (PII redacted)'
     - name: attachment links
       implemented: false
       priority: medium
@@ -814,12 +813,18 @@
         value: event_data
       - name: event_data
         value:
+        - name: event_name
+          value: select_content
         - name: action
           value: opened/closed
-        - name: event_name
         - name: index
-        - name: index_total
+          value:
+          - name: index_section
+            value: The section that this step is in. The section in this case refers to the step number.
+          - name: index_section_count
+            value: The total amount of steps within this step by step component.
         - name: text
+          value: (the opened/closed step's title)
         - name: type
           value: "step by step"
     - name: Show/hide all steps
@@ -836,10 +841,13 @@
         - name: action
           value: opened/closed
         - name: event_name
+          value: select_content
         - name: index
-          value: 0
-        - name: index_total
+          value:
+          - name: index_section
+            value: '0'
         - name: text
+          value: Show all steps
         - name: type
           value: "step by step"
     - name: link clicks
@@ -862,9 +870,8 @@
             value: The section that this link is in. The section in this case refers to the step number.
           - name: index_link
             value: The position of the link within this section.
-          - name: index_section_count
-            value: The total amount of links within this section.
         - name: index_total
+          value: The total amount of links within this section.
         - name: link_domain
         - name: link_path_parts
         - name: method


### PR DESCRIPTION
Fixes missing/incorrect data on the link and step by step documentation.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
