### PR TITLE
Update docker-collectd-plugin owner

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -265,7 +265,7 @@
   type: Data science
 
 - repo_name: docker-collectd-plugin
-  team: "#govuk-platform-reliability-team"
+  team: "#govuk-platform-security-reliability-team"
   type: Utilities
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
#govuk-platform-reliability-team was renamed to
#govuk-platform-security-reliability-team

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
