### PR TITLE
Add guidance for automated SSL/TLS certificates

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -116,6 +116,10 @@ Note that some requests come directly via the [hostmaster Google group](https://
 
 For actioning these requests, [read our DNS documentation](/manual/dns.html).
 
+## Automated requests from Amazon ACM or AWS Certificate Manager
+
+Please refer to the [SRE interruptible documentation](https://docs.google.com/document/d/1QzxwlN9-HoewVlyrOhFRZYc1S0zX-pd97igY8__ZLAo/edit#heading=h.91quw0ws3zim).
+
 ## Leaver tickets
 
 As part of the leaver process, 1st line pass leaver tickets over to us so that we can check if they still have any GOV.UK access.


### PR DESCRIPTION
It took us a while to find the guidance for this so feels helpful to include here.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
