### PR TITLE
Mark email-alert-monitoring as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -319,6 +319,11 @@
   production_hosted_on: eks
   sentry_url: false
   dashboard_url: false
+  retired: true
+  description: |
+    Was used to check that Medical Safety and Travel Advice email alerts were
+    being delivered.
+    Replaced by internal checks in email-alert-api in January 2024.
 
 - repo_name: email-alert-service
   type: Services


### PR DESCRIPTION
https://trello.com/c/HutMFiHP/2329-retire-email-alert-monitoring-application

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
