### PR TITLE
Make StringToId more robust to arbitrary input.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "ffi"
 gem "rake"
 gem "rspec"
 gem "rubocop-govuk", require: false
+gem "sanitize"
 gem "simplecov"
 gem "webmock"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,6 +644,9 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sanitize (6.1.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     sass (3.4.25)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -720,6 +723,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop-govuk
+  sanitize
   simplecov
   webmock
 

--- a/app/string_to_id.rb
+++ b/app/string_to_id.rb
@@ -1,10 +1,12 @@
+require "sanitize"
+
 class StringToId
   def self.convert(string)
-    string
-      .downcase # lower case
-      .gsub(/<[^>]*>/, "") # crudely remove html tags
-      .gsub(/[^\w\-. ]/, "") # remove any non-word, non-hyphen & non-period characters
-      .gsub(/[ .]/, "-") # replace spaces & periods with hyphens
-      .gsub(/-{2,}/, "-") # replace two (or more) subsequent hyphens with single hyphens
+    Sanitize.fragment(string)
+      .downcase
+      .gsub(/&(amp|gt|lt);/, "")
+      .tr(" .", "-")
+      .tr("^a-z0-9_-", "")
+      .gsub(/--+/, "-")
   end
 end

--- a/spec/app/string_to_id_spec.rb
+++ b/spec/app/string_to_id_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe StringToId do
+  describe "convert" do
+    subject(:c) { StringToId }
+
+    it "removes HTML tags" do
+      expect(c.convert("<marquee loop=\"-1\" scrolldelay='50'><b>lol</b></marquee>")).to eq("lol")
+    end
+
+    it "removes script elements and their content" do
+      expect(c.convert("<script>foo</script>")).to eq("")
+    end
+
+    it "removes characters other than ASCII alphanumeric, dot, dash and underscore" do
+      expect(c.convert("1!@#%^*()-+=[]{}|\\'\"`~?/,")).to eq("1-")
+      expect(c.convert("💩")).to eq("")
+    end
+
+    it "removes ampersand, less-than and greater-than" do
+      expect(c.convert("><<>&")).to eq("")
+    end
+
+    it "preserves entity names that are not part of actual entities" do
+      expect(c.convert("ampere")).to eq("ampere")
+      expect(c.convert("amp;ere")).to eq("ampere")
+      expect(c.convert("felt;-tip-pen")).to eq("felt-tip-pen")
+    end
+
+    it "preserves empty string" do
+      expect(c.convert("")).to eq("")
+    end
+
+    it "preserves lowercase alphanumeric ASCII, underscores and non-consecutive dashes" do
+      expect(c.convert("xyz890-123abc_")).to eq("xyz890-123abc_")
+    end
+
+    it "converts space and . to -" do
+      expect(c.convert("foo.bar baz")).to eq("foo-bar-baz")
+    end
+
+    it "converts to lowercase" do
+      expect(c.convert("MICROPIGS")).to eq("micropigs")
+    end
+
+    it "elides runs of dashes" do
+      expect(c.convert("o---o")).to eq("o-o")
+      expect(c.convert("o----o")).to eq("o-o")
+    end
+
+    it "elides runs of dashes after converting characters to dashes" do
+      expect(c.convert("o-...  -o")).to eq("o-o")
+    end
+
+    it "does not elide runs of underscores" do
+      expect(c.convert("__")).to eq("__")
+    end
+  end
+end


### PR DESCRIPTION
- Add some tests.
- Don't "crudely remove HTML tags"; use a library that does it properly. Not a huge deal cos this is only gonna see semi-trusted input, but it's not a good look to be rolling our own with that.
- Remove comments that just give false reassurance.
- Use the simplest string functions for the job rather than hitting everything with the regex hammer.

Fixes https://github.com/alphagov/govuk-developer-docs/security/code-scanning/2.

Gemfile.lock changes were generated by `bundle install`.

Alternatives considered:

Since we're already pulling in `activesupport`, we could just use `ActiveSupport::Inflector::parameterize` and do away with this little utility module altogether. I assumed that would probably break a bunch of existing links to heading anchors, though. (If not then let's just ditch this thing!)