### PR TITLE
Add more GA4 analytics data

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -185,6 +185,14 @@
   type: string
   redact: false
 
+- name: percent_scrolled
+  description: indicates how far down the page was scrolled, typically 20%, 40%, 60%, 80% or 100%
+  value: 20, 40, 60, 80 or 100
+  example: 20
+  required: no
+  type: string (number)
+  redact: false
+
 - name: publishing_app
   description: application that published the content
   value: content attribute of meta tag govuk:publishing-app

--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -185,6 +185,11 @@
   type: string
   redact: false
 
+- name: organisations
+  required: no
+  type: string
+  redact: false
+
 - name: percent_scrolled
   description: indicates how far down the page was scrolled, typically 20%, 40%, 60%, 80% or 100%
   value: 20, 40, 60, 80 or 100
@@ -193,10 +198,31 @@
   type: string (number)
   redact: false
 
+- name: political_status
+  required: no
+  type: string
+  redact: false
+
+- name: primary_publishing_organisation
+  required: no
+  type: string
+  redact: false
+
+- name: public_updated_at
+  required: no
+  type: string
+  redact: false
+
 - name: publishing_app
   description: application that published the content
   value: content attribute of meta tag govuk:publishing-app
   example: collections-publisher
+  required: no
+  type: string
+  redact: false
+
+- name: publishing_government
+  description: The government that was responsible for publishing a piece of content.
   required: no
   type: string
   redact: false
@@ -348,6 +374,29 @@
   required: no
   type: string
   redact: true
+
+- name: video_current_time
+  description: The current position of the video being played, in seconds.
+  required: no
+  type: string (number)
+  redact: false
+
+- name: video_duration
+  description: The length of a video, in seconds.
+  required: no
+  type: string (number)
+  redact: false
+
+- name: video_percent
+  description: Used to record when the video being played is at 0%, 25%, 50%, 75% or 100%.
+  required: no
+  type: string (number)
+  redact: false
+
+- name: world_locations
+  required: no
+  type: string
+  redact: false
 
 - name: withdrawn
   description:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -101,24 +101,93 @@
 
 - name: browse
   events:
-    - name: topic browse link click
-      implemented: false
+    - name: browse (browse level 0)
+      implemented: true
       priority: medium
+      description: Tracking the top level of the browse pages.
+      examples:
+        - text: Browse level 0
+          link: https://www.gov.uk/browse
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
-    - name: page view topic page parameters
-      implemented: false
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: browse card
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
+    - name: browse topic (browse level 1)
+      implemented: true
       priority: medium
+      description: Tracking the second level of the browse pages.
+      examples:
+        - text: Browse level 1
+          link: https://www.gov.uk/browse/benefits
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
-    - name: see more in this topic link click
-      implemented: false
-      priority: low
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: browse card
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
+    - name: browse subtopic (browse level 2)
+      implemented: true
+      priority: medium
+      description: Tracking the final level of the browse pages.
+      examples:
+        - text: Browse level 2
+          link: https://www.gov.uk/browse/births-deaths-marriages/child
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: browse card
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+          - name: index_section
+          - name: index_section_count
+        - name: index_total
+        - name: section
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
 
 - name: call out box
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -788,12 +788,53 @@
 
 - name: scroll tracking
   events:
-    - name: scroll tracking
-      implemented: false
+    - name: percentage scroll tracking
+      implemented: true
       priority: medium
+      tracker: scroll_tracker
+      examples:
+        - text: Search results
+          link: https://www.gov.uk/search/all?keywords=minister&order=relevance
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: scroll
+        - name: event_name
+          value: scroll
+        - name: type
+          value: percent
+        - name: percent_scrolled
+    - name: heading scroll tracking
+      implemented: true
+      priority: medium
+      tracker: scroll_tracker
+      examples:
+        - text: GOV.UK homepage
+          link: https://www.gov.uk/
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: scroll
+        - name: event_name
+          value: scroll
+        - name: index
+          value:
+          - name: index_section
+            value: index of the heading reached
+          - name: index_section_count
+            value: total number of headings being tracked
+        - name: text
+          value: text of heading reached
+        - name: section
+          value: text of heading reached
+        - name: type
+          value: heading
 
 - name: see all link
   events:

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -12,6 +12,8 @@ data:
       link: events.html
     - name: Attributes
       link: attributes.html
+    - name: Data schemas
+      link: schema.html
 
 docs:
   name: Documentation
