### PR TITLE
fix typo in asset manager link

### DIFF
--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -34,7 +34,7 @@ will proxy asset requests to Government Frontend
 
 ## Uploaded assets
 
-[Asset Manager](repos/asset-manager.html) is an API that is called internally
+[Asset Manager](/repos/asset-manager.html) is an API that is called internally
 by [GOV.UK publishing applications](/#publishing-apps) to manage
 their uploads. It serves the uploaded assets on
 `assets.publishing.service.gov.uk`.


### PR DESCRIPTION
Fixes a tiny broken link to asset manager (was using a relative url not absolute one)
