### PR TITLE
Revamp travel/medical email alert playbook.

### DIFF
--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -6,79 +6,92 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-We expect that when new GOV.UK content is published, or when existing content
-is updated in a significant way, emails will be sent to any subscribers to
-notify them of the change.
+GOV.UK's [email-alert-api] sends two kinds of time-sensitive email notifications:
 
-We actively monitor this for [medical safety alerts][] and [travel advice
-alerts][] with scheduled jobs running in [email-alert-api][].
+* [travel advice alerts]
+* [medical safety alerts], for example product recalls of medical devices
 
-These jobs determine a list of content that we expect subscribers to have
-been emailed. We use the Notify system's callback to record whether emails
-sent out via this alert have been received.
+These _email alerts_ are supposed to be delivered to subscribers within a few
+hours.
 
-## Finding out more details about the failed check
+email-alert-api-worker monitors deliverability by comparing records of
+what should have been sent against callbacks from GOV.UK Notify, which is the
+system that sends the bulk email to subscribers.
 
-Open this [Kibana Search][kibana last 24 hours] to see potentially undelivered
-alerts in the last 24 hours (note the same alerts will appear on each run, so
-you might see the same alert more than once in this log view)
+> _Email alerts_ have nothing to do with Prometheus/Alertmanager/PagerDuty
+> alerts. They're just ambiguously named.
 
-This will get you the Content ID and Path of the alert, and visiting the path
-on GOV.UK will get you the title of the alert.
+## Find out which mailshot was affected
 
-## Verifying whether the email was received
+Search for recent WARN-level [logs from email-alert-api-worker]. Workers log a
+`Couldn't find any delivered emails for ...` warning periodically when there
+are potentially undelivered medical/travel alerts.
 
-To verify if the Gmail account has received the email or not you can join the
-google group 'Email Alert API Alert Listener', which is subscribed to all travel
-advice and medical safety alerts, and see if the email has been received.
+The log message should contain the Content ID and path of the affected
+mailshot. Visit the path on GOV.UK to find the title of the alert.
+
+## Verify whether the email was received
+
+The [email-alert-api-alert-listener] mailing list is subscribed to all travel
+advice and medical safety alerts. Check whether the message appears there.
 
 ## Troubleshooting
 
-* If an email matching the details in the logs has been received by the google
-  account, it is possible that a false alarm has occurred. Check to see if there
-  is a Notify outage. (NOTIFY STATUS PAGE)
-* Using the Content ID from the logs, get send/delivery statistics from
-  email-alert-api using the [email statistics rake task][] in email-alert-api
-  to determine whether there was a problem sending the emails to Notify, or
-  problems returned from Notify after it attempted to deliver them.
-* determine whether Email Alert API has a backlog of work to do using the
-  [Sidekiq dashboard][] and [Email Alert API Technical
-  dashboard][tech dashboard] - the email may just be delayed;
-* whether the change was a result of a new type of medical safety content
-  sub-type, this was the previous cause of an [incident][checkbox-incident] and
-  is recorded as [GOV.UK Tech Debt][checkbox tech debt];
-* check the [Kibana logs][] and [Sentry][] for any errors or clues;
-* if all else fails you may need to investigate the Email Alert API database
-  to determine whether the content change was received and what state it is in.
+* Check whether an email matching the details from the logs was delivered to
+  the [email-alert-api-alert-listener] mailing list.
 
