### PR TITLE
Mark old CDN repositories as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -447,11 +447,13 @@
   type: Utilities
   sentry_url: false
   dashboard_url: false
+  retired: true
 
 - repo_name: govuk-cdn-config-secrets
   private_repo: true
   team: "#govuk-platform-security-reliability-team"
   type: Utilities
+  retired: true
 
 - repo_name: govuk-cdn-logs-monitor
   type: Utilities


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
