### PR TITLE
Clarify docs on document types and content schemas.

### DIFF
--- a/source/content-schemas.html.md
+++ b/source/content-schemas.html.md
@@ -3,9 +3,8 @@ layout: schema_layout
 title: Content schemas
 ---
 
-The content schemas describe the underlying structure of a piece of content. This is different to the [document types][] which describe the different types of content on GOV.UK.
+A GOV.UK _content schema_ is a [JSON Schema](https://json-schema.org/) that defines the underlying structure of a piece of content. Content schemas are different from [GOV.UK document types](document-types.html).
 
-The content schemas are defined in the [publishing api repo][].
+Content schemas are defined in the [publishing-api repo].
 
-[document types]: /document-types.html
-[publishing api repo]: https://github.com/alphagov/publishing-api/tree/main/content_schemas
+[publishing-api repo]: https://github.com/alphagov/publishing-api/tree/main/content_schemas

--- a/source/document-types.html.md
+++ b/source/document-types.html.md
@@ -3,26 +3,31 @@ layout: document_type_layout
 title: Document types on GOV.UK
 ---
 
-The document type describes a type of page that can exist on GOV.UK. This is different to the [content schemas][] which describe the underlying structure of a piece of content.
+A _document type_ describes a category of pages that can exist on GOV.UK. Document types are different from [content schemas], which define the structure of a piece of content.
 
-The document types included in these docs are pulled in automatically based on data in the [govuk_document_types repo][].
+GOV.UK Developer Docs automatically generates documentation about document types based on data in the [govuk_document_types repo].
 
-## Analysing document types
+## Relationship between document type and content schema
 
-You can also [download this data as CSV](/document-types.csv). To view the current data in Google Spreadsheets, copy the following formula into a new spreadsheet:
+The mapping between GOV.UK document types and content schemas is many-to-many. A document type can correspond to one or more content schemas. A content schema can permit one or more document types for content items that conform to that schema.
+
+## Analyse document types
+
+Data about document types is available [in CSV format](document-types.csv). You can import this data into Google Sheets using the `importData` function:
 
 ```
 =importData("https://docs.publishing.service.gov.uk/document-types.csv")
 ```
 
-> Note: this is only a snapshot of the data and isn't kept up to date automatically.
+Google Sheets will [refresh the data hourly].
 
-### Using the Search API to find similar data
+### Query document types in Search API
 
-It's also possible to use the Search API to [query for document types][].
+You can use Search API to [query for document types].
 
-> Note: this won't include document types which are not yet migrated out of Whitehall.
+> Search API will not return document types which have yet to be migrated out of Whitehall.
 
-[content schemas]: /content-schemas.html
+[content schemas]: content-schemas.html
 [govuk_document_types repo]: https://github.com/alphagov/govuk_document_types
 [query for document types]: https://www.gov.uk/api/search.json?count=0&facet_content_store_document_type=115,examples:1,example_scope:query,example_fields:rendering_app
+[refresh the data hourly]: https://support.google.com/docs/answer/58515?hl=en#zippy=%2Cchoose-how-often-formulas-calculate


### PR DESCRIPTION
- Add a short paragraph about how document types and content schemas relate to each other. (Could use a fact check on this — hopefully I've not introduced any inaccuracies!)
- Fix wrong information about importing CSV data into Google Sheets.
- Remove redundant empty `[]` from reference links.
- House style / general tech writing style fixes: prefer active voice, delete unnecessary "Note:" prefixes, etc.