### PR TITLE
Document asset size limit

### DIFF
--- a/source/manual/assets.html.md
+++ b/source/manual/assets.html.md
@@ -53,6 +53,14 @@ following features:
   the replacement. Currently only Whitehall and Specialist Publisher support
   this.
 
+### File size limit
+
+There is a [hard limit of 500 MB](https://github.com/alphagov/govuk-helm-charts/blob/2e565071865d5e7b64bd1b961c2cdc69cbc04927/charts/asset-manager/templates/nginx-configmap.yaml#L145) for assets.
+
+Publishers may see timeouts if they attempt to upload very large attachments.
+In the past, we've worked around this by uploading a small file (in Whitehall) and
+then [replacing the file in Asset Manager](https://docs.publishing.service.gov.uk/manual/manage-assets.html#replacing-an-asset).
+
 ## Static templates
 
 The templates that Static hosts are used by

--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -95,15 +95,6 @@ host, for example:
 https://assets.publishing.service.gov.uk/media/57358658ed915d58bd000000/my_file.jpg
 ```
 
-### Large attachments
-
-Sometimes publishers ask us to help them upload very large attachments to
-documents in Whitehall because they see timeouts when they try to upload the
-document themselves.
-
-The simplest way to do this is to upload a small file (in Whitehall) and then
-[replace the file in Asset Manager](#replacing-an-asset).
-
 ## Replacing an asset
 
 If you need to replace the file of an existing attachment without


### PR DESCRIPTION
This question comes up quite often on 2nd line.

The limit is 500MB, imposed by our nginx config.
In practice, publishers would do well to keep far below this limit, for a variety of reasons.

That said, the biggest asset we have is 425 MB in size. I'll avoid linking to it directly here in case that info gets abused, but it's referenced in this Trello comment: https://trello.com/c/snmx8e2L/368-test-uploading-of-massive-pdf-to-whitehall-3#comment-5fe0840c15463b4930dd4c8e