### PR TITLE
Document change note update process for publishing apps

### DIFF
--- a/source/manual/howto-modify-change-note.html.md.erb
+++ b/source/manual/howto-modify-change-note.html.md.erb
@@ -35,6 +35,12 @@ ed.save
 
 Content Publisher has a [set of rake tasks](https://github.com/alphagov/content-publisher/blob/main/lib/tasks/change_history.rake) for adding, deleting and editing change notes.
 
+## Other Publishing Apps
+
+The other publishing apps do not currently provide an automated means of updating a change note, and therefore unfortunately direct modification via the Rails console is required before republishing the document.
+
+The exception to this is Specialist Publisher, which does not have its own database. Specialist Publisher persists all of its data straight to Publishing API, so [the steps documented below](#publishing-api) for updating a change note there can be followed.
+
 ## Publishing API
 
 Updating change notes in Publishing API is rarely adviseable and should ONLY be done if unable to do so from the corresponding publishing app. This is to mitigate the risk of Publishing API being overwritten by the publishing app later on. Thoroughly explore your publishing app first, to see if such functionality exists (we've documented Whitehall and Content Publisher above), and if it doesn't, consider building the feature in! However, in an emergency, you can edit the changenote directly in Publishing API.


### PR DESCRIPTION
Unfortunately at present only Whitehall and Content Publisher have an automated method for updating change notes. Hopefully this note will save time spent on 2nd line looking for something that isn't there.

The Publishing Experience team will look into providing a better way of doing this going forward, as it's obviously something that comes up on 2nd line fairly often.
