### PR TITLE
Document the workaround for deploying Puppet.

### DIFF
--- a/source/manual/deploy-puppet.html.md
+++ b/source/manual/deploy-puppet.html.md
@@ -6,6 +6,14 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
+## Building a release
+
+> Jenkins should normally build govuk-puppet automatically on push to any branch, but unfortunately this is currently broken (May 2023).
+>
+> To work around this, go to [govuk-puppet in CI Jenkins](https://ci.integration.publishing.service.gov.uk/job/govuk-puppet/) and choose `Scan Repository Now` from the left-hand column.
+>
+> You will usually need to do this twice: once to make the pre-merge checks run against your branch and again to build the release after you have merged your PR.
+
 ## Deploying a branch
 
 Before merging your PR, it's recommended that you deploy the change to


### PR DESCRIPTION
Jenkins repo scanning has been broken for a while and nobody's figured it out yet (including me). Reluctantly documenting the workaround for now, since that's at least a slight improvement on the current situation.

We don't expect Jenkins/Puppet to live more than another 4-12 weeks, give or take.

<details>
<summary>
Preview (raster image, sorry)
</summary>

![Screenshot 2023-05-24 at 15 08 39-nq8](https://github.com/alphagov/govuk-developer-docs/assets/1170635/3720f45b-76dc-4e48-ac13-bfa3e3f91c69)
</details>