### PR TITLE
Remove independent-commission.uk from list of manually managed DNS zones

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -91,7 +91,6 @@ GOV.UK also manages DNS zones for some non-`gov.uk` domains.
 
 These include (but are not limited to):
 
-- `independent-commission.uk`
 - `independent-inquiry.uk`
 - `public-inquiry.uk`
 - `royal-commission.uk`


### PR DESCRIPTION
Related: https://github.com/alphagov/govuk-dns-tf/pull/64