### PR TITLE
Add govuk-chat application to repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -265,6 +265,11 @@
   type: Utilities
   sentry_url: false
 
+- repo_name: govuk-chat
+  private_repo: true
+  team: "#ai-govuk"
+  type: AI apps
+
 - repo_name: govuk-content-api-docs
   team: "#govuk-publishing-platform"
   type: Utilities


### PR DESCRIPTION
## Description

This adds govuk_chat to the repos.yml file. I've added a new type of `AI apps` as it doesn't fit the other categories.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
