### PR TITLE
Remove govuk-user-reviewer instruction from AWS step

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -378,15 +378,6 @@ to find out how to deploy infrastructure changes. The stackname is `govuk` and t
 
 See the [AWS IAM users documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html) for more information.
 
-Lastly, you will need to add the integration permissions provided in [GOV.UK User Reviewer][govuk-user-reviewer], for example:
-
-```yml
-aws:
-  integration: user
-```
-
-[Example PR](https://github.com/alphagov/govuk-user-reviewer/pull/924)
-
 ## 10. Access AWS for the first time
 
 If you are a frontend developer you do not need to complete this step as part of your initial setup.


### PR DESCRIPTION
This instruction is no longer necessary as setting up the user reviewer (step 6) already configures AWS access. 

This instruction has led to unnecessary PRs being created.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
