### PR TITLE
Re-write the Licensing Third Party Docs for the EKS Move

### DIFF
--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -21,13 +21,15 @@ The source code is hosted on GitHub at [alphagov/licensify](https://github.com/a
 
 Licensify uses an Elasticsearch / Logstash / Kibana system hosted by Logit.io for its logs.
 
-If you haven't already got access to the GDS LogIt account, you'll need to [follow the instructions in the Reliability Engineering documentation to create an account in Logit](https://reliability-engineering.cloudapps.digital/logging.html#get-started-with-logit).
+If you haven't already got access to the GDS Logit account, you'll need to [follow the instructions in the Reliability Engineering documentation to create an account in Logit](https://reliability-engineering.cloudapps.digital/logging.html#get-started-with-logit).
 
 ## Creating new Builds
 
 Licensify is built into Docker container images with Github Actions Workflows.
 
 If you have access to merge code into main, you will have access to start builds that, once completed, will push container images into AWS ECR (Elastic Container Registry) and then trigger ArgoCD to start a deployment.
+
+Merges to the `main` branch will automatically trigger a build that deploys into Integration. In order to deploy into Staging or Production, you will need to trigger those deploys manually.
 
 ## Deploying builds with ArgoCD
 
@@ -144,7 +146,7 @@ kubectl -n apps rollout restart deployment/licensify-admin
 
 ## Accessing MongoDB
 
-**(This secretion needs updating)**
+**(This section needs updating)**
 
 Licensify uses a MongoDB cluster hosted by AWS (DocumentDB). The database hosts in use by a particular Licensify instance can be found in `/etc/licensing/gds-licensing-config.properties` on the `licensing_backend` machines, in the `mongo.database.*` keys.
 
@@ -163,21 +165,3 @@ Enter password: REDACTED
 
 …
 ```
-
-## Managing Config and Secrets
-
-Configuration defaults are declared in the `values.yaml` file in [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/licensify).
-
-Per-environment overrides are set in the shared `app-config` Chart:
-
-* [Values for Integration](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-integration.yaml)
-* [Values for Staging](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-staging.yaml)
-* [Values for Production](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-production.yaml)
-
-Secrets are stored in [AWS Secrets Manager](https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=govuk%2Flicensify&region=eu-west-1) in the relevant account environment, under `govuk/licensify`.
-
-If you change the config or secrets, you may need to relaunch or re-deploy the app in order for it to see the new changes.
-
-## Updating Helm Charts
-
-If you need to change the way any of the licensing components speak to each other, you will want to update the Helm Charts. These are stored in the [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/licensify) Repository.

--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -61,22 +61,22 @@ Access to GDS AWS accounts is managed via GDS Users. You can request a user via 
 Once you have the necessary permissions and access, you can continue.
 
 The easiest way to do this is with the GDS CLI. You can either chain your commands onto the GDS CLI:
-```
+```sh
 gds aws govuk-integration-admin -- aws sts get-caller-identity
 ```
 
 ...or you can use the `-e` flag with the GDS CLI to export an AWS session into your terminal:
-```
+```sh
 gds aws govuk-integration-admin -e
 ```
 
 If you can't use the GDS CLI, you can use the `aws-vault exec` command with your manually-created AWS tokens instead:
-```
+```sh
 aws-vault exec govuk-integration -- aws sts get-caller-identity
 ```
 
 Once you're authenticated with AWS, you can check your connection to Kubernetes:
-```
+```sh
 gds aws govuk-integration-admin --  kubectl cluster-info
 ```
 
@@ -84,11 +84,15 @@ If this works, you can now use `kubectl` to manage the apps in the cluster. We'l
 
 ### Observing Apps on Kubernetes
 
-The licensing resources all share a common label: `app.kubernetes.io/part-of=licensify` - you can use this as a filter for most commands to find it among the other apps running in the GOV.UK `apps` namespace.
+The licensing resources all exist in their own `licensify` namespace, but also carry a set of labels to identify them. You can use these as filters for most commands to find certain deployments, pods or services running within the same namespace:
+```txt
+app.kubernetes.io/name=licensify-admin
+app.kubernetes.io/part-of=licensify
+```
 
 To observe all the licensing deployments on the cluster: 
-```
-kubectl -n apps get deploy -l app.kubernetes.io/part-of=licensify
+```sh
+kubectl -n licensify get deploy -l app.kubernetes.io/part-of=licensify
 ```
 
 You should receive a response like: 
@@ -101,33 +105,33 @@ licensify-frontend   1/1     1            1           11d
 ```
 
 To view more details about one of the deployments:
-```
-kubectl -n apps describe deploy licensify-admin
+```sh
+kubectl -n licensify describe deploy licensify-admin
 ````
 
 To view the logs from a deployment:
-```
-kubectl -n apps logs deploy/licensify-admin
+```sh
+kubectl -n licensify logs deploy/licensify-admin
 ```
 
 You can reuse most of the above commands to view information about the individual pods, for example:
 
-```
-kubectl -n apps get pods -l app.kubernetes.io/part-of=licensify
+```sh
+kubectl -n licensify get pods -l app.kubernetes.io/part-of=licensify
 ```
 
 ### Accessing live containers
 
 Since the application has been migrated onto Kubernetes, we no longer have a concept of SSH access. Instead, you can exec commands directly on the relevant containers, including an interactive Bash or Shell session:
 
-```
-kubectl -n apps exec -it deploy/licensify-admin -- bash
+```sh
+kubectl -n licensify exec -it deploy/licensify-admin -- bash
 ```
 
 If you want to access a specific pod, substitute the deployment for one of the pod names:
 
-```
-kubectl -n apps exec -it pod/licensify-admin-5dcf84545-58b9k -- bash
+```sh
+kubectl -n licensify exec -it pod/licensify-admin-5dcf84545-58b9k -- bash
 ```
 
 The files most relevant to the Licensify applications can be found in:
@@ -140,8 +144,8 @@ The files most relevant to the Licensify applications can be found in:
 
 If you want to relaunch an existing deployment, you can either kill the pods (so Kubernetes will replace them), or for more predictable behaviour, you should use the rollout restart command:
 
-```
-kubectl -n apps rollout restart deployment/licensify-admin
+```sh
+kubectl -n licensify rollout restart deployment/licensify-admin
 ```
 
 ## Accessing MongoDB

--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -50,9 +50,10 @@ By default, a successful build on the main branch in Github will notify Argo to 
 
 ## Using Kubernetes
 
-The licensing application stack is now orchestrated on Kubernetes clusters (running on AWS EKS). 
+The licensing application stack is now orchestrated on Kubernetes clusters (running on AWS EKS).
 
 ### Getting Accesss
+
 To interact with the Kubernetes cluster, you will need to authenticate via the AWS CLI. For more help on how to set up the necessary CLI tools, read [Set up tools to use the GOV.UK Kubernetes platform
 ](https://docs.publishing.service.gov.uk/kubernetes/get-started/set-up-tools/).
 
@@ -61,21 +62,25 @@ Access to GDS AWS accounts is managed via GDS Users. You can request a user via 
 Once you have the necessary permissions and access, you can continue.
 
 The easiest way to do this is with the GDS CLI. You can either chain your commands onto the GDS CLI:
+
 ```sh
 gds aws govuk-integration-admin -- aws sts get-caller-identity
 ```
 
 ...or you can use the `-e` flag with the GDS CLI to export an AWS session into your terminal:
+
 ```sh
 gds aws govuk-integration-admin -e
 ```
 
 If you can't use the GDS CLI, you can use the `aws-vault exec` command with your manually-created AWS tokens instead:
+
 ```sh
 aws-vault exec govuk-integration -- aws sts get-caller-identity
 ```
 
 Once you're authenticated with AWS, you can check your connection to Kubernetes:
+
 ```sh
 gds aws govuk-integration-admin --  kubectl cluster-info
 ```
@@ -85,17 +90,20 @@ If this works, you can now use `kubectl` to manage the apps in the cluster. We'l
 ### Observing Apps on Kubernetes
 
 The licensing resources all exist in their own `licensify` namespace, but also carry a set of labels to identify them. You can use these as filters for most commands to find certain deployments, pods or services running within the same namespace:
+
 ```txt
 app.kubernetes.io/name=licensify-admin
 app.kubernetes.io/part-of=licensify
 ```
 
-To observe all the licensing deployments on the cluster: 
+To observe all the licensing deployments on the cluster:
+
 ```sh
 kubectl -n licensify get deploy -l app.kubernetes.io/part-of=licensify
 ```
 
-You should receive a response like: 
+You should receive a response like:
+
 ```
 NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
 clamav               1/1     1            1           11d
@@ -105,11 +113,13 @@ licensify-frontend   1/1     1            1           11d
 ```
 
 To view more details about one of the deployments:
+
 ```sh
 kubectl -n licensify describe deploy licensify-admin
 ````
 
 To view the logs from a deployment:
+
 ```sh
 kubectl -n licensify logs deploy/licensify-admin
 ```
@@ -150,7 +160,8 @@ kubectl -n licensify rollout restart deployment/licensify-admin
 
 ## Accessing MongoDB
 
-**(This section needs updating)**
+> **Note: This section may need updating**  
+> Since the change to Kubernetes, this procedure may no longer work or be a reliable means for accessing the Database.
 
 Licensify uses a MongoDB cluster hosted by AWS (DocumentDB). The database hosts in use by a particular Licensify instance can be found in `/etc/licensing/gds-licensing-config.properties` on the `licensing_backend` machines, in the `mongo.database.*` keys.
 

--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -134,6 +134,14 @@ The files most relevant to the Licensify applications can be found in:
 * Logs: `/var/log/licensify`
 * Config: `/etc/licensify`
 
+### Relaunching containers
+
+If you want to relaunch an existing deployment, you can either kill the pods (so Kubernetes will replace them), or for more predictable behaviour, you should use the rollout restart command:
+
+```
+kubectl -n apps rollout restart deployment/licensify-admin
+```
+
 ## Accessing MongoDB
 
 **(This secretion needs updating)**
@@ -167,6 +175,8 @@ Per-environment overrides are set in the shared `app-config` Chart:
 * [Values for Production](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-production.yaml)
 
 Secrets are stored in [AWS Secrets Manager](https://eu-west-1.console.aws.amazon.com/secretsmanager/secret?name=govuk%2Flicensify&region=eu-west-1) in the relevant account environment, under `govuk/licensify`.
+
+If you change the config or secrets, you may need to relaunch or re-deploy the app in order for it to see the new changes.
 
 ## Updating Helm Charts
 


### PR DESCRIPTION
## What?
This updates the Third Party Documentation for the Licensing app stack. It provides examples of how to use the `kubectl` command line to interact with the apps in the cluster and how to perform basic checks, as well as how to find and update the configuration and update secrets.