### PR TITLE
Add clarification about MFA device name

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -312,7 +312,7 @@ Use the following instructions to set up your MFA device.
 1. Select the link for your email address.
 1. Select the __Security credentials__ tab.
 1. Select __Manage__, which is next to __Assigned MFA device__.
-1. Specify your email address as the MFA device name
+1. Specify your email address as the entire MFA device name. Do __not__ add anything else to the name, or will receive a permissions error.
 1. Follow the instructions to set up your MFA device.
 
 #### If you have a Yubikey


### PR DESCRIPTION
Two new team members have separately made the same assumption, and came up against the same error, when naming our MFA devices in AWS.

The assumption was that "must be prefixed" meant the name could, and maybe even should, also have a suffix.

However, we couldn't authenticate in the AWS console on the command line with the codes generated by devices with suffixed names. The only way to successfully authenticate was to add an MFA device and name it with the exact string of the email address.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
