### PR TITLE
Update Licensify to be hosted on EKS

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1011,27 +1011,24 @@
   app_name: licensify
   private_repo: true
   type: Licensing apps
-  production_hosted_on: aws
+  production_hosted_on: eks
   team: "#govuk-licensing"
-  puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify.pp
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: licensify
   app_name: licensify-admin
   private_repo: true
   type: Licensing apps
-  production_hosted_on: aws
+  production_hosted_on: eks
   team: "#govuk-licensing"
-  puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify_admin.pp
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: licensify
   app_name: licensify-feed
   private_repo: true
   type: Licensing apps
-  production_hosted_on: aws
+  production_hosted_on: eks
   team: "#govuk-licensing"
-  puppet_url: https://github.com/alphagov/govuk-puppet/blob/master/modules/licensify/manifests/apps/licensify_feed.pp
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: link-checker-api


### PR DESCRIPTION
To be merged post migration.