### PR TITLE
Retire transition config

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1403,6 +1403,7 @@
 
 - repo_name: transition-config
   type: Transition apps
+  retired: true
   team: "#govuk-publishing-platform"
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
Merge after archiving [transition-config](https://github.com/alphagov/transition-config). (I don't have permissions to archive it myself.)

[Trello](https://trello.com/c/toGB61iI/809-remove-cron-job-that-imports-site-data-from-transition-config-to-transition-then-archive-the-transition-config-repo)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
