### PR TITLE
Keep non-production logs for one week instead of two.

### DIFF
--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -161,7 +161,12 @@ should be consistent across stacks.
 
 ## Retention period
 
-[14 days](https://dashboard.logit.io/a/1c6b2316-16e2-4ca5-a3df-ff18631b0e74/s/2dd89c13-a0ed-4743-9440-825e2e52329e).
+- Production: 14 days
+- Staging: 7 days
+- Integration: 7 days
+
+The retention window for an environment is configurable under the Settings page
+for the corresponding Logit stack, for users with the Stack Editor permission.
 
 ## Further reading
 


### PR DESCRIPTION
We currently have a 14-day retention window in Logit both for production and non-production.

Logit quota is quite expensive and I doubt we're getting value from storing integration/staging logs for more than a week.

I propose reducing the non-prod retention window from 14 to 7 days, saving $1092 / month ($832 / month once we drop the stacks for the old EC2/Puppet environments).

Raising this PR here for discussion/awareness since the actual setting is only in the Logit web UI.

Context: part of a broader push on [making logging more usable and cost-effective](https://docs.google.com/document/d/e/2PACX-1vS31XeKiFRcLmqcmjp2V6Zob-mxLV2oIALb_ZHj7MCK34-8Dko1PQCW0zjDtGG5cxLjChxKIN2g7f3x/pub).