### PR TITLE
Add "MVP" devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json
+{
+	"name": "GOV.UK Developer Docs",
+	"image": "ruby:3.1",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"nodeGypDependencies": true,
+			"version": "lts",
+			"nvmVersion": "latest"
+		}
+	},
+	"forwardPorts": [4567],
+	"postCreateCommand": "bundle install",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"Shopify.ruby-lsp",
+				"redhat.vscode-yaml"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Set up a basic Ruby devcontainer with all necessary dependencies,
allowing users to run the Middleman app locally without needing anything
set up locally other than Docker and devcontainer tooling (such as
through a supported editor like Visual Studio Code), or even completely
on a cloud development environment like Github Codespaces.

Includes the Node.js feature (as Middleman depends on having a
Javascript engine installed).