### PR TITLE
Remove 'retired: true' from puppet-aptly repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1119,7 +1119,6 @@
     October 2022.
 
 - repo_name: puppet-aptly
-  retired: true
   type: Utilities
   team: "#govuk-platform-security-reliability-team"
 


### PR DESCRIPTION
It's still an active repo (for the time being) so this was set by mistake.
