### PR TITLE
GA4 implementation record updates

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -37,6 +37,12 @@
   type: string
   redact: false
 
+- name: ecommerce
+  description: A Google Analytics ecommerce object, containing an array named 'items' that contains details of the results/links on the page.
+  required: no
+  type: object
+  redact: false
+
 - name: event
   description: Needed by Google to contain a specific thing to cause a trigger to happen.
   example: page_view, event_data
@@ -106,6 +112,12 @@
   type: string (number)
   redact: false
 
+- name: items
+  description: Occurs within the ecommerce attribute and contains details of all of the results/links on the page. Each element of the array contains an index (starting from 1), an item_id (link path e.g. '/pension-credit'), and an item_list_name (the title of the page).
+  required: yes
+  type: array
+  redact: false
+
 - name: language
   description: the language the page is rendered in
   value: lang attribute of the '#content' element
@@ -167,6 +179,12 @@
   description: application that renders the page
   value: content attribute of meta tag govuk:rendering-app
   example: government-frontend
+  required: no
+  type: string
+  redact: false
+
+- name: results
+  description: Used by ecommerce to give a total number of the results/links on the page.
   required: no
   type: string
   redact: false
@@ -241,6 +259,13 @@
 - name: text
   description: The text of the thing being tracked, for example the text of a link, button or tab. This can either be read directly from the element, passed from a data attribute, or generated automatically for elements where the text changes, for example the 'Show all sections' link in an accordion, which can also read 'Hide all sections'.
   value: text of the element
+  required: no
+  type: string
+  redact: false
+
+- name: tool_name
+  description: Refers to the tool being tracked, for example the name of a smart answer or 'Find your local council'.
+  value:
   required: no
   type: string
   redact: false

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -779,54 +779,207 @@
 
 - name: smart answers
   events:
-    - name: completed
+    - name: smart answer start
       implemented: true
       priority: high
+      examples:
+        - text: Towing rules
+          link: https://www.gov.uk/towing-rules
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
-    - name: results link click
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_start
+        - name: type
+          value: smart answer
+        - name: url
+        - name: text
+          value: Start now
+        - name: section
+          value: start page
+        - name: action
+          value: start
+        - name: external
+          value: false
+        - name: link_domain
+        - name: link_path_parts
+        - name: tool_name
+    - name: submit question
       implemented: true
       priority: high
+      examples:
+        - text: Smart answer question
+          link: https://www.gov.uk/towing-rules/y
+      tracker: form_tracker
       data:
       - name: event
         value: event_data
-    - name: start again link click
-      implemented: true
-      priority: high
-      data:
-      - name: event
-        value: event_data
-    - name: question
-      implemented: true
-      priority: high
-      data:
-      - name: event
-        value: event_data
-    - name: change answer
-      implemented: true
-      priority: high
-      data:
-      - name: event
-        value: event_data
-    - name: start again
-      implemented: true
-      priority: high
-      data:
-      - name: event
-        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_response
+        - name: type
+          value: smart answer
+        - name: text
+          value: text of the selected answer
+        - name: section
+          value: text of the current question
+        - name: action
+          value: continue
+        - name: tool_name
     - name: form error
       implemented: true
       priority: high
+      examples:
+        - text: Smart answer error page
+          link: https://www.gov.uk/towing-rules/y/medium-sized-vehicle?next=1
+      tracker: auto_tracker
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_error
+        - name: action
+          value: error
+        - name: section
+          value: text of the current question
+        - name: text
+          value: text of the error message
+        - name: tool_name
+        - name: type
+          value: smart answer
+    - name: change answer
+      implemented: true
+      priority: high
+      examples:
+        - text: Smart answer question
+          link: https://www.gov.uk/towing-rules/y/medium-sized-vehicle
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_change_response
+        - name: type
+          value: smart answer
+        - name: url
+        - name: text
+          value: (Change) text of the question to be changed
+        - name: section
+          value: text of the question to be changed
+        - name: action
+          value: change response
+        - name: external
+          value: false
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
+        - name: tool_name
+    - name: smart answer complete
+      implemented: true
+      priority: high
+      examples:
+        - text: Smart answer complete page
+          link: https://www.gov.uk/towing-rules/y/medium-sized-vehicle/yes/21-or-over
+      tracker: auto_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: complete
+        - name: event_name
+          value: form complete
+        - name: section
+          value: Information based on your answers
+        - name: tool_name
+        - name: type
+          value: smart answer
+    - name: results link click
+      implemented: true
+      priority: high
+      examples:
+        - text: Smart answer complete page
+          link: https://www.gov.uk/towing-rules/y/medium-sized-vehicle/yes/21-or-over
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: information_click
+        - name: type
+          value: smart answer
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: section
+          value: Information based on your answers
+        - name: action
+          value: information click
+        - name: external
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
+        - name: tool_name
     - name: results ecommerce list views and click
       implemented: true
       priority: medium
