### PR TITLE
Mark whitehall prototype 2023 as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1490,6 +1490,10 @@
   production_hosted_on: heroku
   sentry_url: false
   dashboard_url: false
+  retired: true
+  description: |
+    A prototype built for testing proposed changes to the Whitehall publishing workflow. Retired as the experiments have
+    been completed.
 
 - repo_name: widdershins
   type: Gems


### PR DESCRIPTION
The prototype is no longer in use for design experimentation.