### PR TITLE
Fix GA4 file attachment docs

### DIFF
--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -561,18 +561,18 @@
         - name: type
           value: email
         - name: url
-    - name: attachment links
-      implemented: false
+    - name: file attachment links
+      implemented: true
       priority: medium
       description: 'Links on our guidance pages that contain file attachments, such as https://www.gov.uk/government/publications/equality-act-guidance'
-      tracker: specialist_link_tracker
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
       - name: event_data
         value:
         - name: event_name
-          value: navigation
+          value: file_download
         - name: external
         - name: link_domain
         - name: link_path_parts


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
I realised the file attachment docs were out of date, so I've updated it in this PR. Thanks :+1: 
