### PR TITLE
Re-add rack-logstasher

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1222,6 +1222,12 @@
     complicated to debug when they break. They were retired in
     October 2022.
 
+- repo_name: rack-logstasher
+  team: "#govuk-platform-security-reliability-team"
+  type: Gems
+  sentry_url: false
+  dashboard_url: false
+
 - repo_name: rails_translation_manager
   team: "#govuk-navigation-tech"
   type: Gems


### PR DESCRIPTION
This was removed in #4424, but is still used by search-api: https://github.com/alphagov/search-api/blob/faf0e74546aa3a491c19c648e61ada17c3f58329/Gemfile#L26
