### PR TITLE
Update GDS Way links

### DIFF
--- a/source/manual/configure-linting.html.md
+++ b/source/manual/configure-linting.html.md
@@ -51,7 +51,7 @@ After running `bundle install` you can test the linting by running
 
 ## Linting JavaScript and SCSS
 
-We follow the [GDS Way](https://gds-way.cloudapps.digital/) guidance
+We follow the [GDS Way](https://gds-way.digital.cabinet-office.gov.uk/) guidance
 on linting [Javascript][gds-way-js] and [CSS][gds-way-css].
 
 To configure this for a Rails application you will need to install
@@ -98,8 +98,8 @@ You can now test the linting by running `yarn run lint`.
 To finish up you should add `node_modules` and `yarn-error.log` to
 your `.gitignore` file.
 
-[gds-way-js]: https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting
-[gds-way-css]: https://gds-way.cloudapps.digital/manuals/programming-languages/css.html#linting
+[gds-way-js]: https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#linting
+[gds-way-css]: https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/css.html#linting
 [standardx]: https://github.com/standard/standardx
 [stylelint-config-gds]: https://github.com/alphagov/stylelint-config-gds
 [yarn-install]: https://classic.yarnpkg.com/en/docs/install/

--- a/source/manual/debian-packaging.html.md
+++ b/source/manual/debian-packaging.html.md
@@ -25,7 +25,7 @@ Adding a package should be motivated by
 security or architecture requirements and aim to minimise unnecessary
 dependencies.
 
-Additional guidance can be found in the [GDS way](https://gds-way.cloudapps.digital/standards/tracking-dependencies.html#dependency-management-tools)
+Additional guidance can be found in the [GDS way](https://gds-way.digital.cabinet-office.gov.uk/standards/tracking-dependencies.html#dependency-management-tools)
 as well as the [service manual](https://www.gov.uk/service-manual/technology/managing-software-dependencies#how-to-work-with-third-party-code).
 
 If you are satisfied that adding a local or third party package via aptly is the

--- a/source/manual/development-pipeline.html.md
+++ b/source/manual/development-pipeline.html.md
@@ -52,7 +52,7 @@ and click 'Build with Parameters':
 
 ## Get someone to review your Pull Request
 
-The GDS Way has guidelines on [how to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html).
+The GDS Way has guidelines on [how to review code](https://gds-way.digital.cabinet-office.gov.uk/manuals/code-review-guidelines.html).
 
 Only when the tests pass and the code has been approved the Pull Request can be merged, since we've
 [configured GitHub to prevent merges](/manual/github.html) otherwise.

--- a/source/manual/github.html.md
+++ b/source/manual/github.html.md
@@ -57,7 +57,7 @@ Users are removed from the GitHub organisation when their entry in [govuk-user-r
 
 When creating a new GOV.UK repo, you must ensure it:
 
-- has a well-written README (see [READMEs for GOV.UK applications](/manual/readmes.html), or the [GDS Way guidance](https://gds-way.cloudapps.digital/manuals/readme-guidance.html#writing-readmes) for general repositories)
+- has a well-written README (see [READMEs for GOV.UK applications](/manual/readmes.html), or the [GDS Way guidance](https://gds-way.digital.cabinet-office.gov.uk/manuals/readme-guidance.html#writing-readmes) for general repositories)
 - is tagged with the [`govuk`](https://github.com/search?q=topic:govuk) topic
 - has [Dependency Review](/manual/dependency-review.html) and [CodeQL](/manual/codeql.html) scans in its CI pipeline
 - is added to the [repos.yml](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml) file in the Developer Docs.

--- a/source/manual/how-to-test-with-assitive-technology.html.html.md
+++ b/source/manual/how-to-test-with-assitive-technology.html.html.md
@@ -35,4 +35,4 @@ We have been assured by Assistiv Labs that the Virtual Machine (VM) is deleted w
 
 You should also make sure you understand how using the service affects any other requirements for your service, such as PCI (Payment Card Industry) compliance, and assess any additional risks. You can speak to your service's information assurance lead or the GDS Privacy Team for specific guidance.
 
-[Read more within the GDS Way](https://gds-way.cloudapps.digital/manuals/accessibility.html#testing-with-assistive-technologies)
+[Read more within the GDS Way](https://gds-way.digital.cabinet-office.gov.uk/manuals/accessibility.html#testing-with-assistive-technologies)

--- a/source/manual/readmes.html.md
+++ b/source/manual/readmes.html.md
@@ -7,7 +7,7 @@ type: learn
 parent: "/manual.html"
 ---
 
-This is a guide to writing and maintaining README documents for GOV.UK's public repositories. It's based on [guidance we have in the GDS Way for READMEs](https://gds-way.cloudapps.digital/manuals/readme-guidance.html#writing-readmes).
+This is a guide to writing and maintaining README documents for GOV.UK's public repositories. It's based on [guidance we have in the GDS Way for READMEs](https://gds-way.digital.cabinet-office.gov.uk/manuals/readme-guidance.html#writing-readmes).
 
 READMEs are for a technical audience. This could be a new starter or an existing developer. Using the following template will help to ensure each README is consistent, correct, short and actionable.
 

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -47,7 +47,7 @@ Access can be granted to both civil servants and contractors as needed, at the d
 Before approving access, the sponsor should ensure that the engineer:
 
 - has the required level of security clearance (BPSS)
-- is aware of our processes and standards around [code review](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html)
+- is aware of our processes and standards around [code review](https://gds-way.digital.cabinet-office.gov.uk/manuals/code-review-guidelines.html)
 - understands the responsibilities that [releasing code](/manual/development-pipeline.html#deployment) brings with it
 - knows how to roll back to an older release if there are any issues
 - knows [how to get help](/manual/ask-for-help.html) from someone with more access if they need it

--- a/source/partials/_intro.html.md
+++ b/source/partials/_intro.html.md
@@ -4,6 +4,6 @@ Toolkit][]. For technical documentation applicable to GDS as a whole, see [The
 GDS Way][GDS Way].
 
 [GDS]: https://gds.blog.gov.uk/about/
-[GDS Way]: https://gds-way.cloudapps.digital/
+[GDS Way]: https://gds-way.digital.cabinet-office.gov.uk/
 [GOV.UK]: https://www.gov.uk/
 [Service Toolkit]: https://www.gov.uk/service-toolkit


### PR DESCRIPTION
GDS Way has moved from PaaS. There is a redirect in place, but apparently this will disappear when PaaS is shut down.


