### PR TITLE
Transfer ownership of some repos to Platform Engineering

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -270,7 +270,7 @@
   type: Data science
 
 - repo_name: docker-collectd-plugin
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
   sentry_url: false
   dashboard_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -900,7 +900,7 @@
 
 - repo_name: icinga_slack_webhook
   type: Utilities
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
 
 - repo_name: imminence
   type: APIs

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -821,7 +821,7 @@
     [content-store](/repos/content-store.html).
 
 - repo_name: govuk_crawler_worker
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
   production_hosted_on: aws
 
@@ -870,7 +870,7 @@
   dashboard_url: false
 
 - repo_name: govuk_seed_crawler
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Gems
 
 - repo_name: govuk_sidekiq

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -585,7 +585,7 @@
   type: Utilities
 
 - repo_name: govuk-jenkinslib
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
   description: Groovy library for common GOV.UK Jenkins CI tasks
   sentry_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -98,7 +98,7 @@
 
 - repo_name: capistrano_rsync_with_remote_cache
   type: Utilities
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
 
 - repo_name: ckan
   type: data.gov.uk apps

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -397,7 +397,7 @@
   type: Utilities
 
 - repo_name: govuk-app-deployment
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
   description: Capistrano deployment scripts for applications running on GOV.UK.
   sentry_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1063,7 +1063,7 @@
     people and roles, taking over from whitehall. It was never released.
 
 - repo_name: packager
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
 
 - repo_name: panopticon
@@ -1150,7 +1150,7 @@
 
 - repo_name: puppet-aptly
   type: Utilities
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
 
 - repo_name: puppet-gor
   retired: true

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -652,7 +652,7 @@
     This held infra-as-code for the old GOV.UK provider, which is no longer needed.
 
 - repo_name: govuk-puppet
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
   deploy_url: https://github.com/alphagov/govuk-secrets/blob/main/puppet_aws/deploy.sh
   sentry_url: false

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -699,7 +699,7 @@
   dashboard_url: false
 
 - repo_name: govuk-ruby
-  team: "#govuk-platform-security-reliability-team"
+  team: "#govuk-platform-engineering"
   type: Utilities
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
These repos were owned by Platform Security and Reliability (PSR), however it makes more sense for them to be owned by Platform Engineering (PE). PE are retiring Puppet and Jenkins this quarter, which will render all of these repositories obsolete. In the meantime, therefore, there is no point in PSR attempting to make any improvements to these repos.