### PR TITLE
Amend GA4 browse data

### DIFF
--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -246,6 +246,7 @@
         - name: external
         - name: link_domain
         - name: method
+        - name: url
     - name: browse subtopic (browse level 2)
       implemented: true
       priority: medium


### PR DESCRIPTION
## What
Updates a very small thing in the implementation record for GA4 event data, browse pages.

## Why
I missed adding it in a previous PR.

Trello card: https://trello.com/c/mI6jxJru/752-fix-indexes-on-action-links-when-more-than-one-link-present

