### PR TITLE
Update the licensing team slack channel

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -478,7 +478,7 @@
   private_repo: true
   type: Licensing apps
   production_hosted_on: eks
-  team: "#govuk-licensing"
+  team: "#gds-apto-collaboration"
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: licensify
@@ -486,7 +486,7 @@
   private_repo: true
   type: Licensing apps
   production_hosted_on: eks
-  team: "#govuk-licensing"
+  team: "#gds-apto-collaboration"
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: licensify
@@ -494,7 +494,7 @@
   private_repo: true
   type: Licensing apps
   production_hosted_on: eks
-  team: "#govuk-licensing"
+  team: "#gds-apto-collaboration"
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: link-checker-api


### PR DESCRIPTION
This is more likely to reach relevant engineers.

As well as the docs, this config powers the Release app's [deploy badger](https://docs.publishing.service.gov.uk/manual/slack-integrations.html#release-app-badger). I think it will get more response going to the new channel.
