### PR TITLE
Update RabbitMQ connection docs

### DIFF
--- a/source/manual/rabbitmq.html.md
+++ b/source/manual/rabbitmq.html.md
@@ -13,11 +13,13 @@ Protocol][AMQP] (AMQP).
 
 ## Connecting to the RabbitMQ web control panel
 
-Run `gds govuk connect rabbitmq -e integration aws/rabbitmq` and point your
-browser at <http://127.0.0.1:15672> (also available for `staging` and `production`).
+Make sure you have the latest `gds-cli` and `govuk-connect` installed.
+
+Run `gds govuk connect amazonmq -e integration` and point your
+browser at http://127.0.0.1:<whatever> (also available for `staging` and `production`).
 
 The username for connecting to the RabbitMQ web control panel is `root` and the password
-can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_rabbitmq::root_password]'` (from the `puppet_aws` directory).
+can be decrypted from the `govuk-secrets` repo via `bundle exec rake 'eyaml:decrypt_value[integration,govuk_publishing_amazonmq::passwords::root]'` (from the `puppet_aws` directory).
 
 ## RabbitMQ metrics
 


### PR DESCRIPTION
We're on AmazonMQ so connecting has changed.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
