### PR TITLE
Clean up k8s cheatsheet.

### DIFF
--- a/source/kubernetes/cheatsheet.html.md
+++ b/source/kubernetes/cheatsheet.html.md
@@ -9,11 +9,14 @@ weight: 5
 This page lists some example commands for interacting with the GOV.UK
 Kubernetes clusters.
 
-See <https://kubernetes.io/docs/reference/kubectl/quick-reference/> for a more general quick-reference guide.
+See <https://kubernetes.io/docs/reference/kubectl/quick-reference/> for a more
+general quick-reference guide.
 
 ## Prerequisites
 
-1. You need to have completed [Get started with the GOV.UK Kubernetes clusters](get-started/). If you skimmed those instructions, make sure you have configured your shell:
+1. You need to have completed [Get started with the GOV.UK Kubernetes
+   clusters](get-started/). If you skimmed those instructions, make sure you
+   have configured your shell:
 
     ```sh
     export AWS_REGION=eu-west-1
@@ -38,7 +41,8 @@ See <https://kubernetes.io/docs/reference/kubectl/quick-reference/> for a more g
 
     - `-readonly` roles can view logs and configuration
     - `-poweruser` roles can run Rake tasks or open a shell
-    - `-administrator` roles can modify base cluster services (you should not normally need this)
+    - `-administrator` roles can modify base cluster services (you should not
+      normally need this)
 
     See [Access an EKS cluster](get-started/access-eks-cluster/) for more.
 
@@ -85,22 +89,29 @@ k exec deploy/email-alert-api -- rake -T
 ### Run a Rake task
 
 ```sh
