### PR TITLE
Retire govuk-ask-export

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -428,10 +428,10 @@
   dashboard_url: false
 
 - repo_name: govuk-ask-export
-  team: "#dev-notifications-ai-govuk"
+  retired: true
   type: Utilities
   description: |
-    A tool for exporting the user responses and metadata from Smart Survey which is used for the [https://www.gov.uk/ask](https://www.gov.uk/ask) service.
+    A tool for exporting the user responses and metadata from Smart Survey which is used for the [https://www.gov.uk/ask](https://www.gov.uk/ask) service. Retired in February 2024, since it was no longer used.
 
 - repo_name: govuk-aws
   team: "#govuk-platform-security-reliability-team"


### PR DESCRIPTION
This tool has not been running since Jenkins was switched off and the repo is being archived.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
