### PR TITLE
Remove untagged repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -400,11 +400,6 @@
   team: "#govuk-publishing-platform"
   type: Utilities
 
-- repo_name: govuk-content-metadata
-  private_repo: true
-  team: "#data-products"
-  type: Data science
-
 - repo_name: govuk-content-schemas
   team: "#govuk-publishing-platform"
   type: Utilities
@@ -423,10 +418,6 @@
   retired: true
 
 - repo_name: govuk-data-science-workshop
-  team: "#data-products"
-  type: Data science
-
-- repo_name: govuk-datalabs-streamlit-NER
   team: "#data-products"
   type: Data science
 
@@ -496,11 +487,6 @@
   team: "#data-products"
   type: Data science
 
-- repo_name: govuk-feedback-spam-classifier
-  private_repo: true
-  team: "#data-products"
-  type: Data science
-
 - repo_name: govuk-google-analytics
   team: "#user-experience-measurement-govuk-robot-invasion"
   type: Utilities
@@ -560,17 +546,8 @@
   sentry_url: false
   dashboard_url: false
 
-- repo_name: govuk-mongodb-content
-  team: "#data-products"
-  type: Data science
-
 - repo_name: govuk-network-data
   retired: true
-  team: "#data-products"
-  type: Data science
-
-- repo_name: govuk-networks
-  private_repo: true
   team: "#data-products"
   type: Data science
 
@@ -725,10 +702,6 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
-
-- repo_name: govuk-wuj-network-analysis
-  team: "#data-products"
-  type: Data science
 
 - repo_name: govuk_ab_analysis
   retired: true
@@ -899,11 +872,6 @@
   team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
 
-- repo_name: lstm_segmentation
-  private_repo: true
-  team: "#data-products"
-  type: Data science
-
 - repo_name: manuals-frontend
   retired: true
   type: Frontend apps
@@ -1072,11 +1040,6 @@
   type: Gems
   sentry_url: false
   dashboard_url: false
-
-- repo_name: related-links-data
-  private_repo: true
-  team: "#data-products"
-  type: Data science
 
 - repo_name: release
   type: Supporting apps


### PR DESCRIPTION
These were all added in #3547, but without much context. We don't want to import _all_ Data Products' repos into the GOV.UK Developer Docs, just the ones that are pertinent to us. See justification in #4051.

By omitting the `govuk` topic from these repos, the Data Products teams have implied that these repos are not pertinent to GOV.UK and should therefore be removed from our repos.json list.

Trello: https://trello.com/c/tsBL9lPH/3161-work-through-list-of-missing-repos
