### PR TITLE
Remove stylelint-config-gds repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1415,10 +1415,6 @@
     - static
     - draft-static
 
-- repo_name: stylelint-config-gds
-  team: "#govuk-frontenders"
-  type: Utilities
-
 - repo_name: support
   type: Supporting apps
   team: "#govuk-platform-security-reliability-team"


### PR DESCRIPTION
The GOV.UK Design System owns this repo and it shouldn't be listed here, just as their other repos aren't.