### PR TITLE
Spike putting OAuth proxy in front of Developer Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 # Ignore the build directory
 /build
 
+# Ignore OAuth2-related files created by `startup_local_auth.sh`
+/auth/oauth2-proxy
+/auth/*.tar.gz
+/auth/*-sha256sum.txt
+
 # Ignore cache
 /.sass-cache
 /.cache

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ env SKIP_PROXY_PAGES=true ./startup.sh
 
 Disabling proxy pages means you'll get a "Not Found" error if you try to access them locally.
 
+You can test the GitHub OAuth aspects of the Developer Docs by running the startup script above in one shell, and then running the following in another shell:
+
+```
+OAUTH2_PROXY_CLIENT_ID=abc123456 OAUTH2_PROXY_CLIENT_SECRET=def789101112 ./startup_local_auth.sh
+```
+
+You'll need to swap out the client ID and secret. Create an OAuth app at <https://github.com/settings/developers>, with a Homepage URL of <http://localhost:8088> and an Authorization Callback URL of <http://localhost:8088/oauth2/callback>.
+
+Try visiting `http://localhost:8088/private/example.html` and you'll be prompted to sign in with GitHub.
+
 ### Testing the app
 
 ```

--- a/auth/oauth2-proxy-localhost.cfg
+++ b/auth/oauth2-proxy-localhost.cfg
@@ -1,0 +1,68 @@
+## OAuth2 Proxy Config File
+## See example config file:
+## https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example
+
+## <addr>:<port> to listen on for HTTP/HTTPS clients
+http_address = "127.0.0.1:8088"
+# https_address = ":443"
+
+## Are we running behind a reverse proxy? Will not accept headers like X-Real-Ip unless this is set.
+reverse_proxy = true
+
+## the http url(s) of the upstream endpoint. If multiple, routing is based on path
+upstreams = [
+    "http://localhost:4567"
+]
+
+## pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
+pass_basic_auth = true
+pass_user_headers = true
+## pass the request Host Header to upstream
+## when disabled the upstream Host is used as the Host Header
+pass_host_header = true
+
+## Email Domains to allow authentication for (this authorizes any email on this domain)
+## for more granular authorization use `authenticated_emails_file`
+## To authorize any email addresses use "*"
+email_domains = [
+    "*"
+]
+
+## bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods
+skip_auth_routes = [
+  "!=^/private"
+]
+
+## Templates
+## optional directory with custom sign_in.html and error.html
+# custom_templates_dir = ""
+
+## Provider Settings (Github)
+provider = "github"
+# github_org = "alphagov"
+# github_team = ""
+# github_repo = ""
+# github_token = ""
+# github_user = ""
+
+
+## Cookie Settings
+## Name     - the cookie name
+## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##            for use with an AES cipher when cookie_refresh or pass_access_token
+##            is set
+## Domain   - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
+## Expire   - (duration) expire timeframe for cookie
+## Refresh  - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
+##            Should be less than cookie_expire; set to 0 to disable.
+##            On refresh, OAuth token is re-validated.
+##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
+## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
+## HttpOnly - httponly cookies are not readable by javascript (recommended)
+cookie_name = "_oauth2_proxy_localhost"
+cookie_secret = "N0t4R34LS3cr3t%!"
+# cookie_domains = ""
+# cookie_expire = "168h"
+# cookie_refresh = ""
+cookie_secure = false
+cookie_httponly = true

--- a/source/private/example.html.md
+++ b/source/private/example.html.md
@@ -1,0 +1,8 @@
+---
+owner_slack: "#govuk-2ndline-tech"
+title: Example private doc
+layout: manual_layout
+section: 2nd line
+---
+
+Private information here.

--- a/startup_local_auth.sh
+++ b/startup_local_auth.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -e
+
+## Name: startup_local_auth.sh
+## Description: This script attempts to start-up the fully authenticated pay-team-manual stack locally
+## Since: 2021-09-14
+PROXY_ARCH="darwin-amd64"
+PROXY_VER="7.5.1"
+
+# Release Paths
+PROXY_BIN_SUM="oauth2-proxy-v${PROXY_VER}.${PROXY_ARCH}-sha256sum.txt"
+PROXY_BIN_TAR="oauth2-proxy-v${PROXY_VER}.${PROXY_ARCH}.tar.gz"
+PROXY_REL_ROOT="https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v${PROXY_VER}"
+
+if [[ -z "${OAUTH2_PROXY_CLIENT_ID}" ]]; then
+  printf "The OAUTH2_PROXY_CLIENT_ID env var is not set. If you need a Client ID, you can go here:\n https://github.com/settings/developers "
+  exit 1
+fi
+
+if [[ -z "${OAUTH2_PROXY_CLIENT_SECRET}" ]]; then
+  printf "The OAUTH2_PROXY_CLIENT_SECRET env var is not set. If you need a Client Secret, you can go here:\n https://github.com/settings/developers "
+  exit 1
+fi
+
+## Change working directory to /auth...
+cd auth
+
+function download {
+    echo "Getting latest OAuth2 Proxy Tar from Github..."
+    wget -q --show-progress -N "${PROXY_REL_ROOT}/${PROXY_BIN_TAR}"
+
+    echo "Extracting OAuth2 Proxy Binary from Tar..."
+    tar -zxvf ${PROXY_BIN_TAR} --strip=1
+
+    rm "${PROXY_BIN_TAR}"
+}
+
+echo "Getting latest OAuth2 Proxy Checksum from Github..."
+wget -q --show-progress -N "${PROXY_REL_ROOT}/${PROXY_BIN_SUM}"
+
+if test -f "oauth2-proxy"; then
+    echo "oauth2-proxy already exists. Checking if it matches the checksum..."
+    EXISTING_SUM=$(sha256sum oauth2-proxy | cut -d " " -f 1)
+    REMOTE_SUM=$(cat $PROXY_BIN_SUM | cut -d " " -f 1)
+
+    if [[ "$EXISTING_SUM" == "$REMOTE_SUM" ]]; then
+        echo "Binary is already up to date."
+    else
+        echo "Binary checksum failed. Downloading new version..."
+        download
+    fi
+else
+    echo "Oauth2 Proxy not found. Downloading..."
+    download
+fi
+
+cd ..
+
+bundle check || bundle install
+
+# # Launch Middleman to host the Manual, fork it, then store the PID...
+# echo "Starting Middleman Server..."
+# NO_CONTRACTS=true bundle exec middleman server -d &> middleman.log &
+
+# # Trap Ctrl+C and terminate Middleman and the OAuth2 Proxy...
+# trap onexit INT
+# function onexit() {
+#     echo "Terminating Middleman Server..."
+#     lsof -t -i tcp:4567 | xargs kill -9
+# }
+
+# Launch OAuth2 Proxy (with Localhost Config)...
+echo "Starting OAuth Proxy Server..."
+auth/oauth2-proxy --config=./auth/oauth2-proxy-localhost.cfg


### PR DESCRIPTION
This heavily borrows from a PR doing the same thing for the Pay team manual back in September 2021:
https://github.com/alphagov/pay-team-manual/pull/1121

It uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) to require signing in via GitHub to view any pages in the `source/private` folder.

Notes:
- This is a proof of concept for local development only. The Pay PR had an additional oauth2-proxy.cfg file for production, which we would need too.
- We'd move hosting to something like Heroku, so that we can have this proxy in front of the docs (not supported by GitHub Pages, which allows for static sites only).
- The GitHub provider settings currently allow anyone with a GitHub account to view private pages. In production we'd need to set the `github_org` setting to "alphagov" to lock it down to GDS folks.
- The `startup_local_auth.sh` script has logic in it that is supposed to remove the need to run the middleman server in another shell, but this wasn't working so I commented it out.

Decisions to make from here:
1. *Whether to be public or private by default*. The config is currently public by default, in that it allows unrestricted access to all routes except those under `/private`. We could instead deny access to all routes by default, and remove authentication from certain routes where desired. Ideally, the following routes would be public:
  - Homepage (to describe what this site is and how to access it)
  - The `/analytics` prefix, which is the public documentation for our GA4 implementation record.
  - Our API endpoints (e.g. repos.json).
2. *How to store private documentation*. Having a `private` folder in our public repo would not make much sense! We could make the repo private, or make use of git submodules to pull in a private repo dedicated to private docs. Implementation largely depends on the decision made in 1.
3. *Which OAuth provider to use*. Probably Google, as it means access is automatically lost when someone leaves the org (as opposed to GitHub Access, which has a manual/Terraform removal step). Also makes it more likely that OAuth won't impede the initial onboarding. Looks marginally more difficult to set up than GitHub, as it doesn't allow setting up against localhost URLs and custom ports.

Other functional considerations:
- Keeping search public would require that we omit the indexing of private documentation - potentially impacting its usefulness. If everything is private, we don't have to worry about this.
- Having some things public and some private means the private docs need to be declared private up front and stored in the 'private' folder. Alternatively, we could have a full allowlist of docs that should be private, but we then need to ensure that a rename of a private file won't accidentally make it publicly visible.

Trello: https://trello.com/c/BpaOgcsY/43-explore-putting-developer-docs-behind-sso
