### PR TITLE
Mark govuk-related-links-recommender as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -705,6 +705,7 @@
   description: Machine learning model to recommend related content
   sentry_url: false
   dashboard_url: false
+  retired: true
 
 - repo_name: govuk-replatform-test-app
   type: Utilities


### PR DESCRIPTION
As spotted by Chris Banks:

> govuk-related-links-recommender (the ML pipeline that used to augment hand-curated recommended links with auto-generated ones) has been disused since around the beginning of this year, isn't actually installed anywhere as far as I can tell