-k exec deploy/email-alert-api -- rake 'support:view_emails[your.email@digital.cabinet-office.gov.uk]'
+k exec deploy/email-alert-api -- \
+  rake 'support:view_emails[your.email@digital.cabinet-office.gov.uk]'
 ```
 
 See [Run a Rake task on EKS](/manual/running-rake-tasks.html#run-a-rake-task-on-eks).
 
 ## App releases and rollouts / deployments
 
-- The [Release app](https://release.publishing.service.gov.uk/applications) shows what's deployed where.
-- Deployment automation is via [Argo CD](https://argo.eks.integration.govuk.digital/applications). Post-deploy smoke tests run via [Argo Workflows](https://argo-workflows.eks.integration.govuk.digital/workflows/apps?limit=100).
+- The [Release app](https://release.publishing.service.gov.uk/applications)
+  shows what's deployed where.
+- Deployment automation is via [Argo
+  CD](https://argo.eks.integration.govuk.digital/applications). Post-deploy
+  smoke tests run via [Argo
+  Workflows](https://argo-workflows.eks.integration.govuk.digital/workflows/apps?limit=100).
 - To deploy a branch or manually promote a release:
     1. Go to the app's repo in GitHub.
     1. Choose **Actions**.
     1. Choose **Deploy** from the left-hand column.
     1. Click **Run workflow**.
-    1. Leave the **Use workflow from** dropdown set to `main`, unless you are testing a change to the workflow itself.
-    1. Under **Commit, tag or branch name to deploy**, enter the branch or release tag.
+    1. Leave the **Use workflow from** dropdown set to `main`, unless you are
+       testing a change to the workflow itself.
+    1. Under **Commit, tag or branch name to deploy**, enter the branch or
+       release tag.
 
 ## Smokey test logs
 
@@ -112,4 +123,5 @@ The Smokey cronjob keeps the last 3 successes and the last 3 failures.
 
 Dashboards are on [Grafana](https://grafana.eks.production.govuk.digital/).
 
-You can see Sidekiq queue lengths on the [Sidekiq Grafana dashboard](https://grafana.eks.production.govuk.digital/d/sidekiq-queues).
+You can see Sidekiq queue lengths on the [Sidekiq Grafana
+dashboard](https://grafana.eks.production.govuk.digital/d/sidekiq-queues).

--- a/source/kubernetes/cheatsheet.html.md
+++ b/source/kubernetes/cheatsheet.html.md
@@ -1,180 +1,115 @@
 ---
-title: EKS/Kubernetes GOV.UK cheatsheet
+title: Kubernetes/EKS cheatsheet
 layout: multipage_layout
 weight: 5
 ---
 
-# EKS/Kubernetes GOV.UK cheatsheet
+# Kubernetes/EKS cheatsheet for GOV.UK developers
 
-This is a quick summary of the most useful commands and guidance for interacting with GOV.UK's EKS platform.
+This page lists some example commands for interacting with the GOV.UK
+Kubernetes clusters.
 
-This page assumes you have completed the [set up instructions](/kubernetes/get-started/set-up-tools/), [tested your access](/kubernetes/get-started/access-eks-cluster/#test-your-access) and set up the [recommended aliases](#recommended-aliases).
+See <https://kubernetes.io/docs/reference/kubectl/quick-reference/> for a more general quick-reference guide.
+
+## Prerequisites
+
+1. You need to have completed [Get started with the GOV.UK Kubernetes clusters](get-started/). If you skimmed those instructions, make sure you have configured your shell:
+
+    ```sh
+    export AWS_REGION=eu-west-1
+    alias k=kubectl
+    ```
+
+1. Obtain credentials to access the cluster.
+
+    ```sh
+    # Obtain IAM credentials for the AWS account (integration, staging, production).
+    eval $(gds aws govuk-integration-poweruser -e --art 8h)
+
+    # Select the corresponding kubectl context. `k config get-contexts` lists them.
+    k config use-context integration
+
+    # Use the `apps` namespace by default. You only need to do this the first
+    # time you use each cluster.
+    k config set-context --current --namespace=apps
+    ```
+
+    Use an IAM role with sufficient permissions:
+
+    - `-readonly` roles can view logs and configuration
+    - `-poweruser` roles can run Rake tasks or open a shell
+    - `-administrator` roles can modify base cluster services (you should not normally need this)
+
+    See [Access an EKS cluster](get-started/access-eks-cluster/) for more.
 
 ## Common tasks
 
-- To access logs for an app:
-    - `k logs deploy/account-api`
-- To open a [read-only rails console](https://andycroll.com/ruby/play-in-a-sandbox-in-production/):
-    - `k exec -it deploy/router-api -- rails c --sandbox`
-- To open a normal rails console:
-    - `k exec -it deploy/router-api -- rails c`
-- To open a shell:
-    - `k exec -it deploy/government-frontend -- bash`
-- To open a shell on Router:
-    - `k exec -it deploy/router -c nginx`
+### View recent logs for an app
 
-Read more about each command further on in the document.
-
-## Set your AWS environment and role
-
-```sh
-# set the correct kubectl context (`k config get-contexts` to see available ones)
-k config use-context integration
-# set the appropriate AWS environment (integration/staging/production) and role (see below)
-eval $(gds aws govuk-integration-poweruser -e --art 8h)
-```
-
-Use an AWS role with sufficient permissions:
-
-- readonly can view logs
-- poweruser can run Rake tasks or open a shell
-- administrator gives full access (you'll rarely need this)
-
-See [full instructions for more detail](/kubernetes/get-started/access-eks-cluster/).
-
-## Recommended aliases
-
-Prior to using kubectl, you'll need to set the recommended aliases (see the [kubectl cheatsheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)), default contexts and globals:
-
-```sh
-alias k=kubectl
-k config set-context --current --namespace=apps
-export AWS_REGION=eu-west-1
-```
-
-## What’s staying and going?
-
-All front-end traffic and back-end publisher traffic is now on Kubernetes (EKS) instead of EC2.
-
-Some things haven't yet been replatformed, and some things will remain unchanged - see [what stays/goes/changes with Platform Engineering](https://docs.google.com/document/d/1R8C3BtvhqTXEga4C3_KxTopjWuYVbiEgKiikTyRXXiA/edit).
-
-## App deployments
-
-- To see *what's deployed where*, use the [Release](https://release.publishing.service.gov.uk/applications) app.
-- Continuously deployed apps will continue to be deployed post-merge, using [ArgoCD](https://argo.eks.integration.govuk.digital/applications). You can see the progress of a workflow in [Argo Workflows](https://argo-workflows.eks.integration.govuk.digital/workflows/apps?limit=50)
-- To deploy a branch (or for non-continuously deployed apps):
-  - Go to the app’s repo in GitHub
-  - Choose Actions
-  - Choose Deploy (from the left-hand column).
-  - Click “Run workflow”
-  - Enter the name of the branch to deploy under "Commit, tag or branch name to deploy".
-  - (Always leave the "Use workflow from" option set as `main`, unless you’re actually trying to change the workflow itself)
-
-## CDN and DNS deployments
-
-- [DNS rollouts](/manual/dns.html) and [Fastly CDN config rollouts](/repos/govuk-fastly.html) are now via [Terraform Cloud](/manual/terraform-cloud.html)
-
-## Smokey
-
-Smokey runs in Argo Workflows persist for longer only if they have failed (because of limitations of Argo Workflows that we can't easily get around).
-The Smokey cronjob keeps the last 3 successes and the last 3 failures.
-
-## Dashboards, alerting and Icinga
-
-- The Technical 2nd Line Dashboard will be kept up to date as we improve our dashboards. It's worth bookmarking <https://govuk-2ndline-dashboard.herokuapp.com/>
-- The detailed Sidekiq dashboard is not yet available for EKS (the [old one](https://sidekiq-monitoring.integration.govuk.digital/publishing-api/queues) still looks at EC2) but you can see queue lengths and age-of-oldest-job on the [Sidekiq Grafana dashboard](https://grafana.eks.production.govuk.digital/d/sidekiq-queues).
-- Dashboards are on <https://grafana.eks.production.govuk.digital/> and no longer require VPN. Don’t get confused by the [old Grafana](https://grafana.production.govuk.digital/), which will show mostly empty graphs about the old EC2 setup.
-- Most Icinga alerts are irrelevant now, **except for a few**, which are all listed on the 2nd line dashboard.
-
-## Fetch logs
-
-You can fetch the list of pods:
-
-```sh
-k get pods
-```
-
-This will return a list, including output like:
-
-```
-NAME                                                              READY   STATUS             RESTARTS           AGE
-account-api-568d46d6f7-4pnld                                      2/2     Running            0                  34m
-account-api-568d46d6f7-txwsx                                      2/2     Running            0                  34m
-account-api-dbmigrate-6n5mp                                       0/1     Completed          0                  35m
-account-api-worker-54597b666c-jlcfn                               1/1     Running            0                  34m
-asset-manager-7bd745d655-tzlgz                                    2/2     Running            0                  15h
-...
-```
-
-As you can see above, each pod either runs the application (we can see two pods running Account API, for example) or runs a worker or cron job for the application (we can see one pod running the Account API application worker).
-
-You can also fetch just a subset list of pods by passing the `lapp` argument:
-
-```
-$ k get pods -lapp=account-api
-
-NAME                           READY   STATUS    RESTARTS   AGE
-account-api-75f95899f6-gjdmg   2/2     Running   0          21h
-account-api-75f95899f6-nn56t   2/2     Running   0          21h
-```
-
-You can fetch the logs for all running containers in a pod. Take one of the pods from the output above:
-
-```sh
-k logs account-api-568d46d6f7-4pnld
-```
-
-Or you can fetch the logs using its 'app deployment' name. This will choose one of the Account API pods at random, much like the old jumpbox methods:
+From one pod, chosen arbitrarily:
 
 ```sh
 k logs deploy/account-api
 ```
 
-## Open a rails console
-
-Open a rails console with:
+From all pods:
 
 ```sh
