### PR TITLE
Fix links in datagovuk docs

### DIFF
--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -11,6 +11,8 @@ parent: "/manual.html"
 [dgu-ckan]: https://ckan.publishing.service.gov.uk
 [dgu-docs]: https://guidance.data.gov.uk
 [find]: repos/datagovuk_find
+[Grafana]: https://grafana.eks.production.govuk.digital/d/app-requests/app3a-request-rates-errors-durations?orgId=1&refresh=1m&var-namespace=datagovuk&var-app=All&var-error_status=All
+[logit]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3
 [pagerduty]: https://govuk.pagerduty.com/
 [pingdom]: /manual/pingdom
 [publish]: repos/datagovuk_publish
@@ -65,7 +67,7 @@ Example query: `kubernetes.namespace: datagovuk AND kubernetes.container.name: f
 
 ### Grafana
 
-You can see the dashboard showing some metrics of datagovuk apps, [ckan][ckan-app], [Publish] and [Find], on [Grafana].
+There is a [Grafana dashboard][Grafana] showing some metrics for datagovuk apps.
 
 ### Sidekiq ([Publish])
 

--- a/source/manual/data-gov-uk-2nd-line.html.md
+++ b/source/manual/data-gov-uk-2nd-line.html.md
@@ -673,7 +673,7 @@ $ ckan ckan-pycsw load -p /config/pycsw.cfg -u http://ckan-ckan:5000
 
 Map previews on data.gov.uk have been deprecated. Map preview links are no longer available and existing map preview pages will have a note about them being deprecated.
 
-The Ordanance Survey API that sat behind this service was turned off. We also conducted an audit of the use of map previews, which showed that less than 1% of requests were to map preview datasets and of the 6% of map preview datasets available on DGU, only 2% were working as expected.
+The Ordnance Survey API that sat behind this service was turned off. We also conducted an audit of the use of map previews, which showed that less than 1% of requests were to map preview datasets and of the 6% of map preview datasets available on DGU, only 2% were working as expected.
 
 ## Register a brownfield dataset
 


### PR DESCRIPTION
This reinstates links to Logit and Grafana (and fixes one unrelated typo)
