### PR TITLE
Update retire app docs

### DIFF
--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -77,9 +77,8 @@ these.
 
 [dns-changes]: /manual/dns.html#dns-for-the-publishingservicegovuk-domain
 
-## 9. Update docs
+## 9. Remove the GOV.UK architecture diagram
 
-- Mark the application as `retired` in [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs)
 - Remove the application from the [GOV.UK architecture diagram](/manual/architecture.html)
 
 ## 10. Drop database
@@ -130,7 +129,7 @@ In the staging and production environments, deleting an Argo CD app will not [au
 You will need to list and delete these resources yourself, for example:
 
 ```
-  kubectl get all | grep <app-name>
+  kubectl --namespace apps get all | grep <app-name>
 
   kubectl delete deploy/<app-name> svc/<app-name> job/<app-name>-upload-assets
 ```


### PR DESCRIPTION
The mark an app as retired step is already covered in the last step [1] in the retiring an app doc and doing this prematurely of archiving the repo will cause consistency checks to fail in govuk-sass-config [2].

Also updates the kube command for retrieving resources for an app as the old command doesn't return anything.

Trello:
https://trello.com/c/Mv4qiBEI/2386-check-and-remove-kubernetes-resources

[1]: https://docs.publishing.service.gov.uk/manual/retiring-a-repo.html
[2]: https://github.com/alphagov/govuk-saas-config

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
