### PR TITLE
Analytics browse update

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -369,19 +369,17 @@
   redact: false
 
 - name: taxonomy_all
-  description: An object containing the content attribute of the meta tag govuk:taxon_slugs in 100 character parts. This is stored like this to get around the 100 character limit on attribute values. Regardless of the length of the meta tag, the object will always contain 5 key/value pairs. If the values are less than 500 characters, unused key/value pairs will be undefined. If the values are longer than 500 characters, the extra characters will be lost.
+  description: A string containing the content attribute of the meta tag govuk:taxon_slugs.
   value: content attribute of meta tag govuk:taxon_slugs
-  example: |
-    {"1"=>"finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-wo", "2"=>"rking-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-label", "3"=>"ling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific", "4"=>"-research-and-development,self-employed", "5"=>"undefined"}
+  example: "finance-support,premises-rates,company-closure-administration-liquidation-and-insolvency,contract-working-hours,dismissals-redundancies,food-and-farming-industry,producing-distributing-food-food-labelling,recruiting-hiring,recruiting-hiring,redundancies-dismissals,sale-goods-services-data,scientific-research-and-development,self-employed"
   required: no
   type: string
   redact: false
 
 - name: taxonomy_all_ids
-  description: An object containing the content attribute of the meta tag govuk:taxon_ids in 100 character parts. This is stored like this to get around the 100 character limit on attribute values. Regardless of the length of the meta tag, the object will always contain 5 key/value pairs. If the values are less than 500 characters, unused key/value pairs will be undefined. If the values are longer than 500 characters, the extra characters will be lost.
+  description: A string containing the content attribute of the meta tag govuk:taxon_ids.
   value: content attribute of meta tag govuk:taxon_ids
-  example: |
-    {"1"=>"ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a5", "2"=>"0d57be943f,23a712ff-23b3-4f5a-83f1-44ac679fe615,a1c6c263-e4ef-4b96-b82f-e070ff157367,e2559668-cf36-4", "3"=>"7fc-8a77-2e760e12a812", "4"=>"undefined", "5"=>"undefined"}
+  example: "ccfc50f5-e193-4dac-9d78-50b3a8bb24c5,68cc0b3c-7f80-4869-9dc7-b2ceef5f4f08,864fe969-7d5a-4251-b8b5-a50d57be943f,23a712ff-23b3-4f5a-83f1-44ac679fe615,a1c6c263-e4ef-4b96-b82f-e070ff157367,e2559668-cf36-47fc-8a77-2e760e12a812"
   required: no
   type: string
   redact: false

--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -200,15 +200,6 @@
   type: string
   redact: false
 
-- name: link_path_parts
-  description: An object containing a URL in 100 character parts, usually the href attribute of a link. This is stored like this to get around the 100 character limit on attribute values - many URLs are longer than this. Regardless of the length of the URL, the object will always contain 5 key/value pairs. If the URL is less than 500 characters, unused key/value pairs will be undefined. If the URL is longer than 500 characters, the extra characters will be lost.
-  value:
-  example: |
-    {1=>"/conditions/vaccinations/flu-influenza-vaccine/", 2=>"undefined", 3=>"undefined", 4=>"undefined", 5=>"undefined"}
-  required: yes
-  type: object
-  redact: true
-
 - name: location
   description:
   value: document.location

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -228,6 +228,30 @@
         - name: link_domain
         - name: link_path_parts
         - name: section
+    - name: action link (browse level 1)
+      implemented: true
+      priority: low
+      description: Tracks the action links shown on only some browse pages.
+      examples:
+        - text: Benefits
+          link: https://www.gov.uk/browse/benefits
+      tracker: link_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: action
+        - name: index
+          value:
+          - name: index_link
+        - name: index_total
+        - name: external
+        - name: link_domain
+        - name: method
     - name: browse subtopic (browse level 2)
       implemented: true
       priority: medium

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -76,7 +76,6 @@
         - name: external
         - name: method
         - name: link_domain
-        - name: link_path_parts
 - name: banners
   description: Note that the presence of banners is tracked via our Pageview tracker.
   events:
@@ -108,7 +107,6 @@
         - name: external
         - name: method
         - name: link_domain
-        - name: link_path_parts
     - name: dismiss button
       description: Event that occurs when a user clicks a dismiss button to hide an intervention, survey, or cookie banner.
       examples:
