### PR TITLE
Support multiple apps per repo in our data models

### DIFF
--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -59,13 +59,13 @@ class ProxyPages
   def self.repo_overviews
     Repos.all.map do |repo|
       {
-        path: "/repos/#{repo.repo_name}.html",
+        path: "/repos/#{repo.app_name}.html",
         template: "templates/repo_template.html",
         frontmatter: {
           title: repo.page_title,
           locals: {
             title: repo.page_title,
-            description: "Everything about #{repo.repo_name} (#{repo.description})",
+            description: "Everything about #{repo.app_name} (#{repo.description})",
             repo:,
           },
         },

--- a/app/repo.rb
+++ b/app/repo.rb
@@ -7,13 +7,13 @@ class Repo
 
   def api_payload
     {
-      app_name: repo_name, # beware renaming the key - it's used here: https://github.com/alphagov/govuk-dependencies/blob/b3a2a29eb80aefa08098a08633b4a08b05bcc527/lib/gateways/team.rb#L15
+      app_name:, # beware renaming the key - it's used here: https://github.com/alphagov/seal/blob/36a897b099943713ea14fa2cfe1abff8b25a83a7/lib/team_builder.rb#L97
       team:,
       dependencies_team:,
       shortname:,
       production_hosted_on:,
       links: {
-        self: "https://docs.publishing.service.gov.uk/repos/#{repo_name}.json",
+        self: "https://docs.publishing.service.gov.uk/repos/#{app_name}.json",
         html_url:,
         repo_url:,
         sentry_url:,
@@ -55,7 +55,7 @@ class Repo
   end
 
   def html_url
-    "https://docs.publishing.service.gov.uk/repos/#{repo_name}.html"
+    "https://docs.publishing.service.gov.uk/repos/#{app_name}.html"
   end
 
   def retired?
@@ -69,10 +69,14 @@ class Repo
   def page_title
     type = is_app? ? "Application" : "Repository"
     if retired?
-      "#{type}: #{repo_name} (retired)"
+      "#{type}: #{app_name} (retired)"
     else
-      "#{type}: #{repo_name}"
+      "#{type}: #{app_name}"
     end
+  end
+
+  def app_name
+    repo_data["app_name"] || repo_name
   end
 
   def repo_name

--- a/app/repo.rb
+++ b/app/repo.rb
@@ -209,7 +209,7 @@ private
   end
 
   def shortname
-    repo_data["shortname"] || repo_name.underscore
+    repo_data["shortname"] || app_name.underscore
   end
 
   def description_from_github

--- a/app/repos.rb
+++ b/app/repos.rb
@@ -13,7 +13,7 @@ class Repos
   end
 
   def self.active
-    Repos.all.reject(&:retired?)
+    Repos.all.reject(&:retired?).uniq(&:repo_name)
   end
 
   def self.active_public
@@ -21,6 +21,6 @@ class Repos
   end
 
   def self.active_apps
-    Repos.active.select(&:is_app?)
+    Repos.all.reject(&:retired?).select(&:is_app?)
   end
 end

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -910,6 +910,7 @@
     - licencefinder
 
 - repo_name: licensify
+  app_name: licensify
   private_repo: true
   type: Licensing apps
   production_hosted_on: aws
@@ -917,7 +918,8 @@
   puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify.pp
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
-- repo_name: licensify-admin
+- repo_name: licensify
+  app_name: licensify-admin
   private_repo: true
   type: Licensing apps
   production_hosted_on: aws
@@ -925,7 +927,8 @@
   puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify_admin.pp
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
-- repo_name: licensify-feed
+- repo_name: licensify
+  app_name: licensify-feed
   private_repo: true
   type: Licensing apps
   production_hosted_on: aws

--- a/source/apps.html.md.erb
+++ b/source/apps.html.md.erb
@@ -20,7 +20,7 @@ Apps can be loosely grouped into different types, including:
 | Type | Count | Applications |
 | --- | --- | --- |
 <% Repos.active_apps.group_by(&:type).sort.each do |name, apps| %>
-| # <%= name %> | <%= apps.count %> | <%= apps.map { |app| "[#{app.repo_name}](/repos/#{app.repo_name}.html)" }.join(", ") %> |
+| # <%= name %> | <%= apps.count %> | <%= apps.map { |app| "[#{app.app_name}](/repos/#{app.app_name}.html)" }.join(", ") %> |
 <% end %>
 
 ## Apps by team
@@ -28,7 +28,7 @@ Apps can be loosely grouped into different types, including:
 | Team | Count | Applications |
 | --- | --- | --- |
 <% Repos.active_apps.group_by(&:team).sort.each do |name, apps| %>
-| # <%= name %> | <%= apps.count %> | <%= apps.map { |app| "[#{app.repo_name}](/repos/#{app.repo_name}.html)" }.join(", ") %> |
+| # <%= name %> | <%= apps.count %> | <%= apps.map { |app| "[#{app.app_name}](/repos/#{app.app_name}.html)" }.join(", ") %> |
 <% end %>
 
 ## Apps by host
@@ -36,7 +36,7 @@ Apps can be loosely grouped into different types, including:
 | Hosting | Count | Applications |
 | --- | --- | --- |
 <% Repos.active_apps.group_by(&:hosting_name).sort.each do |name, apps| %>
-| # <%= name %> | <%= apps.count %> | <%= apps.map { |app| "[#{app.repo_name}](/repos/#{app.repo_name}.html)" }.join(", ") %> |
+| # <%= name %> | <%= apps.count %> | <%= apps.map { |app| "[#{app.app_name}](/repos/#{app.app_name}.html)" }.join(", ") %> |
 <% end %>
 
 ## Reuse this data

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ProxyPages do
   before do
     allow(Repos).to receive(:all)
-      .and_return([double("Repo", repo_name: "", page_title: "", description: "", private_repo?: false, retired?: false)])
+      .and_return([double("Repo", app_name: "", repo_name: "", page_title: "", description: "", private_repo?: false, retired?: false)])
     allow(DocumentTypes).to receive(:pages)
       .and_return([double("Page", name: "")])
     allow(Supertypes).to receive(:all)

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe Repo do
     end
   end
 
+  describe "app_name" do
+    it "returns repo_name if app_name not specified" do
+      expect(Repo.new({ "repo_name" => "foo" }).app_name).to eq("foo")
+    end
+
+    it "returns app_name if both app_name and repo_name are specified" do
+      expect(Repo.new({ "app_name" => "foo", "repo_name" => "bar" }).app_name).to eq("foo")
+    end
+  end
+
   describe "api_payload" do
     it "returns a hash of keys describing the app" do
       app_details = {

--- a/spec/app/repos_spec.rb
+++ b/spec/app/repos_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe Repos do
     it "should return only repos that are not retired" do
       expect(Repos.active.map(&:repo_name)).to eq(%w[asset-manager])
     end
+
+    context "repo contains multiple apps" do
+      let(:repos) do
+        [
+          { repo_name: "licensify", app_name: "licensify" },
+          { repo_name: "licensify", app_name: "licensify-feed" },
+          { repo_name: "licensify", app_name: "licensify-admin" },
+        ]
+      end
+
+      it "should return one repo name" do
+        expect(Repos.active.map(&:repo_name)).to eq(%w[licensify])
+      end
+    end
   end
 
   describe "active_public" do


### PR DESCRIPTION
## What

Defines new optional `app_name` property for our repos.yml config, to allow specifying multiple applications per repo.
This fixes the GitHub repo link (on various pages / JSON endpoints) for the two Licensify projects that live in the [licensify](https://github.com/alphagov/licensify) repo but do not share its name (i.e. `licensify-feed` and `licensify-admin`).

The Release app [will need updating)(https://github.com/alphagov/release/blob/8a2d2e1daefb41be3db6c0ce4bbbcc85f23fee72/app/models/repo.rb#L6) to use the new endpoint, as it cares about 'apps' and deployment status, as opposed to abstract repos. The `repos.json` endpoint is also used by govuk-dependencies, seal and govuk-saas-config but in these cases we _do_ care about the repo rather than the app, so they don't need updating.

## Why

We have a [script](https://github.com/alphagov/govuk-saas-config/pull/142) that compares the list of repos in the Developer Docs with all of the alphagov GitHub repos tagged with the 'govuk' topic. We would like it to report no inconsistencies!

It is currently highlighting this inconsistency:

```
Untagged govuk repos:
licensify-admin
licensify-feed
```

In other words, it is expecting a `licensify-admin` and `licensify-feed` repo under alphagov, and for those repos to be tagged with the `govuk` topic. But those repos don't exist: they're a result of a limitation in the Developer Docs' current data modelling, which equates `repo_name` with the application name, making a false assumption that there can only be 0-1 apps per repository. The [licensify](https://github.com/alphagov/licensify) repo actually has 3 apps (`licensify`, `licensify-admin` and `licensify-feed`).

Trello: https://trello.com/c/tsBL9lPH/3161-work-through-list-of-missing-repos

## Screenshots

Repos page (now shows just `licensify`, not its 3 apps):

| Before | After |
|--------|------|
|![before](https://github.com/alphagov/govuk-developer-docs/assets/5111927/c838b8e3-3c9f-450e-a420-23f9d38bf423)|![after](https://github.com/alphagov/govuk-developer-docs/assets/5111927/708f77d7-5625-480d-8a98-a184cdada613)|

Repos JSON (now shows just `licensify`, not its 3 apps):

| Before | After |
|--------|------|
|![before](https://github.com/alphagov/govuk-developer-docs/assets/5111927/7ba28743-7758-4f30-b18f-bb9504a50489)|![after](https://github.com/alphagov/govuk-developer-docs/assets/5111927/30e76df4-7982-46d5-bb60-93d400df03f0)|

Apps page (unchanged):

| Before | After |
|--------|------|
|![before](https://github.com/alphagov/govuk-developer-docs/assets/5111927/815ff9ef-41fb-423a-b777-905c97794706)|![after](https://github.com/alphagov/govuk-developer-docs/assets/5111927/67c5677a-557b-43e7-9b13-b07ebed11b3f)|

Apps JSON (repo URL fixed, otherwise unchanged):

| Before | After |
|--------|------|
|![before](https://github.com/alphagov/govuk-developer-docs/assets/5111927/3f59cd95-1b3f-4e12-8f67-f12df5987269)|![after](https://github.com/alphagov/govuk-developer-docs/assets/5111927/d5a3564f-38b1-42c0-9aba-6b8a0f23940a)|

Repo page (repo URL fixed, otherwise unchanged):

| Before | After |
|--------|------|
|![before](https://github.com/alphagov/govuk-developer-docs/assets/5111927/f72ac917-10f5-4dc5-b1a2-5002ca7d0c64)|![after](https://github.com/alphagov/govuk-developer-docs/assets/5111927/30a374b7-5dc2-4247-b509-141cf25bb6de)|
