### PR TITLE
Correct owner and non-retired status of unicornherder

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1338,9 +1338,8 @@
   production_hosted_on: eks
 
 - repo_name: unicornherder
-  retired: true
   type: Utilities
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-datagovuk"
 
 - repo_name: upgrade-ruby-version
   type: Utilities


### PR DESCRIPTION
This was mistakenly set to `retired: true`, but the repo is not archived and it is still referenced in govuk-puppet: https://github.com/alphagov/govuk-puppet/blob/603dc08f1a0e9148c844590d006ad22d0bc21737/modules/unicornherder/manifests/init.pp

Looking into it further, this is a Python package, and, as far as I can tell, is only used by CKAN:
https://github.com/alphagov/ckanext-datagovuk/blob/9a7d54a5c5e2f9ddc1657ad180bad88263a61738/Procfile#L1C1-L2

Therefore the owner team should be set to `#govuk-datagovuk`, who can then archive the repo once the CKAN replatform project has completed.

Trello: https://trello.com/c/tsBL9lPH/3161-work-through-list-of-missing-repos
