### PR TITLE
Update docs for Sentry permissions

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -63,7 +63,7 @@ Access should be granted at the discretion of the engineer's tech lead, once the
 - `engineer` and "Access all services" permissions in Fastly
 - GOV.UK PaaS [Space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer) and `Org manager`
   access to all spaces in the [govuk_development](https://admin.cloud.service.gov.uk/organisations/f8718311-b9a4-49d3-b1c7-7c5345a74e35) and [data-gov-uk](https://admin.cloud.service.gov.uk/organisations/39c3d2c5-8809-4dcf-8cd6-a8f62923a295/users) organisations
-- [Sentry](https://sentry.io/settings/govuk/members/) "Manager" role to administer teams and people
+- [Sentry](https://sentry.io/settings/govuk/members/) "Admin" role to administer teams and projects
 
 The steps above are outlined in the [GOV.UK Production Admin template Trello card](https://trello.com/c/GIHPZi2o/382-production-admin-access-for-2nd-line), which is normally given whilst on 2nd line.
 


### PR DESCRIPTION
Production Admin users no longer get manager permissions, which prevents them from manually managing org users.

Depends on this change: https://github.com/alphagov/govuk-user-reviewer/pull/979