### PR TITLE
Retire info-frontend

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -469,6 +469,7 @@
   production_hosted_on: eks
 
 - repo_name: info-frontend
+  retired: true
   type: Frontend apps
   team: "#govuk-navigation-tech"
   production_hosted_on: eks


### PR DESCRIPTION
Mark repo as retired.

Trello: https://trello.com/c/sWZM0a38/2387-archive-repo-in-github

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
