### PR TITLE
Add hosting details for whitehall-prototype-2023

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1407,6 +1407,11 @@
 - repo_name: whitehall-prototype-2023
   type: Publishing apps
   team: "#govuk-publishing-experience-tech"
+  production_url: https://whitehall-prototype-91f05d25216a.herokuapp.com
+  management_url: https://dashboard.heroku.com/pipelines/2f915a5e-edfd-4c90-b24d-00ed5c8c3c66
+  production_hosted_on: heroku
+  sentry_url: false
+  dashboard_url: false
 
 - repo_name: widdershins
   type: Gems


### PR DESCRIPTION
Related to PR alphagov/whitehall-prototype-2023#10

This prototype app is hosted in Heroku so it can be accessed for user testing. This PR updates the developer docs accordingly.

| Before | After |
| --- | --- |
| ![whitehall-prototype-2023-before](https://github.com/alphagov/govuk-developer-docs/assets/7735945/8052b906-69a6-4797-ac02-a9eb0ba4a804) | ![whitehall-prototype-2023-after](https://github.com/alphagov/govuk-developer-docs/assets/7735945/a2e7f1f4-0c89-454f-8507-7b08e7f1e147) |
