### PR TITLE
Update docs on Emerg. Alerts Fastly automation token.

### DIFF
--- a/source/manual/emergency-alerts.html.md
+++ b/source/manual/emergency-alerts.html.md
@@ -12,8 +12,7 @@ The Cabinet Office [COBR](https://www.instituteforgovernment.org.uk/explainer/co
 
 As part of this service, GOV.UK delegate serving [www.gov.uk/alerts](https://www.gov.uk/alerts) to the GOV.UK Emergency Alerts team.
 
-How does www.gov.uk/alerts work?
---------------------------------
+## How does www.gov.uk/alerts work?
 
 We have a custom host in Fastly for /alerts which points at an AWS CloudFront CDN which is managed by the GOV.UK Emergency Alerts team. Each GOV.UK environment points at a different custom host:
 
@@ -27,13 +26,13 @@ This is configured in govuk-fastly, by [dynamically selecting the backend](https
 
 We [only have one backend](https://github.com/alphagov/govuk-fastly-secrets/blob/fbf5333dafdca0250d67c043b15750a6b160de6a/secrets.yaml#L58-L61), at the time of writing. Backends have [POP shield enabled by default](https://github.com/alphagov/govuk-fastly/blob/ffd54b5c495a6daad6f6a774d53296924cb4e784/modules/www/service.tf#L83).
 
-API Keys
---------
+## Fastly automation token for cache purge
 
-Emergency Alerts have three Fastly API keys with [`purge_select` scope](https://developer.fastly.com/reference/api/auth/#scopes), one for
-integration, staging and production. These allow them to purge individual pages or surrogate keys from the cache. Note that the scope
-of these keys is not restricted to `/alerts` - in principle they could be used to purge any page from the cache. We trust the Emergency
-Alerts team to take appropriate care with these credentials.
+The Emergency Alerts team has a Fastly automation token which allows their
+application to invalidate objects in the Fastly CDN cache for www.gov.uk.
 
-The API keys are not configured to expire, but it is good practice to rotate them regularly. The Emergency Alerts team will instigate API key rotations,
-see [Rotate Fastly API Keys for Emergency Alerts](/manual/how-to-rotate-fastly-api-keys-for-emergency-alerts.html).
+This purge token should not normally need to be changed. In rare circumstances
+the Emergency Alerts team may need us to reissue a token, for example if a
+token has been lost or compromised. See [Rotate Fastly automation token for
+Emergency Alerts
+application](/manual/how-to-rotate-fastly-api-keys-for-emergency-alerts.html).

--- a/source/manual/how-to-rotate-fastly-api-keys-for-emergency-alerts.html.md
+++ b/source/manual/how-to-rotate-fastly-api-keys-for-emergency-alerts.html.md
@@ -49,10 +49,14 @@ Follow these steps to revoke old tokens and issue new one.
    GOV.UK`, `Staging GOV.UK` and `Integration GOV.UK`, then choose Apply.
 1. Under Expiration, choose __Never expire__. Do not set an expiry date.
 1. Choose __Create Token__.
+1. Copy the token and securely transfer it to the person from Emergency Alerts
+   team who is requesting it. For example, calling the person via Google Meet
+   and pasting it into the chat would be acceptable. Avoid sending the token by
+   email or any communication tool that might leave lasting copies.
 
-Someone on Emergency Alerts team will need to set the new token in each of the
-3 AWS accounts for Emergency Alerts: preview, staging and production. For each
-account, they will need to:
+The person from Emergency Alerts team will then update the configuration in
+their 3 AWS accounts: preview, staging and production. For each account, they
+will need to:
 
 1. Update `fastly-api-key` in SSM Parameter Store.
 1. Find the `eas-app-govuk-alerts` service in `eas-app-cluster` in ECS.


### PR DESCRIPTION
- We only provide them one token now, because it's not a very privileged token. Having separate tokens per environment was no better for security and definitely worse for maintainability.
- Remove extraneous detail. The details are already in the linked playbook on changing the token.
- In the playbook, mention an acceptable way to transfer the token after generating it.
- Use the same Markdown heading syntax as the rest of devdocs.