### PR TITLE
Add alt/option click to GA4 docs

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -220,7 +220,7 @@
 - name: method
   description: How a link was clicked.
   value:
-  example: primary click, secondary click, middle click, ctrl click, command/win click, shift click
+  example: primary click, secondary click, middle click, ctrl click, command/win click, shift click, alt/option click
   required: yes
   type: string
   redact: false


### PR DESCRIPTION
Adds `alt/option` click to the examples for `method`