### PR TITLE
Remove govuk-technical-2ndline-dashboard

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -393,13 +393,6 @@
   type: Utilities
   production_hosted_on: eks
 
-- repo_name: govuk-technical-2ndline-dashboard
-  team: "#govuk-platform-security-reliability-team"
-  management_url: https://dashboard.heroku.com/apps/govuk-2ndline-dashboard
-  production_hosted_on: heroku
-  type: Utilities
-  sentry_url: false
-
 - repo_name: govuk-user-feedback-processing
   private_repo: true
   team: "#data-products"


### PR DESCRIPTION
Remove govuk-technical-2ndline-dashboard which is now retired