### PR TITLE
Update ZenDesk leaver ticket process

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -126,8 +126,9 @@ As part of the leaver process, 1st line pass leaver tickets over to us so that w
 
 Search for their name/email in the [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer) repository.
 
+1. If you don't find a reference, you can close the ticket with an internal comment
 1. If you find a reference in [config/govuk_tech.yml](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml), create a card using the ["Leaver (tech role)"](https://trello.com/c/IQIV54Pc/378-leaver-tech-role) template card on the Technical 2nd Line Trello board
-1. If you don't find a reference - or you find a reference in the `govuk_non_tech.yml` - create a card using the ["Leaver (non tech role)"](https://trello.com/c/g9iK9fcL/1115-leaver-non-tech-role) template card
+1. If you find a reference in [config/govuk_non_tech.yml](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_non_tech.yml), create a card using the ["Leaver (non tech role)"](https://trello.com/c/g9iK9fcL/1115-leaver-non-tech-role) template card on the Technical 2nd Line Trello board
 
 Add the card to the "To do" column with a due date, which will be the leaving date from the Zendesk ticket.
 


### PR DESCRIPTION
## What

Update the Zendesk leaver ticket documentation to advise that the leaver ticket can be closed if no reference is found when searching the `govuk-user-reviewer` repository.

## Why

This should help improve the process when dealing with leaver tickets and avoid creating Trello cards that require no further action. Currently, the only other action to do when a user is not listed in either govuk_tech or govuk_non_tech, is to check if they are a member of a GitHub team, for which we already have automated checks in place for.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