@@ -59,6 +61,11 @@ events:
     Events are collections of data that are sent to a GA4 property when users do certain things, like opening an accordion or clicking a link.
 
     We use the following events:
+
+schema:
+  name: Data schemas
+  desc: |
+    This page shows our complete schemas for our different events.
 
 cookies:
   name: Cookies on the implementation record

--- a/data/analytics/schemas.yml
+++ b/data/analytics/schemas.yml
@@ -1,0 +1,106 @@
+- name: event schema
+  data:
+  - name: event
+    value: event_data
+  - name: event_data
+    value:
+    - name: event_name
+      value: undefined
+    - name: type
+      value: undefined
+    - name: url
+      value: undefined
+    - name: text
+      value: undefined
+    - name: index
+      value:
+      - name: index_link
+        value: undefined
+      - name: index_section
+        value: undefined
+      - name: index_section_count
+        value: undefined
+    - name: index_total
+      value: undefined
+    - name: section
+      value: undefined
+    - name: action
+      value: undefined
+    - name: external
+      value: undefined
+    - name: method
+      value: undefined
+    - name: link_domain
+      value: undefined
+    - name: link_path_parts
+      value: undefined
+    - name: tool_name
+      value: undefined
+    - name: percent_scrolled
+      value: undefined
+    - name: video_current_time
+      value: undefined
+    - name: video_duration
+      value: undefined
+    - name: video_percent
+      value: undefined
+- name: page view schema
+  data:
+  - name: event
+    value: page_view
+  - name: page_view
+    value:
+    - name: browse_topic
+      value: undefined
+    - name: content_id
+      value: undefined
+    - name: document_type
+      value: undefined
+    - name: dynamic
+      value: undefined
+    - name: first_published_at
+      value: undefined
+    - name: history
+      value: undefined
+    - name: language
+      value: undefined
+    - name: location
+      value: undefined
+    - name: organisations
+      value: undefined
+    - name: political_status
+      value: undefined
+    - name: primary_publishing_organisation
+      value: undefined
+    - name: public_updated_at
+      value: undefined
+    - name: publishing_app
+      value: undefined
+    - name: publishing_government
+      value: undefined
+    - name: referrer
+      value: undefined
+    - name: rendering_app
+      value: undefined
+    - name: schema_name
+      value: undefined
+    - name: status_code
+      value: undefined
+    - name: taxonomy_all
+      value: undefined
+    - name: taxonomy_all_ids
+      value: undefined
+    - name: taxonomy_level1
+      value: undefined
+    - name: taxonomy_main
+      value: undefined
+    - name: taxonomy_main_id
+      value: undefined
+    - name: title
+      value: undefined
+    - name: updated_at
+      value: undefined
+    - name: withdrawn
+      value: undefined
+    - name: world_locations
+      value: undefined

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -22,6 +22,12 @@
   description: This script automatically tracks clicks on links such as external links, download links, and mailto links.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
 
+- name: Scroll tracker
+  technical_name: scroll_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-scroll-tracker.md
+  description: Provides scroll tracking when applied to a page.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
+
 - name: Form tracker
   technical_name: form_tracker
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-form-tracker.md

--- a/source/analytics/schema.html.md.erb
+++ b/source/analytics/schema.html.md.erb
@@ -1,0 +1,17 @@
+<% content_for :title, create_page_title(data.analytics.navigation.schema.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.schema.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.schema.desc %>
+</p>
+
+<% data.analytics.schemas.each do |schema| %>
+  <h2 class="govuk-heading-m analytics-heading"><%= schema.name %></h2>
+  <% event_hash = build_event(schema.data) %>
+  <div class="govuk-inset-text">
+    <%= to_html(event_hash) %>
+  </div>
+<% end %>

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -11,6 +11,7 @@
 
 <% event.events.each do |page_event| %>
   <div class="event">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <h2 class="govuk-heading-m analytics-heading">
       <%= page_event.name %>
     </h2>
@@ -58,5 +59,6 @@
     <div class="govuk-inset-text">
       <%= to_html(event_hash) %>
     </div>
+    <p class="govuk-body govuk-body-s">You can also view our <a href="/analytics/schema.html" class="govuk-link">complete schemas</a>.</p>
   </div>
 <% end %>


### PR DESCRIPTION
## What
Adds some more data to the analytics pages, specifically filling in some gaps for scroll tracking and browse, as well as adding a copy of our complete schemas for events and page views.

## Why
Part of our GA4 migration work.

Trello card: https://trello.com/c/KjI9KBwC/590-add-schema-to-implementation-record
