### PR TITLE
Fix `alphagov/govspeak-visual-editor not found` in CI.

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -398,6 +398,7 @@
   dashboard_url: false
 
 - repo_name: govspeak-visual-editor
+  private_repo: true
   type: Utilities
   team: "#govuk-publishing-experience-tech"
 


### PR DESCRIPTION
This is really just hacking around a bug (#4259), but for now it seems that when a private repo is listed in repos.yml without `private_repo: true`, CI [fails](https://github.com/alphagov/govuk-developer-docs/actions/runs/7450974838/job/20271040876#step:6:646) in at least some circumstances.