### PR TITLE
Add link to on-call allowance rates

### DIFF
--- a/source/manual/on-call.html.md
+++ b/source/manual/on-call.html.md
@@ -150,6 +150,7 @@ support (assuming everything is working).
 - Logs are not as important as being available - if you need to lose some logs
   in order to bring the site back up, that's probably a good trade-off to make
 - Get paid. Make sure you submit your [payment claim form][] after your shift.
+  Payment rates can be found on the [GDS Wiki](https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-to-guides/out-of-hours-allowance).
 
 [So, you're having an incident]: /manual/incident-what-to-do.html
 [docs]: https://github.com/alphagov/govuk-developer-docs/


### PR DESCRIPTION
This links to a table that shows the breakdown of on-call rates (e.g. the higher rate for bank holidays).

Not including the rates here as I'm not sure whether they should be public and don't want to include yet another thing we'll need to keep up-to-date.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
