### PR TITLE
Rewrite "Domain Name System (DNS) records" page

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -100,8 +100,6 @@ The Platform Security & Reliability team are [looking at the future management o
 
 GOV.UK manages DNS zones for some non-`gov.uk` domains (e.g. `independent-inquiry.uk`). Another example is `alphagov.co.uk`, which is the old domain name GOV.UK publishing used to live on - we maintain records which point to Bouncer so that these URLs redirect.
 
-Some of these domains are managed by us for legacy reasons. Others are defensively registered variations of domains that are in the GOV.UK proposition.
-
 All domains should be managed in Terraform, with each domain having its own zone configuration file in [govuk-dns-tf](https://github.com/alphagov/govuk-dns-tf), with the exception of the domains in the next section.
 
 ### Domains and zones managed outside of govuk-dns-tf


### PR DESCRIPTION
- Documents the GOV.UK proposition, which otherwise is unmentioned anywhere else in the Developer Docs.
- Documents how the domains listed in the GOV.UK proposition are linked to the domains and DNS zones we're managing today.
- Documents some of the edge-cases/quirks of domains that are in the proposition but not managed by us, or are not in the proposition but _are_ managed by us.
- Links to some ongoing work to revisit these quirks.
- Describes each GOV.UK proposition domain in turn.
- Documents how the TLD to www redirects are implemented on GOV.UK and on data.gov.uk.
- Removes instructions on how to deploy DNS changes. This is covered in the govuk-dns-tf README.
