### PR TITLE
Add link to SageMaker endpoint

### DIFF
--- a/source/manual/alerts/search-reranker-healthcheck-not-ok.html.md
+++ b/source/manual/alerts/search-reranker-healthcheck-not-ok.html.md
@@ -23,6 +23,7 @@ Find out why the Search API can't connect to SageMaker.
 
 - Look at the error message in the healthcheck response
 - Look at the Search API logs
-- Check the status of the SageMaker endpoint in the AWS console
+- Check the status of the [SageMaker endpoint in the AWS console][sagemaker-endpoint]
 
 [aws-sagemaker]: https://aws.amazon.com/sagemaker/
+[sagemaker-endpoint]: https://eu-west-1.console.aws.amazon.com/sagemaker/home?region=eu-west-1#/endpoints/govuk-production-search-ltr-endpoint


### PR DESCRIPTION
The logs are difficult to find from the AWS SageMaker landing page

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
