### PR TITLE
Add Siteimprove gem to repos list

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1284,6 +1284,14 @@
   team: "#govuk-publishing-access-and-permissions-team"
   production_hosted_on: eks
 
+- repo_name: siteimprove_api_client
+  team: "#govuk-developers"
+  type: Gems
+  sentry_url: false
+  dashboard_url: false
+  description: |
+    Used by content-data-admin Siteimprove integration.
+
 - repo_name: slimmer
   team: "#govuk-navigation-tech"
   type: Gems


### PR DESCRIPTION
Add siteimprove_api_client gem to repos list.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
