### PR TITLE
Move Router and Router-API Ownership to Platform Engineering

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1221,7 +1221,7 @@
 
 - repo_name: router
   type: Supporting apps
-  team: "#govuk-navigation-tech"
+  team: "#govuk-platform-engineering"
   production_hosted_on: eks
   production_url: false
   argo_cd_apps:
@@ -1230,7 +1230,7 @@
 
 - repo_name: router-api
   type: APIs
-  team: "#govuk-navigation-tech"
+  team: "#govuk-platform-engineering"
   production_hosted_on: eks
   argo_cd_apps:
     - router-api


### PR DESCRIPTION
Nav team is no longer responsible for these apps.

https://trello.com/c/5uSILmtp/2200-router-and-router-api-cleanup-tasks-s

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
