### PR TITLE
Move Signon to Access and Permissions team

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1162,7 +1162,7 @@
 
 - repo_name: signon
   type: Supporting apps
-  team: "#govuk-publishing-platform"
+  team: "#govuk-publishing-access-and-permissions-team"
   production_hosted_on: eks
 
 - repo_name: slimmer


### PR DESCRIPTION
The Access and Permissions team are now responsible for Signon.

I believe this change is enough to update the docs, dependapanda and seal.
