### PR TITLE
Link to Publishing's architecture diagram

### DIFF
--- a/source/manual/architecture.html.md
+++ b/source/manual/architecture.html.md
@@ -21,5 +21,7 @@ parent: "/manual.html"
 
 If you'd like to explore further, read the [architectural deep-dive](/manual/architecture-deep-dive.html).
 
+A more recent architecture diagram, created for the publishing teams, is available at <https://app.mural.co/t/govuk1422/m/govuk1422/1694525134284/5fea5844e36344eb1bc98c20cd0755d2a0c2266e>.
+
 [src]: https://drive.google.com/open?id=1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm
 [arch-folder]: https://drive.google.com/drive/folders/1xIjPkD_MSKMR65FbDAb-ToXy2GmBcaJ5


### PR DESCRIPTION
One day it would probably be good to consolidate our diagrams, but for now, adding a link here so it doesn't get lost.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
