### PR TITLE
Update content-store-proxy description after archiving the repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -202,14 +202,18 @@
   team: "#govuk-publishing-platform"
   description: |
     A temporary proxy to aid with the migration of content-store from
-    MongoDB to PostgreSQL. On integration, we have two versions of content-store
-    running side-by-side, one on each database. The proxy sits in front of them,
-    forwards all incoming requests to its PRIMARY_UPSTREAM (currently the MongoDB
-    version) and returns that response, but also replays the request to its
-    SECONDARY_UPSTREAM (currently the PostgreSQL version). This allows us to
-    compare the responses from both versions in order to satisfy ourselves that
-    the two are completely equivalent and address any differences, before we
-    migrate production.
+    MongoDB to PostgreSQL. We had two versions of content-store
+    running side-by-side, one using each database. The proxy sat in front of them,
+    forwarding all incoming requests to its PRIMARY_UPSTREAM (at first the MongoDB
+    version, later PostgreSQL) and returned that response. It also replayed the 
+    request to its SECONDARY_UPSTREAM (at first the PostgreSQL version, later 
+    MongoDB). This allowed us to compare the responses from both versions to 
+    satisfy ourselves that the two were completely equivalent and address any 
+    differences, before we migrated production.
+
+    The migration was completed in December 2023, and the proxy repo was archived
+    on 3rd Jan 2024.
+  retired: true
 
 - repo_name: content-tagger
   type: Publishing apps


### PR DESCRIPTION
The content-store migration from Mongo to Postgres is now completed, we're no longer running content-store-proxy, and we've archived the content-store-proxy repo. So we need to update the description of the repo in these pages to reflect that.

[Trello card](https://trello.com/c/sQIA1Q7d/977-update-all-content-store-documentation-relevant-to-mongo-postgres-switch)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
