### PR TITLE
Add Kibana urls to app pages

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -147,6 +147,18 @@ class Repo
     repo_data["dashboard_url"] || default_url
   end
 
+  def kibana_url
+    return if repo_data["kibana_url"] == false
+
+    kibana_url_for(app: app_name, hours: 3)
+  end
+
+  def kibana_worker_url
+    return if repo_data["kibana_worker_url"] == false
+
+    kibana_url_for(app: "#{app_name}-worker", hours: 3, include: %w[level message])
+  end
+
   def api_docs_url
     repo_data["api_docs_url"]
   end
@@ -203,6 +215,14 @@ class Repo
   end
 
 private
+
+  def kibana_url_for(app:, hours: 3, include: %w[level request status message])
+    if production_hosted_on_eks?
+      "https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-#{hours}h,to:now))&_a=(columns:!(#{include.join(',')}),filters:!(),index:'filebeat-*',interval:auto,query:(language:lucene,query:'kubernetes.deployment.name:#{app}'),sort:!())"
+    else
+      "https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-#{hours}h,mode:quick,to:now))&_a=(columns:!(#{include.join(',')}),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'application:#{app}')),sort:!('@timestamp',desc))"
+    end
+  end
 
   def argo_cd_apps
     repo_data["argo_cd_apps"] || [repo_name]

--- a/source/partials/repo/_links.html.erb
+++ b/source/partials/repo/_links.html.erb
@@ -10,6 +10,8 @@ links = [
   (link_to("API docs", repo.api_docs_url, class: "govuk-link") if repo.api_docs_url),
   (link_to("Component guide", repo.component_guide_url, class: "govuk-link") if repo.component_guide_url),
   (link_to("Metrics dashboard", repo.metrics_dashboard_url, class: "govuk-link") if repo.metrics_dashboard_url),
+  (link_to("Kibana App Logs (Production, last 3 hours)", repo.kibana_url, class: "govuk-link") if repo.kibana_url),
+  (link_to("Kibana Worker Logs (Production, last 3 hours)", repo.kibana_worker_url, class: "govuk-link") if repo.kibana_worker_url),
 ]
 
 links += repo.argo_cd_urls.map do |argo_cd_app_name, argo_cd_url|

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -143,5 +143,55 @@ RSpec.describe Repo do
         it { is_expected.to eql("https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=content-publisher&MACHINE_CLASS=backend&RAKE_TASK=task") }
       end
     end
+
+    describe "kibana_url" do
+      let(:production_hosted_on) { nil }
+      let(:environment) { nil }
+      let(:app) do
+        described_class.new(
+          "repo_name" => "content-publisher",
+          "machine_class" => "backend",
+          "production_hosted_on" => production_hosted_on,
+        )
+      end
+      subject(:kibana_url) { app.kibana_url }
+
+      describe "hosted on EKS" do
+        let(:production_hosted_on) { "eks" }
+
+        it { is_expected.to eql("https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,request,status,message),filters:!(),index:'filebeat-*',interval:auto,query:(language:lucene,query:'kubernetes.deployment.name:content-publisher'),sort:!())") }
+      end
+
+      describe "hosted on AWS" do
+        let(:production_hosted_on) { "aws" }
+
+        it { is_expected.to eql("https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-3h,mode:quick,to:now))&_a=(columns:!(level,request,status,message),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'application:content-publisher')),sort:!('@timestamp',desc))") }
+      end
+    end
+
+    describe "kibana_worker_url" do
+      let(:production_hosted_on) { nil }
+      let(:environment) { nil }
+      let(:app) do
+        described_class.new(
+          "repo_name" => "content-publisher",
+          "machine_class" => "backend",
+          "production_hosted_on" => production_hosted_on,
+        )
+      end
+      subject(:kibana_worker_url) { app.kibana_worker_url }
+
+      describe "hosted on EKS" do
+        let(:production_hosted_on) { "eks" }
+
+        it { is_expected.to eql("https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,message),filters:!(),index:'filebeat-*',interval:auto,query:(language:lucene,query:'kubernetes.deployment.name:content-publisher-worker'),sort:!())") }
+      end
+
+      describe "hosted on AWS" do
+        let(:production_hosted_on) { "aws" }
+
+        it { is_expected.to eql("https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-3h,mode:quick,to:now))&_a=(columns:!(level,message),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'application:content-publisher-worker')),sort:!('@timestamp',desc))") }
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds logit links - these links for apps go to a now-3h view in Kibana/Logit.io filtered to the appropriate app, showing time/request/status and message, giving people an easy way into viewing appropriate logs.

https://trello.com/c/n8ZCNgzv/189-add-logit-links-into-apps-pages-links-in-dev-docs

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
