### PR TITLE
Replace Access and Permissions team with Publishing Platform team

### DIFF
--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -17,7 +17,7 @@ expiring tokens to ensure the associated application keeps working.
 
 If the token is for `Trade Tariff Admin` or `Trade Tariff Backend`, see [Trade Tariff Admin on the Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/3155099649/Trade+Tariff+Admin)
 
-If the token is for `Signon API Client (permission and suspension updater)`, talk with the [Access and Permissions team](https://gds.slack.com/channels/govuk-publishing-access-and-permissions-team).
+If the token is for `Signon API Client (permission and suspension updater)`, talk with the [Publishing Platform team](https://gds.slack.com/channels/govuk-publishing-platform).
 
 ### 1. Issue a new token
 


### PR DESCRIPTION
## What
This PR updates a Slack channel link that referenced the Access and Permissions team but it has since disbanded. The Publishing Platform team has since assumed the responsibilities in this doc that were previously assigned to the Access and Permissions team.

## Why
The Access and Permissions team has disbanded.