### PR TITLE
Switch ownership of some publishing-related apps

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -27,7 +27,7 @@
 
 - repo_name: authenticating-proxy
   type: Supporting apps
-  team: "#govuk-publishing-access-and-permissions-team"
+  team: "#govuk-publishing-platform"
   production_hosted_on: eks
   production_url: false
 
@@ -333,7 +333,7 @@
   sentry_url: false
 
 - repo_name: gds-sso
-  team: "#govuk-publishing-access-and-permissions-team"
+  team: "#govuk-publishing-platform"
   type: Gems
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
   sentry_url: false
@@ -1258,7 +1258,7 @@
 
 - repo_name: signon
   type: Supporting apps
-  team: "#govuk-publishing-access-and-permissions-team"
+  team: "#govuk-publishing-platform"
   production_hosted_on: eks
 
 - repo_name: siteimprove_api_client


### PR DESCRIPTION
This moves ownership of 2 apps and a gem to the Publishing Platform team. 