### PR TITLE
Remove pay-pagerduty

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -544,11 +544,6 @@
   team: "#govuk-publishing-experience-tech"
   type: Utilities
 
-- repo_name: pay-pagerduty
-  team: "#govuk-platform-security-reliability-team"
-  type: Utilities
-  sentry_url: false
-
 - repo_name: plek
   team: "#govuk-platform-security-reliability-team"
   type: Gems


### PR DESCRIPTION
Pagerduty synchronisation is [now built into govuk-rota-generator](https://github.com/alphagov/govuk-rota-generator/pull/30).
