### PR TITLE
Remove a broken link from repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1261,7 +1261,6 @@
 
 - repo_name: seal
   team: "#govuk-platform-security-reliability-team"
-  management_url: https://dashboard.heroku.com/apps/govuk-seal
   type: Utilities
   sentry_url: false
   dashboard_url: false


### PR DESCRIPTION
Seal isn't hosted on Heroku anymore. I should've removed this in #4250 but missed it somehow 🙈

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