-k exec -it deploy/whitehall-admin -- rails c
+k logs -l app=account-api
 ```
 
-If you try doing this having assumed a `readonly` role when setting context, you'll see a permissions error:
+### Open a Rails console
 
 ```sh
-Defaulted container "app" out of: app, nginx
-Error from server (Forbidden): pods "whitehall-admin-6bb47c48d-wkkxk" is forbidden: User "christopher.ashton-user" cannot create resource "pods/exec" in API group "" in the namespace "apps"
+k exec -it deploy/router-api -- rails c
 ```
 
-You need write permissions to be able to open a console (`poweruser` or above).
-
-## Open a shell
-
-Open a shell (requires `poweruser` or above):
+### Open a shell in an app container
 
 ```sh
-k exec -it deploy/whitehall-admin -- bash
+k exec -it deploy/government-frontend -- bash
 ```
 
-Note that the prompt will have prefix that may feel a little unfamiliar: `I have no name!@whitehall-admin-6bb47c48d-wkkxk:/app$`.
-This only happens for asset-manager and whitehall-admin, because those have to run as a specific user ID that matches what's on NFS (due to how NFS was set up on the old system).
-
-To open a shell on Router, you'll need to exec into the nginx container:
+### Open a shell on Router
 
 ```sh
-k exec -it deploy/router -c nginx -- bash
+k exec -it deploy/router -c nginx
 ```
 
-This is because [Router's image is `FROM scratch`](https://github.com/alphagov/router/blob/9797473edbbcbb5085fdca006bec7f6b1552f4e6/Dockerfile#L7), so bash isn't available.
+### List the available Rake tasks for an app
 
-## Run a rake task
+```sh
+k exec deploy/email-alert-api -- rake -T
+```
 
-See [Run a Rake task on EKS](/manual/running-rake-tasks.html#run-a-rake-task-on-eks)
-
-Here's an idempotent rake task you can run to try one out:
+### Run a Rake task
 
 ```sh
 k exec deploy/email-alert-api -- rake 'support:view_emails[your.email@digital.cabinet-office.gov.uk]'
 ```
 
-Note that we haven't specified the `-it` flags in the command above because we don't need to interact with the task.
-To find out what they do, run `k exec --help`.
+See [Run a Rake task on EKS](/manual/running-rake-tasks.html#run-a-rake-task-on-eks).
+
+## App releases and rollouts / deployments
+
+- The [Release app](https://release.publishing.service.gov.uk/applications) shows what's deployed where.
+- Deployment automation is via [Argo CD](https://argo.eks.integration.govuk.digital/applications). Post-deploy smoke tests run via [Argo Workflows](https://argo-workflows.eks.integration.govuk.digital/workflows/apps?limit=100).
+- To deploy a branch or manually promote a release:
+    1. Go to the app's repo in GitHub.
+    1. Choose **Actions**.
+    1. Choose **Deploy** from the left-hand column.
+    1. Click **Run workflow**.
+    1. Leave the **Use workflow from** dropdown set to `main`, unless you are testing a change to the workflow itself.
+    1. Under **Commit, tag or branch name to deploy**, enter the branch or release tag.
+
+## Smokey test logs
+
+Argo Workflows keeps logs only for failed workflow tasks.
+
+The Smokey cronjob keeps the last 3 successes and the last 3 failures.
+
+## Dashboards
+
+Dashboards are on [Grafana](https://grafana.eks.production.govuk.digital/).
+
+You can see Sidekiq queue lengths on the [Sidekiq Grafana dashboard](https://grafana.eks.production.govuk.digital/d/sidekiq-queues).

--- a/source/kubernetes/get-started/access-eks-cluster/index.html.md
+++ b/source/kubernetes/get-started/access-eks-cluster/index.html.md
@@ -47,7 +47,7 @@ This document assumes that you have already followed the steps in [Get started d
 
 1. Set the current context:
 
-    ```bash
+    ```sh
     kubectl config use-context <govuk-environment>
     ```
 
