### PR TITLE
Revert "Make content schemas' "document_type" items linkable"

### DIFF
--- a/helpers/properties_table_helpers.rb
+++ b/helpers/properties_table_helpers.rb
@@ -24,8 +24,8 @@ private
   def enums(attrs)
     return unless attrs["enum"]
 
-    values = attrs["enum"].map { |value| "<a href='/document-types/#{value}.html'>#{value}</a>" }
-    "Allowed values: <br>#{values.join('<br>')}"
+    values = attrs["enum"].map { |value| "<code>#{value}</code>" }
+    "Allowed values: #{values.join(', ')}"
   end
 
   def possible_types(attrs)


### PR DESCRIPTION
This reverts commit 070b74540a3e0a5fb907a13003381545e59dabfa.

Whilst it succeeded in linking to a schema's associated document type...
> ![good](https://github.com/alphagov/govuk-developer-docs/assets/5111927/78219e66-f515-4824-ae31-6dcbf005e898)

...it also unexpectedly added links to things that were _not_ document types...

> ![bad](https://github.com/alphagov/govuk-developer-docs/assets/5111927/c286a625-4f4a-4fdf-aef5-e34371f5d95c)

Having the link apply only to document types requires too tight a coupling between govuk-developer-docs and content schemas, so it's simplest to just revert this, as it was only a micro optimisation in the first place.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
