### PR TITLE
Remove VPN link from Republishing Content page

### DIFF
--- a/source/manual/republishing-content.html.md.erb
+++ b/source/manual/republishing-content.html.md.erb
@@ -10,10 +10,7 @@ Sometimes it may be necessary to republish content to the Publishing API. This w
 
 For example if we make an update to [govspeak][govspeak-repo] and a publishing application pre-renders that content prior to its submission to Publishing API, that would require us to re-render and save new HTML for content.
 
-This process varies per app and requires
-
-- Connection to the [VPN][vpn] and
-- [Production access][production-access]
+This process varies per app and requires [Production access][production-access].
 
 You may wish to test first on integration, prior to carrying out the republish in production.
 


### PR DESCRIPTION
VPN access is no longer required and the link was broken anyway.