### PR TITLE
Update main documentation about GOV.UK mirrors

### DIFF
--- a/source/manual/fall-back-to-mirror.html.md
+++ b/source/manual/fall-back-to-mirror.html.md
@@ -1,138 +1,52 @@
 ---
 owner_slack: "#govuk-2ndline-tech"
-title: GOV.UK CDN static mirrors
+title: GOV.UK content mirrors
 section: Deployment
 layout: manual_layout
 parent: "/manual.html"
 ---
 
-The GOV.UK mirror is a static copy of GOV.UK.
+A GOV.UK mirror is a static copy of pages and assets hosted on www.gov.uk or assets.publishing.service.gov.uk (or equivalent domains in integration and staging). A mirror includes:
+
+- HTML pages
+- related assets for those pages (e.g. JavaScript, CSS, images, fonts)
+- other linked assets (or "attachments") such as CSVs, PDFs etc
+
+## Available mirrors
+
+We maintain three mirrors, ranked by priority:
+
+1. Primary: AWS S3 bucket named `govuk-<environment>-mirror` in eu-west-2
+1. Secondary: AWS S3 bucket named `govuk-<environment>-mirror-replica` in eu-west-1 (production only)
+1. Tertiary: Google Cloud Storage (GCS) bucket named `govuk-<environment>-mirror`
+
+We use multiple mirrors across various AWS regions and GCP to ensure redundancy and increase availability.
 
 ## When is the GOV.UK mirror used?
 
