### PR TITLE
Retire govuk-google-analytics

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -615,10 +615,11 @@
 - repo_name: govuk-google-analytics
   team: "#analytics_team"
   type: Utilities
+  retired: true
   description: |
     Documentation and tools for GOV.UK and others that describes
     the approach taken when converting from Universal Analytics (UA)
-    to Google Analytics 4 (GA4).
+    to Google Analytics 4 (GA4). Retired in Jan 2024, content moved to govuk-developer-docs
 
 - repo_name: govuk-helm-charts
   type: Utilities


### PR DESCRIPTION
## What
Mark `govuk-google-analytics` repo information as retired.

## Why
Repo has been archived and content moved here.

Trello card: https://trello.com/c/xaWtlQ8O/754-archive-repo-for-govuk-google-analytics

