### PR TITLE
Fix cookie banner showing when it shouldn't

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -102,14 +102,6 @@ ul.subdir__menu {
   text-transform: capitalize;
 }
 
-.govuk-cookie-banner {
-  display: none;
-}
-
-.js-enabled .govuk-cookie-banner {
-  display: block;
-}
-
 .cookie-js-info {
   display: none;
 }


### PR DESCRIPTION
- cookie banner was recently updated to be hidden when JS is disabled
- but we had styles in here that also handled this behaviour, which were aligned with the component until the change
- removing unnecessary styles fixes the problem
- fortunately cookie consent was still being done correctly, even though the banner wasn't disappearing
