### PR TITLE
Mark `govuk-user-journey-analysis-tools` as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -820,6 +820,7 @@
 - repo_name: govuk-user-journey-analysis-tools
   team: "#data-products"
   type: Data science
+  retired: true
 
 - repo_name: govuk-user-journey-models
   private_repo: true


### PR DESCRIPTION
This repo has been archived,so can be marked as retired in the list of repos.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
