### PR TITLE
Stop scraping docs from retired repos.

### DIFF
--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -9,7 +9,7 @@ class ProxyPages
   end
 
   def self.repo_docs
-    docs = Repos.public.map do |repo|
+    docs = Repos.active_public.map do |repo|
       docs_for_repo = GitHubRepoFetcher.instance.docs(repo.repo_name) || []
       docs_for_repo.map do |page|
         {

--- a/app/repos.rb
+++ b/app/repos.rb
@@ -16,6 +16,10 @@ class Repos
     Repos.all.reject(&:retired?)
   end
 
+  def self.active_public
+    Repos.active.reject(&:private_repo?)
+  end
+
   def self.active_apps
     Repos.active.select(&:is_app?)
   end

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ProxyPages do
   before do
     allow(Repos).to receive(:all)
-      .and_return([double("Repo", repo_name: "", page_title: "", description: "", private_repo?: false)])
+      .and_return([double("Repo", repo_name: "", page_title: "", description: "", private_repo?: false, retired?: false)])
     allow(DocumentTypes).to receive(:pages)
       .and_return([double("Page", name: "")])
     allow(Supertypes).to receive(:all)

--- a/spec/app/repos_spec.rb
+++ b/spec/app/repos_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe Repos do
     end
   end
 
+  describe "active_public" do
+    let(:repos) do
+      [
+        { repo_name: "secret-squirrel", private_repo: true },
+        { repo_name: "olde-time-public-repo", retired: true },
+        { repo_name: "active-public-repo", retired: false },
+        { repo_name: "retired-secret-squirrel", private_repo: true, retired: true },
+      ]
+    end
+
+    it "should return only repos that are both public and not retired" do
+      expect(Repos.active_public.map(&:repo_name)).to eq(%w[active-public-repo])
+    end
+  end
+
   describe "active_apps" do
     let(:repos) do
       [


### PR DESCRIPTION
Scraping docs from retired repos is more harmful than beneficial to user experience, because it causes unmaintained and often irrelevant pages to appear in search results. It also makes local development of devdocs painful because so many additional requests are made on startup.

Excluding these legacy pages will improve relevance of search results and make it easier for developers to find relevant, up-to-date information.

We already exclude retired repos from the lists of repos by category on `/repos`.

This doesn't stop us from scraping the repo metadata for retired repos/apps. Retired repos will still appear in search results when searching for all or part of their name, and we'll still generate pages for them under `/repos/${repo-name}.html`.