### PR TITLE
Remove repo govuk-intent-detector

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -574,11 +574,6 @@
   type: Utilities
   team: "#govuk-platform-engineering"
 
-- repo_name: govuk-intent-detector
-  private_repo: true
-  team: "#data-products"
-  type: Data science
-
 - repo_name: govuk-ithc-documentation
   retired: true
   private_repo: true


### PR DESCRIPTION
This repo has been archived, so it needs to be removed from the repos.yml file.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
