### PR TITLE
Reflect the current transition process

### DIFF
--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -94,14 +94,12 @@ uploaded directly to Fastly via [govuk-cdn-config].
 
 Other redirects that happen at the Fastly level include [bouncer]: a GOV.UK
 application responsible for redirecting traffic from old pre-GOV.UK websites.
-This is configured via [transition] and [transition-config]. Read
-[Transition architecture] for more detail.
+This is configured via [transition]. Read [Transition architecture] for more detail.
 
 [bouncer]: https://github.com/alphagov/bouncer
 [govuk-cdn-config]: https://github.com/alphagov/govuk-cdn-config
 [Transition architecture]: /manual/transition-architecture.html
 [transition]: https://github.com/alphagov/transition
-[transition-config]: https://github.com/alphagov/transition-config
 
 ### Routing on GOV.UK
 

--- a/source/manual/changing-organisation-slug.html.md
+++ b/source/manual/changing-organisation-slug.html.md
@@ -22,18 +22,7 @@ Run the appropriate rake task:
 
 Note: it's important that single-quotes are used in the tasks otherwise they will fail.
 
-### 2. Update the organisation in transition/transition-config:
-
-The [transition-config repo](https://github.com/alphagov/transition-config) may
-contain slugs. Change any references to the old slug:
-
-- [Search the codebase for the slug](https://github.com/alphagov/transition-config/search?utf8=%E2%9C%93&q=old-slug)
-- Update the slugs
-- Open a pull request, and get it reviewed and merged
-
-Merging will trigger the changes to be imported automatically.
-
-### 3. Update the organisation slug in Manuals Publisher
+### 2. Update the organisation slug in Manuals Publisher
 
 Find out if any manuals are published by this organisation, by running the
 following in the Manuals Publisher Rails console:
@@ -45,7 +34,7 @@ ManualRecord.where(organisation_slug: "old-slug").exists?
 If there are, create a migration to update the slugs. Republish all affected
 manuals after deploying your change.
 
-### 4. Sync the organisations with Signon
+### 3. Sync the organisations with Signon
 
 [Signon][signon] assigns users to organisations. This is used by apps such as
 Whitehall for authorisation.
@@ -56,7 +45,7 @@ permissions for the renamed organisation.
 
 [signon]: https://signon.publishing.service.gov.uk/
 
-### 5. Update any best bet searches in Search Admin
+### 4. Update any best bet searches in Search Admin
 
 Search the best bets in [search-admin][search-admin] for references to the old
 organisation name and update them.

--- a/source/manual/remove-site-from-transition-tool.html.md
+++ b/source/manual/remove-site-from-transition-tool.html.md
@@ -8,16 +8,10 @@ section: Transition
 
 Sometimes we get requests to delete sites from the [Transition tool](https://transition.publishing.service.gov.uk).
 
-## 1. Remove site config YAML files
+## 1. Remove the site from Transition using the Delete functionality
 
-Sites that appear in the Transition tool are configured in YAML in the [alphagov/transition-config](https://github.com/alphagov/transition-config) repo. To remove one, `git rm` it from the `data/transition-sites` directory. There's [some prior art](https://github.com/alphagov/transition-config/pull/1306).
+If you have the Site Manager permission for Transition, you will see a "Delete" link on each site page. You'll have to confirm the deletion before any action is taken.
 
-## 2. Run rake task
-
-Once your changes have been merged, run the `import:revert:sites[site_abbr]` Rake on the Transition app with the site abbreviation that you want to delete. This task will only work for sites with zero mappings and zero hits - i.e. no associated data beyond that which was created by importing the site YAML file. It [triggers the `transition_load_site_config` Jenkins job](https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/) to update the Transition tool's loaded site config.
-
-To remove a redirect with existing mappings or hits, use the `import:revert_entirely_unsafe[site_abbr]` Rake task.
-
-## 3. Check that the site is no longer recognised by the Transition tool
+## 2. Check that the site is no longer recognised by the Transition tool
 
 When all caches have cleared, the host will not appear in [hosts.json](https://transition.publishing.service.gov.uk/hosts).

--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -11,7 +11,7 @@ When a site is going to move to GOV.UK, there are two ways that the old site
 can be redirected. They can do it themselves, or they can repoint the domain at
 us. This page is about the latter.
 
-The [Transition][] app exists to allow editing of mapping of old URLs to pages
+The [Transition][] app exists to allow old URLs to be mapped to pages
 on GOV.UK. These mappings are stored in a database and used by [Bouncer][] to
 handle requests to those old domains.
 
@@ -20,16 +20,29 @@ it, or changing the configuration of an existing site in the Transition app.
 
 ## Changing the configuration of a site that is already in the Transition app
 
-The [transition-config README][transition-config] gives more details on how to
-edit the relevant [transition configuration file].
-
-[transition configuration file]: https://github.com/alphagov/transition-config/tree/main/data/transition-sites
+If you have the Site Manager permission for Transition, you will see an Edit button on each site page (for example, [the site page for Department for Education's old domain](https://transition.publishing.service.gov.uk/sites/dfe)). This form will allow you to change the configuration of the site.
 
 ## Checklist for transitioning a new site
 
+### Prerequisites
+
+Before you start, you need to know:
+
+- the domain name being transitioned and any aliases
+- the organisation that owns the site (and any additional organisations that should have access)
+- the new homepage for the old site - often this is the organisation's page on GOV.UK, but sometimes it can be a different page on GOV.UK
+
+The organisation that owns the site determines several things:
+
+- where the site is found in the Transition app
+- who has access to edit and create mappings for the site
+- what organisation name and branding is used on pages served by Bouncer for URLs which aren't redirected
+
+Extra organisations can be added later.
+
 ### 1) Add a site to the Transition app
 
-Follow the instructions in the [transition-config README][transition-config].
+If you have the Site Manager permission for Transition, you will see an "Add a transition site" button on each organisation page (for example, [Department for Education’s organisation page](https://transition.integration.publishing.service.gov.uk/organisations/department-for-education). Follow the instructions on that form to add a site.
 
 ### 2) Consider AKA domains
 
@@ -86,7 +99,7 @@ There are lots of file formats we don't want to provide mappings for, like
 static assets, images, or common spammy/malicious crawlers. These can be
 stripped using the [strip_mappings.sh][smsh] script.
 
-[smsh]: https://github.com/alphagov/transition-config/blob/main/tools/strip_mappings.sh
+[smsh]: https://github.com/alphagov/transition/blob/main/tools/strip_mappings.sh
 
 #### Query parameter analysis
 
@@ -96,10 +109,10 @@ parameter names and then add them to the site configuration file in
 significantly changes the content seen on the old site and/or it would be
 mapped to a different new URL.
 
-There are some transition-config scripts to help analyse query param usage:
+There are some transition scripts to help analyse query param usage:
 
-- [analyse_query_params.sh](https://github.com/alphagov/transition-config/blob/main/tools/analyse_query_params.sh)
-- [analyse_query_usage.sh](https://github.com/alphagov/transition-config/blob/main/tools/analyse_query_usage.sh)
+- [analyse_query_params.sh](https://github.com/alphagov/transition/blob/main/tools/analyse_query_params.sh)
+- [analyse_query_usage.sh](https://github.com/alphagov/transition/blob/main/tools/analyse_query_usage.sh)
 
 Some common examples of significant parameters:
 
@@ -163,7 +176,7 @@ For security reasons, *.gov.uk subdomains are delegated upon request. When the s
 
 We need to:
 
-1. Obtain the TXT record by submitting Fastly support request. You will need to provide 'Production bouncer' service ID and the subdomain you want to add. See an [example of support request](https://support.fastly.com/hc/en-us/requests/700875).
+1. Obtain the TXT record by submitting a Fastly support request. You will need to provide the 'Production bouncer' service ID and the subdomain you want to add. See an [example of support request](https://support.fastly.com/hc/en-us/requests/700875).
 
 2. Add the DNS record to [govuk-dns-tf](https://github.com/alphagov/govuk-dns-tf) and apply terraform configuration.
 
@@ -199,10 +212,11 @@ There are two things that need to be responded to:
 
 ## Further reading
 
+> The documents below may contain outdated information.
+
 The transition checklist covers the whole process of transitioning a site from the technical side. There’s a [full version for complex sites](https://docs.google.com/document/d/1SiBwYtV_d_D9pPcqzpqvRWs0kscUtB7yqxN8Ub_uRSA/edit) and a [slightly simplified one](https://docs.google.com/document/d/1gIJBUuPaZqtYsrgwqMBSrU4lpr2e93tuhQcgylnSHb4/edit) - we probably only need the simpler one for upcoming transitions.
 
 [Transition]: /repos/transition.html
 [Bouncer]: /repos/bouncer.html
-[transition-config]: https://github.com/alphagov/transition-config/blob/main/README.md
 [request a Fastly TLS certificate]: /manual/request-fastly-tls-certificate.html
 [code change]: https://github.com/alphagov/govuk-dns-tf/compare/0cf283b6...18471c36

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -28,9 +28,6 @@ Source diagram in the [GOV.UK architecture folder][arch-folder].
 ### Components
 
 - [transition][] is the admin app that departments use to transition.
-- [transition-config][] contains YAML files to configure transitioning
-  websites. It's imported into the Transition database by the
-  [Transition_load_site_config job][config-import].
 - The [cloudwatch / athena / lambda][infra-fastly-logs] trio process the logs
   from Fastly to produce the statistics. Those are then loaded into Transition
   by the [Transition_load_all_data job][stats-import].
@@ -40,9 +37,6 @@ Source diagram in the [GOV.UK architecture folder][arch-folder].
 
 ## Transition data sources
 
-Site configuration is automatically imported every hour via
-[a Jenkins job][config-import] from [transition-config][].
-
 Traffic data is automatically imported every day via [a Jenkins
 job][stats-import].  This import puts a high load on the database. CDN logs
 for the "Production Bouncer" Fastly service are sent (by Fastly) to the
@@ -50,8 +44,6 @@ for the "Production Bouncer" Fastly service are sent (by Fastly) to the
 defined in the [infra-fastly-logs][] Terraform project.
 
 [transition]: /repos/transition.html
-[config-import]: https://deploy.blue.production.govuk.digital/job/Transition_load_site_config
-[transition-config]: https://github.com/alphagov/transition-config
 [stats-import]: https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/
 [infra-fastly-logs]: https://github.com/alphagov/govuk-aws/tree/master/terraform/projects/infra-fastly-logs
 


### PR DESCRIPTION
[Trello](https://trello.com/c/puypazMP/817-update-documentation-for-transitioning-a-site)

The Publishing Platform team has enabled support for adding and removing sites and hosts directly through the Transition app, deprecating the previous process that involved transition-config.

**Note**: I have not updated the architecture diagram. I asked permission to access the source diagram but haven't heard back yet.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
