### PR TITLE
Updates following the codecommit drill

### DIFF
--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -62,6 +62,10 @@ docker push $REGISTRY/$REPO:$IMAGE_TAG
 1. Find the `image:` field for the `app` container. It should look something like `172025368201.dkr.ecr.eu-west-1.amazonaws.com/<app-name>:release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
 1. Update the tag part of the `image:` value to the new image tag that you pushed to ECR. The part you are changing should look something like `release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
 1. Click `Save`. Argo CD will start the deployment, which should complete in under ten minutes.
+1. After confirming deployment of the app re-enable auto-sync for the `app-config` application:
+    1. From the Applications page (the Argo CD homepage), choose the `app-config` application.
+    1. Press the `App Details` button near the top of the page.
+    1. Scroll down to the bottom of the page and press `Enable auto-sync`.
 
 ## Troubleshooting 403 errors from AWS
 

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -31,7 +31,7 @@ REPO=$(basename "$PWD")
 1. Build the container image and tag it appropriately.
 
 ```
-docker build --platform linux/amd64 -t $IMAGE_TAG .
+docker build --platform linux/amd64 -t $REGISTRY/$REPO:$IMAGE_TAG .
 ```
 
 1. Log into ECR and push the image:

--- a/source/manual/howto-checkout-and-commit-to-codecommit.html.md
+++ b/source/manual/howto-checkout-and-commit-to-codecommit.html.md
@@ -14,16 +14,16 @@ Accessing CodeCommit requires AWS credentials, which you can obtain in the usual
 
 ## Quick reference guide
 
-This example demonstrates a simple workflow using the `whitehall` repository in CodeCommit.
+This example demonstrates a simple workflow using the `govuk-replatform-test-app` repository in CodeCommit.
 
 > Follow [the installation steps](#install-dependencies-and-set-up-local-environment) first.
 
 ```
 # Clone the repo.
-gds aws govuk-tools-poweruser git clone codecommit::eu-west-2://whitehall
+gds aws govuk-tools-poweruser git clone codecommit::eu-west-2://govuk-replatform-test-app
 
 # Create a local branch.
-cd whitehall
+cd govuk-replatform-test-app
 git checkout -b mybranch
 
 # Commit a change locally.
@@ -79,7 +79,7 @@ You need to have first [set up the GDS command line tools](/manual/get-started.h
     For example:
 
     ```
-    gds aws govuk-tools-poweruser git clone codecommit::eu-west-2://whitehall
+    gds aws govuk-tools-poweruser git clone codecommit::eu-west-2://govuk-replatform-test-app
     ```
 
 > `git clone` on CodeCommit can sometimes be very slow initially. If `git


### PR DESCRIPTION
During the drill we discovered a number of things which can improve the docs:

- add missing tags, the `docker push` would fail otherwise
- re-enable auto-sync after confirming that the deployment of the image from code commit has worked
- use `govuk-replatform-test-app` rather than `whitehall` as the example as we spent quite a long time downloading and waiting for `whitehall` to build, and we should be able to make visible changes to the test app without affecting a live service.