### PR TITLE
Add the repo govuk-analytics-engineering

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -410,6 +410,10 @@
   team: "#tech-content-interactions-on-platform-govuk"
   type: Utilities
 
+- repo_name: govuk-analytics-engineering
+  team: "#data-products"
+  type: Data science
+
 - repo_name: govuk-app-deployment
   team: "#govuk-platform-engineering"
   type: Utilities


### PR DESCRIPTION
This is owned by the #data-products team, as per this Slack thread:

https://gds.slack.com/archives/C015XA8KC4F/p1698236780002839

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
