### PR TITLE
Access and Permissions team own gds-sso

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -296,7 +296,7 @@
   dashboard_url: false
 
 - repo_name: gds-sso
-  team: "#govuk-publishing-platform"
+  team: "#govuk-publishing-access-and-permissions-team"
   type: Gems
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
   sentry_url: false
@@ -1273,7 +1273,7 @@
 - repo_name: whitehall-prototype-2023
   type: Publishing apps
   team: "#govuk-publishing-experience-tech"
-  
+
 - repo_name: widdershins
   type: Gems
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
We recently formed a new team in GOV.UK, Access and Permissions, they have taken ownership of the GDS SSO gem as part of owning signon.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
