### PR TITLE
Reorder asset removal steps

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -41,10 +41,6 @@ follow these steps:
 
 1. Request removal of the asset using the [Google Search Console](https://www.google.com/webmasters/tools/removals).
 
-1. Remove the asset from the Amazon Web Services (AWS) mirror:
-
-   `gds aws govuk-production-poweruser aws s3 rm s3://govuk-production-mirror/assets.publishing.service.gov.uk/<slug>`
-
 1. Remove the asset from the Google Cloud Platform (GCP) mirror:
    - Log into the [GCP console](https://console.cloud.google.com/).
    - Go to the `GOVUK Production` project under the `DIGITAL.CABINET-OFFICE.GOV.UK`
@@ -52,6 +48,10 @@ follow these steps:
    - Select `Cloud Storage -> Browser`, go to the [`govuk-production-mirror`
      bucket][govuk-production-mirror-gcp].
    - Navigate to the file, then delete it.
+
+1. Remove the asset from the Amazon Web Services (AWS) mirror:
+
+   `gds aws govuk-production-poweruser aws s3 rm s3://govuk-production-mirror/assets.publishing.service.gov.uk/<slug>`
 
 [clear-cache]: /manual/purge-cache.html#assets
 [govuk-production-mirror-gcp]: https://console.cloud.google.com/storage/browser/govuk-production-mirror;tab=objects?forceOnBucketsSortingFiltering=false&project=govuk-production


### PR DESCRIPTION
Swap the order of Google and AWS mirror steps to ensure that they are correctly numbered (6. 7. instead of 6. 1.)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
