### PR TITLE
Update guidance: `test` "job" is now `CI` "workflow"

### DIFF
--- a/source/manual/test-and-build-a-project-with-github-actions.html.md
+++ b/source/manual/test-and-build-a-project-with-github-actions.html.md
@@ -7,11 +7,9 @@ parent: "/manual.html"
 ---
 
 [GitHub Actions](https://github.com/features/actions) is an automated workflow
-system that GOV.UK uses for [Continuous Integration (CI)][ci]. We also have
-[Jenkins](/manual/testing-projects.html) (and previously had Concourse) which
-provides similar functionality. In [GOV.UK RFC 123][] we decided that
-GitHub Actions is the preferred platform for GOV.UK CI usage where the wider
-platform integration of Jenkins is not required.
+system that GOV.UK uses for [Continuous Integration (CI)][ci]. In
+[GOV.UK RFC 123][] we decided that GitHub Actions is the preferred platform for
+GOV.UK CI usage where the wider platform integration of Jenkins is not required.
 
 **If your workflow requires the use of secrets, please talk to
 [GOV.UK senior tech](/manual/ask-for-help.html#contact-senior-tech)
@@ -24,6 +22,44 @@ GitHub organisation.
 ### Name of CI workflow file
 
 You should name the file used for configuring the CI workflow `ci.yml`.
+It should live in the `.github/workflows` directory.
+
+### Name of CI workflow and jobs
+
+The CI workflow configured above should have a `name` property with a
+value of `CI`. The workflow should have a number of self-contained jobs
+configured, for actions such as running tests, linting and security scans.
+These should [use reusable workflows](#reuse-workflows-where-possible) where
+possible. For example:
+
+```yaml
+jobs:
+  security-analysis:
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+
+  lint-javascript:
+    uses: alphagov/govuk-infrastructure/.github/workflows/standardx.yml@main
+    with:
+      files: "'app/assets/javascripts/**/*.js'"
+
+  lint-ruby:
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+```
+
+The jobs and steps do not need to be given a [name attribute][actions-name-attribute]
+as the job/step key should be sufficiently descriptive. In contrast, the
+`ci.yml` _must_ have a `name` property called `CI`, as this is
+[relied upon by our automated tooling](https://github.com/alphagov/govuk-dependabot-merger/pull/30).
+
+We previously recommended that repos should always define a job called `test`.
+Historically, this job would be responsible for running the repo's tests, linter
+and so on, usually via something like `bundle exec rake`. In January 2023, a
+[new convention](https://github.com/alphagov/content-data-admin/commit/89a888bf1d9d303cff50ae65ac9c0821c5c17e93)
+was established, giving each task its own 'job' (e.g. 'test-ruby' for running
+tests and 'lint-ruby' for running the linter), within an overall 'workflow'
+called `CI`. Whilst this decoupling does make it harder to run the entire check suite
+locally, it allows us to take advantage of GitHub Action parallelisation, as well
+as better code reuse through reusable workflows.
 
 ### When the CI workflow should run
 
@@ -40,6 +76,8 @@ Example configuration:
 
 ```yml
 # ./github/workflows/ci.yml
+name: CI
+
 on:
   push:
     branches:
@@ -47,6 +85,17 @@ on:
   pull_request:
 
 ```
+
+We previously recommended CI jobs to run on `[push, pull_request]` as per
+[RFC-123][] however this caused duplicate runs of the CI jobs
+of a pull request (one for the `push` another for the `pull_request`)
+which were both superfluous for our testing, a point of confusion and were
+depleting our allowance quotas.
+
+[merge-comment]: https://github.com/alphagov/govuk-developer-docs/pull/3961#discussion_r1171071337
+[RFC-123]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md#findings-from-some-initial-explorations-into-using-github-actions
+
+#### Running CI on demand
 
 To run CI on-demand, outside a pull request, for example before opening a PR,
 you may configure a repository to have a `workflow_dispatch` event so you can
@@ -56,6 +105,8 @@ to configure the checkout action to reference the appropriate commit.
 Example configuration:
 
 ```yml
+name: CI
+
 on:
   push:
     branches:
@@ -69,7 +120,8 @@ on:
         type: string
 
 jobs:
-  test:
+  # for example
+  test-ruby:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -77,97 +129,32 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 ```
 
-We previously recommended CI jobs to run on `[push, pull_request]` as per
-[RFC-123][] however this caused duplicate runs of the CI jobs
-of a pull request (one for the `push` another for the `pull_request`)
-which were both superfluous for our testing, a point of confusion and were
-depleting our allowance quotas.
-
-[merge-comment]: https://github.com/alphagov/govuk-developer-docs/pull/3961#discussion_r1171071337
-[RFC-123]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md#findings-from-some-initial-explorations-into-using-github-actions
-
-### Avoid superfluous naming of workflows, jobs and steps
-
-In workflow files you have the option to specify a
-[name attribute][actions-name-attribute] for the workflow itself, the jobs and
-each individual step.
-
-The workflow and any jobs should not be given a name as the workflow filename
-and job_id should be sufficiently explanatory.
-
-Steps should also not be named, as the text in the run command is normally
-sufficiently descriptive. We only should add names to steps where they are
-used to either explain a particularly cryptic set of commands or where there
-are identically appearing steps that we wish to disambiguate between.
-
-You should also avoid providing a `name` for your `test` job (see below).
-
 ### Branch protection rules
 
-Pull Requests [cannot be merged][branch-rule] until the `test` job has passed.
-Your workflow should always define a job called `test`.
+Pull Requests must not be merged until the jobs defined in the `CI`
+workflow have passed. You should always define a workflow called `CI`.
 
-Some automation relies on the presence of the `test` job. Whilst care has been
-taken to support custom names [in some places](https://github.com/alphagov/govuk-saas-config/pull/139),
-other places may not support them, so it is safer to just omit the `name`
-property for your `test` job.
+### Reuse workflows where possible
 
-### Prefer a single or small number of steps within a CI workflow
+We define a number of reusable workflows in the govuk-infrastructure repo.
 
-Rather than having a number of granular steps (such as: "Lint Ruby", "Lint JS",
-"Run Ruby tests", "Run JS Tests") prefer a single step (such as `bundle exec
-rake`) where more of the CI task configuration is handled in application code.
-
-This is so we can:
-
-- keep CI configurations simple and consistent;
-- make it easier to replicate CI checks in a development environment.
-
-### Base your workflow on one of our documented examples
-
-GitHub Actions currently [lack templating functionality][action-templates]
-to enable re-use of workflow configuration across projects. Therefore, in order
-to maintain consistency across GOV.UK projects, it is beneficial that we
-document and re-use common practices.
-
-This documentation contains examples of a number of common build needs for
-GOV.UK projects. You are encouraged to base your project's configuration on
-these and to follow their conventions. If your preferences, or common action
-conventions, deviate from these examples you are encouraged to open a PR to
-this repository to propose a change here. This is preferential to taking a
-project in a different direction and losing consistency.
-
-## GitHub Action Examples
-
-### Simple Ruby Application
+For example, here's [how Content Publisher uses a reusable workflow](https://github.com/alphagov/content-publisher/blob/70cafa40a5680a062d31f0e1d14ede3716318600/.github/workflows/ci.yml#L40-L42) that is [defined in govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure/blob/d31a9792f70b3857b83596e6dacc7f6d591c6b0e/.github/workflows/rubocop.yml):
 
 ```yml
-# .github/workflows/ci.yml
-on: [push, pull_request]
+name: CI
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - run: bundle exec rake
+  lint-ruby:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
 ```
 
-Notes:
-
-- [ruby/setup-ruby](https://github.com/ruby/setup-ruby) will automatically
-  select the Ruby version based on a `.ruby-version` file and will install
-  bundler if a necessary.
-  - The [`bundler-cache: true` option](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically)
-    automatically runs `bundle install` and caches the result between builds.
-
-### A Ruby Gem
+### CI workflow for Ruby gems
 
 This differs to a simple Ruby application because Ruby gems are not tied to
 particular Ruby or Rails versions. Therefore we should test against various
 combinations of supported versions.
+See [example in govspeak](https://github.com/alphagov/govspeak/blob/a42facbbc2365a47f9695b12fdfa6faac46cdb11/.github/workflows/ci.yml).
 
 To do this, we use a [build matrix][]. In this example, we test against three
 Ruby versions (`2.7`, `3.0`, `3.1`) and two Rails versions (`6`, `7`). Combined,
@@ -239,100 +226,11 @@ Notes:
   [GOV.UK Senior Tech](/manual/ask-for-help.html#contact-senior-tech)
   for this to be added to a repo.
 
-### GOV.UK Rails application with Postgres, Redis, Yarn and GOV.UK Content Schemas dependencies
-
-This is an example that suits a relatively complex GOV.UK Rails application
-(this was written for [Content Publisher][]) that has software dependencies
-(provided by [Docker containers][actions-docker-services]), cloning of a
-supplementary repository, and the use of Node.js for JavaScript dependency
-management.
-
-```yml
-on: [push, pull_request]
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:9.4
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_HOST_AUTH_METHOD: trust
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-    env:
-      RAILS_ENV: test
-      REDIS_URL: redis://localhost:6379/0
-      TEST_DATABASE_URL: postgresql://postgres@localhost/content-publisher
-      GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
-    steps:
-      - name: Clone project
-        uses: actions/checkout@v2
-      - name: Clone publishing api for content schemas
-        uses: actions/checkout@v2
-        with:
-          repository: alphagov/publishing-api
-          ref: deployed-to-production
-          path: vendor/publishing-api
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - uses: actions/setup-node@v1
-      - name: Check for cached node modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: yarn
-      - run: yarn install --frozen-lockfile
-      - run: bundle exec rails db:setup
-      - run: bundle exec rails assets:precompile
-      - run: bundle exec rake
-```
-
-Notes:
-
-- [Similar service configurations][service-configuration] to PostgreSQL and
-  Redis can be applied to other software dependencies such as MySQL, MongoDB
-  or Rabbit MQ.
-- The `health-cmd` checks are used on services to ensure the build does not
-  continue until the service is running.
-- Additional repositories are cloned to the vendor directory for a consistent
-  location for third party code, this is consistent with Bundler.
-- Since the same actions are used in different contexts the `name` option has
-  been used in steps to distinguish the different steps.
-- The `bundle exec rails assets:precompile` task is used to build a warm cache
-  of assets before starting tests to reduce risk of timeouts, this is due to
-  an [underlying performance issue][govuk-frontend-issue] with GOV.UK asset
-  compilation.
-- In the underlying project (Content Publisher) `bundle exec rake` performs:
-  Ruby & JS unit testing; Ruby, SCSS, JavaScript and FactoryBot linting; and
-  brakeman security audit.
-- This example does not include tagging the [main branch with a particular
-  release tag][release-tag] when there is a successful main build.
-
 [ci]: https://en.wikipedia.org/wiki/Continuous_integration
-[Jenkins]: /manual/testing-projects.html
 [GOV.UK RFC 123]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md
-[actions-secrets]: https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-[gem-release]: /manual/publishing-a-ruby-gem.html#releasing-gem-versions
-[govuk-puppet]: https://github.com/alphagov/govuk-puppet
-[actions-marketplace]: https://github.com/marketplace?type=actions
 [push-event]: https://help.github.com/en/actions/reference/events-that-trigger-workflows#push-event-push
 [pull-request-event]: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
 [actions-name-attribute]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#name
-[branch-rule]: https://github.com/alphagov/govuk-saas-config/blob/4d68f59f9af61e0f62bb074abc740aa53db300c1/github/lib/configure_repo.rb#L107
-[action-templates]: https://github.community/t5/GitHub-Actions/Templates-for-GitHub-Actions/m-p/52811
 [build matrix]: https://docs.github.com/en/actions/using-workflows/advanced-workflow-features#using-a-build-matrix
 [ruby-branches]: https://www.ruby-lang.org/en/downloads/branches/
 [govuk_admin_template]: https://github.com/alphagov/govuk_admin_template
-[Content Publisher]: https://github.com/alphagov/content-publisher
-[actions-docker-services]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idservices
-[service-configuration]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idservices
-[govuk-frontend-issue]: https://github.com/alphagov/govuk-frontend/issues/1671
-[release-tag]: /manual/testing-projects.html#fixing-the-build-number


### PR DESCRIPTION
As described in the documentation change, we no longer define
`test` jobs, and now define `CI` workflows, which work slightly
differently insofar as they're made up of several parallel jobs.

This commit makes a few other updates, including:

- Remove reference to small steps within a CI workflow:
  We've actually been heading in the opposite direction: lots of
  small steps defined within the CI workflow. This is partly because
  we're now making use of a lot of shared workflows, so what we lose
  in ease of local development, we gain in cross-GOV.UK consistency.
- Remove old example code
  Looking at the Content Publisher GitHub Actions, we no longer have
  the complexity referred to in these docs. I've deleted the docs
  that are no longer relevant.
  I've kept the instructions for testing Ruby gems, as that is still
  being applied.
- Move "previous recommendation" section further up:
  Moving it closer to where we're justifying our choices for "when
  the CI workflow should run".
  Also creates a new subsection for running CI on demand.
- Softening the language around omitting names for jobs and steps.
  In practice, a great many of our repos needlessly define job and
  step names that override the job/step key, but there is no harm
  in doing so.