### PR TITLE
Rename puppet_name to shortname

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -10,7 +10,7 @@ class Repo
       app_name: repo_name, # beware renaming the key - it's used here: https://github.com/alphagov/govuk-dependencies/blob/b3a2a29eb80aefa08098a08633b4a08b05bcc527/lib/gateways/team.rb#L15
       team:,
       dependencies_team:,
-      puppet_name:,
+      shortname:,
       production_hosted_on:,
       links: {
         self: "https://docs.publishing.service.gov.uk/repos/#{repo_name}.json",
@@ -23,7 +23,7 @@ class Repo
 
   def aws_puppet_class
     Hosts.aws_machines.each do |puppet_class, keys|
-      if keys["apps"].include?(repo_name) || keys["apps"].include?(puppet_name)
+      if keys["apps"].include?(repo_name) || keys["apps"].include?(shortname)
         return puppet_class
       end
     end
@@ -118,7 +118,7 @@ class Repo
 
     return repo_data["puppet_url"] if repo_data["puppet_url"]
 
-    "https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/#{puppet_name}.pp"
+    "https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/#{shortname}.pp"
   end
 
   def deploy_url
@@ -204,8 +204,8 @@ private
     repo_data["argo_cd_apps"] || [repo_name]
   end
 
-  def puppet_name
-    repo_data["puppet_name"] || repo_name.underscore
+  def shortname
+    repo_data["shortname"] || repo_name.underscore
   end
 
   def description_from_github

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -116,7 +116,7 @@
   team: "#govuk-datagovuk"
 
 - repo_name: ckanext-datagovuk
-  puppet_name: ckan
+  shortname: ckan
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
   production_hosted_on: aws
@@ -157,7 +157,7 @@
 
 - repo_name: contacts-admin
   type: Publishing apps
-  puppet_name: contacts
+  shortname: contacts
   team: "#govuk-publishing-experience-tech"
   production_hosted_on: eks
 
@@ -251,7 +251,7 @@
 - repo_name: design-principles
   type: Frontend apps
   retired: true
-  puppet_name: designprinciples
+  shortname: designprinciples
   description: |
     A frontend app that used to render the GDS design principles as static
     pages.  This required developer effort to update the content so in
@@ -797,7 +797,7 @@
 - repo_name: govuk_content_api
   retired: true
   type: APIs
-  puppet_name: contentapi
+  shortname: contentapi
   description: |
     API that used to store and serve published content to the rendering applications
     for display from public-facing URLs. This has now been superceded by the
@@ -829,7 +829,7 @@
 - repo_name: govuk_need_api
   retired: true
   type: APIs
-  puppet_name: need_api
+  shortname: need_api
   description: |
     A JSON read and write API for information about user needs on GOV.UK. It was a Rails
     app which was part of the GOV.UK Publishing Platform. The need information is now
@@ -903,7 +903,7 @@
 
 - repo_name: licence-finder
   type: Frontend apps
-  puppet_name: licencefinder
+  shortname: licencefinder
   team: "#tech-content-interactions-on-platform-govuk"
   production_hosted_on: eks
   argo_cd_apps:
@@ -1261,7 +1261,7 @@
 - repo_name: smart-answers
   type: Frontend apps
   team: "#user-experience-measurement-govuk-robot-invasion"
-  puppet_name: smartanswers
+  shortname: smartanswers
   production_hosted_on: eks
   argo_cd_apps:
     - smartanswers

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Repo do
       expect(Repo.new("repo_name" => "finder-frontend").aws_puppet_class).to eq("calculators_frontend")
     end
 
-    it "should find puppet class via puppet name" do
-      expect(Repo.new("puppet_name" => "smartanswers", "repo_name" => "foo").aws_puppet_class).to eq("calculators_frontend")
+    it "should find puppet class via shortname" do
+      expect(Repo.new("shortname" => "smartanswers", "repo_name" => "foo").aws_puppet_class).to eq("calculators_frontend")
     end
 
     it "should return error message if no puppet class found" do


### PR DESCRIPTION
`shortname` is the terminology used in the Release app, where exactly the same values have been provided there as they have here, e.g. `licence-finder` => `licencefinder`:
https://release.publishing.service.gov.uk/applications/licencefinder/edit

An app's 'shortname' is used for several things, all of which will probably go away at some point:

- name of the app in Puppet, e.g. https://github.com/alphagov/govuk-puppet/blob/603dc08f1a0e9148c844590d006ad22d0bc21737/modules/govuk/manifests/apps/licencefinder.pp
- Sentry DSN configuration, e.g. https://github.com/alphagov/govuk-saas-config/blob/ba6a612caa61920a57d388013b0a7968b51c60fd/sentry/Rakefile#L32
- For use in Graphite metrics
- Colloquially, e.g. "Contacts" shortname as opposed to "Contacts Admin" application name. (But not always, e.g. "Mainstream Publisher" term used by GDS people instead of "Publisher", but not represented as such in any of our config).

Renaming `puppet_name` to `shortname` reflects the fact that we're retiring govuk-puppet soon, but that we may still need to keep these values for the other reasons above. It is also more descriptive.
