### PR TITLE
Add step to update the architecture diagram when retiring an application

### DIFF
--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -79,7 +79,8 @@ these.
 
 ## 9. Update docs
 
-Mark the application as `retired` in [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs)
+- Mark the application as `retired` in [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs)
+- Remove the application from the [GOV.UK architecture diagram](/manual/architecture.html)
 
 ## 10. Drop database
 


### PR DESCRIPTION
This adds a step about updating the architecture diagram to the guidance on retiring an application, which should help us keep an accurate picture of things.