### PR TITLE
Remove ref to Production Deploy team & Jenkins

### DIFF
--- a/source/manual/configure-github-repo.html.md
+++ b/source/manual/configure-github-repo.html.md
@@ -8,7 +8,7 @@ section: GitHub
 
 ## When you create a new repo
 
-- Give the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production Admin][govuk-production-team] teams `Admin` access
+- Give the [GOV.UK CI Bots][govuk-ci-bots-team] and [GOV.UK Production Admin][govuk-production-team] teams `Admin` access
 - Give the [GOV.UK team][govuk-team] `Write` access
 - Tag it with the [`govuk`][govuk-topic] topic
 
@@ -18,13 +18,13 @@ If your repo will be continuously deployed, restrict merge access to users with 
 
 When your repo is tagged with `govuk`, it will be auto-configured by [govuk-saas-config][], applying many of the rules below.
 
-The govuk-saas-config job runs overnight, but you can kick off a build of the [Jenkins job][jenkins-job] to trigger it sooner.
+The govuk-saas-config job runs overnight, but you can kick off a build of the [GitHub Action workflow][] to trigger it sooner.
 
 ## Rules
 
 Repositories in GOV.UK must:
 
-- Have the [GOV.UK CI Bots][govuk-ci-bots-team], [GOV.UK Production Deploy][govuk-production-deploy-team], and [GOV.UK Production Admin][govuk-production-team] teams as `Admin`
+- Have the [GOV.UK CI Bots][govuk-ci-bots-team] and [GOV.UK Production Admin][govuk-production-team] teams as `Admin`
 - Give the [GOV.UK team][govuk-team] `Write` access
 - Have a good description
 - Link to relevant documentation
@@ -38,9 +38,9 @@ Almost all repos should:
 - Have [GitHub Actions CI](/manual/test-and-build-a-project-with-github-actions.html) configured
 - Have [GitHub Trello Poster](/manual/github-trello-poster.html) enabled
 
+[GitHub Action workflow]: https://github.com/alphagov/govuk-saas-config/blob/163497868926ffe9d7c7d789fb79c5cf8026ab93/.github/workflows/configure-github.yml
 [govuk-ci-bots-team]: https://github.com/orgs/alphagov/teams/gov-uk-ci-bots
 [govuk-production-team]: https://github.com/orgs/alphagov/teams/gov-uk-production-admin
-[govuk-production-deploy-team]: https://github.com/orgs/alphagov/teams/gov-uk-production-deploy
 [govuk-saas-config]: https://github.com/alphagov/govuk-saas-config
 [govuk-team]: https://github.com/orgs/alphagov/teams/gov-uk
 [govuk-topic]: https://github.com/search?q=topic:govuk


### PR DESCRIPTION
Updated to:

- Remove reference to Production Deploy team having admin access to the repo. This is not the case (looking at a handful of production apps at random) and should never have been the case either, since it would leave apps vulnerable to privilege escalation. We only [use the team as 'metadata'](https://github.com/alphagov/govuk-infrastructure/blob/f97e2e420f875a3b5fb9d4a575a98de499c2b075/.github/workflows/deploy.yml#L84-L97) in deciding whether or not to allow merging.
- Removes link to old Jenkins job, now links to GitHub Action workflow instead.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
