### PR TITLE
Update get started: distinct user reviewer step and new supporting services step

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -428,6 +428,15 @@ Signon](https://signon.publishing.service.gov.uk/users/invitation/new), at 'Norm
 the 'Release' app only. No permissions should be given for other applications, until [production access](/manual/rules-for-getting-production-access.html)
 is granted.
 
+## 15. Talk to your tech lead about supporting services you should have access to
+
+Depending on the team you've joined, you will likely need access to other supporting services to fulfil your role. Talk to your tech lead about which ones you need as part of onboarding and they can arrange access (or escalate to their allocated Lead Developer) to provide access. Services you may need access to are:
+
+- [Sentry](/manual/sentry.html) - the error monitoring software we use
+- [Logit](/manual/logit.html#accessing-logit) - the software we use for access application logs, where new starters are given access to the integration environment
+- [Google Analytics](/manual/analytics.html) - the software we use to track user behaviour, typically only needed if you work on a team working frequently with analytics
+- [Zendesk](/manual/zendesk.html) - the software we use for tracking support tickets, typically access isn't needed until working as part of the [2nd line](/manual/2nd-line.html) support team
+
 ## Supporting information
 
 Now you have completed the get started process, you should look at the following supporting information:

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -84,7 +84,6 @@ If you have a YubiKey, you will use `gpg-agent` in place of `ssh-agent`, which r
 1. Set up a [GitHub] account (or use your existing personal account).
 1. [Associate your GitHub account with your GDS email address][associate-email-github], which can be in addition to your personal email address.
 1. [Get added to the alphagov org and the "GOV.UK" team](https://docs.publishing.service.gov.uk/manual/github-access.html).
-   Your `ssh_username` should be added to the user reviewer as part of this step (see [7. Get SSH access to integration](#7-get-ssh-access-to-integration))
 1. [Add the SSH key to your GitHub account][add-ssh-key].
 1. Test that the SSH key works by running `ssh -T git@github.com`.
 1. Add your name and email to your git commits. For example:
@@ -146,7 +145,15 @@ Follow the [VPN guide for Bring Your Own Devices (BYOD)](https://docs.google.com
 [gds-it-helpdesk]: https://gdshelpdesk.digital.cabinet-office.gov.uk/helpdesk/WebObjects/Helpdesk.woa
 [gds-vpn-wiki]: https://docs.google.com/document/d/1O1LmLByDLlKU4F1-3chwS8qddd2WjYQgMaaEgTfK5To/edit
 
-## 6. Set up GOV.UK Docker
+## 6. Get added to the GOV.UK user monitor system
+
+We store who has access to GOV.UK tooling in a git repo, [GOV.UK User Reviewer](https://github.com/alphagov/govuk-user-reviewer) and use automation to alert when people should not have access. It's a private repo so you won't be able to access it until step 3 is completed.
+
+Either yourself (access dependent) or your tech lead should create a pull request to add you to the [tech users](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml). The repo readme specifies the [format new starters should have, with integration admin access](https://github.com/alphagov/govuk-user-reviewer/tree/main#properties-in-the-config-file). The `ssh_username` is in the format of `firstnamelastname` and is utilised in [8. Get SSH access to integration](#7-get-ssh-access-to-integration)).
+
+If you are working with us as a contractor from a supplier, please include the supplier's name in the `why_do_they_need_access` field.
+
+## 7. Set up GOV.UK Docker
 
 We use a `govuk-docker` Docker environment for local development.
 
@@ -156,15 +163,9 @@ You can also try developing outside of Docker, using tools like [rbenv](https://
 
 [govuk-docker]: https://github.com/alphagov/govuk-docker/blob/master/README.md
 
-## 7. Get SSH access to integration
+## 8. Get SSH access to integration
 
 If you are a frontend developer you do not need to complete this step as part of your initial setup.
-
-### Get access
-
-Ask a developer with production access on your team (e.g. your tech lead) to add your SSH username (`firstnamelastname`) to the [list of GOV.UK tech users](https://github.com/alphagov/govuk-user-reviewer/blob/master/config/govuk_tech.yml) in the [user monitoring system][user-reviewer].
-
-[user-reviewer]: https://github.com/alphagov/govuk-user-reviewer
 
 ### Create a user to SSH into integration
 
@@ -268,7 +269,7 @@ As a shortcut, to remove the need to look up the machine class for an applicatio
 gds govuk connect --environment integration app-console publisher
 ```
 
-## 8. Get AWS access
+## 9. Get AWS access
 
 If you are a frontend developer you do not need to complete this step as part of your initial setup.
 
@@ -368,7 +369,7 @@ to find out how to deploy infrastructure changes. The stackname is `govuk` and t
 
 See the [AWS IAM users documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html) for more information.
 
-## 9. Access AWS for the first time
+## 10. Access AWS for the first time
 
 If you are a frontend developer you do not need to complete this step as part of your initial setup.
 
@@ -405,11 +406,11 @@ If you forget your `aws-vault` password, you must reset that password.
 1. Delete the `aws-vault` keychain by running `rm ~/Library/Keychains/aws-vault.keychain-db` in the command line.
 1. Re-initialise the `gds-cli` by opening `~/.gds/config.yml` and changing `initialised: true` to `initialised: false`.
 
-## 10. Set up tools to use the GOV.UK Kubernetes platform
+## 11. Set up tools to use the GOV.UK Kubernetes platform
 
 Follow [the instructions for setting up tools to use the GOV.UK Kubernetes platform](https://govuk-k8s-user-docs.publishing.service.gov.uk/get-started/set-up-tools/).
 
-## 11. Get a Signon account for integration
+## 12. Get a Signon account for integration
 
 [Signon](https://docs.publishing.service.gov.uk/repos/signon.html) is the application used to control access to the
 GOV.UK Publishing applications.
@@ -417,7 +418,7 @@ GOV.UK Publishing applications.
 Ask another developer to [create an account for the integration Signon](https://signon.integration.publishing.service.gov.uk/users/invitation/new),
 at 'Superadmin' level with permission to access the applications that your team are likely to work on.
 
-## 12. Get access to the Release app
+## 13. Get access to the Release app
 
 [Release](https://docs.publishing.service.gov.uk/repos/release.html) is the application we use to track deployments,
 work out which branch/tag is deployed to each environment and link to Jenkins to deploy code.

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: Get started on GOV.UK
+title: Get started developing on GOV.UK
 description: Guide for new developers on GOV.UK
 layout: manual_layout
 section: Learning GOV.UK


### PR DESCRIPTION
Following feedback from recent GOV.UK starters I've updated the "Get started developing on GOV.UK" with a distinct step on GOV.UK User Reviewer, for more clarity of role and purpose, and a section on supporting services that a dev may need to access.

More info in the commits.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
