### PR TITLE
Fix typo in URL to documentation on how to fall back to CloudFront

### DIFF
--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -142,4 +142,4 @@ Once deployed, [check your change](https://www-origin.integration.govuk.digital/
 
 Warn in `#govuk-2ndline-tech` that you're about to do this, because our failover CDN does not have full feature parity with our primary one.
 
-Follow the [Fall back to AWS CloudFront](/manual/fall-back-to-aws-cloudfront.html.md) instructions for staging only.
+Follow the [Fall back to AWS CloudFront](/manual/fall-back-to-aws-cloudfront.html) instructions for staging only.


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
