### PR TITLE
Add preflight checks to OpenSearch reindexing

### DIFF
--- a/source/manual/reindex-elasticsearch.html.md.erb
+++ b/source/manual/reindex-elasticsearch.html.md.erb
@@ -42,7 +42,56 @@ in-place. Updating supertypes can be done during working hours.
 
 ## Reindex an Elasticsearch index
 
-### 1. Run the reindex
+### 1. Preflight checks
+
+Make sure that you have sufficient space to complete an index migration.
+
+You can check this in:
+
+- The [AWS Opensearch cluster health dashboard](https://eu-west-1.console.aws.amazon.com/aos/home?region=eu-west-1#opensearch/domains/blue-elasticsearch6-domain?tabId=clusterHealth)
+- [Total free storage space](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(metrics~(~(~(expression~'FLOOR*28m1*2f1024*29~label~'FreeStorageSpace~id~'e1~region~'eu-west-1~yAxis~'right))~(~'AWS*2fES~'FreeStorageSpace~'DomainName~'blue-elasticsearch6-domain~'ClientId~'172025368201~(id~'m1~region~'eu-west-1~visible~false)))~view~'timeSeries~stacked~false~region~'eu-west-1~title~'Total*20free*20storage*20space*20*28GiB*29~period~60~stat~'Sum~yAxis~(left~(showUnits~true~min~0)~right~(min~0))~legend~(position~'hidden)~start~'-PT12H~end~'P0D)) for the cluster in AWS CloudWatch
+
+If the free storage is below 250GB, check to see if there are any old indices from a previous migration that have not been cleaned up.
+
+#### Check for old indices
+
+Sign in as a poweruser:
+
+```sh
+eval $(gds aws govuk-production-poweruser -e --art 8h)
+```
+
+List the search indices (sorting by index name):
+
+```sh
+k exec deploy/search-api -- sh -c 'curl -s "$ELASTICSEARCH_URI/_cat/indices?v&s=i"'
+```
+
+You should see a table listing the indices. There should be one each of `detailed`, `government`, `govuk`, `metasearch` and `page-traffic` (plus others which are not affected by this task).
+
+Example healthy output (columns trimmed for brevity):
+
+```sh
+health status index
+green  open   .kibana_1
+green  open   .tasks
+green  open   detailed-2023-01-01t21-09-52z-0630e696-9d7f-
+green  open   government-2023-01-01t19-46-41z-e44c324c-644
+green  open   govuk-2023-01-01t23-09-56z-2a4ec293-2123-40f
+green  open   licence-finder
+green  open   metasearch-2023-01-01t21-41-47z-4a398b23-8bb
+green  open   page-traffic-2023-01-01t04-32-04z-cd2264ce-3
+```
+
+If you see multiple indices which start with the same name, they probably need to be cleaned up. Check the time stamp on the index name. Anything older than a week is likely to have been forgotten by the last person.
+
+If you think you can clean up some indices, please do so:
+
+<%= RunRakeTask.links("search-api", "search:clean SEARCH_INDEX=alias_of_index_to_clean_up") %>
+
+The `alias_of_index_to_clean_up` is the part of the name before the date/time stamp: `govuk`, `government`, `detailed`, `metasearch`, `page-traffic`, or alternatively `all`.
+
+### 2. Run the reindex
 
 To reindex all indices, run the `search:migrate_schema` Rake task on search-api:
 


### PR DESCRIPTION
This is the process that is run to adopt OpenSearch schema changes within search-api.

People are meant to clean up old indices once they're content that their change worked, but this has a habit of slipping through the net.

This process is eminently automatable, but writing it down helps, as does the instructions for finding out the state of the search cluster.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
