### PR TITLE
Revert "Revert "Move smart-answers""

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1291,11 +1291,8 @@
 
 - repo_name: smart-answers
   type: Frontend apps
-  team: "#user-experience-measurement-govuk-robot-invasion"
-  shortname: smartanswers
+  team: "#govuk-publishing-on-platform-content-tech"
   production_hosted_on: eks
-  argo_cd_apps:
-    - smartanswers
 
 - repo_name: smokey
   team: "#govuk-platform-security-reliability-team"


### PR DESCRIPTION
This reverts commit dc7dfda1a4c60213b32590c80340b3a628a04e53.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

This completes transfer of ownership of `smart-answer` to On-platform Content Creation team