### PR TITLE
Add govuk-mirror and govuk-dependabot-merger to repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -505,6 +505,13 @@
     translation of Whitehall feed URLs into Govdelivery topics. Retired in favour
     of email-alert-api in September 2017.
 
+- repo_name: govuk-dependabot-merger
+  team: "#govuk-platform-security-reliability-team"
+  type: Utilities
+  description: GitHub Action for auto-merging Dependabot PRs as per RFC-156
+  sentry_url: false
+  dashboard_url: false
+
 - repo_name: govuk-dependencies
   retired: true
   team: "#govuk-platform-security-reliability-team"
@@ -644,6 +651,13 @@
 - repo_name: govuk-load-testing
   type: Utilities
   team: "#govuk-platform-security-reliability-team"
+  sentry_url: false
+  dashboard_url: false
+
+- repo_name: govuk-mirror
+  team: "#govuk-platform-engineering"
+  type: Utilities
+  description: A simple Go program used by GOV.UK to populate mirrors hosted by AWS S3 and GCP Storage
   sentry_url: false
   dashboard_url: false
 


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
