### PR TITLE
Remove 'govuk_frontend_toolkit_gem'

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -893,12 +893,6 @@
   sentry_url: false
   dashboard_url: false
 
-- repo_name: govuk_frontend_toolkit_gem
-  team: "#govuk-publishing-experience-tech"
-  type: Gems
-  sentry_url: false
-  dashboard_url: false
-
 - repo_name: govuk_message_queue_consumer
   team: "#govuk-publishing-platform"
   type: Gems


### PR DESCRIPTION
Now removed the `govuk` topic from the repo.

A [chat on Slack](https://gds.slack.com/archives/CARGH33JS/p1707320417551859) concluded that this repo is owned by the Design System and should not be monitored here.
