### PR TITLE
Link to team channels from repo pages

### DIFF
--- a/helpers/url_helpers.rb
+++ b/helpers/url_helpers.rb
@@ -2,4 +2,8 @@ module UrlHelpers
   def document_type_url(document_type_name)
     "/document-types/#{document_type_name}.html"
   end
+
+  def slack_url(channel_name)
+    "https://gds.slack.com/channels/#{channel_name.sub('#', '')}"
+  end
 end

--- a/source/partials/repo/_ownership.html.erb
+++ b/source/partials/repo/_ownership.html.erb
@@ -1,10 +1,10 @@
 <% if repo.team && repo.dependencies_team &&
       repo.team != repo.dependencies_team %>
-  <strong><%= repo.team %></strong> owns the repo. <strong><%= repo.dependencies_team %></strong> is responsible for updating its dependencies.
+  <strong><%= link_to repo.team, slack_url(repo.team) %></strong> owns the repo. <strong><%= links_to repo.dependencies_team, slack_url(repo.dependencies_team) %></strong> is responsible for updating its dependencies.
 <% elsif repo.team %>
-  <%= repo.team %>
+  <%= link_to repo.team, slack_url(repo.team) %>
 <% elsif repo.dependencies_team %>
-  <%= repo.dependencies_team %>
+  <%= links_to repo.dependencies_team, slack_url(repo.dependencies_team) %>
 <% else %>
   N/A
 <% end %>

--- a/spec/helpers/url_helpers_spec.rb
+++ b/spec/helpers/url_helpers_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require_relative "../../helpers/url_helpers"
+
+RSpec.describe UrlHelpers do
+  let(:helper) { Class.new { extend UrlHelpers } }
+
+  describe "#document_type_url" do
+    it "returns the path to a document type page" do
+      document_type = "html_publication"
+      expect(helper.document_type_url(document_type)).to eq("/document-types/html_publication.html")
+    end
+  end
+
+  describe "#slack_url" do
+    it "returns the URL to open a channel in GDS Slack" do
+      channel_name = "#general"
+      expect(helper.slack_url(channel_name)).to eq("https://gds.slack.com/channels/general")
+    end
+  end
+end


### PR DESCRIPTION
This adds a hyperlink to the team Slack channel names so they can be clicked on.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
