### PR TITLE
Update documentation for finding usage of Govspeak in content

### DIFF
--- a/source/manual/howto-find-hardcoded-markup-govspeak.html.md
+++ b/source/manual/howto-find-hardcoded-markup-govspeak.html.md
@@ -1,64 +1,63 @@
 ---
 owner_slack: '#govuk-developers'
-title: Find hardcoded markup in GovSpeak
+title: Find usage of Govspeak in content
 section: Publishing
 layout: manual_layout
 parent: "/manual.html"
 ---
 
-Usually to find usage of markup we can look in our source code.
+[Govspeak](https://govspeak-preview.publishing.service.gov.uk) is an extension for Markdown used in GOV.UK's publishing applications.
 
-For example if we wanted to see which templates use a class called 'button' you could search in GitHub.
+After making a change to the Govspeak gem, you may need to republish content that uses that markdown.
 
-However [GovSpeak][] (our variant of Markdown) includes markup such as buttons that will be in published content.
+In nearly all cases, Govspeak is converted to HTML within the publishing application before being sent to Publishing API. This means there are two options for finding affected content: searching for raw Govspeak within the publishing application or converted HTML in Publishing API.
 
-So, with this in mind you'll need to search all published content.
+## Searching for raw Govspeak in Whitehall
 
-## Searching the Content Store via Jenkins
+There is a rake task to find published content that matches a regular expression:
 
-See the Content Team's instruction on the wiki: [Find instances of a keyword on GOV.UK]
-
-## Searching the Publishing API
-
-First make sure you can SSH into our integration environment, you can follow the [Getting Started] guide.
-
-Now if everything is setup you can ssh onto the machine with the publishing api using:
-
-```shell
-$ ssh publishing-api-1.staging
+```
+rake 'reporting:matching_docs[regex]'
 ```
 
-Then to get access to the console for the [publishing-api] so you can execute commands do the following:
+Replace `regex` with an escaped version of the regular expression. This should be run on a `whitehall-admin` pod using the instructions in [Run a rake task on EKS](https://docs.publishing.service.gov.uk/manual/running-rake-tasks.html#run-a-rake-task-on-eks).
 
-```shell
-$ govuk_app_console publishing-api
+For example, to find all uses of inline attachments contained within steps, you would use the following regex:
+
+```
+^s[0-9]+\..*?\[AttachmentLink:.*?\].*$
 ```
 
-## Example commands
+This is escaped and used in the rake task as follows:
+
+```
+rake 'reporting:matching_docs[s\[0-9\]+\\..*?\\\[AttachmentLink:.*?\\\].*$]'
+```
+
+## Searching for converted HTML in Publishing API
+
+Follow the instructions to [open a Rails console](https://docs.publishing.service.gov.uk/kubernetes/cheatsheet.html#common-tasks) for Publishing API.
+
+### Example commands
 
 Here's some example commands you can run, feel free to modify the regex for your specific usecase (and add more here if you fancy :))
 
 This will take a few minutes to execute since it's iterating over a lot of editions!
 
-### Find 'call to action'
+#### Find 'call to action'
 
 ```ruby
 Edition.where.not(content_store: nil).find_each { |e| puts "https://gov.uk#{e.base_path}" if e.details.to_s =~ /class=\\"call-to-action/ }
 ```
 
-### Find YouTube links
+#### Find YouTube links
 
 ```ruby
 Edition.where.not(content_store: nil).find_each { |e| puts "https://gov.uk#{e.base_path}" if e.details.to_s =~ /href=\\"https:\/\/www.youtube.com\/watch?v=/ }
 ```
 
-### Find hardcoded buttons
+#### Find hardcoded buttons
 
 ```ruby
 Edition.where.not(content_store: nil).find_each { |e| puts "https://gov.uk#{e.base_path}" if e.details.to_s =~ /class=\\"button/ }
 ```
-
-[Govspeak]: https://govspeak-preview.publishing.service.gov.uk
-[Getting Started]: /manual/get-started.html
-[publishing-api]: https://github.com/alphagov/publishing-api
-[Find instances of a keyword on GOV.UK]: https://gov-uk.atlassian.net/wiki/spaces/CC/pages/1314488405/Find+instances+of+a+keyword+on+GOV.UK


### PR DESCRIPTION
This makes the following changes:
- includes instructions for a rake task that has been added to Whitehall
- updates the title to be more reflective of the content
- removes instructions linking to the wiki that are no longer valid (running GovGraph on Jenkins)
- updates the instructions for accessing a Publishing API Rails console to reflect the current infrastructure

[Trello card](https://trello.com/c/jD9VLG1A)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