+      examples:
+        - text: Cost of living smart answer results page
+          link: https://www.gov.uk/check-benefits-financial-support/y/wales/yes/no_retired/no/no/no/dont_know/none_16000
+      tracker: ecommerce_tracker
+      data:
+      - name: event
+        value: search_results
+      - name: search_results
+        value:
+        - name: ecommerce
+          value:
+          - name: items
+        - name: event_name
+          value: view_item_list
+        - name: results
+    - name: start again link click
+      implemented: true
+      priority: high
+      examples:
+        - text: Smart answer complete page
+          link: https://www.gov.uk/towing-rules/y/medium-sized-vehicle/yes/21-or-over
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: form_start_again
+        - name: type
+          value: smart answer
+        - name: url
+        - name: text
+        - name: section
+          value: Information based on your answers
+        - name: action
+          value: start again
+        - name: external
+          value: false
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
+        - name: tool_name
 
 - name: step by step navigation
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -162,6 +162,92 @@
       - name: event
         value: event_data
 
+- name: email alerts and rss subscriptions
+  events:
+    - name: email alerts
+      implemented: true
+      priority: medium
+      examples:
+        - text: Search pages
+          link: https://www.gov.uk/search/all?keywords=minister&order=relevance
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: subscribe
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: section
+        - name: external
+          value: false
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+    - name: rss subscriptions
+      implemented: true
+      priority: medium
+      examples:
+        - text: Search pages
+          link: https://www.gov.uk/search/all?keywords=minister&order=relevance
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: subscribe
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: section
+        - name: external
+          value: false
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+
+- name: email subscriptions
+  events:
+    - name: get emails about this page link click
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: change how often you get emails
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: unsubscribe
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+    - name: unsubscribe from everything
+      implemented: false
+      priority: medium
+      data:
+      - name: event
+        value: event_data
+
 - name: feedback
   events:
     - name: Is this page useful? Yes
@@ -297,33 +383,6 @@
     - name: form success alert
       implemented: false
       priority: low
-      data:
-      - name: event
-        value: event_data
-
-- name: get emails
-  events:
-    - name: get emails about this page link click
-      implemented: false
-      priority: medium
-      data:
-      - name: event
-        value: event_data
-    - name: change how often you get emails
-      implemented: false
-      priority: medium
-      data:
-      - name: event
-        value: event_data
-    - name: unsubscribe
-      implemented: false
-      priority: medium
-      data:
-      - name: event
-        value: event_data
-    - name: unsubscribe from everything
-      implemented: false
-      priority: medium
       data:
       - name: event
         value: event_data

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -4,7 +4,11 @@
       implemented: true
       priority: high
       description: When a section of the accordion is opened or closed.
-      example_url: https://www.gov.uk/coronavirus
+      examples:
+        - text: Coronavirus page
+          link: https://www.gov.uk/coronavirus
+        - text: Manual page
+          link: https://www.gov.uk/guidance/immigration-rules/immigration-rules-part-11b
       tracker: event_tracker
       data:
       - name: event
@@ -67,7 +71,11 @@
       implemented: true
       priority: medium
       description: Triggered when a breadcrumb link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
-      example_url: https://www.gov.uk/learn-to-drive-a-car
+      examples:
+        - text: Generic page with a breadcrumb
+          link: https://www.gov.uk/vehicle-tax-refund
+        - text: Another generic page with a breadcrumb
+          link: https://www.gov.uk/check-coastal-erosion-management-in-your-area
       tracker: link_tracker
       data:
       - name: event
@@ -253,7 +261,9 @@
       implemented: true
       priority: medium
       description: Triggered when a footer link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
-      example_url: https://www.gov.uk/
+      examples:
+        - text: GOV.UK homepage
+          link: https://www.gov.uk/
       tracker: link_tracker
       data:
       - name: event
@@ -344,11 +354,13 @@
 
 - name: html attachments
   events:
-    - name: link clicks (not implemented yet)
+    - name: link clicks
       implemented: true
       priority: high
       description: Triggered when a HTML attachment link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
