### PR TITLE
Ga4 consent

### DIFF
--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -23,6 +23,8 @@ docs:
   subsections:
     - name: Development approach
       link: approach.html
+    - name: Consent handling
+      link: consent.html
     - name: Personally identifiable information
       link: pii.html
     - name: Trackers
@@ -37,6 +39,9 @@ progress:
 
 approach:
   name: Development approach
+
+consent:
+  name: Consent handling
 
 pii:
   name: Personally Identifiable Information

--- a/source/analytics/consent.html.md.erb
+++ b/source/analytics/consent.html.md.erb
@@ -1,0 +1,15 @@
+<% content_for :title, create_page_title(data.analytics.navigation.consent.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.analytics.navigation.consent.name %>
+</h1>
+
+<p class="govuk-body">The <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/consent.md" class="govuk-link">GOV.UK analytics JavaScript</a> has been implemented so that no analytics code is run until users consent to cookies. This includes calling the GA4/GTM script from Google.</p>
+
+<p class="govuk-body">This JavaScript implements a blocklist when initialising Google Tag Manager. This <a href="https://github.com/alphagov/govuk_publishing_components/blob/494c9fdbc50365a902e3e49a32b5417a4a761aad/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js#L16" class="govuk-link">prevents various items from being included</a> from GTM, such as custom scripts and HTML.</p>
+
+<p class="govuk-body">Additionally, consent has been configured in GTM as an additional layer of certainty. All tags have the Exception - All Events - Declined Cookies exception (blocking trigger) applied, which prevents the tags from firing if the user's consent cookie does not match "usage":true.</p>
+
+<p class="govuk-body">The trigger leverages a Lookup variable (LT - cookies_policy - check) that returns 'true' where the string matches and 'false' where it does not. The exception then evaluates to TRUE (and will block tags from firing) when the LT - cookies_policy - check returns false.</p>
+
+<p class="govuk-body">Another exception (Exception - All Events - hostname filter) has also been added to all tags that prevents them from firing unless the Page Hostname matches one of the specified dev, integration, staging or production gov.uk domains.</p>

--- a/source/analytics/docs.html.md.erb
+++ b/source/analytics/docs.html.md.erb
@@ -14,4 +14,9 @@
   <% end %>
 </ul>
 
-<p class="govuk-body">Our main documentation source is <a href="https://github.com/alphagov/govuk_publishing_components" class="govuk-link">govuk_publishing_components</a>. This is where <a href="https://github.com/alphagov/govuk_publishing_components/tree/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4" class="govuk-link">our analytics code</a> is located. Read our <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">overview of our GA4 code</a> for more information.</p>
+<p class="govuk-body">Further documentation can be found below.</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Documentation relating to the GA4 code on GOV.UK can be found in <a href="https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/analytics.md" class="govuk-link">govuk_publishing_components</a>.</li>
+  <li>Documentation for the GOV.UK data community can be found in <a href="https://docs.data-community.publishing.service.gov.uk/" class="govuk-link">Data Services technical documentation</a>.</li>
+</ul>


### PR DESCRIPTION
## What
Updates the GA4 implementation record with a link to the data docs and consent handling information.

## Why
Part of improving the implementation record.

Trello card: https://trello.com/c/MrU0YOd5/757-update-implementation-record-with-consent-handling-gtm-blocklist-information-and-data-docs-link