### PR TITLE
Update Ruby doc

### DIFF
--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -28,12 +28,6 @@ We use [bulk-changer][] to automatically raise pull requests in GOV.UK repositor
 
 For applications, you will usually need to change the ruby version in two places - in .ruby-version (which is used by rbenv), and in Dockerfile (which is used during deployment)
 
-It's advised not to use your personal GitHub account to create the access token required by the script, as another developer will need to approve the PRs. You can use [govuk-ci GitHub account](https://github.com/govuk-ci). The login credentials for the account can be fetched from [govuk-secrets](https://github.com/alphagov/govuk-secrets/tree/main/pass) with:
-
-```
-PASSWORD_STORE_DIR=~/govuk/govuk-secrets/pass/2ndline pass github/govuk-ci
-```
-
 #### Manually raising a PR
 
 You can also create your own branch, update the two files as above, and raise a PR.


### PR DESCRIPTION
The use of a service account/machine user was a workaround to replicate someone creating a trivial PR, but is not recommended as it is a security loophole.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
