### PR TITLE
You need poweruser or greater access to query CSP

### DIFF
--- a/source/manual/content-security-policy.html.md
+++ b/source/manual/content-security-policy.html.md
@@ -56,8 +56,9 @@ a CSP is enforced.
 
 ### Querying violations
 
-Athena is available through the AWS control panel. To access, [log into AWS](/manual/get-started.html#sign-in-to-aws),
-navigate to [Athena](https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#/query-editor) and select
+Athena is available through the AWS control panel. To access, [log into AWS](/manual/get-started.html#sign-in-to-aws)
+as a poweruser or greater privilege access, navigate to
+[Athena](https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#/query-editor) and select
 the `csp_reports` database. The database is available in all environments, however the production environment one is
 that only one that will have good quality data.
 


### PR DESCRIPTION
As queries to Athena involve writing to an S3 bucket they can't be run as a readonly user. This seems surprising as you'd expect that you could run a query as readonly.

Hopefully this clarification stops people getting stuck.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
