### PR TITLE
Add analytics to the analytics pages

### DIFF
--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -55,3 +55,5 @@ events:
 
     We use the following events:
 
+cookies:
+  name: Cookies on the implementation record

--- a/helpers/analytics_helpers.rb
+++ b/helpers/analytics_helpers.rb
@@ -50,4 +50,10 @@ module AnalyticsHelpers
     percentage = 0 if implemented.zero? || events.count.zero?
     "#{implemented} of #{events.count} (#{percentage}%)"
   end
+
+  def create_page_title(title)
+    header = ["GOV.UK GA4 Implementation record"]
+    header.prepend(title) if title
+    header.join(" | ")
+  end
 end

--- a/source/analytics/approach.html.md.erb
+++ b/source/analytics/approach.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.approach.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.approach.name %>
 </h1>

--- a/source/analytics/attributes.html.md.erb
+++ b/source/analytics/attributes.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.attributes.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.attributes.name %>
 </h1>

--- a/source/analytics/cookies.html.md.erb
+++ b/source/analytics/cookies.html.md.erb
@@ -1,0 +1,71 @@
+<% content_for :title, create_page_title(data.analytics.navigation.cookies.name) %>
+
+<div id="cookie-page-notice" class="cookie-page-notice">
+  <%= GovukPublishingComponents.render("govuk_publishing_components/components/success_alert", {
+    message: "Cookie preferences updated"
+  }) %>
+</div>
+
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.cookies.name %>
+</h1>
+
+<p class="govuk-body">Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
+<p class="govuk-body">We use cookies to collect and store information about how you use this site, such as the pages you visit.</p>
+<p class="govuk-body">This page has a brief explanation of each type of cookie we use.</p>
+
+<form data-module="cookie-settings">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      <h2 class="govuk-fieldset__heading">
+        Cookie settings
+      </h2>
+    </legend>
+    <p class="govuk-body">We use 2 types of cookie. You can choose which cookies you're happy for us to use.</p>
+
+    <% cookies_usage_hint = capture do %>
+      <p class="govuk-body govuk-hint">We use Google Analytics cookies to measure how you use this site.</p>
+      <p class="govuk-body govuk-hint">These cookies collect information about:</p>
+      <ul class="govuk-list--bullet govuk-hint">
+        <li>how you got to these sites</li>
+        <li>the pages you visit and how long you spend on each page</li>
+        <li>what you click on while you're visiting these sites</li>
+      </ul>
+      <p class="govuk-body govuk-hint">We do not allow Google to use or share the data about how you use these sites.</p>
+    <% end %>
+
+    <%= GovukPublishingComponents.render("govuk_publishing_components/components/radio", {
+      heading: "Cookies that measure website use",
+      heading_size: "s",
+      hint: cookies_usage_hint.html_safe,
+      name: "cookie-consent",
+      id_prefix: "cookie-consent",
+      items: [
+        {
+          value: "true",
+          text: "Use cookies that measure my website use"
+        },
+        {
+          value: "false",
+          text: "Do not use cookies that measure my website use"
+        }
+      ]
+    }) %>
+  </fieldset>
+
+  <%= GovukPublishingComponents.render("govuk_publishing_components/components/heading", {
+    text: "Strictly necessary cookies",
+    heading_level: 2,
+    font_size: "s",
+    margin_bottom: 2
+  }) %>
+
+  <p class="govuk-body">These essential cookies do things like remember your progress through a form (for example a licence application)</p>
+  <p class="govuk-body">They always need to be on.</p>
+
+  <%= GovukPublishingComponents.render("govuk_publishing_components/components/button", {
+    text: "Save changes",
+    type: "submit",
+    classes: "js-set-cookie-consent"
+  }) %>  
+</form>

--- a/source/analytics/data.html.md.erb
+++ b/source/analytics/data.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.data.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.data.name %>
 </h1>

--- a/source/analytics/docs.html.md.erb
+++ b/source/analytics/docs.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.docs.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.docs.name %>
 </h1>

--- a/source/analytics/events.html.md.erb
+++ b/source/analytics/events.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.events.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.events.name %>
 </h1>

--- a/source/analytics/pii.html.md.erb
+++ b/source/analytics/pii.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.pii.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.pii.name %>
 </h1>

