### PR TITLE
Retire datagovuk_publish_elasticsearch_monitor

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -251,7 +251,7 @@
 - repo_name: datagovuk_publish_elasticsearch_monitor
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
-  production_hosted_on: paas
+  retired: true
 
 - repo_name: datagovuk_publish_queue_monitor
   type: data.gov.uk apps


### PR DESCRIPTION
This app used to be used for monitoring the Elasticsearch queue pre-replatforming. It is no longer used, and its days are numbered as the GOV.UK PaaS is being switched off in December 2023.

https://trello.com/c/NikGC9ja/3319-retire-datagovukpublishelasticsearchmonitor-2

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
