### PR TITLE
Fix link for 'Update popular links' docs in 2nd line drill page

### DIFF
--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -135,9 +135,9 @@ Once you have successfully updated the change note you can drill [removing a cha
 
 ### Drill updating homepage popular links
 
-Change the homepage popular links following [Update popular links](/manual/update_popular_links.html.md). Open a draft PR, and deploy your branch to integration. Once deployed, check your change and redeploy the previous branch to integration.
+Change the homepage popular links following [Update popular links](/manual/update_popular_links.html). Open a draft PR, and deploy your branch to integration. Once deployed, check your change and redeploy the previous branch to integration.
 
-### Update homepage promotion slots
+### Drill updating homepage promotion slots
 
 Follow the [Update homepage promotion slots](/repos/frontend/update-homepage-promotion-slots.html) instructions, using an appropriate image and text.
 Open a draft PR, and [deploy your branch to integration](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/).


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
