### PR TITLE
Update Signon key rotation docs

### DIFF
--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -53,6 +53,8 @@ The nightly `signon-sync-token-secrets-to-k8s` cronjob will update the token in 
     k logs -f job/signon-token-sync-$USER
     ```
 
+    Alternatively, this job can be triggered through the ArgoCD user interface. Navigate to the [console for Signon](https://argo.eks.production.govuk.digital/applications/cluster-services/signon?view=tree&orphaned=false&resource=), click the "signon-sync-token-secrets-to-k8s" cron job, then press the three dots in the top right, then "Create Job". The logs can be viewed by clicking the newly created job.
+
 1. Open a Rails console on the client app. For example, if the `api_user` is `short-url-manager@alphagov.co.uk`, open a console on `short-url-manager`.
 
     ```sh


### PR DESCRIPTION
It is possible to trigger the cron job through the Argo user interface, which is probably easier than working out how to login to run the command.

Therefore adding this as an alternative method.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
