### PR TITLE
Retire the Whitehall Asset Analysis repository

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1479,8 +1479,9 @@
   private_repo: true
   sentry_url: false
   dashboard_url: false
+  retired: true
   description: |
-    Repo for analysis scripts used to improve Whitehall asset management
+    Repo for analysis scripts used to improve Whitehall asset management. Retired as resulting work has been completed.
 
 - repo_name: whitehall-prototype-2023
   type: Publishing apps


### PR DESCRIPTION
This repository is no longer in use because the work that was informed by this analysis has been completed.