-## Resending medical safety emails
+* Check [Notify's service
+  status](https://status.notifications.service.gov.uk/).
 
-If you need to force the sending of a travel advice email alert, run the
-`email_alerts:trigger[PUT_EDITION_ID_HERE]` rake task in Travel Advice
-Publisher.
+* Using the Content ID from the logs, use the [email statistics rake task] to
+  determine whether the app failed to send messages to Notify, or whether
+  Notify failed to deliver them.
 
-The edition ID of the travel advice content item can be found in the
-URL of the country's edit page in Travel Advice Publisher and looks like
-`fedc13e231ccd7d63e1abf65`.
+* Check the size of email-alert-api's work queue using the [Sidekiq dashboard]
+  and [email-alert-api dashboard]. Is there a backlog? If so, is it
+  diminishing? Are the workers making sufficient progress?
 
-## Resending travel advice emails
+* Check [logs in
+  Kibana](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/goto/06faa093ecf75957ccc04700ea52515d?security_tenant=global)
+  and events in [Sentry] for errors or clues.
 
-If you need to force the sending of a travel advice email alert, run the
-`email_alerts:trigger[PUT_EDITION_ID_HERE]` rake task in Travel Advice
-Publisher.
+* Previously, the introduction of a new content sub-type of medical safety
+  alerts caused an [outage][checkbox-incident]. See ["all" checkbox is
+  misleading for finder_email_signups](https://trello.com/c/v2ees2fD).
 
-The edition ID of the travel advice content item can be found in the
-URL of the country's edit page in Travel Advice Publisher and looks like
-`fedc13e231ccd7d63e1abf65`.
+* If all else fails, investigate the Email Alert API database to determine
+  whether the content change was received and what state it is in.
+
+## Resend a medical safety alert
+
+1. Find the content ID of the affected content item. In Specialist Publisher,
+   go to [Medical
+   Alerts](https://specialist-publisher.publishing.service.gov.uk/medical-safety-alerts)
+   and choose the affected document. The content ID is the UUID in the URL. For
+   example, in
+   `https://specialist-publisher.publishing.service.gov.uk/medical-safety-alerts/de8a10f1-eac7-49a8-a8ef-1769a6f6cef9:en`
+   the content ID is `de8a10f1-eac7-49a8-a8ef-1769a6f6cef9`.
+
+1. Run the `republish:one[<CONTENT_ID>]` Rake task in specialist-publisher,
+   replacing `<CONTENT_ID>` with the one from the previous step.
+
+## Resend a travel advice alert
+
+1. Find the edition ID of the affected content item. In Travel Advice Publisher,
+   go to the URL of the country's Edit page. The edition ID is a 24-digit hex
+   number, for example `fedc13e231ccd7d63e1abf65`.
+
+1. Run the `email_alerts:trigger[<EDITION_ID>]` Rake task in
+   travel-advice-publisher, replacing `<EDITION_ID>` with the one from the
+   previous step.
 
 [medical safety alerts]: https://www.gov.uk/drug-device-alerts
 [travel advice alerts]: https://www.gov.uk/foreign-travel-advice
 [email-alert-api]: https://github.com/alphagov/email-alert-api
-[kibana last 24 hours]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/view/4147d5b0-99f8-11ee-aed3-9b7debb07809?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Cto%3Anow))
-[email statistics rake task]: /repos/email-alert-api/alert_check_scheduled_jobs.html#support-tasks
-[Sidekiq dashboard]: https://grafana.eks.production.govuk.digital/d/sidekiq-queues/sidekiq3a-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=email-alert-api-worker&from=now-24h&to=now
-[tech dashboard]: https://grafana.eks.production.govuk.digital/d/app-requests/app3a-request-rates-errors-durations?orgId=1&refresh=1m&var-namespace=apps&var-app=email-alert-api&var-error_status=All&from=now-24h&to=now
+[logs from email-alert-api-worker]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/view/4147d5b0-99f8-11ee-aed3-9b7debb07809?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:email-alert-api-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:email-alert-api-worker))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:level,negate:!f,params:(query:WARN),type:phrase),query:(match_phrase:(level:WARN)))),index:'filebeat-*',interval:auto,query:(language:lucene,query:'%22any%20delivered%22'),sort:!())
+[email statistics rake task]: https://github.com/alphagov/email-alert-api/blob/main/docs/alert_check_scheduled_jobs.md#support-tasks
+[Sidekiq dashboard]: https://grafana.eks.production.govuk.digital/d/sidekiq-queues/?var-namespace=apps&var-app=email-alert-api-worker&from=now-24h&to=now
+[email-alert-api dashboard]: https://grafana.eks.production.govuk.digital/d/app-requests/?var-namespace=apps&var-app=email-alert-api&var-error_status=All&from=now-24h&to=now
 [checkbox-incident]: https://docs.google.com/document/d/1AwpXPF1c7fbsOL8KX10ko_wLok4YykabmRfkHJjRqfA/edit#
-[checkbox tech debt]: https://trello.com/c/v2ees2fD/199-all-checkbox-is-misleading-for-finderemailsignups
-[Kibana logs]: https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/goto/43fc79ee47ac49f248e0f29a174be240
 [Sentry]: https://sentry.io/organizations/govuk/issues/?project=202220&statsPeriod=12h
+[email-alert-api-alert-listener]: https://groups.google.com/a/digital.cabinet-office.gov.uk/g/email-alert-api-alert-listener


### PR DESCRIPTION
- Add missing instructions for re-sending a medical safety alert email.
- Edit for clarity.
- Use lists where appropriate.
- [House style].

[House style]: https://www.gov.uk/guidance/style-guide/technical-content-a-to-z

[Preview](https://github.com/alphagov/govuk-developer-docs/blob/sengi/email-alert-playbook/source/manual/alerts/email-alerts-travel-medical.html.md)