### PR TITLE
Remove two more repos from repos.yml list

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -96,10 +96,6 @@
     when-do-the-clocks-change pages. Since May 2020 those pages are
     rendered by frontend.
 
-- repo_name: capistrano_rsync_with_remote_cache
-  type: Utilities
-  team: "#govuk-platform-engineering"
-
 - repo_name: ckan
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
@@ -286,12 +282,6 @@
   private_repo: true
   team: "#data-products"
   type: Data science
-
-- repo_name: docker-collectd-plugin
-  team: "#govuk-platform-engineering"
-  type: Utilities
-  sentry_url: false
-  dashboard_url: false
 
 - repo_name: eligibility-viewer
   private_repo: true


### PR DESCRIPTION
Following convention in #4424, we'll remove these rather than mark them as retired, as they have little value in being surfaced in the developer docs from now on.
