### PR TITLE
Update analytics section

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -436,7 +436,7 @@
 
 - name: tool_name
   description: Refers to the tool being tracked, for example the name of a smart answer or 'Find your local council'.
-  value:
+  value: text
   required: no
   type: string
   redact: false

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -903,14 +903,14 @@
         - name: link_domain
         - name: link_path_parts
 
-- name: print page
+- name: printing
   events:
-    - name: print page
+    - name: print page button
       implemented: true
       priority: low
       description: When a 'print this page' button is used
       examples:
-        - text: Page with print button
+        - text: Register a trust as a trustee
           link: https://www.gov.uk/guidance/register-a-trust-as-a-trustee
       tracker: event_tracker
       data:
@@ -928,6 +928,47 @@
         - name: type
           value: print page
         - name: text
+    - name: print page dialog
+      implemented: true
+      priority: low
+      description: Tracks when the browser print dialog is opened by the user, for example through the browser File->Print menu.
+      tracker: print_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: print_page
+        - name: type
+          value: print page
+        - name: method
+          value: browser print
+    - name: view printable version
+      implemented: true
+      priority: low
+      description: Tracking links to a printable version of a multi page guide
+      examples:
+        - text: Buy a rod fishing licence
+          link: https://www.gov.uk/fishing-licences/types-of-licences-and-rod-limits
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: print page
+        - name: url
+        - name: text
+        - name: section
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
 
 - name: related navigation
   description: Events gathered in the contextual sidebar, contextual footer and related navigation components.

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1661,10 +1661,10 @@
       priority: high
       description: When a tab is selected.
       examples:
-        - text: Tax your vehicle
-          link: https://www.gov.uk/vehicle-tax
         - text: Bank holidays
           link: https://www.gov.uk/bank-holidays
+        - text: Tax your vehicle
+          link: https://www.gov.uk/vehicle-tax
       tracker: event_tracker
       data:
       - name: event
@@ -1676,7 +1676,7 @@
         - name: type
           value: tabs
         - name: url
-          value: tab identifier/url hash e.g. "#scotland"
+          value: url path and hash (tab identifier) e.g. "/bank-holidays#scotland"
         - name: text
           value: text of the selected tab
         - name: index

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -454,7 +454,7 @@
           - name: index_link
             value: The position of the link within its section.
           - name: index_section_count
-            value: 5
+            value: "5"
         - name: index_total
         - name: link_domain
         - name: link_path_parts
@@ -464,7 +464,7 @@
           value: footer
         - name: url
         - name: section
-          value: One of "Topics", "Government Activity", "Support Links", "Licence", or "Copyright"
+          value: One of "Services and information", "Government Activity", "Support Links", "Licence", or "Copyright"
 
 - name: forms
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1367,10 +1367,11 @@
         - name: action
           value: start
         - name: external
-          value: false
+          value: "false"
         - name: link_domain
         - name: link_path_parts
         - name: tool_name
+        - name: method
     - name: submit question
       implemented: true
       priority: high
@@ -1441,7 +1442,7 @@
         - name: action
           value: change response
         - name: external
-          value: false
+          value: "false"
         - name: method
         - name: link_domain
         - name: link_path_parts
@@ -1508,13 +1509,16 @@
       data:
       - name: event
         value: search_results
+      - name: event_data
+        value:
+        - name: external
       - name: search_results
         value:
         - name: ecommerce
           value:
           - name: items
         - name: event_name
-          value: view_item_list
+          value: select_item
         - name: results
     - name: start again link click
       implemented: true
@@ -1539,7 +1543,7 @@
         - name: action
           value: start again
         - name: external
-          value: false
+          value: "false"
         - name: method
         - name: link_domain
         - name: link_path_parts

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -49,7 +49,34 @@
           - name: index_section_count
         - name: action
           value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
-
+    - name: Accordion links
+      implemented: true
+      priority: high
+      description: When links within accordion sections are clicked.
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: accordion
+        - name: url
+        - name: text
+          value: Text of the link
+        - name: index
+          value:
+          - name: index_link
+          - name: index_section
+          - name: index_section_count
+        - name: index_total
+        - name: section
+        - name: external
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
 - name: banners
   events:
     - name: banner shown

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1546,6 +1546,7 @@
           value:
           - name: index_section
           - name: index_section_count
+        - name: index_total
         - name: text
           value: title of the opened/closed step
         - name: type
@@ -1571,8 +1572,9 @@
           value:
           - name: index_section
             value: '0'
+          - name: index_section_count
         - name: text
