### PR TITLE
Remove references to Ruby when talking about dependencies

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -213,6 +213,7 @@ redirects:
   /manual/kubernetes-infrastructure.html: /manual/kubernetes/cheatsheet.html
   /manual/load-test-email-alert-api.html: /apps/email-alert-api/load-test-email-alert-api.html
   /manual/manage-email-subscribers.html: /apps/email-alert-api/tasks.html
+  /manual/manage-ruby-dependencies.html: /manual/manage-dependencies.html
   /manual/migrate-testing-from-phantomjs-to-selenium-chrome.html: /manual.html
   /manual/mirror-fallback.html: /manual/fall-back-to-mirror.html
   /manual/nagios.html: /manual.html

--- a/source/manual/manage-dependencies.html.md
+++ b/source/manual/manage-dependencies.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
-title: Manage Ruby dependencies with Dependabot
-description: How we manage our Ruby dependencies using Dependabot, who can merge PRs and security
+title: Manage dependencies with Dependabot
+description: How we manage our dependencies using Dependabot, including setup, automation and how to review dependency update PRs.
 section: Dependencies
 layout: manual_layout
 parent: "/manual.html"


### PR DESCRIPTION
Our dependency update approach isn't just about Ruby, so let's remove that reference. This includes renaming and redirecting the page
