### PR TITLE
Update the Contracts Finder Archive docs

### DIFF
--- a/source/manual/data-gov-uk-contracts-archive.html.md
+++ b/source/manual/data-gov-uk-contracts-archive.html.md
@@ -7,6 +7,8 @@ type: learn
 parent: "/manual.html"
 ---
 
+> This service is no longer available and was superseded by a new [Contracts Finder](https://www.gov.uk/contracts-finder) designed and operated by the Crown Commercial Service.
+
 ## Application
 
 Visit the [contracts archive finder](https://data.gov.uk/data/contracts-finder-archive).


### PR DESCRIPTION
We are completing the process of retiring this service, but the docs might still be useful if we ever need to reinstate it again.

Trello card: https://trello.com/c/lN55wEjL/3289-finish-retiring-contracts-finder-archive-3

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
