### PR TITLE
Update "Request an AWS account" URL

### DIFF
--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -52,7 +52,7 @@ The licensing application stack is now orchestrated on Kubernetes clusters (runn
 To interact with the Kubernetes cluster, you will need to authenticate via the AWS CLI. For more help on how to set up the necessary CLI tools, read [Set up tools to use the GOV.UK Kubernetes platform
 ](https://docs.publishing.service.gov.uk/kubernetes/get-started/set-up-tools/).
 
-Access to GDS AWS accounts is managed via GDS Users. You can request a user via the [self-service tool](https://gds-request-an-aws-account.cloudapps.digital/) if you have a `@digital-cabinet-office.gov.uk` email address. Once you have a user, ask a GOV.UK Tech Lead to be given the necessary roles in [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer).
+Access to GDS AWS accounts is managed via GDS Users. You can request a user via the [self-service tool](https://request-an-aws-account.gds-reliability.engineering/) if you have a `@digital-cabinet-office.gov.uk` email address. Once you have a user, ask a GOV.UK Tech Lead to be given the necessary roles in [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer).
 
 Once you have the necessary permissions and access, you can continue.
 

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -65,7 +65,7 @@ You should [use your Yubikey as your MFA device][yubikey-aws-mfa] if you have on
 
 [aws-account-info]: https://reliability-engineering.cloudapps.digital/iaas.html#amazon-web-services-aws
 [iam-role-creation]: #6-get-permissions-for-aws-github-and-other-third-party-services
-[request-aws-user]: https://gds-request-an-aws-account.cloudapps.digital/
+[request-aws-user]: https://request-an-aws-account.gds-reliability.engineering/
 [enable-mfa]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html#enable-virt-mfa-for-iam-user
 [yubikey-aws-mfa]: /manual/setup-a-yubikey.html#set-up-as-an-mfa-device-for-aws
 [aws-cli-auth]: https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-user.html#cli-authentication-user-get


### PR DESCRIPTION
The GDS Request an AWS Account Tool is being migrated off PaaS this month.

From a user perspective, the tool will still function exactly as before, although the URL of the tool will change. For the time being, the current URL for the tool will redirect to the new URL, which is: https://request-an-aws-account.gds-reliability.engineering

The change is going live by the 26th February.

Via email from Patrick Berkeley

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
