### PR TITLE
Remove references to "leavers tickets" on 2nd line

### DIFF
--- a/source/manual/2nd-line.html.md
+++ b/source/manual/2nd-line.html.md
@@ -106,7 +106,6 @@ Read more about [processing Zendesk tickets on Technical 2nd Line](/manual/zende
 
 We use the [GOV.UK Technical 2nd Line Trello board][] to capture pieces of work 2nd Line are required to do, such as:
 
-- Leaver tickets
 - Setting up production access
 - Recording technical issues
 

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -86,6 +86,4 @@ You will also begin to fill the Primary role on some in-hours shifts.
 
 ## Temporarily revoking access
 
-If you're absent more than 6 weeks, your access will be revoked. See [the Trello
-leaver template card](https://trello.com/c/IQIV54Pc/378-leaver-name-here-tech-role)
-for the steps.
+If you're absent more than 6 weeks, your access should be revoked.

--- a/source/manual/tech-lead-responsibilities.html.md
+++ b/source/manual/tech-lead-responsibilities.html.md
@@ -34,11 +34,10 @@ If the developer is new to GOV.UK, then it’s worth taking them through the [ov
 
 ## Managing leavers
 
-When a team member leaves GOV.UK, the tech lead must raise a PR in the GOV.UK [user reviewer][] ([sample pr][]) and ensure a [leaver’s trello card][] is created on the Technical 2nd Line trello board.
+When a team member leaves GOV.UK, the tech lead should raise a PR in the GOV.UK [user reviewer][] ([sample pr][]) and ensure their team's Delivery Manager has informed Business Operations of the leaver/mover.
 
 [user reviewer]: https://github.com/alphagov/govuk-user-reviewer
 [sample pr]: https://github.com/alphagov/govuk-user-reviewer/pull/542
-[leaver’s trello card]: https://trello.com/c/IQIV54Pc/378-leaver
 
 ## Being aware of the health of your team
 

--- a/source/manual/tech-lead-responsibilities.html.md
+++ b/source/manual/tech-lead-responsibilities.html.md
@@ -34,10 +34,9 @@ If the developer is new to GOV.UK, then it’s worth taking them through the [ov
 
 ## Managing leavers
 
-When a team member leaves GOV.UK, the tech lead should raise a PR in the GOV.UK [user reviewer][] ([sample pr][]) and ensure their team's Delivery Manager has informed Business Operations of the leaver/mover.
+When a team member leaves GOV.UK, the team's Delivery Manager should inform Business Operations of the leaver/mover.
 
-[user reviewer]: https://github.com/alphagov/govuk-user-reviewer
-[sample pr]: https://github.com/alphagov/govuk-user-reviewer/pull/542
+This eventually leads to a ticket in the [JML view](https://govuk.zendesk.com/agent/filters/63966232) Zendesk group, which Senior Tech will process.
 
 ## Being aware of the health of your team
 

--- a/source/manual/zendesk.html.md
+++ b/source/manual/zendesk.html.md
@@ -127,22 +127,6 @@ For actioning these requests, [read our DNS documentation](/manual/dns.html).
 
 Please refer to the [SRE interruptible documentation](https://docs.google.com/document/d/1QzxwlN9-HoewVlyrOhFRZYc1S0zX-pd97igY8__ZLAo/edit#heading=h.91quw0ws3zim).
 
-## Leaver tickets
-
-As part of the leaver process, 1st line pass leaver tickets over to us so that we can check if they still have any GOV.UK access.
-
-Search for their name/email in the [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer) repository.
-
-1. If you don't find a reference, you can close the ticket with an internal comment
-1. If you find a reference in [config/govuk_tech.yml](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml), create a card using the ["Leaver (tech role)"](https://trello.com/c/IQIV54Pc/378-leaver-tech-role) template card on the Technical 2nd Line Trello board
-1. If you find a reference in [config/govuk_non_tech.yml](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_non_tech.yml), create a card using the ["Leaver (non tech role)"](https://trello.com/c/g9iK9fcL/1115-leaver-non-tech-role) template card on the Technical 2nd Line Trello board
-
-Add the card to the "To do" column with a due date, which will be the leaving date from the Zendesk ticket.
-
-You can then close the ticket with an internal comment which includes a link to the new Trello card.
-
-Finally, it's a case of working through the Trello card checklist (on or after the due date), then moving the card to Done.
-
 ## Closing a ticket
 
 Once you've resolved a ticket, click "Submit as Solved". You do not need to wait for user confirmation to


### PR DESCRIPTION
We no longer process leavers on 2nd line. It is currently handled by members of Senior Tech, but is also ultimately a Platform responsibility and should be handled internally there, rather than delegated to 2nd line.

This commit therefore removes documentation that instructed devs to raise leavers tickets.

It also softens the documentation around revoking access if you will be away for 6 months, since we don't consistently do this in practice.
