### PR TITLE
Fix Markdown link syntax

### DIFF
--- a/source/manual/howto-block-arbitrary-urls.html.md
+++ b/source/manual/howto-block-arbitrary-urls.html.md
@@ -58,5 +58,5 @@ In order to block `<LEAK_URL>` on `<INSTANCE_CLASS>` in `<GOVUK_ENVIRONMENT>`:
 
 1. Finally, [re-enable Puppet on each machine](/manual/howto-run-ssh-commands-on-many-machines.html#enable-puppet) of the `<INSTANCE_CLASS>`
 
-- [Digital ocean]: https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms
-- [Linode]: https://www.linode.com/docs/web-servers/nginx/how-to-configure-nginx/#location-blocks
+- [DigitalOcean](https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms)
+- [Linode](https://www.linode.com/docs/web-servers/nginx/how-to-configure-nginx/#location-blocks)


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
