### PR TITLE
Add CDN failover steps for staging, and add to list of 2nd line drills

### DIFF
--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -138,3 +138,9 @@ Change the homepage popular links following [Update popular links](/manual/updat
 Follow the [Update homepage promotion slots](/repos/frontend/update-homepage-promotion-slots.html) instructions, using an appropriate image and text.
 Open a draft PR, and [deploy your branch to integration](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/).
 Once deployed, [check your change](https://www-origin.integration.govuk.digital/) and redeploy the previous branch to integration.
+
+## Drill CDN failover
+
+Warn in `#govuk-2ndline-tech` that you're about to do this, because our failover CDN does not have full feature parity with our primary one.
+
+Follow the [Fall back to AWS CloudFront](/manual/fall-back-to-aws-cloudfront.html.md) instructions for staging only.

--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -24,30 +24,43 @@ This backup CDN is currently provided by AWS CloudFront.
 - Escalate to GOV.UK SMT as soon as you begin to consider failing over
 - Sign in to the AWS console as an admin (`gds aws govuk-production-admin -l`, or however you prefer to sign in to AWS)
 - Sign in to [the GCP console](https://console.cloud.google.com/home/dashboard?project=govuk-production)
-- Open the following four pages as separate tabs:
+- For **production**, open the following four pages as separate tabs:
   - [GCP Cloud DNS www-cdn.production.govuk.service.gov.uk](https://console.cloud.google.com/net-services/dns/zones/govuk-service-gov-uk/rrsets/www-cdn.production.govuk.service.gov.uk./CNAME/edit?project=govuk-production)
   - [AWS Route 53 govuk.service.gov.uk](https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/Z22RPYZA77J620)
   - [GCP Cloud DNS assets.publishing.service.gov.uk](https://console.cloud.google.com/net-services/dns/zones/publishing-service-gov-uk/rrsets/assets.publishing.service.gov.uk./CNAME/edit?project=govuk-production)
   - [AWS Route 53 publishing.service.gov.uk](https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/Z3SBFBO09PD5HF)
-- Find the correct `CNAME`s for `www-cdn.production.govuk.service.gov.uk` and `assets.publishing.service.gov.uk`
-  - This [Draft PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-tf/pull/69) shows the `CNAME`s you need to change, and how to test that they are correct
-  - You can also get the `CNAME`s to use for the secondary CDN from the AWS CLI:
+- For **staging**, open the following three pages as separate tabs:
+  - [GCP Cloud DNS www.staging.publishing.service.gov.uk](https://console.cloud.google.com/net-services/dns/zones/publishing-service-gov-uk/rrsets/www.staging.publishing.service.gov.uk./CNAME/edit-standard?project=govuk-production)
+  - [GCP Cloud DNS assets.staging.publishing.service.gov.uk](https://console.cloud.google.com/net-services/dns/zones/publishing-service-gov-uk/rrsets/assets.staging.publishing.service.gov.uk./CNAME/edit-standard?project=govuk-production)
+  - [AWS Route 53 publishing.service.gov.uk](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/Z3SBFBO09PD5HF)
+- You are going to update the `CNAME` records for two different domains, in both GCP and AWS:
+  - For **production**, these two domains are `www-cdn.production.govuk.service.gov.uk` and `assets.publishing.service.gov.uk`
+    - This [Draft PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-tf/pull/69) shows the `CNAME`s you need to change, and how to test that they are correct
+    - You can also get the `CNAME`s to use for the secondary CDN from the AWS CLI:
 
-    ```bash
-    # www.gov.uk
-    gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[0]=='www.gov.uk'].DomainName | [0]"
-    # assets.publishing.service.gov.uk
-    gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[0]=='assets.publishing.service.gov.uk'].DomainName | [0]"
-    ```
+      ```bash
+      # www-cdn.production.govuk.service.gov.uk
+      gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[0]=='www.gov.uk'].DomainName | [0]"
+      # assets.publishing.service.gov.uk
+      gds aws govuk-production-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[0]=='assets.publishing.service.gov.uk'].DomainName | [0]"
+      ```
 
-  - The records should look like `d0000000000000.cloudfront.net.` (with 0s replaced with letters and numbers)
-- When you are ready to fail over:
-  - Manually update the `CNAME` record for www-cdn.production.govuk.service.gov.uk in GCP and AWS
-  - Manually update the `CNAME` record for assets.publishing.service.gov.uk in GCP and AWS
-- After failing over manually:
+  - For **staging**, these two domains are `www.staging.publishing.service.gov.uk` and `assets.staging.publishing.service.gov.uk`
+    - You can get the `CNAME`s to use for the secondary CDN from the AWS CLI:
+
+      ```bash
+      # www.staging.publishing.service.gov.uk
+      gds aws govuk-staging-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[0]=='www.staging.publishing.service.gov.uk'].DomainName | [0]"
+      # assets.staging.publishing.service.gov.uk
+      gds aws govuk-staging-readonly aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items[0]=='assets.staging.publishing.service.gov.uk'].DomainName | [0]"
+      ```
+
+  - In either case, the records should look like `d0000000000000.cloudfront.net.` (with 0s replaced with letters and numbers)
+- Manually update the `CNAME` records for both domains in both GCP and AWS, via the tabs you opened in your web browser earlier
+- **On production only**, after performing the manual failover, you should also update our infrastructure-as-code to match the changes you just made:
   - Merge [the PR to Failover to AWS CloudFront](https://github.com/alphagov/govuk-dns-tf/pull/69)
   - Terraform Cloud should automatically perform a plan when your PR is merged, but the apply will require manual approval - you can do this in the [govuk-dns-tf workspace](https://app.terraform.io/app/govuk/workspaces/govuk-dns-tf)
 - Once you've failed over, keep a close eye on Fastly's status
 - As soon as you are confident that Fastly has recovered
-  - Manually set the CNAME records you changed above back to www-gov-uk.map.fastly.net.
-  - Raise a PR in [govuk-dns-tf](https://github.com/alphagov/govuk-dns-tf) to revert your previous changes and restore the old records. Get it approved, merged and approve the Terraform apply via the [govuk-dns-tf workspace](https://app.terraform.io/app/govuk/workspaces/govuk-dns-tf) on Terraform Cloud.
+  - Manually set each of the `CNAME` records you changed above back to `www-gov-uk.map.fastly.net`
+  - If you previously raised a PR in [govuk-dns-tf](https://github.com/alphagov/govuk-dns-tf), raise another PR to revert your changes and restore the old records. Get it approved, merged and approve the Terraform apply via the [govuk-dns-tf workspace](https://app.terraform.io/app/govuk/workspaces/govuk-dns-tf) on Terraform Cloud.


### PR DESCRIPTION
[Trello card](https://trello.com/c/51gZjhxH/3292-update-tech-docs-with-step-by-step-procedure-to-switch-from-fastly-to-cloudfront-and-back-1)
Based on [Cloudfront failover test procedure](https://docs.google.com/document/d/1RkYwVJAqEwQkWyAuOwAcsFu0Sg6qEspNhtYf8HFZIiY/edit)

Adds steps for performing CDN failover in staging, and adds a link to the list of 2nd line drills. I will add a link to [the spreadsheet](https://docs.google.com/spreadsheets/d/1iopyMaXgdseUINzpjENJtg6AnHSqfiSmzKmliJua9KI/edit#gid=0) after this PR is merged.