### PR TITLE
Skip proxy pages for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOVUK_CONTENT_SCHEMAS_PATH: tmp/publishing-api/content_schemas
+          SKIP_PROXY_PAGES: true


### PR DESCRIPTION
The build is taking somewhere in the region of [12m](https://github.com/alphagov/govuk-developer-docs/actions/runs/6099566750) to [21m](https://github.com/alphagov/govuk-developer-docs/actions/runs/6098915283). The vast majority of the time comes from all of the GitHub API requests made by the build script, to pull in documentation from all of our external repos.

That's necessary for building and deploying the site, but is not necessary for CI.

_Occasionally_ we see issues with the build script struggling with unexpected characters etc in a remote file, but we haven't seen this in a long time. In the meantime, docs are painful to update because the build script takes so long.

Better to just test our local docs, and step in later if the deploy script fails.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