-          value: Show all steps
+          value: Show/Hide all steps
         - name: type
           value: "step by step"
     - name: link clicks
@@ -1596,6 +1598,7 @@
           - name: index_section
           - name: index_link
             value: The position of the link within this section.
+          - name: index_section_count
         - name: index_total
         - name: link_domain
         - name: link_path_parts

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -709,8 +709,8 @@
       implemented: true
       priority: medium
       examples:
-      - text: Licence lookup
-        link: https://www.gov.uk/food-business-registration/westminster
+      - text: Tattoo, piercing and electrolysis licence (the 'change location' link)
+        link: https://www.gov.uk/find-licences/tattooists-piercing-and-electrolysis-licence-scotland/edinburgh
       tracker: link_tracker
       data:
       - name: event
@@ -722,14 +722,16 @@
         - name: action
           value: change response
         - name: external
-          value: '"true"'
         - name: method
         - name: section
         - name: text
         - name: tool_name
         - name: type
+        - name: link_domain
+        - name: link_path_parts
     - name: information click
       implemented: true
+      description: Tracks clicks from the results page, for example the 'go to council website' button.
       priority: medium
       examples:
       - text: Council lookup complete page
@@ -756,12 +758,11 @@
           - name: index_link
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
-        - name: section
         - name: text
         - name: tool_name
         - name: type
+        - name: url
 
 - name: miscellaneous
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -123,7 +123,7 @@
         - name: method
         - name: text
         - name: type
-          value: breadcrumbs
+          value: breadcrumb
         - name: url
 
 - name: browse

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -874,6 +874,35 @@
         - name: withdrawn
         - name: world_locations
 
+- name: previous and next
+  events:
+    - name: previous and next
+      implemented: true
+      priority: medium
+      description:
+      examples:
+        - text: Buy a rod fishing licence
+          link: https://www.gov.uk/fishing-licences/types-of-licences-and-rod-limits
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: previous and next
+        - name: url
+        - name: text
+        - name: section
+          value: Either "Previous" or "Next"
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
+
 - name: print page
   events:
     - name: print page

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -178,19 +178,24 @@
         - name: index
           value:
           - name: index_link
+          - name: index_section
+          - name: index_section_count
         - name: index_total
         - name: external
           value: "false"
         - name: method
         - name: link_domain
         - name: link_path_parts
+        - name: section
     - name: browse subtopic (browse level 2)
       implemented: true
       priority: medium
       description: Tracking the final level of the browse pages.
       examples:
-        - text: Browse level 2
+        - text: Browse level 2 (A to Z)
           link: https://www.gov.uk/browse/births-deaths-marriages/child
+        - text: Browse level 2 (curated)
+          link: https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce
       tracker: link_tracker
       data:
       - name: event
@@ -200,7 +205,7 @@
         - name: event_name
           value: navigation
         - name: type
-          value: browse card
+          value: browse list
         - name: url
         - name: text
         - name: index
@@ -210,6 +215,7 @@
           - name: index_section_count
         - name: index_total
         - name: section
+          value: Either name of the section or "A to Z"
         - name: external
           value: "false"
         - name: method

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -225,17 +225,48 @@
       - name: event
         value: event_data
 
-- name: contents link
+- name: contents list
   events:
     - name: link click
-      implemented: false
+      implemented: true
+      description: Tracking links on the contents list for the page or section.
       priority: medium
+      examples:
+        - text: Jobseeker's allowance (links to new pages)
+          link: https://www.gov.uk/jobseekers-allowance
+        - text: Cost of living payments (anchor links to same page)
+          link: https://www.gov.uk/guidance/cost-of-living-payment
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation (link to new page) or select_content (anchor link to same page)
+        - name: type
+          value: contents list
+        - name: url
+        - name: text
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: section
+          value: Contents
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
     - name: back to contents link click
       implemented: false
       priority: low
+      description: Tracks the 'contents' link to return to the contents list, appearing either at the bottom of the left hand column or in an element fixed to the bottom of the page.
+      examples:
+        - text: Cost of living payments (fixed to bottom of page)
+          link: https://www.gov.uk/guidance/cost-of-living-payment
+        - text: Budget 2016 (bottom of left hand column)
+          link: https://www.gov.uk/government/publications/budget-2016-documents/budget-2016
       data:
       - name: event
         value: event_data

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -286,8 +286,8 @@
       implemented: true
       priority: medium
       examples:
