### PR TITLE
Add GA4 'filter' events to the analytics docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 Staticfile.auth
 coverage
 tmp
+
+node_modules
+.DS_Store

--- a/data/analytics/events.yml
+++ b/data/analytics/events.yml
@@ -673,7 +673,60 @@
           value: Get emails from GOV.UK
         - name: type
           value: email subscription
-
+- name: filter
+  description: Interactions that can be conducted after filtering the content using CSS instead of HTTP or API requests.
+  events:
+  - name: filter search
+    implemented: true
+    priority: low
+    description: When a search box is used to filter a long list of things on a page, by hiding irrelevant matches, rather than fetching a new page of results from the server.
+    tracker: focus_loss_tracker
+    examples:
+      - text: Government organisations page
+        link: https://www.gov.uk/government/organisations
+      - text: Help and services around the world page
+        link: https://www.gov.uk/world
+    data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: filter
+        - name: type
+          value: filter
+        - name: action
+          value: filter
+        - name: section
+        - name: text
+          value: the user's search term
+  - name: filter link clicks
+    implemented: true
+    priority: low
+    description: Link clicks in a filter search list
+    tracker: focus_loss_tracker
+    examples:
+      - text: Government organisations page
+        link: https://www.gov.uk/government/organisations
+      - text: Help and services around the world page
+        link: https://www.gov.uk/world
+    data:
+      - name: event
+        value: event_data
+      - name: event_data
+        value:
+        - name: event_name
+          value: filter
+        - name: type
+          value: filter
+        - name: action
+          value: filter
+        - name: section
+        - name: external
+        - name: link_domain
+        - name: method
+        - name: text
+        - name: url
 - name: feedback
   description: Tracking the 'is this page useful?' component at the bottom of every GOV.UK page.
   events:

--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -63,3 +63,10 @@
   url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-copy-tracker.md
   description: Tracks when users copy text from a GOV.UK page.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js
+
+- name: Focus loss tracker
+  technical_name: focus_loss_tracker
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-focus-loss-tracker.md
+  description: Tracks when a user moves their browser focus away from an element with this tracker initialised on it.
+  code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.js
+


### PR DESCRIPTION
## What
- Adds the filter events to the docs
- Adds the focus loss tracker to the docs
- Updates the `.gitignore` as it tries to add `node_modules` to your commits and `.DS_Store` if you've ever worked with images in this repo

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
