### PR TITLE
Make the note about AWS MFA device name bold

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -97,7 +97,11 @@ GDS has a central `gds-users` AWS account where you create your IAM User. Your [
 1. [Request a AWS IAM User][request-aws-user] for the central `gds-users` AWS account.
 1. You should receive an email when your account is created.
 1. Follow instructions in the email to sign into the `gds-users` AWS account for the first time.
-1. [Enable Multi-factor Authentication (MFA)][enable-mfa] for your IAM User. You must specify your email address as the MFA device name. If you were issued a Yubikey, you can [use it as a MFA device][yubikey-aws-mfa].
+1. [Enable Multi-factor Authentication (MFA)][enable-mfa] for your IAM User.
+
+***Important - You must specify your email address as the MFA device name.***
+
+If you were issued a Yubikey, you can [use it as a MFA device][yubikey-aws-mfa].
 
 [aws-account-info]: https://reliability-engineering.cloudapps.digital/iaas.html#amazon-web-services-aws
 [iam-role-creation]: #6-get-permissions-for-aws-github-and-other-third-party-services


### PR DESCRIPTION
2 new starters on the team have missed this.

When I asked in slack others had already asked - in fact it's in the `reliability-eng` channel header.

***Making it bold and obvious***

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
