### PR TITLE
Fix rake task snippets for Whitehall

### DIFF
--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -20,7 +20,7 @@ state of the job using [Sidekiq monitoring apps][sidekiq-monitoring].
 
 You can verify that there are overdue published documents using:
 
-<%= RunRakeTask.links("whitehall", "publishing:overdue:list") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing:overdue:list") %>
 
 You'll see output like this:
 
@@ -31,7 +31,7 @@ ID  Scheduled date             Title
 If there are overdue publications you can publish by running the
 following:
 
-<%= RunRakeTask.links("whitehall", "publishing:overdue:publish") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing:overdue:publish") %>
 
 ### After a database restore
 
@@ -39,7 +39,7 @@ If the above rake tasks aren't working, it could be because the database was
 recently restored, perhaps due to the data sync. In that case, you can try
 running the following Rake task on a `whitehall_backend` machine:
 
-<%= RunRakeTask.links("whitehall", "publishing:scheduled:requeue_all_jobs") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing:scheduled:requeue_all_jobs") %>
 
 Due to the overnight [data anonymisation process](https://github.com/alphagov/whitehall/blob/7b5c5a086b89cb62ffba62b152a0a8dcfc10c8e6/script/scrub-database) you may notice
 that some of the pending documents have one or more edition that is in a
@@ -61,7 +61,7 @@ in the queue.
 Run the `publishing:scheduled:requeue_all_jobs` Rake task to requeue all
 scheduled editions:
 
-<%= RunRakeTask.links("whitehall", "publishing:scheduled:requeue_all_jobs") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing:scheduled:requeue_all_jobs") %>
 
 Historically, this error has happened in the staging and integration
 environments, after the nightly [data sync](/manual/govuk-env-sync.html).

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -81,7 +81,7 @@ be set manually.
 There is a Rake task to reindex all political content in search. This must be
 done after a government is closed.
 
-<%= RunRakeTask.links("whitehall", "search:political") %>
+<%= RunRakeTask.links("whitehall-admin", "search:political") %>
 
 ### Backdating
 
@@ -90,14 +90,14 @@ distinct dates, we need to run a rake task to republish all political content
 from Whitehall to properly associate content with the government at it's first
 published date:
 
-<%= RunRakeTask.links("whitehall", "election:republish_political_content") %>
+<%= RunRakeTask.links("whitehall-admin", "election:republish_political_content") %>
 
 ### Ending ministerial roles without closing a government
 
 If we need to end all ministerial roles without explicitly closing a government,
 we can run a rake task:
 
-<%= RunRakeTask.links("whitehall", "election:end_ministerial_appointments") %>
+<%= RunRakeTask.links("whitehall-admin", "election:end_ministerial_appointments") %>
 
 This will end all ministerial roles except the Prime Minister. You might have to
 do that one manually.

--- a/source/manual/republishing-content.html.md.erb
+++ b/source/manual/republishing-content.html.md.erb
@@ -27,7 +27,7 @@ If the documents are in Whitehall, there are Rake tasks you can run as outlined 
 
 ### To republish a single document by slug
 
-<%= RunRakeTask.links("whitehall", "publishing_api:republish:document_by_slug[slug]") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing_api:republish:document_by_slug[slug]") %>
 
 > Replace `slug` with the document's slug, but not the full base path. For example the slug for `https://www.gov.uk/government/important-news` would be `important-news`.
 
@@ -62,7 +62,7 @@ To republish all instances of the following document types, run the following ra
 - WorldwideOffice
 - WorldwideOrganisation
 
-<%= RunRakeTask.links("whitehall", "publishing_api:bulk_republish:document_type[DocumentClass]") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing_api:bulk_republish:document_type[DocumentClass]") %>
 
 > Replace `DocumentClass` with the camelized (i.e. as it is written above) class name.
 
@@ -70,7 +70,7 @@ To republish all instances of the following document types, run the following ra
 
 For a small number of documents, use the following rake task:
 
-<%= RunRakeTask.links("whitehall", "publishing_api:bulk_republish:documents_by_content_ids[content_id_1 content_id_2]") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing_api:bulk_republish:documents_by_content_ids[content_id_1 content_id_2]") %>
 
 > Replace `content_id_1` and `content_id_2` with the content ID (i.e. UUID) for the documents to republish. You can add more than 2 content IDs.
 
@@ -79,7 +79,7 @@ For a significant number of documents, a CSV file should be added to the reposit
 1. Create a CSV file that contains a single column headed `content_id`. Put the content ID for each document on a separate line below this. The file should be saved in `lib/tasks/{FILENAME}.csv` and a PR raised.
 1. Merge and deploy the PR to the relevant environment.
 1. Run the `documents_by_content_ids_from_csv` rake task:
-   <%= RunRakeTask.links("whitehall", "publishing_api:bulk_republish:documents_by_content_ids_from_csv[csv_file_name]") %>
+   <%= RunRakeTask.links("whitehall-admin", "publishing_api:bulk_republish:documents_by_content_ids_from_csv[csv_file_name]") %>
    > Replace `csv_file_name` with the filename of the CSV, including the `.csv` extension.
 1. After the job has completed, remove the CSV from the repository.
 
@@ -87,7 +87,7 @@ For a significant number of documents, a CSV file should be added to the reposit
 
 > Caution: this is a lot of content and will take hours to complete. If it is possible to scope the republish do so and use a different task, but if you have made a change such as something in govspeak that will affect the majority of content, this is available. Before running this job confirm with Technical 2nd Line that they are happy for you to proceed as it could cause backed up publishing queues and alerts.
 
-<%= RunRakeTask.links("whitehall", "publishing_api:bulk_republish:all") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing_api:bulk_republish:all") %>
 
 ## Content Publisher
 


### PR DESCRIPTION
These were outputting commands like:

```
k exec deploy/whitehall -- rake publishing:overdue:list
```

...which would not work, as the pod name differs. It should actually be:

```
k exec deploy/whitehall-admin -- rake publishing:overdue:list
```
