### PR TITLE
Remove ancient data products related repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -689,10 +689,6 @@
   team: "#data-products"
   type: Data science
 
-- repo_name: govuk-networkx-tutorial
-  team: "#data-products"
-  type: Data science
-
 - repo_name: govuk-paas-office-ip-router
   private_repo: true
   team: "#govuk-platform-security-reliability-team"
@@ -800,10 +796,6 @@
   team: "#govuk-publishing-platform"
   type: Utilities
   production_hosted_on: eks
-
-- repo_name: govuk-spaCy
-  team: "#data-products"
-  type: Data science
 
 - repo_name: govuk-technical-2ndline-dashboard
   team: "#govuk-platform-security-reliability-team"
@@ -1439,10 +1431,6 @@
   type: APIs
   team: "#govuk-platform-security-reliability-team"
   production_hosted_on: eks
-
-- repo_name: tagging-suggester
-  team: "#data-products"
-  type: Data science
 
 - repo_name: transition
   type: Transition apps


### PR DESCRIPTION
None of these have been touched in 5 years.
[Have checked in Slack](https://gds.slack.com/archives/CHR4UQKU4/p1704194218367839) and we're fine to archive them.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
