### PR TITLE
Impl record events type

### DIFF
--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -1785,7 +1785,7 @@
         - name: action
           value: complete
         - name: event_name
-          value: form complete
+          value: form_complete
         - name: section
           value: Information based on your answers
         - name: tool_name

--- a/helpers/analytics_helpers.rb
+++ b/helpers/analytics_helpers.rb
@@ -56,4 +56,43 @@ module AnalyticsHelpers
     header.prepend(title) if title
     header.join(" | ")
   end
+
+  def events_by_type(events = nil)
+    events ||= data.analytics.events.map { |e| JSON.parse(e.to_json) }
+    by_type = {}
+    events.each do |event|
+      event["events"].each_with_index do |e, index|
+        event_name = find_event_name(e["data"])
+        result = {
+          name: event["name"],
+          event_name: e["name"],
+          index:,
+        }
+        if by_type[event_name.to_sym]
+          by_type[event_name.to_sym][:events] << result
+        else
+          by_type[event_name.to_sym] = {
+            name: event_name,
+            events: [
+              result,
+            ],
+          }
+        end
+      end
+    end
+
+    by_type
+  end
+
+  def find_event_name(data)
+    data.each do |item|
+      next unless item["name"] == "event_data"
+
+      item["value"].each do |i|
+        return i["value"] if i["name"] == "event_name"
+      end
+    end
+
+    "undefined"
+  end
 end

--- a/source/analytics/events.html.md.erb
+++ b/source/analytics/events.html.md.erb
@@ -8,13 +8,32 @@
   <%= data.analytics.navigation.events.desc %>
 </p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <% events = data.analytics.events.sort_by { |e| e[:name] } %>
-  <% events.each do |event| %>
-    <li>
-      <a href="event_<%= urlize(event['name']) %>.html" class="govuk-link">
-        <%= event.name %>
-      </a>
-    </li>
-  <% end %>
-</ul>
+<%= GovukPublishingComponents.render("govuk_publishing_components/components/tabs", {
+  panel_border: false,
+  as_links: true,
+  tabs: [
+    {
+      href: "events.html",
+      label: "By type",
+      active: true
+    },
+    {
+      href: "events_by_name.html",
+      label: "By name",
+    }
+  ]
+}) %>
+
+<% events = events_by_type %>
+<% events = events.sort_by { |key| key }.to_h %>
+<% events.each do |key, value| %>
+  <h2 class="govuk-heading-s"><%= key %></h2>
+  <ul class="govuk-list govuk-list--bullet">
+    <% value[:events].each do |e| %>
+      <li>
+        <% anchor_link = "#heading-#{e[:index]}" %>
+        <a href="event_<%= urlize(e[:name]) %>.html<%= anchor_link %>" class="govuk-link"><%= e[:event_name] %></a> (<%= e[:name] %>)
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/source/analytics/events_by_name.html.erb
+++ b/source/analytics/events_by_name.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, create_page_title(data.analytics.navigation.events.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.events.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.analytics.navigation.events.desc %>
+</p>
+
+<%= GovukPublishingComponents.render("govuk_publishing_components/components/tabs", {
+  panel_border: false,
+  as_links: true,
+  tabs: [
+    {
+      href: "events.html",
+      label: "By type"
+    },
+    {
+      href: "events_by_name.html",
+      label: "By name",
+      active: true
+    }
+  ]
+}) %>
+
+<ul class="govuk-list govuk-list--bullet">
+<% events = data.analytics.events.sort_by { |e| e[:name] } %>
+<% events.each do |event| %>
+  <li>
+    <a href="event_<%= urlize(event['name']) %>.html" class="govuk-link">
+      <%= event.name %>
+    </a>
+  </li>
+<% end %>
+</ul>

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/lib/cookie-functions
 //= require govuk_publishing_components/lib/cookie-settings
 //= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/tabs
 //= require govuk_publishing_components/load-analytics
 
 // reworked version of modules.js from govuk_publishing_components

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -7,6 +7,7 @@
 @import "govuk_publishing_components/components/_heading";
 @import "govuk_publishing_components/components/_radio";
 @import "govuk_publishing_components/components/_success-alert";
+@import "govuk_publishing_components/components/_tabs";
 
 .gem-c-summary-list {
   border-bottom: 0; /* We have an extra border-bottom for some reason */

--- a/spec/fixtures/events-fixture.yml
+++ b/spec/fixtures/events-fixture.yml
@@ -1,0 +1,80 @@
+- name: accordion
+  events:
+    - name: Accordion section
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: select_content
+        - name: type
+          value: accordion
+        - name: text
+          value: text of selected accordion
+        - name: index
+          value:
+          - name: index_section
+          - name: index_section_count
+        - name: action
+          value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
+    - name: Show all sections
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: select_content
+        - name: type
+          value: accordion
+        - name: text
+          value: text of show all link when clicked e.g. "Show all sections"
+        - name: index
+          value:
+          - name: index_section
+          - name: index_section_count
+        - name: action
+          value: '"opened" when clicked to expand, or "closed" when clicked to collapse'
+    - name: Accordion links
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: accordion
+        - name: url
+        - name: text
+          value: Text of the link
+        - name: index
+          value:
+          - name: index_link
+          - name: index_section
+          - name: index_section_count
+        - name: index_total
+        - name: section
+        - name: external
+        - name: method
+        - name: link_domain
+
+- name: back link
+  description:
+  events:
+    - name: link click
+      data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: navigation
+        - name: type
+          value: back
+        - name: url
+        - name: text
+        - name: external
+        - name: link_domain
+        - name: method

--- a/spec/helpers/analytics_helpers_spec.rb
+++ b/spec/helpers/analytics_helpers_spec.rb
@@ -207,4 +207,43 @@ RSpec.describe AnalyticsHelpers do
       expect(helper.implementation_percentage(events)).to eq("1 of 2 (50.0%)")
     end
   end
+
+  describe "#events_by_type" do
+    it "converts YML into a usable object" do
+      input = YAML.load_file("spec/fixtures/events-fixture.yml", aliases: true)
+      expected = {
+        navigation: {
+          name: "navigation",
+          events: [
+            {
+              event_name: "Accordion links",
+              index: 2,
+              name: "accordion",
+            },
+            {
+              event_name: "link click",
+              index: 0,
+              name: "back link",
+            },
+          ],
+        },
+        select_content: {
+          name: "select_content",
+          events: [
+            {
+              event_name: "Accordion section",
+              index: 0,
+              name: "accordion",
+            },
+            {
+              event_name: "Show all sections",
+              index: 1,
+              name: "accordion",
+            },
+          ],
+        },
+      }
+      expect(helper.events_by_type(input)).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
## What
Extend the list of events within the GA4 implementation record to include two lists, the original (alphabetically ordered) and a new one, showing individual event types within these events, ordered by type.

This change has exposed some possible inconsistencies in our data, I've corrected one of them but decided to leave the rest for a separate PR rather than block this one.

## Why
Part of the feedback on the implementation record suggested this is a feature people want.

## Visual changes

![Screenshot 2024-02-28 at 14 37 50](https://github.com/alphagov/govuk-developer-docs/assets/861310/65f2c6ac-96ac-4bac-8af8-afbcdec8e87f)
