### PR TITLE
Move authenticating-proxy to Access and Permissions team

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -28,7 +28,7 @@
 
 - repo_name: authenticating-proxy
   type: Supporting apps
-  team: "#govuk-navigation-tech"
+  team: "#govuk-publishing-access-and-permissions-team"
   production_hosted_on: eks
   production_url: false
 


### PR DESCRIPTION
The GOV.UK Publishing Access and Permissions team are now responsible for the authenticating-proxy app.