### PR TITLE
Delete govuk-ruby repo.

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -698,12 +698,6 @@
   sentry_url: false
   dashboard_url: false
 
-- repo_name: govuk-ruby
-  team: "#govuk-platform-engineering"
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
-
 - repo_name: govuk-ruby-images
   description: Base container images for GOV.UK Ruby apps
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
This was temporary fork of docker-library/ruby which only had a single, trivial commit from 2 years ago that just changed a version number.

Considered archiving it, but that would be of negative value both to us and to the wider community.