### PR TITLE
Add timestamp value to GA4 docs

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -438,6 +438,13 @@
   type: string
   redact: true
 
+- name: timestamp
+  description: The user's unix timestamp during a dataLayer push. Performance Analysts use this to sort dataLayer pushes from a user in a sequential order.
+  example: "1704796270204"
+  required: no
+  type: string
+  redact: false
+
 - name: type
   description: Relates to the top level attribute of event_name but contains a value that we have defined.
   example:

--- a/data/analytics/schemas.yml
+++ b/data/analytics/schemas.yml
@@ -42,6 +42,8 @@
       value: undefined
     - name: video_percent
       value: undefined
+  - name: timestamp
+    value: "(user's unix timestamp)"
 - name: page view schema
   data:
   - name: event
@@ -128,6 +130,8 @@
       value: undefined
     - name: world_locations
       value: undefined
+  - name: timestamp
+    value: "(user's unix timestamp)"
 - name: ecommerce schema
   data:
   - name: event
@@ -146,3 +150,5 @@
       value:
       - name: items
         value: undefined
+  - name: timestamp
+    value: "(user's unix timestamp)"


### PR DESCRIPTION
Adds the `timestamp` value to the GA4 docs. I placed it in `schemas.yml` but noticed it should probably link to something, so I kept the initial `attributes.yml` entry so that it could something with a description of the value. However I'm happy to remove the reference to it in `attributes.yml` if preferred.