-        - text: Search pages
-          link: https://www.gov.uk/search/all?keywords=minister&order=relevance
+        - text: Research and statistics
+          link: https://www.gov.uk/search/research-and-statistics
       tracker: link_tracker
       data:
       - name: event
@@ -306,7 +306,7 @@
         - name: index_total
         - name: section
         - name: external
-          value: false
+          value: "false"
         - name: link_domain
         - name: link_path_parts
         - name: method
@@ -334,7 +334,7 @@
         - name: index_total
         - name: section
         - name: external
-          value: false
+          value: "false"
         - name: link_domain
         - name: link_path_parts
         - name: method

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1058,12 +1058,52 @@
 
 - name: see all link
   events:
-    - name: see all link click
-      implemented: false
+    - name: see all link click (in page)
+      implemented: true
       priority: medium
+      description: Tracks clicks on the see all link when that link goes to another part of the same page.
+      examples:
+        - text: Cost of Living payments (click on 'See all updates')
+          link: https://www.gov.uk/guidance/cost-of-living-payment
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: select_content
+        - name: type
+          value: content history
+        - name: text
+        - name: section
+        - name: action
+          value: Either "opened" or "closed"
+    - name: see all link click (to another page)
+      implemented: true
+      priority: medium
+      description: Tracks clicks on the see all link when that link goes to a different page.
+      examples:
+        - text: Air passenger duty
+          link: https://www.gov.uk/hmrc-internal-manuals/air-passenger-duty
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: opened
+        - name: event_name
+          value: navigation
+        - name: external
+          value: "false"
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: section
+        - name: type
+          value: content history
+        - name: text
+        - name: url
 
 - name: search
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1987,6 +1987,40 @@
           - name: index_section
           - name: index_section_count
 
+- name: taxonomy pages
+  events:
+    - name: taxonomy page links
+      implemented: true
+      priority: medium
+      description:
+      examples:
+        - text: Parenting, childcare and children's services
+          link: https://www.gov.uk/childcare-parenting
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+          value: "false"
+        - name: index
+          value:
+          - name: index_link
+          - name: index_section
+          - name: index_section_count
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: section
+        - name: text
+        - name: type
+          value: document list/organisation logo/subtopic list/see all
+        - name: url
+
 - name: video
   events:
     - name: Video start

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1084,14 +1084,12 @@
         - name: external
 
 - name: scroll tracking
+  description: Scroll tracking is currently not being used on any pages on GOV.UK.
   events:
     - name: percentage scroll tracking
       implemented: true
       priority: medium
       tracker: scroll_tracker
-      examples:
-        - text: Search results
-          link: https://www.gov.uk/search/all?keywords=minister&order=relevance
       data:
       - name: event
         value: event_data
@@ -1108,9 +1106,6 @@
       implemented: true
       priority: medium
       tracker: scroll_tracker
-      examples:
-        - text: GOV.UK homepage
-          link: https://www.gov.uk/
       data:
       - name: event
         value: event_data
@@ -1132,6 +1127,30 @@
           value: text of heading reached
         - name: type
           value: heading
+    - name: marker scroll tracking
+      implemented: true
+      priority: medium
+      description: Tracks when a user scrolls to a custom marker that has been placed on any HTML element on the page, such as a specific heading or paragraph. Generally used where scroll tracking is required on some headings, but not all.
+      tracker: scroll_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: scroll
+        - name: event_name
+          value: scroll
+        - name: index
+          value:
+          - name: index_section
+            value: index of the marker reached
+          - name: index_section_count
+            value: total number of markers being tracked
+        - name: text
+        - name: section
+        - name: type
+          value: marker
 
 - name: see all link
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -531,6 +531,9 @@
       implemented: true
       priority: high
       description: When a link is followed to a page outside of www.gov.uk.
+      examples:
+        - text: Apply for a passport ('Start now' button)
+          link: https://www.gov.uk/apply-renew-passport
       tracker: specialist_link_tracker
       data:
       - name: event
@@ -552,6 +555,9 @@
       implemented: true
       priority: high
       description: When a link is followed to an asset such as a PDF.
+      examples:
+        - text: 2023 Government Chemist Conference presentations and recordings (links in the 'all presentation slides' section)
+          link: https://www.gov.uk/government/news/the-2023-government-chemist-conference-presentations
       tracker: specialist_link_tracker
       data:
       - name: event
@@ -561,6 +567,7 @@
         - name: event_name
           value: file_download
         - name: external
+          value: "true"
         - name: link_domain
         - name: link_path_parts
         - name: method
