### PR TITLE
Add undocumented Data Products repos where GOV.UK needs visibility

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -543,6 +543,10 @@
   sentry_url: false
   dashboard_url: false
 
+- repo_name: govuk-knowledge-graph-search
+  team: "#data-products"
+  type: Data science
+
 - repo_name: govuk-kubernetes-cluster-user-docs
   type: Utilities
   team: "#govuk-platform-engineering"
@@ -642,6 +646,12 @@
   description: Base container images for GOV.UK Ruby apps
   team: "#govuk-platform-engineering"
   type: Utilities
+  sentry_url: false
+  dashboard_url: false
+
+- repo_name: govuk-s3-mirror
+  team: "#data-products"
+  type: Data science
   sentry_url: false
   dashboard_url: false
 


### PR DESCRIPTION
govuk-s3-mirror is "important for GOV.UK to know about": https://github.com/alphagov/govuk-developer-docs/pull/3913/files#r1132282271

govuk-knowledge-graph-search "should be [referenced in the Developer Docs]. Not only it's going to be on signon alongside the publishing apps, but the dependency with gov.uk content is very strong so it's important that it's mentioned somewhere here, if only to link to its own documentation on the data community docs."

See
https://github.com/alphagov/govuk-developer-docs/pull/3913/files#r1132281588

There's a wider conversation to be had about how Data Products (and indeed other directorates like Pay and Notify) fit into GOV.UK. But in the meantime, our rough litmus test for whether or not an external repo should have the `govuk` topic (anf therefore be included in the GOV.UK Developer Docs) is this:

> Some repos are owned by the Data team but GOV.UK (and
> particularly GOV.UK 2nd line) need to know about it.
> Repos that aren't particularly tied to something that is maintained
> in GOV.UK don't need to be tagged with the `govuk` topic.

See https://github.com/alphagov/govuk-developer-docs/pull/3913/files#r1149043894

Trello: https://trello.com/c/tsBL9lPH/3161-work-through-list-of-missing-repos
