### PR TITLE
Retire govuk-kubernetes-cluster-user-docs

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -630,6 +630,8 @@
 - repo_name: govuk-kubernetes-cluster-user-docs
   type: Utilities
   team: "#govuk-platform-engineering"
+  retired: true
+  description: The kubernetes cluster user documentation site was merged into the GOV.UK Developer Docs in September 2023.
 
 - repo_name: govuk-lambda-app-deployment
   type: Utilities


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-kubernetes-cluster-user-docs/pull/100

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
