### PR TITLE
Remove example command

### DIFF
--- a/source/manual/kubernetes-infrastructure.html.md
+++ b/source/manual/kubernetes-infrastructure.html.md
@@ -29,7 +29,6 @@ eval $(gds aws govuk-integration-poweruser -e --art 8h)
     - `k -n apps exec -it deploy/router-api -- rails c`
 - To open a shell:
     - `k -n apps exec -it deploy/government-frontend -- bash`
-      \>> `curl` # (for example)
 - To open a shell on Router:
     - `k -n apps exec -it deploy/router -c nginx`
 


### PR DESCRIPTION
The example curl command doesn't render on a new line as the author intended.

> <img width="730" alt="Screenshot 2023-06-20 at 14 57 24" src="https://github.com/alphagov/govuk-developer-docs/assets/5111927/8c247541-3af7-45bf-a8d7-02430ce20793">

Better to just omit the example command altogether (we can expect engineers following these docs to know that they can run any arbitrary command once they've opened a shell).