@@ -55,8 +55,8 @@ This document assumes that you have already followed the steps in [Get started d
 
 1. Set the [default namespace](/kubernetes/manage-app/get-app-info/#choose-and-set-a-namespace)
 
-    ```
-    bash kubectl config set-context --current --namespace=apps
+    ```sh
+    kubectl config set-context --current --namespace=apps
     ```
 
 1. Check that you can access the cluster:

--- a/source/kubernetes/get-started/index.html.md
+++ b/source/kubernetes/get-started/index.html.md
@@ -8,8 +8,6 @@ layout: multipage_layout
 
 To start using the GOV.UK Kubernetes clusters, you should:
 
-- try the [tutorials](tutorials)
-- [set up the necessary tools](set-up-tools)
-- check that you can [access the Elastic Kubernetes Service (EKS) clusters](access-eks-cluster)
-
-Please note that the tutorials do not require any set up of the tools.
+1. try the [tutorials](tutorials), unless you are already familiar with Kubernetes
+1. [set up the necessary tools](set-up-tools)
+1. check that you can [access the Elastic Kubernetes Service (EKS) clusters](access-eks-cluster)


### PR DESCRIPTION
- Omit unnecessary detail and commentary.
- Keep the document focused on being a quick-reference.
- Avoid duplicating information from elsewhere in devdocs, except where it's important to the quick-reference purpose of the document.
- Add an example for listing available Rake tasks.
- Add a couple of links to further information.
- Use numbered and unnumbered lists appropriately.

[Preview](https://github.com/alphagov/govuk-developer-docs/blob/sengi/clean-up-k8s-cheatsheet/source/kubernetes/cheatsheet.html.md)