### PR TITLE
Mark govuk-analytics-engineering repo as private

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -411,6 +411,7 @@
   type: Utilities
 
 - repo_name: govuk-analytics-engineering
+  private_repo: true
   team: "#data-products"
   type: Data science
 


### PR DESCRIPTION
Builds were failing because I'd forgotten to mark this repo as private in #4273 / 1909d6603bf333aea9950f3bab85e06d425b60c4.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
