### PR TITLE
Implementation record document copy event

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -466,8 +466,8 @@
   type: string (number)
   redact: false
 
-- name: video_duration
-  description: The length of a video, in seconds.
+- name: length
+  description: The length of something. This could be the number of seconds in a video, or the number of characters in a string.
   required: no
   type: string (number)
   redact: false

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -130,7 +130,6 @@
         - name: action
           value: closed
 
-
 - name: breadcrumbs
   events:
     - name: link clicks
@@ -334,6 +333,31 @@
       data:
       - name: event
         value: event_data
+
+- name: copy
+  events:
+    - name: copy text
+      implemented: true
+      priority: low
+      description: Tracks when a user has copied text from a page.
+      tracker: copy_tracker
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: copy
+        - name: type
+          value: copy
+        - name: action
+          value: copy
+        - name: method
+          value: browser copy
+        - name: text
+          value: The first 30 characters of the copied text
+        - name: length
+          value: The original length of the copied text, after the removal of extra spaces, line breaks, and PII
 
 - name: details elements
   events:

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -2082,7 +2082,7 @@
           value: start
         - name: video_current_time
           value: "0"
-        - name: video_duration
+        - name: length
         - name: video_percent
           value: "0"
     - name: Video progress
@@ -2108,7 +2108,7 @@
         - name: action
           value: progress
         - name: video_current_time
-        - name: video_duration
+        - name: length
         - name: video_percent
     - name: Video complete
       implemented: true
@@ -2133,6 +2133,6 @@
         - name: action
           value: complete
         - name: video_current_time
-        - name: video_duration
+        - name: length
         - name: video_percent
           value: "100"

--- a/data/analytics/schemas.yml
+++ b/data/analytics/schemas.yml
@@ -38,7 +38,7 @@
       value: undefined
     - name: video_current_time
       value: undefined
-    - name: video_duration
+    - name: length
       value: undefined
     - name: video_percent
       value: undefined

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -57,3 +57,9 @@
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-print-intent-tracker.md
   description: Tracks when users open the browser print dialog.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js
+
+- name: Copy tracker
+  technical_name: copy_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-copy-tracker.md
+  description: Tracks when users copy text from a GOV.UK page.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js


### PR DESCRIPTION
## What
Update the GA4 implementation record. See individual commits for details.

## Why
Part of the GA4 migration.

Trello card: https://trello.com/c/s6uLhovR/751-add-tracking-browser-copy-events
