### PR TITLE
Tighten up instructions for teams without a tech lead

### DIFF
--- a/source/manual/github-access.html.md
+++ b/source/manual/github-access.html.md
@@ -12,11 +12,12 @@ Not everyone on GOV.UK requires GitHub access, as much of what we do is in the o
 
 If you're a content designer, your request should go through Zendesk (see [example ticket](https://govuk.zendesk.com/agent/tickets/5297731/events)).
 
-If you're an engineer or contractor, ask your tech lead to follow the steps below. If you don't have a tech lead, ask in the [Technical 2nd Line Slack channel](https://gds.slack.com/archives/CADKZN519) for them to add you. You must state:
+If you're an engineer or contractor, ask your tech lead to follow the steps below. If you don't have a tech lead, [ask someone in Senior Tech](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-senior-tech-members/members) to add you. You must state:
 
 - your role
 - which team you're in
 - your GitHub handle
+- which GitHub team(s) you should join ([see list](#teams-in-alphagov)
 - why you need access
 
 ## Granting GitHub access


### PR DESCRIPTION
In an offline conversation with @kevindew, we felt it was more appropriate that requests for GitHub access (where a team technical lead does not exist) is better routed to GOV.UK Senior Tech rather than 2nd Line.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
