### PR TITLE
Mark `sidekiq-monitoring` as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1303,11 +1303,8 @@
     functionality.
 
 - repo_name: sidekiq-monitoring
-  team: "#govuk-publishing-platform"
+  retired: true
   type: Utilities
-  sentry_url: false
-  dashboard_url: false
-  production_hosted_on: aws
 
 - repo_name: signon
   type: Supporting apps


### PR DESCRIPTION
Sidekiq Monitoring was switched off as part of replatforming to EKS.  Therefore marking the repo as retired.

Depends on https://github.com/alphagov/sidekiq-monitoring/pull/113.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