@@ -572,6 +579,9 @@
       implemented: true
       priority: low
       description: 'When a link points to an email address using mailto:'
+      examples:
+        - text: Attorney General's Office ('Contact AGO' section)
+          link: https://www.gov.uk/government/organisations/attorney-generals-office
       tracker: specialist_link_tracker
       data:
       - name: event
@@ -582,7 +592,6 @@
           value: navigation
         - name: external
           value: '"true"'
-        - name: link_domain
         - name: link_path_parts
         - name: method
         - name: text
@@ -592,7 +601,10 @@
     - name: file attachment links
       implemented: true
       priority: medium
-      description: 'Links on our guidance pages that contain file attachments, such as https://www.gov.uk/government/publications/equality-act-guidance'
+      description: Links on our guidance pages that contain file attachments, such as .zip files.
+      examples:
+        - text: Lasting power of attorney forms
+          link: https://www.gov.uk/government/publications/make-a-lasting-power-of-attorney
       tracker: link_tracker
       data:
       - name: event

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1634,6 +1634,37 @@
 
 - name: super navigation header
   events:
+    - name: Crown icon link
+      implemented: true
+      priority: high
+      description: When the crown link to the homepage is clicked.
+      examples:
+        - text: GOV.UK homepage
+          link: https://www.gov.uk
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: header menu bar
+        - name: url
+          value: https://www.gov.uk
+        - name: index
+          value:
+          - name: index_link
+          - name: index_section
+          - name: index_section_count
+        - name: index_total
+        - name: section
+          value: Logo
+        - name: external
+          value: "false"
+        - name: method
+        - name: link_domain
     - name: Header menu bar buttons
       implemented: true
       priority: high
@@ -1664,7 +1695,7 @@
     - name: link clicks
       implemented: true
       priority: high
-      description: Triggered when the GOVUK logo, a header "menu" section link, or a link under the search component is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
+      description: Triggered when a header "menu" section link is clicked, right clicked, shift clicked, control clicked, or windows key/command key clicked.
       examples:
         - text: GOV.UK homepage
           link: https://www.gov.uk
@@ -1681,11 +1712,8 @@
         - name: index
           value:
           - name: index_section
-            value: The section that this link is in (Menu is 1, Search is 2)
           - name: index_link
-            value: The position of the link within its section. GOVUK Logo has an index of 0.
           - name: index_section_count
-            value: 2 (Menu and Search)
         - name: index_total
         - name: link_domain
         - name: link_path_parts

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -898,18 +898,6 @@
       data:
       - name: event
         value: event_data
-    - name: view printable version of page
-      implemented: false
-      priority: low
-      data:
-      - name: event
-        value: event_data
-    - name: video
-      implemented: false
-      priority: low
-      data:
-      - name: event
-        value: event_data
 
 - name: page view
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -340,31 +340,102 @@
         - name: method
 
 - name: email subscriptions
+  description: Tracking email subscriptions across GOV.UK, for example from search results or topic pages.
   events:
-    - name: get emails about this page link click
-      implemented: false
+    - name: get emails about this page
+      implemented: true
       priority: medium
+      examples:
+        - text: Welfare topic page (start of email subscription journey)
+          link: https://www.gov.uk/welfare
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
-    - name: change how often you get emails
-      implemented: false
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: external
+          value: "false"
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: link_domain
+        - name: link_path_parts
+        - name: method
+        - name: section
+        - name: text
+        - name: type
+          value: subscribe
+        - name: url
+    - name: responses
+      implemented: true
       priority: medium
+      description: Tracks when questions are answered throughout the email subscriptions journey, for example 'how often do you want to receive emails?'. Note that some questions do not include options other than to continue, for example the 'Confirm you want to get emails' question is asked towards the end of the journey, but only has 'Confirm' or 'cancel' as options.
+      tracker: form_tracker
       data:
       - name: event
         value: event_data
-    - name: unsubscribe
-      implemented: false
+      - name: event_data
+        value:
+        - name: action
+          value: continue/save/unsubscribe
+        - name: event_name
+          value: form_response
+        - name: section
+          value: The text of the question, for example 'What do you want to get emails about?'
+        - name: text
+          value: The question option selected, or PII redacted text value
+        - name: tool_name
+          value: Get emails from GOV.UK
+        - name: type
+          value: email subscription
+    - name: form error
+      implemented: true
       priority: medium
+      description: Tracks form errors in questions asked, for example if options are given and a user does not choose one before attempting to continue.
+      tracker: auto_tracker
       data:
       - name: event
         value: event_data
