### PR TITLE
Move smart-answers to OPCC team

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1287,11 +1287,8 @@
 
 - repo_name: smart-answers
   type: Frontend apps
-  team: "#user-experience-measurement-govuk-robot-invasion"
-  shortname: smartanswers
+  team: "#govuk-publishing-on-platform-content-tech"
   production_hosted_on: eks
-  argo_cd_apps:
-    - smartanswers
 
 - repo_name: smokey
   team: "#govuk-platform-security-reliability-team"
@@ -1405,7 +1402,7 @@
 - repo_name: whitehall-prototype-2023
   type: Publishing apps
   team: "#govuk-publishing-experience-tech"
-  
+
 - repo_name: widdershins
   type: Gems
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
[Trello](https://trello.com/c/PFWiG278/615-move-smart-answers-dependabot-notifications-to-opcc-slack-channel)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
