### PR TITLE
gems.json endpoint

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -62,6 +62,10 @@ class Repo
     repo_data["retired"]
   end
 
+  def is_gem?
+    repo_data["type"] == "Gems"
+  end
+
   def private_repo?
     repo_data["private_repo"]
   end

--- a/app/repos.rb
+++ b/app/repos.rb
@@ -16,6 +16,10 @@ class Repos
     Repos.all.reject(&:retired?).uniq(&:repo_name)
   end
 
+  def self.active_gems
+    Repos.all.reject(&:retired?).select(&:is_gem?).uniq(&:repo_name)
+  end
+
   def self.active_public
     Repos.active.reject(&:private_repo?)
   end

--- a/source/gems.json.erb
+++ b/source/gems.json.erb
@@ -1,0 +1,1 @@
+<%= Repos.active_gems.map(&:api_payload).to_json %>

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe Repo do
     end
   end
 
+  describe "is_gem?" do
+    it "returns true if assiged type is Gems" do
+      expect(Repo.new({ "type" => "Gems" }).is_gem?).to be(true)
+    end
+
+    it "returns false if assigned type isn't Gems" do
+      expect(Repo.new({ "type" => "Utilities" }).is_gem?).to be(false)
+    end
+  end
+
   describe "app_name" do
     it "returns repo_name if app_name not specified" do
       expect(Repo.new({ "repo_name" => "foo" }).app_name).to eq("foo")

--- a/spec/app/repos_spec.rb
+++ b/spec/app/repos_spec.rb
@@ -73,4 +73,17 @@ RSpec.describe Repos do
       expect(Repos.active_apps.map(&:repo_name)).to eq(%w[asset-manager])
     end
   end
+
+  describe "active_gems" do
+    let(:repos) do
+      [
+        { repo_name: "cache-clearing-service", type: "Services" },
+        { repo_name: "gds-api-adapters", type: "Gems" },
+      ]
+    end
+
+    it "should return only apps that are classified as gems" do
+      expect(Repos.active_gems.map(&:repo_name)).to eq(%w[gds-api-adapters])
+    end
+  end
 end


### PR DESCRIPTION
Created endpoint to list all GOV.UK gem repositories, in the same fashion as the already existing apps.json and repos.json

This is to aid the [gem-release-alert](https://github.com/alphagov/gem-release-alert) application.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