@@ -160,7 +158,6 @@
             value: The position of the link within the breadcrumbs from left to right.
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -196,7 +193,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
     - name: browse topic (browse level 1)
       implemented: true
       priority: medium
@@ -226,7 +222,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: section
     - name: action link (browse level 1)
       implemented: true
@@ -285,7 +280,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
 
 - name: call out box
   events:
@@ -328,7 +322,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
     - name: back to contents link click
       implemented: false
       priority: low
@@ -379,7 +372,6 @@
         - name: external
           value: "false"
         - name: link_domain
-        - name: link_path_parts
         - name: method
     - name: rss subscriptions
       implemented: true
@@ -407,7 +399,6 @@
         - name: external
           value: "false"
         - name: link_domain
-        - name: link_path_parts
         - name: method
 
 - name: email subscriptions
@@ -434,7 +425,6 @@
           - name: index_link
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: section
         - name: text
@@ -630,7 +620,6 @@
             value: "5"
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -679,7 +668,6 @@
         - name: external
         - name: method
         - name: link_domain
-        - name: link_path_parts
 
 - name: html attachments
   events:
@@ -700,7 +688,6 @@
           value: navigation
         - name: external
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -727,7 +714,6 @@
         - name: external
           value: '"true"'
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -751,7 +737,6 @@
         - name: external
           value: "true"
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -774,7 +759,6 @@
           value: navigation
         - name: external
           value: '"true"'
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -797,7 +781,6 @@
           value: file_download
         - name: external
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -901,7 +884,6 @@
         - name: tool_name
         - name: type
         - name: link_domain
-        - name: link_path_parts
     - name: information click
       implemented: true
       description: Tracks clicks from the results page, for example the 'go to council website' button.
@@ -1043,7 +1025,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
 
 - name: printing
   events:
@@ -1110,7 +1091,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
 
 - name: related navigation
   description: Events gathered in the contextual sidebar, contextual footer and related navigation components.
@@ -1144,7 +1124,6 @@
         - name: url
           value: href attribute of link
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: external
 
@@ -1258,7 +1237,6 @@
         - name: external
           value: "false"
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: section
         - name: type
@@ -1411,7 +1389,6 @@
           - name: index_link
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -1439,7 +1416,6 @@
           - name: index_link
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -1474,7 +1450,6 @@
         - name: external
           value: false
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: tool_name
     - name: submit question
@@ -1550,7 +1525,6 @@
           value: false
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
     - name: simple smart answer complete
       implemented: true
@@ -1600,7 +1574,6 @@
         - name: external
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
     - name: start again link click
       implemented: true
@@ -1627,7 +1600,6 @@
           value: false
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
 
 - name: smart answers
@@ -1658,7 +1630,6 @@
         - name: external
           value: "false"
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
         - name: method
     - name: submit question
@@ -1734,7 +1705,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
     - name: smart answer complete
       implemented: true
@@ -1786,7 +1756,6 @@
         - name: external
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
     - name: results ecommerce list views and click
       implemented: true
@@ -1835,7 +1804,6 @@
           value: "false"
         - name: method
         - name: link_domain
-        - name: link_path_parts
         - name: tool_name
 
 - name: step by step navigation
@@ -1916,7 +1884,6 @@
           - name: index_section_count
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -2018,7 +1985,6 @@
           - name: index_section_count
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: text
         - name: type
@@ -2083,7 +2049,6 @@
           - name: index_section_count
         - name: index_total
         - name: link_domain
-        - name: link_path_parts
         - name: method
         - name: section
         - name: text

--- a/data/analytics/schemas.yml
+++ b/data/analytics/schemas.yml
@@ -32,8 +32,6 @@
       value: undefined
     - name: link_domain
       value: undefined
-    - name: link_path_parts
-      value: undefined
     - name: tool_name
       value: undefined
     - name: percent_scrolled


### PR DESCRIPTION
## What
Update the implementation record (GA4 events data).

- add action link events in browse pages
- remove `link_path_parts` references as no longer in use
- update `taxonomy_all` and `taxonomy_all_ids` as now strings, no longer objects

## Why
Part of the GA4 migration.

Trello card: https://trello.com/c/lstNprcf/717-add-tracking-to-action-link
