### PR TITLE
Remove Cache clearing service

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -76,7 +76,6 @@ redirects:
   /apps/business-support-api.html: /repos/business-support-api.html
   /apps/business-support-finder.html: /repos/business-support-finder.html
   /apps/by-team.html: /apps.html
-  /apps/cache-clearing-service.html: /repos/cache-clearing-service.html
   /apps/calculators.html: /repos/calculators.html
   /apps/calendars.html: /repos/calendars.html
   /apps/ckan-functional-tests.html: /repos/ckan-functional-tests.html

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -78,8 +78,7 @@
 
 - repo_name: cache-clearing-service
   type: Services
-  team: "#govuk-navigation-tech"
-  production_hosted_on: eks
+  retired: true
 
 - repo_name: calculators
   type: Frontend apps

--- a/source/manual/alerts/amazonmq-high-number-of-unprocessed-messages.html.md
+++ b/source/manual/alerts/amazonmq-high-number-of-unprocessed-messages.html.md
@@ -15,7 +15,6 @@ normal amounts on certain queues. The queues this alert applies to are:
 * [`email_unpublishing`][email_unpublishing_config]
 * [`subscriber_list_details_update_major`][email_subscriber_list_major_config]
 * [`subscriber_list_details_update_minor`][email_subscriber_list_minor_config]
-* [`cache_clearing_service-*`][cache_config] (low, medium and high)
 
 The plugin which implements this alert is [here][plugin].
 
@@ -27,10 +26,6 @@ For the `email_alert_service`,  `email_unpublishing`,
 `subscriber_list_details_update_major` and `subscriber_list_details_update_minor`
 queues the [message thresholds][email_thresholds] are:
 25 for critical and 5 for warning.
-
-For `cache_clearing_service-*` queues the [message
-thresholds][cache_clearing_thresholds] are: 100,000 for critical and 80,000 for
-warning.
 
 > **Note**
 >
