### PR TITLE
Add missing 'govuk-replatform-test-app' repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -612,6 +612,12 @@
   sentry_url: false
   dashboard_url: false
 
+- repo_name: govuk-replatform-test-app
+  type: Utilities
+  team: "#govuk-platform-engineering"
+  sentry_url: false
+  dashboard_url: false
+
 - repo_name: govuk-replatforming-discovery-2020
   retired: true
   private_repo: true


### PR DESCRIPTION
This is used by GOV.UK engineers for getting to grips with the new platform.

Trello: https://trello.com/c/tsBL9lPH/3161-work-through-list-of-missing-repos
