### PR TITLE
[BAU] Add helpful links to Docs Homepage.

### DIFF
--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -49,7 +49,7 @@
         - name: Developer Documentation
           url: /manual.html
           description: The contents page of GOV.UK's Developer Documentation
-        - name: Kubernetes Documentation
+        - name: GOV.UK Kubernetes documentation
           url: https://govuk-k8s-user-docs.publishing.service.gov.uk
           description: The documentation site for GOV.UK Kubernetes Development and Deployment
     - name: GOV.UK analytics

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -41,7 +41,7 @@
         - name: Repositories
           url: /repos.html
           description: All the applications and other repositories we use to build GOV.UK.
-    - name: GOV.UK documentation
+    - name: GOV.UK manuals
       sites:
         - name: 2nd-line Tech Support manuals
           url: /manual/2nd-line.html

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -46,12 +46,12 @@
         - name: 2nd-line Tech Support manuals
           url: /manual/2nd-line.html
           description: The documentation for GOV.UK's Second-line Technical Support team.
-        - name: Developer Documentation
+        - name: Developer manuals
           url: /manual.html
-          description: The contents page of GOV.UK's developer documentation.
-        - name: GOV.UK Kubernetes documentation
+          description: The contents page of GOV.UK's developer manuals.
+        - name: GOV.UK Kubernetes manuals
           url: https://govuk-k8s-user-docs.publishing.service.gov.uk
-          description: The developer documentation for GOV.UK's Kubernetes clusters.
+          description: The developer manuals for GOV.UK's Kubernetes clusters.
     - name: GOV.UK analytics
       sites:
         - name: Analytics

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -43,15 +43,15 @@
           description: All the applications and other repositories we use to build GOV.UK.
     - name: GOV.UK documentation
       sites:
-        - name: 2nd-line Support Manuals
+        - name: 2nd-line Tech Support manuals
           url: /manual/2nd-line.html
-          description: The documentation for GOV.UK's "Second-line Support"
+          description: The documentation for GOV.UK's Second-line Technical Support team.
         - name: Developer Documentation
           url: /manual.html
-          description: The contents page of GOV.UK's Developer Documentation
+          description: The contents page of GOV.UK's developer documentation.
         - name: GOV.UK Kubernetes documentation
           url: https://govuk-k8s-user-docs.publishing.service.gov.uk
-          description: The documentation site for GOV.UK Kubernetes Development and Deployment
+          description: The developer documentation for GOV.UK's Kubernetes clusters.
     - name: GOV.UK analytics
       sites:
         - name: Analytics

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -41,6 +41,17 @@
         - name: Repositories
           url: /repos.html
           description: All the applications and other repositories we use to build GOV.UK.
+    - name: GOV.UK documentation
+      sites:
+        - name: 2nd-line Support Manuals
+          url: /manual/2nd-line.html
+          description: The documentation for GOV.UK's "Second-line Support"
+        - name: Developer Documentation
+          url: /manual.html
+          description: The contents page of GOV.UK's Developer Documentation
+        - name: Kubernetes Documentation
+          url: https://govuk-k8s-user-docs.publishing.service.gov.uk
+          description: The documentation site for GOV.UK Kubernetes Development and Deployment
     - name: GOV.UK analytics
       sites:
         - name: Analytics


### PR DESCRIPTION
## What?
So, even though the bulk of the Documentation can be found via search or via "Manual" in the site header, it isn't very intuitive for a user landing at the Dev Docs Dashboard/Home page.

This is just a small change that adds the following links to the landing page, as they are likely the most common destinations for someone arriving at the Developer Docs:

* 2nd-line Support Manuals
* Developer Documentation
* Kubernetes Documentation (hosted separately)

Here's what it looks like:
<img width="778" alt="Screenshot 2023-05-16 at 16 14 28" src="https://github.com/alphagov/govuk-developer-docs/assets/68009085/1fa87fc0-e7dd-4ad6-8049-23a8237b6b4f">
