### PR TITLE
Replace unicorn docs with puma

### DIFF
--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -151,22 +151,16 @@ You should:
 
 1. Configure linting for your Rails app to make sure the app's code is consistent with other GOV.UK apps. Find out more information about [configuring linting][linting].
 
-### Set up a Unicorn web server
+### Setting up a Puma web server
 
-1. If your Rails app's `Gemfile` includes `gem "puma"`, open `Gemfile` and delete `gem "puma"`.
+Puma is already included in the [govuk_app_config](https://github.com/alphagov/govuk_app_config) gem.
 
-1. Create a `Procfile` in your app's root directory that contains the following:
+Create a `config/puma.rb` file that contains the following code:
 
-    ```
-    web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}
-    ```
-
-1. Create a `config/unicorn.rb` file that contains the following code:
-
-    ```
-    require "govuk_app_config/govuk_unicorn"
-    GovukUnicorn.configure(self)
-    ```
+  ```rb
+  require "govuk_app_config/govuk_puma"
+  GovukPuma.configure_rails(self)
+  ```
 
 ### Add your Rails app to GOV.UK Docker
 


### PR DESCRIPTION
Update the docs for setting up a new application to reflect that Puma has replaced Unicorn as the web server [1].

[1]: https://github.com/alphagov/govuk_app_config/pull/286/commits/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
