### PR TITLE
Add docs for purging the standby CDN's cache

### DIFF
--- a/source/manual/purge-cache.html.md
+++ b/source/manual/purge-cache.html.md
@@ -68,6 +68,25 @@ production.
    "Purge all".
 1. The UI will ask you for confirmation before issuing the purge request.
 
+## Purge a page from the standby CloudFront CDN
+
+In addition to our primary CDN (Fastly), we also have a standby CDN set up on
+CloudFront. This standby CDN is only intended to be used during a Fastly
+outage, so there's a limited number of situations in which you would need to
+purge its cache.
+
+If an item urgently needs to be removed from the cache, you can create an
+invalidation from the AWS console.
+
+1. Log into the AWS console with `gds aws govuk-production-poweruser -l`.
+1. Under the [CloudFront distributions page](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=eu-west-1#/distributions),
+   choose the appropriate distribution: `WWW` for www.gov.uk or `Assets` for assets.publishing.service.gov.uk.
+1. Select the "Invalidations" tab, and click "Create invalidation".
+1. Enter the full paths of all resources to purge (that is, everything after
+   the hostname in the URL). You can optionally use wildcards (`*`). To purge
+   all objects, enter the path `/*`.
+1. Click "Create invalidation".
+
 ## Further reading
 
 See [Fastly's documentation on purging](https://developer.fastly.com/learning/concepts/purging/).


### PR DESCRIPTION
[Trello card](https://trello.com/c/zuGLgJZe/3399-have-a-procedure-for-cache-invalidation-with-cloudfront)

Adds documentation for how to purge the cache for our standby CloudFront distributions.