### PR TITLE
Add other internal GOV.UK dependencies

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,9 +1,27 @@
 api_version: 1
 auto_merge:
+  - dependency: govuk_app_config
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_personalisation
+    allowed_semver_bumps:
+      - patch
   - dependency: govuk_publishing_components
     allowed_semver_bumps:
       - patch
       - minor
+  - dependency: govuk_schemas
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_tech_docs
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: middleman-search-gds
+    allowed_semver_bumps:
+      - patch
   - dependency: rubocop-govuk
     allowed_semver_bumps:
       - patch


### PR DESCRIPTION
We're still trialling the auto-merge service. Currently we haven't really seen it in action, as every govuk_publishing_components version bump has also included bumps to other subdependencies, which is not allowed by the service. Extending the list to include all internal dependencies is pretty low risk and should give us a better chance to see the service in action.

I've deliberately only allowed 'patch' versions of govuk_personalisation and middleman-search-gds, as these are still on a 0.x.x version, so a semver 'minor' change could actually be a major breaking change.