-      example_url: https://www.gov.uk/government/publications/equality-act-guidance
+      examples:
+        - text: Page with html attachments
+          link: https://www.gov.uk/government/publications/equality-act-guidance
       tracker: link_tracker
       data:
       - name: event
@@ -536,7 +548,9 @@
       implemented: true
       priority: low
       description: When a 'print this page' button is used
-      example_url: https://www.gov.uk/guidance/register-a-trust-as-a-trustee
+      examples:
+        - text: Page with print button
+          link: https://www.gov.uk/guidance/register-a-trust-as-a-trustee
       tracker: event_tracker
       data:
       - name: event
@@ -561,7 +575,9 @@
       implemented: true
       priority: high
       description: Clicks in the related navigation component
-      example_url: https://www.gov.uk/government/statistics/national-curriculum-assessments-key-stage-2-2016-provisional
+      examples:
+        - text: Page with related navigation
+          link: https://www.gov.uk/government/statistics/national-curriculum-assessments-key-stage-2-2016-provisional
       tracker: link_tracker
       data:
       - name: event
@@ -657,7 +673,9 @@
       implemented: true
       priority: low
       description: Triggered when a 'follow us' social media link is used.
-      example_url: https://www.gov.uk/government/organisations/department-for-culture-media-and-sport
+      examples:
+        - text: Organisation page
+          link: https://www.gov.uk/government/organisations/department-for-culture-media-and-sport
       tracker: link_tracker
       data:
       - name: event
@@ -683,7 +701,9 @@
       implemented: true
       priority: low
       description: Triggered when a 'share on' social media link is used.
-      example_url: https://www.gov.uk/government/news/new-protections-for-children-and-free-speech-added-to-internet-laws
+      examples:
+        - text: Press release
+          link: https://www.gov.uk/government/news/new-protections-for-children-and-free-speech-added-to-internet-laws
       tracker: link_tracker
       data:
       - name: event
@@ -814,7 +834,9 @@
       implemented: true
       priority: high
       description:
-      example_url: https://www.gov.uk/learn-to-drive-a-car
+      examples:
+        - text: Learn to drive a car step by step
+          link: https://www.gov.uk/learn-to-drive-a-car
       tracker: event_tracker
       data:
       - name: event
@@ -837,7 +859,9 @@
       implemented: true
       priority: high
       description:
-      example_url: https://www.gov.uk/learn-to-drive-a-car
+      examples:
+        - text: Learn to drive a car step by step
+          link: https://www.gov.uk/learn-to-drive-a-car
       tracker: event_tracker
       data:
       - name: event
@@ -860,7 +884,9 @@
       implemented: true
       priority: high
       description: Triggered when a link within a step by step is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
-      example_url: https://www.gov.uk/learn-to-drive-a-car
+      examples:
+        - text: Learn to drive a car step by step
+          link: https://www.gov.uk/learn-to-drive-a-car
       tracker: link_tracker
       data:
       - name: event
@@ -901,7 +927,9 @@
       implemented: true
       priority: high
       description: When the Menu or Search button is expanded or collapsed.
-      example_url: https://www.gov.uk/
+      examples:
+        - text: GOV.UK homepage
+          link: https://www.gov.uk
       tracker: event_tracker
       data:
       - name: event
@@ -926,7 +954,9 @@
       implemented: true
       priority: high
       description: Triggered when the GOVUK logo, a header "menu" section link, or a link under the search component is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
-      example_url: https://www.gov.uk/
+      examples:
+        - text: GOV.UK homepage
+          link: https://www.gov.uk
       tracker: link_tracker
       data:
       - name: event
@@ -962,7 +992,11 @@
       implemented: true
       priority: high
       description: When a tab is selected.
-      example_url: https://www.gov.uk/renew-driving-licence
+      examples:
+        - text: Tax your vehicle
+          link: https://www.gov.uk/vehicle-tax
+        - text: Bank holidays
+          link: https://www.gov.uk/bank-holidays
       tracker: event_tracker
       data:
       - name: event

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -25,6 +25,8 @@ docs:
       link: pii.html
     - name: Trackers
       link: trackers.html
+    - name: Further reading
+      link: further_docs.html
 
 progress:
   name: Implementation progress
@@ -41,6 +43,9 @@ trackers:
   name: Trackers
   desc: Trackers are distinct JavaScripts that collect GA4 data in specific ways. Each works differently but produces and sends data to GA4 in the same way.
 
