### PR TITLE
Add 'designprinciples' short name to `description` for retired repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -259,7 +259,7 @@
   retired: true
   shortname: designprinciples
   description: |
-    A frontend app that used to render the GDS design principles as static
+    A frontend app (often referred to as "designprinciples") that used to render the GDS design principles as static
     pages.  This required developer effort to update the content so in
     November 2017 we retired the app after all the content had been replaced
     by a version managed by our publishing apps.


### PR DESCRIPTION
I searched the Developer Docs for `designprinciples` (as it is referenced in govuk-puppet) and nothing came up, because the repo name is `design-principles`. Keyword stuffing should fix the search.
