### PR TITLE
Fix broken link

### DIFF
--- a/source/kubernetes/manage-app/scale-app/index.html.md
+++ b/source/kubernetes/manage-app/scale-app/index.html.md
@@ -14,7 +14,7 @@ If user demand on your app increases, you must increase the resources available 
 2. Change your app's configuration by [following the guidance](#what-you-can-scale) below
 3. Commit this change
 
-When you merge the pull request, the changed configuration file will be [automatically synced by the Argo CD tool](/manage-app/access-ci-cd/#deploying-a-release-of-a-gov-uk-app).
+When you merge the pull request, the changed configuration file will be [automatically synced by the Argo CD tool](/kubernetes/manage-app/access-ci-cd/#deploying-a-release-of-a-gov-uk-app).
 
 You should be aware of:
 


### PR DESCRIPTION
## What
During the 2nd line `Scaling up an application` drill yesterday, I noticed that the `automatically synced by the Argo CD tool` link in the [Scale your app docs](https://docs.publishing.service.gov.uk/kubernetes/manage-app/scale-app/#scale-your-app) was broken. I believe it should point to https://docs.publishing.service.gov.uk/kubernetes/manage-app/access-ci-cd/#deploying-a-release-of-a-gov-uk-app, so I've updated the link accordingly.

## Why
Fixes a broken link.