### PR TITLE
Fix implementation record filtering

### DIFF
--- a/source/javascripts/filter-list.js
+++ b/source/javascripts/filter-list.js
@@ -30,7 +30,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         // show/hide children
         for (var j = 0; j < children.length; j++) {
           var child = children[j]
-          var text = child.innerText.toLowerCase()
+          var text = child.textContent.toLowerCase()
           this.showHide(text, searchTerm, child)
         }
         // show/hide title
@@ -40,7 +40,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           title.classList.remove('filter-list-hidden')
         }
       } else {
-        var text = current.innerText.toLowerCase()
+        var text = current.textContent.toLowerCase()
         this.showHide(text, searchTerm, current)
       }
     }


### PR DESCRIPTION
## What / why
Fix a small bug in the filtering functionality recently added to some pages in the implementation record.

The JS was using `innerText` but we include hidden elements to match the title of the sections on events by type. `innerText` is less reliable than `textContent` as it doesn't include hidden text, and during testing it produced some slightly odd results. This change fixes them.

## Visual changes
None.

Trello card: https://trello.com/c/m6vL7lJy/186-add-filters-to-events-and-attributes-pages-on-implementation-record
