### PR TITLE
Update the playbook for deploying Static.

### DIFF
--- a/source/manual/deploy-static.html.md
+++ b/source/manual/deploy-static.html.md
@@ -6,10 +6,35 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-[Static](https://github.com/alphagov/static) requires extra care when deploying.
-You must wait for at least 30 minutes between environment deploys. This is
-because Static is consumed directly by GOV.UK applications at runtime - not a
-gem version like a normal dependency - and responses from Static are cached for
-half an hour, so problems may not be visible until after this period.
+Before rolling out a release of Static to production, you must:
 
-There are instructions in the release app UI to remind you.
+1. Deploy the Static release to staging.
+1. Check that the deployment succeeded, for example by checking the last synced
+   time in [Argo
+   CD](https://argo.eks.staging.govuk.digital/applications/static)).
+1. Wait 10 minutes.
+1. Check that the next Smokey run passes in staging. Ignore any Smokey run that
+   started less than 5 minutes after the Static rollout, because it may have
+   received responses cached before the rollout.
+1. Double-check that the homepage looks OK and click around a couple of pages
+   on the site.
+
+## Why?
+
+[Static](https://github.com/alphagov/static) requires extra care when
+deploying, because serves partial pages (for example the header and footer)
+that are cached and reused by many of the frontend rendering apps via the
+[Slimmer](https://github.com/alphagov/slimmer/) library.
+
+Releases of Static are not automatically promoted to the staging and production
+environments. This is because:
+
+- the smoke tests do not currently take into
+  account the caching of Static's responses by the frontend apps
+- Static does not yet have sufficient test coverage
+
+Why 10 minutes? Slimmer caches Static's responses for up to 1 minute by default.
+Argo CD polls GitHub for changes every 3 minutes. The rollout itself (within
+Kubernetes) typically takes another minute. The HTTP `cache-control: max-age`
+for most pages is 5 minutes. The smoke tests defeat the edge cache where
+appropriate, so the last 5 minutes really only matters for manual testing.


### PR DESCRIPTION
The aim here isn't so much to change the procedure, rather to document what's (more or less) already happening. The existing doc was clearly out of date and out of sync with the note in the Release app.

- Extract the playbook steps and the background info into separate sections.
- Update the playbook steps to reflect the current state of GOV.UK.
- Clarify why the clunky manual process is the way it is for now, so that it's easier to figure out when it's ok to change or eliminate it in future.

Please review for accuracy in particular :) It's entirely possible that I've made mistakes based on misinterpreting what I've read in the code or other docs while putting this together.

I'd also be open to deleting this entirely, if people feel it's not useful/discoverable enough to be worth keeping.