### PR TITLE
Retire GitHub pages sites carefully

### DIFF
--- a/source/manual/retiring-a-repo.html.md
+++ b/source/manual/retiring-a-repo.html.md
@@ -16,7 +16,11 @@ Once a repository is archived all of its issues and pull requests become read-on
 
 ## 3. Unpublish the GitHub pages site (if it has one)
 
-Archiving a repo doesn't unpublish the GitHub Pages site linked to the repository, so you'll need to do that first.
+Archiving a repo doesn't affect the GitHub Pages site linked to the repository. We should retire the site carefully because it may be possible for someone else to reuse the URL.
+
+- Remove any references to the URL from documentation and code
+- Delete any DNS entries for the site if the site uses a custom domain
+- Unpublish the GitHub Pages site
 
 ## 4. Archive the repo
 


### PR DESCRIPTION
GitHub pages site commonly use URLs like this: https://alphagov.github.io/. If we retire a standard site like this (that has no custom DNS configuration on our side), then we should be mindful to update our docs and code beforehand because it would be a nuisance if something broke because it relied on this.

We should also be a little careful because we don't own the github.io domain. It could change ownership at some point, and we don't want to have to go through our archived repos to clean everything up when we could have done it at the time.

If we use a custom domain and disable the site, we're at risk of a domain takeover. That is: someone else could host a site using our URL.

We can protect against this by using [domain verification](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages) and/or checking for dangling CNAMEs, but it's better if we're not totally reliant on these features.

It's also great to keep our DNS config tidy!

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
