### PR TITLE
Remove govuk-app-deployment-private

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -403,13 +403,6 @@
   sentry_url: false
   dashboard_url: false
 
-- repo_name: govuk-app-deployment-private
-  private_repo: true
-  team: "#govuk-platform-security-reliability-team"
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
-
 - repo_name: govuk-ask-export
   team: "#user-experience-measurement-govuk-robot-invasion"
   type: Utilities


### PR DESCRIPTION
Unclear what this was for. Repo now archived. Not even worth keeping as a 'retired' repo in this file. Suspect it may have been used for developing in private (as needed sometimes, described here: https://docs.publishing.service.gov.uk/manual/make-github-repo-private.html ). These repos are ephemeral in nature and don't need to be recorded in the Developer Docs.
