### PR TITLE
Clarify how users are removed from GitHub

### DIFF
--- a/source/manual/github.html.md
+++ b/source/manual/github.html.md
@@ -47,6 +47,10 @@ Not everyone on GOV.UK requires GitHub access, as much of what we do is in the o
   - which GitHub team(s) you should join ([see list](#govuk-teams))
   - why you need access
 
+## Removing access to GitHub
+
+Users are removed from the GitHub organisation when their entry in [govuk-user-reviewer][govuk-user-reviewer] is deleted.
+
 # GOV.UK repos
 
 ## Create and configure a new GOV.UK repo


### PR DESCRIPTION
Repeats info written in https://github.com/alphagov/govuk-user-reviewer#addingremoving-users, but worth having here for completion.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
