### PR TITLE
Archive govuk-sentry-monitor

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -720,6 +720,10 @@
 - repo_name: govuk-sentry-monitor
   team: "#govuk-platform-security-reliability-team"
   type: Utilities
+  retired: true
+  description: |
+    Script to report the number of errors in Sentry to Graphite.
+    The result was displayed on the Sentry dashboard and on the 2nd line dashboard.
 
 - repo_name: govuk-spaCy
   team: "#data-products"


### PR DESCRIPTION
This was not replatformed in 2023, so no longer works. Nobody has complained or noticed that the service hasn't been reachable in several months, suggesting it is safe for retirement.

There is also a question as to whether metrics were ever that useful, as we’ve got alerts in Sentry.
