### PR TITLE
Remove more outdated info about DGU subdomains

### DIFF
--- a/source/manual/data-gov-uk-architecture.html.md
+++ b/source/manual/data-gov-uk-architecture.html.md
@@ -6,31 +6,15 @@ layout: manual_layout
 type: learn
 parent: "/manual.html"
 ---
-[publish]: repos/datagovuk_publish
-[find]: repos/datagovuk_find
-[ckan]: repos/ckanext-datagovuk
-[signon]: manual/manage-sign-on-accounts
-[deployment]: manual/data-gov-uk-deployment
-[monitoring]: manual/data-gov-uk-monitoring
-[signon-adr]: https://github.com/alphagov/datagovuk_publish/blob/main/docs/adr/0002-signon.md
-[statistics]: http://statistics.data.gov.uk
-[land-registry]: http://landregistry.data.gov.uk
-[csw]: http://csw.data.gov.uk/geonetwork/srv/en/main.home
-[location-mde]: http://locationmde.data.gov.uk
-[guidance]: http://guidance.data.gov.uk
 [business]: http://business.data.gov.uk/id/company/09747720
-[location]: http://location.data.gov.uk/registry/
-[environment]: http://environment.data.gov.uk/index.html
+[ckan]: repos/ckanext-datagovuk
+[environment]: https://environment.data.gov.uk
+[find]: repos/datagovuk_find
+[guidance]: https://guidance.data.gov.uk/
 [guidance-github]: https://github.com/datagovuk/guidance
 [open-data-policy]: https://www.gov.uk/government/publications/open-data-white-paper-unleashing-the-potential
-[inspire]: http://inspire.ec.europa.eu/about-inspire
-[uk-location-programme]: https://inspire.ec.europa.eu/events/conferences/inspire_2010/presentations/258_pdf_presentation.pdf
-[contract-finder]: https://data.gov.uk/data/contracts-finder-archive/
-[contract-finder-new]: https://www.contractsfinder.service.gov.uk/Search
-[land-registry-birth]: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/246732/0247.pdf
-[reference]: http://reference.data.gov.uk
-[time-interval-service]: https://github.com/epimorphics/IntervalServer
-[heroku]: /manual/review-apps.html#use-the-shared-heroku-account
+[publish]: repos/datagovuk_publish
+[statistics]: https://statistics.data.gov.uk
 
 The `data.gov.uk` (DGU) platform is used to publish and view datasets. A dataset contains the metadata for a collection of links to data hosted somewhere on the internet.
 
@@ -38,31 +22,23 @@ The `data.gov.uk` (DGU) platform is used to publish and view datasets. A dataset
 
 ![](/manual/images/2023-dgu-eks-architecture.png)
 
-The original for this diagram is available on the [Platform Health Google Drive](https://drive.google.com/open?id=1xnwgUBrwnQI2aIfZ0FT8nBQ-pERNRo2r) and can be edited with draw.io.
+The original for this diagram is available in [Google Drive](https://drive.google.com/open?id=1xnwgUBrwnQI2aIfZ0FT8nBQ-pERNRo2r) and can be edited with draw.io.
 
 ## data.gov.uk Services
 
-Services owned by data.gov.uk
+Services owned by data.gov.uk:
 
 * [CKAN] is the publishing app for datasets ('packages').
 * [Find] is the public frontend for viewing and searching for datasets (using Opensearch).
-* [Publish] is a prototype publishing app for datasets. Whilst not public facing, it currently syncs data from CKAN into Opensearch for use in Find.
+* [Publish] was a prototype publishing app for datasets. Whilst not public facing, it currently syncs data from CKAN into Opensearch for use in Find.
 
-Services with data.gov.uk sub-domains, but owned by other departments
+Services on data.gov.uk sub-domains, but owned by other departments:
 
-* [Statistics] is owned by the Office for National Statistics and was established as part of the [Open Data Policy][open-data-policy].
-* [Environment][environment] is owned by DEFRA and was created with the [Location] service as part of the [Open Data Policy][open-data-policy].
-* [Land Registry][land-registry] is owned by the same and [was created][land-registry-birth] to publish linked data as part of the [Open Data Policy][open-data-policy].
-* [Catalog Service for the Web][csw] is owned by Ordnance Survey and serves [INSPIRE] datasets to the EU Geoportal.
-* [Location] came before [Location Metadata Editor][location-mde] and was established as part of the [UK Location Programme][uk-location-programme].
-* [Guidance] is a set of manual pages hosted in [GitHub][guidance-github], which ought to be migrated into normal GOV.UK docs.
-* [Contract Finder][contract-finder] is now provided by [Crown Commercial Service][contract-finder-new], which ought to have pre-2015 stuff merged in.
+* [Statistics][statistics] is owned by the Office for National Statistics and was established as part of the [Open Data Policy][open-data-policy].
+* [Environment][environment] is owned by DEFRA and was created as part of the [Open Data Policy][open-data-policy]. Users with issues or questions should contact the [maintainers](https://environment.data.gov.uk/support)
+* [Guidance] is a set of manual pages hosted in [GitHub][guidance-github].
 * [Business] is a legacy redirect to Companies House.
-
-> Several datasets link to [environment.data.gov.uk][environment] and require user login to access.  Although branded
-> as data.gov.uk, this is a totally separate service.  If a user is having difficulty accessing this system, they
-> should contact the [maintainers of this resource](http://environment.data.gov.uk/ds/partners/index.jsp#/contactus).
 
 ## [CKAN], [Publish] and [Find]
 
-[CKAN], [Publish] and [Find] are hosted on AWS EKS and is maintained/deployed in the same way as most other GOV.UK applications.
+[CKAN], [Publish] and [Find] are hosted on AWS EKS and are maintained/deployed in the same way as most other GOV.UK applications.


### PR DESCRIPTION
A general tidy up of this page, plus removing out of date information about subdomains which no longer exist.