### PR TITLE
Add information about including code snippets as Zendesk notes

### DIFF
--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -88,8 +88,14 @@ If you know you cannot solve a ticket immediately, fill in a "Public reply" to t
 know you’re looking into it.
 
 You can use Internal Notes to keep a log of actions you've taken so far: this can make it easier for other
-staff to pick up where you left off if you're unable to solve the ticket yourself. Please note that departments
-can see internal notes, so don’t write anything you wouldn’t say to someone publicly.
+staff to pick up where you left off if you're unable to solve the ticket yourself.
+
+If you run a rake task or execute code directly on a console, include a copy of the commands you ran as an
+internal note on the ticket. This makes it easier to see what has already been done if a user replies to a
+ticket that has previously been worked on.
+
+> Please note that departments can see internal notes, so don’t write anything you wouldn’t say to someone
+> publicly.
 
 If you need more information from the user, fill in the "Public reply" as appropriate and click "Submit as Pending".
 


### PR DESCRIPTION
This updates the Zendesk guidance to state that you should include a copy of any commands that are executed directly on a console as internal notes on Zendesk tickets.

By including the commands, it helps the next shift (and/or product teams) understand what has already been attempted and identify any possible problems that could arise.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
