### PR TITLE
Don't log every header of every HTTP request

### DIFF
--- a/app/github_repo_fetcher.rb
+++ b/app/github_repo_fetcher.rb
@@ -90,7 +90,7 @@ private
   def client
     @client ||= begin
       stack = Faraday::RackBuilder.new do |builder|
-        builder.response :logger
+        builder.response :logger, nil, { headers: false }
         builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
         builder.use Octokit::Response::RaiseError
         builder.use Faraday::Request::Retry, exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError]

--- a/app/http.rb
+++ b/app/http.rb
@@ -16,7 +16,7 @@ module HTTP
     uri = URI.parse(url)
 
     faraday = Faraday.new(url: uri) do |conn|
-      conn.response :logger
+      conn.response :logger, nil, { headers: false }
       conn.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
       conn.use Octokit::Response::RaiseError
       conn.response :json, content_type: /\bjson$/


### PR DESCRIPTION
Build logs currently produce 100ks of log lines - every request / response header of every HTTP request. Feels like a bit much.

Faraday documentation says they can be turned off: https://github.com/lostisland/faraday/blob/5fccc208549650b129b13a173af3f3f40d44c14d/docs/middleware/included/logging.md?plain=1#L79

After this change, we still get logs, but only for the URL of the request and the status code of the response:

    I, [2023-10-20T17:20:53.404626 #75707]  INFO -- request: GET https://api.github.com/users/alphagov/repos?per_page=100
    I, [2023-10-20T17:20:54.871930 #75707]  INFO -- response: Status 200
    I, [2023-10-20T17:20:54.999323 #75707]  INFO -- request: GET https://api.github.com/user/596977/repos?page=2&per_page=100
    I, [2023-10-20T17:20:56.319073 #75707]  INFO -- response: Status 200
    I, [2023-10-20T17:20:56.438697 #75707]  INFO -- request: GET https://api.github.com/user/596977/repos?page=3&per_page=100
    I, [2023-10-20T17:20:57.811702 #75707]  INFO -- response: Status 200

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
