### PR TITLE
Remove link to database engines

### DIFF
--- a/source/manual/databases.html.md
+++ b/source/manual/databases.html.md
@@ -6,8 +6,6 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-Many GOV.UK applications use a database. See our [spreadsheet of applications and database engines](https://docs.google.com/spreadsheets/d/1rBZeeaT9XevaRvstMjw2YsbSsoB7IqgWjpJz5oAO9nM/edit#gid=1368371571) for details.
-
 ## Database engines
 
 GOV.UK uses mostly PostgreSQL and some MySQL for apps that require a relational database. There's no particular reason why we use both, and the fact that we do is considered [tech debt](https://trello.com/c/zlfgSJlV/69-govuk-uses-mysql-and-postgresql-and-mongo).


### PR DESCRIPTION
This link was to a point in time document from 2022 and is not maintained. The information in it is outdated and risks being misleading as time continues to pass by. I'm not aware of an alternative document that is kept up-to-date (the GOV.UK dependencies sheet doesn't have the DB engine specificity https://docs.google.com/spreadsheets/d/137KZhjctJ8qTKYPnq2QNVkyoIC6ok7KA2G1vErNC6Oo/edit#gid=0)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
