### PR TITLE
Update 2nd-line drills page.

### DIFF
--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -9,10 +9,6 @@ type: learn
 
 There are a number of areas that are important to drill on 2nd line and include some tasks you may not necessarily encounter in your mission team. We want to ensure developers have the opportunity to practise these tasks ahead of the real thing and in preparation of going [on call](/manual/on-call.html) if you are part of the out of hours rota.
 
-## Drill detaching an instance
-
-Follow the [Detaching an instance from an Auto Scaling Group](/manual/common-aws-tasks-for-2nd-line-support.html#detaching-an-instance-from-an-auto-scaling-group) guidance.
-
 ## Drill publishing emergency banner
 
 Follow the [Deploy an emergency banner](/manual/emergency-publishing.html) on Staging.

--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -78,13 +78,13 @@ Follow the [Deploy when GitHub is unavailable](/manual/github-unavailable.html#c
 
 ### Drill enabling a code freeze
 
-Choose a continuously-deployed app where you can make a meaningful change to the default branch, e.g. fixing a typo, or merging a Dependabot PR.
+Choose a continuously-deployed app where you can make a meaningful change to the default branch, such as fixing a typo or merging a Dependabot PR.
 
-Either before merging the change, or part way through the continuous deployment process, follow the instructions for [implementing a deploy freeze](/manual/development-pipeline.html#check-for-or-implement-a-deploy-freeze) for that app.
+Before merging the change, [implement a deployment freeze](/manual/development-pipeline.html#check-for-or-implement-a-deploy-freeze) for that app.
 
-Follow the deployment pipeline in Jenkins. Confirm that no further environment deployments are triggered. For example, if you implemented the deploy freeze just after the app was deployed to Staging, confirm that the app was then not automatically deployed to Production.
+View the application's page in Argo CD in each environment to see whether a deployment happened or not.
 
-Remove the code freeze, then manually push the changes to all remaining environments so that they're in sync.
+Remove the code freeze, then make sure the current version is deployed to all three environments.
 
 ## Drill making changes to user accounts
 


### PR DESCRIPTION
- Delete obsolete "Drill detaching an instance".
- Update "Drill enabling a code freeze".

The manual page that the code freeze one links to almost certainly needs updating too, but that's for another PR.