@@ -46,7 +41,6 @@ For troubleshooting steps, see [here][troubleshooting_steps].
 [email_unpublishing_config]: https://github.com/alphagov/govuk-puppet/blob/e769c1dc74484625cf7afdfe943c08884cc7d90d/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L81-L87
 [email_subscriber_list_major_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L73-L79
 [email_subscriber_list_minor_config]: https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#65-L71
-[cache_config]: https://github.com/alphagov/govuk-puppet/blob/616cae598f91406e29ed2e4fc287c71b690c55b0/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp#L112-L137
 [troubleshooting_steps]: https://docs.publishing.service.gov.uk/manual/alerts/amazonmq-no-consumers-listening.html#troubleshooting
 [no_consumers_listening]: https://docs.publishing.service.gov.uk/manual/alerts/amazonmq-no-consumers-listening.html
 [rabbitmq_doc]: https://docs.publishing.service.gov.uk/manual/rabbitmq.html

--- a/source/manual/alerts/amazonmq-no-consumers-listening.html.md
+++ b/source/manual/alerts/amazonmq-no-consumers-listening.html.md
@@ -27,7 +27,7 @@ last 5 minutes. Consumers in an `idle` state are listening to the queue but are
 unable to process the messages on it.
 
 Publishing API [sends a heartbeat message][heartbeat_messages] every minute to
-the following queues - `email-alert-service`, `cache_clearing_service-high` and
+the following queues - `email-alert-service` and
 `content_data_api`. This is configured via the queues bindings (e.g
 [email-alert-service's binding][email_alert_binding]) matching the routing key
 used in the [heartbeat][heartbeat]. This should ensure that the consumers are

--- a/source/manual/amazonmq.html.md
+++ b/source/manual/amazonmq.html.md
@@ -48,7 +48,7 @@ email-alert-api. Queues are [created by consumer applications][create_queues].
 **Bindings** are rules that exchanges use (among other things) to route
 messages to queues. To instruct an exchange E to route messages to a queue Q, Q
 has to be bound to E. Bindings may have an optional routing key attribute. An
-example of a binding is the `cache_clearing_service-high` queue is
+example of a binding is the `email_alert_service` queue is
 [bound][binding_config] to the `published_documents` exchange with a routing
 key matching of `*.major`. E.g messages sent to the exchange with a routing key
 of `guide.major` will be routed to that queue.
@@ -102,4 +102,4 @@ connecting to the RabbitMQ control panel (see above).
 [message_consumer]: https://github.com/alphagov/govuk_message_queue_consumer
 [email-alert-service]: https://github.com/alphagov/email-alert-service
 [major_message_processor]: https://github.com/alphagov/email-alert-service/blob/2ba8ecd982c2226158b528e5442b012639797d41/email_alert_service/models/major_change_message_processor.rb#L35P
-[binding_config]: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp#L42-L48
+[binding_config]: https://github.com/alphagov/govuk-aws/blob/854bf0a652af5badaedd0e14ae4e841807075519/terraform/projects/app-publishing-amazonmq/publishing-rabbitmq-schema.json.tpl#L260-L267

--- a/source/manual/amazonmq.html.md
+++ b/source/manual/amazonmq.html.md
@@ -11,13 +11,13 @@ Protocol][AMQP] (AMQP). Publishing's RabbitMQ cluster is provided by AWS' [Amazo
 
 [Learn more about RabbitMQ][rabbitmq_tutorial].
 
-## Connecting to the AmazonMQ web control panel
+## Connecting to the RabbitMQ web control panel
 
 Run `gds govuk connect amazonmq -e integration` and point your
 browser at the URL it gives you - it will look like <http://127.0.0.1:45612>, but will have a random port number. You can connect to `staging` and `production` the same way, just replace `integration` above with the environment of your choice.
 
 The username for connecting to the RabbitMQ web control panel is `root` and the password
-can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_amazonmq::root_password]'` (from the `puppet_aws` directory).
+can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_publishing_amazonmq::passwords::root]'` (from the `puppet_aws` directory).
 
 ## AmazonMQ metrics
 

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -13,7 +13,9 @@ We can cover a lot of GOV.UK architecture by asking ourselves three questions:
 2. What happens when a publisher hits 'Publish'?
 3. What happens when a developer deploys a change to an application?
 
-Refer to the [architectural summary of GOV.UK](/manual/architecture-shallow-dive.html) for a shorter summary of GOV.UK architecture.
+Refer to the [architectural summary of
+GOV.UK](/manual/architecture-shallow-dive.html) for a shorter summary of GOV.UK
+architecture.
 
 [GOV.UK]: https://www.gov.uk
 
@@ -60,12 +62,10 @@ Fastly uses [Varnish] for caching, with a default cache time of 1 hour. (Read
 ["Our content delivery network"][our-cdn] for more information). If Fastly
 doesn't have a page in its cache, it fetches the page from origin.
 
-[Caches can be purged][purge-cache] using the [cache-clearing-service], which
-tells Fastly to soft-purge (i.e. only remove the cached version once it has
-received the new version from origin). This cache clearing service is
-triggered automatically when pages are updated - more on that later.
+[Caches can be purged][purge-cache], which tells Fastly to soft-purge (i.e.
+only remove the cached version once it has received the new version from
+origin).
 
-[cache-clearing-service]: https://github.com/alphagov/cache-clearing-service
 [Fastly]: https://www.fastly.com/
 [our-cdn]: /manual/cdn.html
 [purge-cache]: /manual/purge-cache.html
@@ -320,7 +320,6 @@ RabbitMQ is a message broker: when a message is broadcast to a RabbitMQ
 exchange, it forwards the message to its consumers. These consumers
 retrieve the content item and do something in response, such as:
 
-- Clear the page's cache, via the cache-clearing-service
 - [Send emails to users subscribed to that content][message-queues-rake]. (The
   exceptions to this are `travel-advice` & `specialist-publisher`, which
   communicate directly with email-alert-api to ensure emails go out immediately)


### PR DESCRIPTION
RabbitMQ docs is left unchanged (cache-clearing-service is used to show an example of binding). Only the govuk_crawler is still on self hosted RabbitMQ and there are plans remove it in the next couple of weeks so that doc can be removed then.

[GIFT week summer 2023 card](https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service)
[Tech debt card](https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
