### PR TITLE
Add command to start the app on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Disabling proxy pages means you'll get a "Not Found" error if you try to access 
 bundle exec rake
 ```
 
+### Running the app
+
+```
+./startup.sh
+```
+
 ### Updating the template
 
 You can pull down the latest version of the Tech Docs template by running:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 
 **Use GOV.UK Docker to run any commands that follow.**
 
-### Before running the app
+### Running the app
+
+```
+./startup.sh
+```
 
 The docs include pages pulled from other GitHub repositories. By default, all these "proxy" pages are pulled when you start the app, which can lead to rate limit error. Using a GitHub API token avoids this.
 
@@ -37,12 +41,6 @@ Disabling proxy pages means you'll get a "Not Found" error if you try to access 
 
 ```
 bundle exec rake
-```
-
-### Running the app
-
-```
-./startup.sh
 ```
 
 ### Updating the template


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

Add command `./startup.sh` to the readme to start the application