+further_docs:
+  name: Further reading
+
 attributes:
   name: Attributes
   desc: |
@@ -51,7 +56,7 @@ attributes:
 events:
   name: Events
   desc: |
-    Events are collections of data that are sent to a GA4 property when users do certain things, like opening an accordion or clicking a link. 
+    Events are collections of data that are sent to a GA4 property when users do certain things, like opening an accordion or clicking a link.
 
     We use the following events:
 

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -21,3 +21,21 @@
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md
   description: This script automatically tracks clicks on links such as external links, download links, and mailto links.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
+
+- name: Form tracker
+  technical_name: form_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-form-tracker.md
+  description: This script captures redacted data from form submissions.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
+
+- name: Auto tracker
+  technical_name: auto_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-auto-tracker.md
+  description: Captures data on page load for significant pages, such as a user reaching the end of a journey e.g. smart answer complete.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
+
+- name: Ecommerce tracker
+  technical_name: ecommerce_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-ecommerce-tracker.md
+  description: Captures data for results page using a Google Analytics ecommerce object format.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js

--- a/source/analytics/further_docs.html.erb
+++ b/source/analytics/further_docs.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, create_page_title(data.analytics.navigation.further_docs.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.further_docs.name %>
+</h1>
+
+<p class="govuk-body">We've written some blog posts about our GA4 work.</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <a href="https://insidegovuk.blog.gov.uk/2022/08/24/how-were-preparing-for-the-migration-to-google-analytics-4/" class="govuk-link">How we’re preparing for the migration to Google Analytics 4</a>
+  </li>
+  <li>
+    <a href="https://insidegovuk.blog.gov.uk/2022/11/03/how-gov-uk-is-upgrading-to-google-analytics-4/" class="govuk-link">How GOV.UK is upgrading to Google Analytics 4</a>
+  </li>
+  <li>
+    <a href="https://gds.blog.gov.uk/2023/03/27/sharing-data-and-lessons-from-our-google-analytics-4-upgrade/" class="govuk-link">Sharing data and lessons from our Google Analytics 4 upgrade</a>
+  </li>
+</ul>

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -16,6 +16,7 @@
     </h2>
 
     <p class="govuk-body">
+      Priority
       <strong class="govuk-tag <%= tag_colours[page_event.priority] %>">
         <%= page_event.priority %>
       </strong>
@@ -30,24 +31,29 @@
         <%= page_event.description %>
       </p>
     <% end %>
-    <ul class="govuk-list govuk-list--bullet">
-      <% if page_event.example_url %>
-        <li>
-          Example of <%= link_to page_event.name, page_event.example_url, class: "govuk-link" %>
-        </li>
-      <% end %>
-      <% if page_event.tracker %>
-        <% data.analytics.trackers.each do |tracker| %>
-          <% if tracker.technical_name == page_event.tracker %>
-            <li>
-              Tracked by <%= link_to page_event.tracker, "tracker_#{page_event.tracker}.html", class: "govuk-link" %>
-            </li>
-          <% end %>
+
+    <% if page_event.tracker %>
+      <% data.analytics.trackers.each do |tracker| %>
+        <% if tracker.technical_name == page_event.tracker %>
+          <p class="govuk-body">
+            This event is tracked by the <%= link_to page_event.tracker, "tracker_#{page_event.tracker}.html", class: "govuk-link" %>.
+          </p>
         <% end %>
       <% end %>
-    </ul>
-    <h3 class="govuk-heading-s">Data sent to the dataLayer</h3>
+    <% end %>
 
+    <% if page_event.examples %>
+      <h3 class="govuk-heading-s">Examples</h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <% page_event.examples.each do |example| %>
+          <li>
+            <a href="<%= example.link %>" class="govuk-link"><%= example.text %></a>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <h3 class="govuk-heading-s">Data sent to the dataLayer</h3>
     <% event_hash = build_event(page_event.data, data.analytics.attributes) %>
     <div class="govuk-inset-text">
       <%= to_html(event_hash) %>


### PR DESCRIPTION
## What
Update some of the information in the GA4 implementation record section, specifically:

- smart answers
- get emails and RSS link clicks

Also adjust how examples are contained in data and displayed, and adds a 'further reading' page in the docs listing our blog posts to date.

## Why
Part of the work to document our GA4 approach.

Trello card: https://trello.com/c/JbLX3n2C/388-implementation-record-additions-and-improvements
