### PR TITLE
Remove retire flag until we archive Github repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -469,7 +469,6 @@
   production_hosted_on: eks
 
 - repo_name: info-frontend
-  retired: true
   type: Frontend apps
   team: "#govuk-navigation-tech"
   production_hosted_on: eks


### PR DESCRIPTION
Causing a check to fail: https://github.com/alphagov/govuk-saas-config/actions/runs/8138204601/job/22238440069

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
