### PR TITLE
Update public asset checker ownership to govuk-publishing-components

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -205,10 +205,10 @@
     MongoDB to PostgreSQL. We had two versions of content-store
     running side-by-side, one using each database. The proxy sat in front of them,
     forwarding all incoming requests to its PRIMARY_UPSTREAM (at first the MongoDB
-    version, later PostgreSQL) and returned that response. It also replayed the 
-    request to its SECONDARY_UPSTREAM (at first the PostgreSQL version, later 
-    MongoDB). This allowed us to compare the responses from both versions to 
-    satisfy ourselves that the two were completely equivalent and address any 
+    version, later PostgreSQL) and returned that response. It also replayed the
+    request to its SECONDARY_UPSTREAM (at first the PostgreSQL version, later
+    MongoDB). This allowed us to compare the responses from both versions to
+    satisfy ourselves that the two were completely equivalent and address any
     differences, before we migrated production.
 
     The migration was completed in December 2023, and the proxy repo was archived
@@ -1192,7 +1192,7 @@
     GOV.UK Topic Taxonomy, removing the need for Policy Publisher.
 
 - repo_name: public-asset-checker
-  team: "#analytics_team"
+  team: "#govuk-publishing-components"
   type: Utilities
   description: |
     Checks publicly hosted asset files against a known baseline and notifies the owning team if any require attention.


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

[Trello](https://trello.com/c/Ls0VAovK/737-junior-dev-suitable-change-the-name-of-the-user-experience-measurement-govuk-robot-invasion-slack-channel-and-move-the-various-n)

Following up on this [PR](https://github.com/alphagov/govuk-developer-docs/pull/4358), the frontend devs have agreed that the public-asset-checker notifications should be moved to the `govuk-publishing-components` team.