### PR TITLE
Delete icinga_slack_webhook from the list of repos.

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -964,10 +964,6 @@
   team: "#govuk-publishing-platform"
   production_hosted_on: eks
 
-- repo_name: icinga_slack_webhook
-  type: Utilities
-  team: "#govuk-platform-engineering"
-
 - repo_name: imminence
   type: APIs
   team: "#tech-content-interactions-on-platform-govuk"


### PR DESCRIPTION
Better to just remove this one than keep it around cluttering up search results.