### PR TITLE
Only re-enable auto-sync at end of drill or when Github is available

### DIFF
--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -62,7 +62,7 @@ docker push $REGISTRY/$REPO:$IMAGE_TAG
 1. Find the `image:` field for the `app` container. It should look something like `172025368201.dkr.ecr.eu-west-1.amazonaws.com/<app-name>:release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
 1. Update the tag part of the `image:` value to the new image tag that you pushed to ECR. The part you are changing should look something like `release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
 1. Click `Save`. Argo CD will start the deployment, which should complete in under ten minutes.
-1. After confirming deployment of the app re-enable auto-sync for the `app-config` application:
+1. If you are following the 2ndline drill or when Github is available, after confirming deployment of the app re-enable auto-sync for the `app-config` application:
     1. From the Applications page (the Argo CD homepage), choose the `app-config` application.
     1. Press the `App Details` button near the top of the page.
     1. Scroll down to the bottom of the page and press `Enable auto-sync`.

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -62,7 +62,9 @@ docker push $REGISTRY/$REPO:$IMAGE_TAG
 1. Find the `image:` field for the `app` container. It should look something like `172025368201.dkr.ecr.eu-west-1.amazonaws.com/<app-name>:release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
 1. Update the tag part of the `image:` value to the new image tag that you pushed to ECR. The part you are changing should look something like `release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
 1. Click `Save`. Argo CD will start the deployment, which should complete in under ten minutes.
-1. If you are following the 2ndline drill or when Github is available, after confirming deployment of the app re-enable auto-sync for the `app-config` application:
+
+When GitHub is available again (or when you've completed the above as part of a Technical 2nd Line drill), return things to normal by re-enabling the auto-sync:
+
     1. From the Applications page (the Argo CD homepage), choose the `app-config` application.
     1. Press the `App Details` button near the top of the page.
     1. Scroll down to the bottom of the page and press `Enable auto-sync`.

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -65,9 +65,9 @@ docker push $REGISTRY/$REPO:$IMAGE_TAG
 
 When GitHub is available again (or when you've completed the above as part of a Technical 2nd Line drill), return things to normal by re-enabling the auto-sync:
 
-    1. From the Applications page (the Argo CD homepage), choose the `app-config` application.
-    1. Press the `App Details` button near the top of the page.
-    1. Scroll down to the bottom of the page and press `Enable auto-sync`.
+  1. From the Applications page (the Argo CD homepage), choose the `app-config` application.
+  1. Press the `App Details` button near the top of the page.
+  1. Scroll down to the bottom of the page and press `Enable auto-sync`.
 
 ## Troubleshooting 403 errors from AWS
 


### PR DESCRIPTION
Do not enable auto-sync if Github is unavailable.