-    - name: unsubscribe from everything
-      implemented: false
+      - name: event_data
+        value:
+        - name: action
+          value: error
+        - name: event_name
+          value: form_error
+        - name: section
+          value: The text of the question, for example 'What do you want to get emails about?'
+        - name: text
+          value: The text of the error message
+        - name: tool_name
+          value: Get emails from GOV.UK
+        - name: type
+          value: email subscription
+    - name: form completion
+      implemented: true
       priority: medium
+      description: Occurs when a user successfully completes an email subscription journey
+      tracker: auto_tracker
       data:
       - name: event
         value: event_data
+      - name: event_data
+        value:
+        - name: action
+          value: complete
+        - name: event_name
+          value: form_complete
+        - name: section
+          value: Manage your GOV.UK email subscriptions
+        - name: text
+          value: You've successfully subscribed to emails about (subject)
+        - name: tool_name
+          value: Get emails from GOV.UK
+        - name: type
+          value: email subscription
 
 - name: feedback
   description: Tracking the 'is this page useful?' component at the bottom of every GOV.UK page.

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -336,6 +336,7 @@
         value: event_data
 
 - name: feedback
+  description: Tracking the 'is this page useful?' component at the bottom of every GOV.UK page.
   events:
     - name: Is this page useful? Yes
       implemented: true
@@ -394,7 +395,7 @@
     - name: Send me the survey
       implemented: true
       priority: medium
-      description:
+      description: Clicking the 'send me the survey' button after choosing 'No'
       tracker: event_tracker
       data:
       - name: event
@@ -412,7 +413,7 @@
     - name: Send
       implemented: true
       priority: medium
-      description:
+      description: Clicking the 'send' button after choosing 'Report a problem with this page'
       tracker: event_tracker
       data:
       - name: event

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1107,7 +1107,7 @@
         - name: event_name
           value: navigation
         - name: external
-          value: true
+          value: "true"
         - name: index
           value:
           - name: index_link
@@ -1133,9 +1133,9 @@
       - name: event_data
         value:
         - name: event_name
-          value: share
+          value: navigation
         - name: external
-          value: true
+          value: "true"
         - name: index
           value:
           - name: index_link
@@ -1145,7 +1145,7 @@
         - name: method
         - name: text
         - name: type
-          value: share this page
+          value: share page
         - name: url
 
 - name: simple smart answers

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -480,8 +480,11 @@
     - name: Link clicks
       implemented: true
       priority: medium
-      description:
-      tracker:
+      description: Tracking links on the homepage.
+      examples:
+        - text: GOV.UK homepage
+          link: https://www.gov.uk
+      tracker: link_tracker
       data:
       - name: event
         value: event_data
@@ -498,6 +501,12 @@
           - name: index_section_count
         - name: index_total
         - name: section
+        - name: url
+        - name: text
+        - name: external
+        - name: method
+        - name: link_domain
+        - name: link_path_parts
 
 - name: html attachments
   events:

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -51,3 +51,9 @@
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-video-tracker.md
   description: Fires events when videos are played.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
+
+- name: Print intent tracker
+  technical_name: print_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-print-intent-tracker.md
+  description: Tracks when users open the browser print dialog.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -9,10 +9,17 @@
   <p class="govuk-body"><%= event.description %></p>
 <% end %>
 
-<% event.events.each do |page_event| %>
+<h2 class="govuk-heading-m analytics-heading">Contents</h2>
+<ul class="govuk-list govuk-list--bullet">
+  <% event.events.each_with_index do |event, index| %>
+    <li><a href="#heading-<%= index %>" class="govuk-link"><%= event.name %></a></li>
+  <% end %>
+</ul>
+
+<% event.events.each_with_index do |page_event, index| %>
   <div class="event">
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <h2 class="govuk-heading-m analytics-heading">
+    <h2 class="govuk-heading-m analytics-heading" id="heading-<%= index %>">
       <%= page_event.name %>
     </h2>
 


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

## What
Updates the [GA4 implementation record](https://docs.publishing.service.gov.uk/analytics/) part of the dev docs to match actual live events.

## Why
Part of the GA4 migration.

## Visual changes
Includes a new jump menu for the events pages, to allow easier navigation to different events within the same category.

![Screenshot 2023-11-02 at 16 53 44](https://github.com/alphagov/govuk-developer-docs/assets/861310/b3a21cc1-2781-40c8-baa4-5717c09e7bf8)


Trello card: https://trello.com/c/JQPHy26m/661-check-implementation-record-is-up-to-date
