### PR TITLE
Mark govuk_crawler_worker and govuk_seed_crawler as retired

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,6 @@ task :verify_deployable_apps do
 
   intentionally_missing =
     %w[
-      govuk_crawler_worker
       smokey
       kibana-gds
       sidekiq-monitoring

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -885,7 +885,11 @@
 - repo_name: govuk_crawler_worker
   team: "#govuk-platform-engineering"
   type: Utilities
-  production_hosted_on: aws
+  retired: true
+  description: |
+    Was used (in conjunction with govuk_seed_crawler) to crawl and take a local
+    copy of GOV.UK, to synchronise upstream with the S3 and GCP mirrors.
+    Replaced by govuk-mirror in October 2023.
 
 - repo_name: govuk_document_types
   team: "#govuk-navigation-tech"
@@ -934,6 +938,11 @@
 - repo_name: govuk_seed_crawler
   team: "#govuk-platform-engineering"
   type: Gems
+  retired: true
+  description: |
+    Was used (in conjunction with govuk_crawler_worker) to crawl and take a local
+    copy of GOV.UK, to synchronise upstream with the S3 and GCP mirrors.
+    Replaced by govuk-mirror in October 2023.
 
 - repo_name: govuk_sidekiq
   team: "#govuk-publishing-platform"

--- a/source/manual/architecture-deep-dive.html.md
+++ b/source/manual/architecture-deep-dive.html.md
@@ -75,16 +75,16 @@ origin).
 
 If a Fastly request to origin returns a 5xx response, Fastly will request
 content from the mirror, which is static HTML hosted in an S3 bucket on AWS.
-The contents of the mirror are updated daily via a [govuk-crawler-worker],
+The contents of the mirror are updated daily via the [govuk-mirror] crawler,
 which recursively crawls GOV.UK URLs from a message queue, visiting the pages
 and saving the output to disk.
 
-- Read more about [fallback to the static mirrors].
+- Read more about [fallback to the static mirrors] and how the mirrors are populated.
 - Read more about [how errors are handled on GOV.UK].
 
 [fallback to the static mirrors]: /manual/fall-back-to-mirror.html
 [how errors are handled on GOV.UK]: /manual/errors.html
-[govuk-crawler-worker]: https://github.com/alphagov/govuk_crawler_worker
+[govuk-mirror]: https://github.com/alphagov/govuk-mirror
 
 #### Routing on the CDN
 


### PR DESCRIPTION
These were replaced by govuk-mirror in October 2023.
