### PR TITLE
Update link in email-alerts-travel-medical.html.md

### DIFF
--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -84,7 +84,7 @@ URL of the country's edit page in Travel Advice Publisher and looks like
 [email-alert-monitoring]: https://github.com/alphagov/email-alert-monitoring
 [Technical 2nd Line password store]: https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline
 [retire alert adr]: https://github.com/alphagov/email-alert-api/blob/main/docs/adr/adr-008-monitoring-and-alerting.md#removal-of-email-alert-monitoring
-[acknowledged email list]: https://github.com/alphagov/email-alert-monitoring/blob/master/lib/email_verifier.rb#L6-L14
+[acknowledged email list]: https://github.com/alphagov/email-alert-monitoring/blob/master/lib/email_verifier.rb#L8
 [gmail status]: https://www.google.co.uk/appsstatus#hl=en-GB&v=status
 [Sidekiq dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Interval=$__auto_interval
 [tech dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api_technical.json?refresh=1m&orgId=1


### PR DESCRIPTION
The array that this link points to seems to have changed position and length since this document was updated. Let's just link to the first line of its definition.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