-Most requests to GOV.UK are handled by the [Fastly content delivery network (CDN)](/manual/cdn.html), which sits between the user and [GOV.UK Origin](/manual/architecture-shallow-dive.html#a-user-visits-the-gov-uk-homepage).
+If [Fastly, our primary CDN](/manual/cdn.html), cannot fetch a page from our backend servers (becuase of a timeout or a 5xx error), then Fastly will attempt to serve a page from a mirror in order of priority.
 
-When a user requests a GOV.UK page, Fastly retrieves that page from its cache, or fetches the page from GOV.UK Origin if Fastly does not have the page in its cache.
+## How are the mirrors populated
 
-Sometimes, GOV.UK Origin may time out or return a 5xx error response. When that happens, Fastly automatically fetches the page from the GOV.UK mirror instead.
+Every day the [govuk-mirror-sync] cronjob crawls the www and assets domains, saves pages and assets to disk and then uploads the files to the primary S3 bucket. The [govuk-mirror] repository contains the code responsible for crawling and saving pages to disk.
 
-If Fastly goes down, we would manually [switch to AWS CloudFront](/manual/fall-back-to-aws-cloudfront.html) instead of Fastly. Where Fastly makes requests to GOV.UK Origin, AWS CloudFront instead makes all its requests to the GOV.UK mirror.
+S3 Replication automatically copies any changes from the primary S3 bucket to the secondary S3 bucket. This is configured in [govuk-aws].
 
-## GOV.UK mirror locations and access
+GCP Storage Transfer Service copies any changes from the primary S3 bucket to the tertiary GCS bucket.
 
-The GOV.UK mirror is hosted in an [Amazon Web Services (AWS) S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html). The bucket contains copies of GOV.UK HTML files. The mirror is static, meaning dynamic pages such as search pages will not work. S3 will return 403 Forbidden response for non-existent pages instead of 404, because we don't allow the ListBucket permission. This also affects requests for features such as Search, which are not covered by the mirrors.
+## What is not covered by mirrors
 
-The term "GOV.UK mirror" actually refers to 3 separate mirrors:
+Certain page types aren't included in the mirrors:
 
-- the main `govuk-<environment>-mirror` S3 bucket in one AWS region
-- the `govuk-<environment>-mirror-replica` S3 bucket in another region, so if the first AWS region is down, we can fall back to this other region
-- the `govuk-<environment>-mirror` bucket in Google Cloud Storage (GCS), so if AWS overall is down, we can fall back to this mirror
-
-Access to the Amazon S3 buckets is restricted. If you have a Fastly, Office or Pingdom IP address, you have read-only access. If you’re an authenticated AWS web console user, you have read-write access.
-
-Access to the GCS bucket is also restricted. You can access the GCS bucket if you can access the secret keys in `govuk-secrets`, or if you’re an authenticated Google Cloud Platform (GCP) web console user.
-
-## Updates to the GOV.UK mirror
-
-Automatic scripts update the GOV.UK mirror every day.
-
-The [`govuk_seed_crawler`](https://github.com/alphagov/govuk_seed_crawler) is a script on the GOV.UK “mirrorer” machine. Every day at 8:00pm, this script fetches all of the URLs in the [GOV.UK sitemap](https://www.gov.uk/sitemap.xml) and adds them to a [RabbitMQ message queue](/manual/rabbitmq.html).
-
-Then the [`govuk_crawler_worker`](https://github.com/alphagov/govuk_crawler_worker) on the mirrorer machine:
-
-- consumes the fetched GOV.UK URLs from the RabbitMQ message queue
-- retrieves the GOV.UK HTML files returned by these URLs
-- saves these HTML files to a `/tmp` folder on the mirrorer machine
-- adds any new URLs found on those pages to the back of the RabbitMQ message queue
-
-Every hour, the [`govuk_sync_mirror`](https://github.com/alphagov/govuk-puppet/blob/86d1480c6e081313c415246063d5931af24473da/modules/govuk_crawler/manifests/init.pp#L109) script runs on the mirrorer machine. This script copies the GOV.UK HTML files from the mirrorer machine to the main `govuk-<environment>-mirror` AWS S3 bucket. AWS then copies this main bucket to the replica `govuk-<environment>-mirror-replica` S3 bucket in another region.
-
-Finally, a job is run in Google Cloud Storage (GCS) at 6:00pm the day after the original `govuk_seed_crawler`script is run. This job syncs the primary AWS S3 bucket `govuk-<environment>-mirror` to the GCS `govuk-<environment>-mirror` bucket. For more information on GCS, see the [Google Cloud Platform documentation](/manual/google-cloud-platform-gcp.html).
-
-The `govuk_seed_crawler` and `govuk_crawler_worker` scripts are independent of the mirrors. Stopping these scripts stops the mirror updates, but does not stop the mirrors from working.
-
-Run the following to inspect the contents of the GOV.UK mirrorer machine:
-
-```
-gds govuk connect -e production ssh mirrorer
-cd /mnt/crawler_worker/www.gov.uk
-```
+- Smart answer pages (as the govuk-mirror crawler doesn't support following form links)
+- [CSV preview pages](https://github.com/alphagov/govuk-helm-charts/pull/1337)
 
 ## Troubleshooting
 
-If the `govuk_sync_mirror` cronjob has not succeeded for 24 hours, it triggers the ‘Mirror GOV.UK content to S3’ alert. See the [Mirror GOV.UK content to S3 alert documentation](/manual/alerts/mirror-sync.html) for more information.
+Check the logs of the govuk-mirror-sync job to see there are any errors during crawling, saving pages or uploading to S3.
 
-- This alert **will not** be raised in the event that `govuk_seed_crawler` is broken but `govuk_sync_mirror` is still working.
+Check buckets in AWS S3 or GCP to see if they are populated.
 
-If the `govuk_seed_crawler` cronjob fails to run:
-
-- The ‘seed_crawler last run status‘ alert should be triggered.
-- Files will stop being mirrored to `/mnt/crawler_worker/www.gov.uk` on the `mirrorer` node (this can be checked with `ls -ltr /mnt/crawler_worker/www.gov.uk`).
-- The [RabbitMQ dashboard](https://grafana.blue.production.govuk.digital/dashboard/file/rabbitmq.json?refresh=10s&orgId=1) will show fewer jobs (or no jobs at all) being published to the `govuk_crawler_queue` queue.
-- [Monitoring for the `cache_public_web_acl` ACL](https://us-east-1.console.aws.amazon.com/wafv2/homev2/web-acl/cache_public_web_acl/d9033e40-69e8-4bbc-a61a-cd3c50254d04/overview?region=eu-west-1) on AWS WAF will show a reduced number of requests to the cache machines (`govuk-infra-cache-requests AllowedRequests`).
-
-## Forcing failover to the GOV.UK mirrors
-
-If Origin is unavailable, Fastly will automatically retry every request against the mirrors.
-
-To avoid Fastly traffic hitting Origin when Origin is down (potentially making the problem worse), we can [fall back to AWS CloudFront](/manual/fall-back-to-aws-cloudfront.html), which serves all content using the GOV.UK mirrors.
-
-Alternatively, we can stop [Nginx](https://www.nginx.com/) on the cache machines, which will prevent requests hitting GOV.UK applications. Fastly will automatically retry these failed requests against the mirror.
-
-SSH into each cache machine (you can increment box number after the colon to hit each one in turn):
-
-```bash
-$ gds govuk connect -e production ssh cache:1
-```
-
-Stop Nginx to force use of mirrors:
-
-```bash
-$ govuk_puppet --test --disable "fail_to_mirror task (by $USER)"
-$ sudo service nginx stop
-```
-
-When required you can re-enable puppet, which will restart Nginx:
-
-```bash
-$ govuk_puppet --test --enable
-```
-
-## Emergency publishing content using the GOV.UK mirror
-
-The escalation on-call contact will tell you if you need to make changes to GOV.UK while Origin is unavailable. To do this, you must change content on the GOV.UK mirrors. Because the mirror is static HTML, it's hard to make broad changes to the site, like putting a banner on every page.
-
-1. If you're outside of GDS premises, connect to the [VPN][gds-vpn].
-
-1. SSH to the mirrorer machine:
-
-    ```bash
-    gds govuk connect -e production ssh mirrorer
-    ```
-
-1. Disable puppet on the machine:
-
-    ```bash
-    govuk_puppet --disable "stopping crawling to avoid mirror changes"
-    ```
-
-1. Stop the `govuk_crawler_worker` script:
-
-    ```bash
-    initctl stop govuk_crawler_worker
-    ```
-
-1. Modify the relevant file in the `/mnt/crawler_worker` directory.
-
-1. Upload the file to the AWS S3 bucket using the AWS console.
-
-1. Upload the file to Google Cloud Storage using the GCP console. Credentials are in the `govuk-secrets` password store, under `google-accounts`.
-
-If you're notified that you can revert the change you've made, you can do this by following the same emergency publishing process.
-
-Once Origin becomes available again, update Origin to reflect the change you made on the mirror.
-
-[govuk_crawler_worker]: https://github.com/alphagov/govuk_crawler_worker
-[govuk_seed_crawler]: https://github.com/alphagov/govuk_seed_crawler
-[govuk_mirror-puppet]: https://github.com/alphagov/govuk_mirror-puppet
-[gds-vpn]: https://docs.google.com/document/d/1O1LmLByDLlKU4F1-3chwS8qddd2WjYQgMaaEgTfK5To/edit
+[govuk-mirror]: https://github.com/alphagov/govuk-mirror
+[govuk-mirror-sync]: https://github.com/alphagov/govuk-helm-charts/blob/main/charts/govuk-jobs/templates/govuk-mirror-sync-cronjob.yaml
+[govuk-aws]: https://github.com/alphagov/govuk-aws/blob/2053b554/terraform/projects/infra-mirror-bucket/main.tf#L197


### PR DESCRIPTION
We've recently migrated the process to populate mirrors to EKS. This updates and improves the existing documentation:

- Change title to make it clear which type of mirror this is referring to
- Remove referrences to CloudFront as not relevant here
- Simplified explaination about how CDN serves traffic, better suited for arch documentation

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