--- a/source/analytics/progress.html.md.erb
+++ b/source/analytics/progress.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.progress.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.progress.name %>
 </h1>

--- a/source/analytics/templates/attribute.html.erb
+++ b/source/analytics/templates/attribute.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title("#{attribute.name.capitalize} attribute data") %>
+
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l">Attribute</span>
   <%= attribute.name %>

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title("#{event.name.capitalize} event data") %>
+
 <h1 class="govuk-heading-l analytics-heading">
   <span class="govuk-caption-l">Event</span>
   <%= event.name %>

--- a/source/analytics/templates/tracker.html.erb
+++ b/source/analytics/templates/tracker.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(tracker.name.capitalize) %>
+
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l">Tracker</span>
   <%= tracker.name %>

--- a/source/analytics/trackers.html.md.erb
+++ b/source/analytics/trackers.html.md.erb
@@ -1,3 +1,5 @@
+<% content_for :title, create_page_title(data.analytics.navigation.trackers.name) %>
+
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.trackers.name %>
 </h1>

--- a/source/javascripts/cookie-consent.js
+++ b/source/javascripts/cookie-consent.js
@@ -1,0 +1,78 @@
+window.GOVUK = window.GOVUK || {}
+
+window.GOVUK.gtm = {
+  init: function () {
+    window.dataLayer = window.dataLayer || [];
+    this.gtag();
+    this.checkConsent();
+  },
+
+  gtag: function () {
+    dataLayer.push(arguments);
+  },
+
+  setupGtm: function () {
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TNKCK97');      
+  },
+
+  checkConsent: function () {
+    var cookies = this.readCookies();
+    cookies = cookies.split(';');
+
+    for (var i = 0; i < cookies.length; i++) {
+      var thisCookie = cookies[i].split('=');
+      if (thisCookie[0] == 'analytics_consent') {
+        // consent cookie exists and is yes, init gtm
+        // if it exists and is no, we just hide the banner
+        if (thisCookie[1] == 'true') {
+          this.setupGtm();
+        }
+        this.hideCookieBanner();
+        break;
+      }
+    }
+  },
+
+  denyCookies: function () {
+    this.gtag('consent', 'default', {
+      'ad_storage': 'denied'
+    });
+    this.cookieConsent("false");
+    this.hideCookieBanner();
+  },
+
+  acceptCookies: function () {
+    this.gtag('consent', 'update', {
+      'ad_storage': 'granted'
+    });
+    this.setupGtm();
+    this.cookieConsent("true");
+    this.hideCookieBanner();
+  },
+
+  cookieConsent: function (trueOrFalse) {
+    var consentCookie = "analytics_consent=" + trueOrFalse + "; Secure" + this.readCookies();
+    this.writeCookies(consentCookie);
+  },
+
+  hideCookieBanner: function () {
+    var banner = document.getElementById('cookiebanner');
+    banner.style.display = 'none';
+  },
+
+  readCookies: function () {
+    return document.cookie;
+  },
+
+  writeCookies: function (cookies) {
+    document.cookie = cookies;
+  }
+}
+
+window.addEventListener("DOMContentLoaded", function(event) {
+  window.GOVUK.gtm.init();
+});

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>GOV.UK Analytics</title>
+  <title>GOV.UK GA4 Implementation record</title>
   <link rel="stylesheet" type="text/css" href="/stylesheets/screen.css"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
@@ -17,12 +17,39 @@
   <% meta_tags.opengraph_tags.each do |property, content| %>
     <%= tag :meta, property: property, content: content %>
   <% end %>
+  <script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+  <script src="/javascripts/cookie-consent.js"></script>
 </head>
 
 <body class="govuk-template__body ">
   <script>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   </script>
+
+  <div id="cookiebanner" class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on GOV.UK GA4 Implementation record">
+    <div class="govuk-cookie-banner__message govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK GA4 Implementation record</h2>
+          <div class="govuk-cookie-banner__content">
+            <p class="govuk-body">We use some essential cookies to make this service work.</p>
+            <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button" onclick="window.GOVUK.gtm.acceptCookies()">
+          Accept analytics cookies
+        </button>
+        <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button" onClick="window.GOVUK.gtm.denyCookies()">
+          Reject analytics cookies
+        </button>
+        <!-- <a class="govuk-link" href="#">View cookies</a> -->
+      </div>
+    </div>
+  </div>
 
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -17,9 +17,6 @@
   <% meta_tags.opengraph_tags.each do |property, content| %>
     <%= tag :meta, property: property, content: content %>
   <% end %>
