### PR TITLE
Add WorldwideOffice to the list of republishable models

### DIFF
--- a/source/manual/republishing-content.html.md.erb
+++ b/source/manual/republishing-content.html.md.erb
@@ -59,6 +59,7 @@ To republish all instances of the following document types, run the following ra
 - TopicalEventAboutPage
 - WorldLocation
 - WorldLocationNews
+- WorldwideOffice
 - WorldwideOrganisation
 
 <%= RunRakeTask.links("whitehall", "publishing_api:bulk_republish:document_type[DocumentClass]") %>


### PR DESCRIPTION
### Add WorldwideOffice to the list of republishable models
The WorldwideOffice model in Whitehall is now publishable with an associated
presenter and content item.

---
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
