### PR TITLE
Add govuk-chat-infrastructure

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -468,6 +468,13 @@
   description: |
     This project monitored the CDN logs for GOV.UK, to find problems with the site. It was archived in July 2018, following RFC-93.
 
+- repo_name: govuk-chat-infrastructure
+  team: "#ai-govuk"
+  type: Utilities
+  sentry_url: false
+  dashboard_url: false
+  private_repo: true
+
 - repo_name: govuk-ckan-charts
   type: data.gov.uk apps
   team: "#govuk-datagovuk"


### PR DESCRIPTION
As per https://docs.publishing.service.gov.uk/manual/github.html#create-and-configure-a-new-gov-uk-repo

The PR to add a README to this repo is still open: https://github.com/alphagov/govuk-chat-infrastructure/pull/1

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
