### PR TITLE
Add a bit of context to retiring of govuk-cdn-config

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -448,6 +448,8 @@
   sentry_url: false
   dashboard_url: false
   retired: true
+  description: |
+    This project managed our Fastly VCL configuration until it was replaced by govuk-fastly in September 2023.
 
 - repo_name: govuk-cdn-config-secrets
   private_repo: true


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
