### PR TITLE
Move gds-sso to Access and Permissions team

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -296,7 +296,7 @@
   dashboard_url: false
 
 - repo_name: gds-sso
-  team: "#govuk-publishing-platform"
+  team: "#govuk-publishing-access-and-permissions-team"
   type: Gems
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
   sentry_url: false


### PR DESCRIPTION
The GOV.UK Publishing Access and Permissions team are now responsible for the gds-sso gem.