### PR TITLE
Add govspeak-visual-editor to repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -398,6 +398,10 @@
   sentry_url: false
   dashboard_url: false
 
+- repo_name: govspeak-visual-editor
+  type: Utilities
+  team: "#govuk-publishing-experience-tech"
+
 - repo_name: govuk-accessibility-reports
   retired: true
   team: "#data-products"


### PR DESCRIPTION
## Description

We've recently added a new repo for development of a visual editor based on ProseMirror. 


<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
