### PR TITLE
Update location of the Terraform Cloud check

### DIFF
--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -35,7 +35,7 @@ When you've verified the authenticity of the request as per the SRE docs above, 
 1. Push your changes to GitHub and open a pull request
 1. Terraform Cloud will automatically perform a plan. Open the [govuk-dns-tf][govuk-dns-tf-cloud] workspace to see it.
 1. If you are happy with the results of the plan, merge your PR
-1. From the PR page in GitHub, look under the pre-merge checks section and open the "details" link from the Terraform Cloud check.
+1. From the [govuk-dns-tf][] landing page, click on the green pre-merge check tick and open the "details" link from the Terraform Cloud check.
 1. Press "Confirm and apply" in Terraform Cloud.
 
 [govuk-dns-tf-cloud]: https://app.terraform.io/app/govuk/workspaces/govuk-dns-tf


### PR DESCRIPTION
Updating the location of the terrafrom cloud check for post PR merge as the link from the PR didn't lead me to the correct Terraform Cloud check.  