### PR TITLE
Remove the outdated architecture diagram

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -104,10 +104,9 @@ stripped using the [strip_mappings.sh][smsh] script.
 #### Query parameter analysis
 
 From your set of URLs, you can attempt to identify significant query string
-parameter names and then add them to the site configuration file in
-`transition-config`. A query string parameter is considered significant if it
-significantly changes the content seen on the old site and/or it would be
-mapped to a different new URL.
+parameter names and then add them to the site configuration. A query string
+parameter is considered significant if it significantly changes the content
+seen on the old site and/or it would be mapped to a different new URL.
 
 There are some transition scripts to help analyse query param usage:
 

--- a/source/manual/transition-architecture.html.md
+++ b/source/manual/transition-architecture.html.md
@@ -17,15 +17,7 @@ on GitHub][repos].
 [blog]: https://insidegovuk.blog.gov.uk/2014/12/19/300-websites-to-just-1-in-15-months
 [repos]: https://github.com/search?q=topic%3Agovuk-transition+org%3Aalphagov
 
-## High level overview
-
-![Overview of the elements involved in transition](images/transition-architecture.png)
-
-Source diagram in the [GOV.UK architecture folder][arch-folder].
-
-[arch-folder]: https://drive.google.com/drive/folders/0B7zRJZy-BNyUS2lMMzJHLUpYM00
-
-### Components
+## Components
 
 - [transition][] is the admin app that departments use to transition.
 - The [cloudwatch / athena / lambda][infra-fastly-logs] trio process the logs


### PR DESCRIPTION
The Publishing Platform team discussed whether to persevere in trying to locate the source for the diagram (not found in the arch-folder) and to rebuild the diagram, or remove it entirely.

We concluded that the system architecture is documented elsewhere, so we don't lose much by removing the outdated diagram entirely.

[Trello](https://trello.com/c/puypazMP/817-update-documentation-for-transitioning-a-site)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
