### PR TITLE
Update production hosts

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -293,6 +293,7 @@
 - repo_name: email-alert-monitoring
   type: Utilities
   team: "#tech-content-interactions-on-platform-govuk"
+  production_hosted_on: eks
   sentry_url: false
   dashboard_url: false
 
@@ -969,7 +970,7 @@
 - repo_name: manuals-publisher
   type: Publishing apps
   team: "#govuk-publishing-experience-tech"
-  production_hosted_on: aws
+  production_hosted_on: eks
 
 - repo_name: mapit
   retired: true


### PR DESCRIPTION
`production_hosted_on` needs to be specified for a repo to be classified as and app.
It's necessary because we switched to use apps.json in the Release app in https://github.com/alphagov/release/pull/1210

manuals-publisher is hosted on EKS: https://github.com/alphagov/govuk-helm-charts/blob/bcfbda7b2dbc2a9cc21f6f6464c349d494ed45e5/charts/app-config/values-production.yaml#L1473

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