-  <script>
-    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-  </script>
   <script src="/javascripts/cookie-consent.js"></script>
 </head>
 
@@ -46,7 +43,7 @@
         <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button" onClick="window.GOVUK.gtm.denyCookies()">
           Reject analytics cookies
         </button>
-        <!-- <a class="govuk-link" href="#">View cookies</a> -->
+        <a class="govuk-link" href="/analytics/cookies.html">View cookies</a>
       </div>
     </div>
   </div>
@@ -136,7 +133,14 @@
     <div class="govuk-width-container ">
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          <ul class="govuk-footer__inline-list">
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/analytics/cookies.html">
+                Cookies
+              </a>
+            </li>
+          </ul>
           <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
             <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
           </svg>

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>GOV.UK GA4 Implementation record</title>
+  <title><%= yield_content(:title) || create_page_title(false) %></title>
   <link rel="stylesheet" type="text/css" href="/stylesheets/screen.css"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -3,6 +3,10 @@
 @import "govuk_publishing_components/components/_breadcrumbs";
 @import "govuk_publishing_components/components/_cookie-banner";
 @import "govuk_publishing_components/components/_button";
+@import "govuk_publishing_components/components/_fieldset";
+@import "govuk_publishing_components/components/_heading";
+@import "govuk_publishing_components/components/_radio";
+@import "govuk_publishing_components/components/_success-alert";
 
 .gem-c-summary-list {
   border-bottom: 0; /* We have an extra border-bottom for some reason */
@@ -104,6 +108,10 @@ ul.subdir__menu {
 
 .js-enabled .govuk-cookie-banner {
   display: block;
+}
+
+.cookie-page-notice {
+  display: none;
 }
 
 .architecture-diagram {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,6 +1,8 @@
 @import "govuk_tech_docs";
 @import "govuk_publishing_components/components/_summary-list";
 @import "govuk_publishing_components/components/_breadcrumbs";
+@import "govuk_publishing_components/components/_cookie-banner";
+@import "govuk_publishing_components/components/_button";
 
 .gem-c-summary-list {
   border-bottom: 0; /* We have an extra border-bottom for some reason */
@@ -94,6 +96,14 @@ ul.subdir__menu {
 
 .analytics-heading {
   text-transform: capitalize;
+}
+
+.govuk-cookie-banner {
+  display: none;
+}
+
+.js-enabled .govuk-cookie-banner {
+  display: block;
 }
 
 .architecture-diagram {


### PR DESCRIPTION
## What
Adds GA4 analytics tracking to the implementation record pages, using Google Tag Manager. This includes:

- cookie banner
- default opt out
- Javascript to handle cookie consent/deny
- a cookies page where users can change their preferences and learn about cookies

Note that this only adds GA4 to the implementation record part of the site, not to any of the rest of the dev docs (the JS to do this is only included in the implementation record page layout).

Also updates all of the pages of the implementation record to have page titles, so that they can be more easily distinguished in GA4.

### Things still to do
This PR is a slightly rush job so here's a quick list of things to fix soon:

- the JS needs refactoring and improving, ideally as a proper GOV.UK module (if possible)
- cookie handling in particular in the JS is a bit rough around the edges, if you accept cookies and then go to the cookies page and unconsent, it doesn't actually delete the GTM cookies (even though consent is successfully denied)
- need some tests for the JS and the new title generator in the helper
- changing preferences on the cookies page isn't as clear as it could be, particularly if you try to do it twice

## Why
We're about to share the implementation record and it would be helpful to know what kind of traffic we get and how people use the site.

## Visual changes

![Screenshot 2023-05-16 at 11 49 50](https://github.com/alphagov/govuk-developer-docs/assets/861310/825019fb-8760-43f4-8c45-4443a26d934b)


Trello card: https://trello.com/c/JbLX3n2C/388-implementation-record-additions-and-improvements
