### PR TITLE
Only run static analysis tools on code changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,17 @@ jobs:
     name: Test Ruby
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          show-progress: false
       - name: Clone publishing api
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
           ref: main
           path: tmp/publishing-api
+          show-progress: false
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,6 @@ on:
     - cron: "0 9-19 * * 1-5"
 
 jobs:
-  snyk-security:
-    name: SNYK security analysis
-    uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
-    secrets: inherit
-  
-  codeql-sast:
-    name: CodeQL SAST scan
-    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
-    permissions:
-      security-events: write
-
-  dependency-review:
-    name: Dependency Review scan
-    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-  
   test-ruby:
     name: Test Ruby
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,33 @@
+name: Security scans
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to check out
+        default: main
+        type: string
+
+jobs:
+  snyk-security:
+    name: SNYK security analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
+    secrets: inherit
+
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main


### PR DESCRIPTION
See #4333.

These checks take a while to run and they don't do anything useful with Markdown, so avoid running them on changes that only touch Markdown files.

We still run all the checks on changes that touch docs that can contain embedded Ruby (`**/*.html.erb`).

Also update the checkout action.