### PR TITLE
Update GA4 links

### DIFF
--- a/data/analytics/trackers.yml
+++ b/data/analytics/trackers.yml
@@ -1,12 +1,12 @@
 - name: Event tracker
   technical_name: event_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-event-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-event-tracker.md
   description: This script is intended for adding GA4 tracking to interactive elements such as buttons or details elements.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-event-tracker.js
 
 - name: Link tracker
   technical_name: link_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-link-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-link-tracker.md
   description: This script is intended for adding GA4 tracking to links.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-link-tracker.js
 
@@ -18,55 +18,55 @@
 
 - name: Specialist link tracker
   technical_name: specialist_link_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-specialist-link-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-specialist-link-tracker.md
   description: This script automatically tracks clicks on links such as external links, download links, and mailto links.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-specialist-link-tracker.js
 
 - name: Scroll tracker
   technical_name: scroll_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-scroll-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-scroll-tracker.md
   description: Provides scroll tracking when applied to a page.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-scroll-tracker.js
 
 - name: Form tracker
   technical_name: form_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-form-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-form-tracker.md
   description: This script captures redacted data from form submissions.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-form-tracker.js
 
 - name: Auto tracker
   technical_name: auto_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-auto-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-auto-tracker.md
   description: Captures data on page load for significant pages, such as a user reaching the end of a journey e.g. smart answer complete.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-auto-tracker.js
 
 - name: Ecommerce tracker
   technical_name: ecommerce_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-ecommerce-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-ecommerce-tracker.md
   description: Captures data for results page using a Google Analytics ecommerce object format.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js
 
 - name: Video tracker
   technical_name: video_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-video-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-video-tracker.md
   description: Fires events when videos are played.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-video-tracker.js
 
 - name: Print intent tracker
   technical_name: print_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-print-intent-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-print-intent-tracker.md
   description: Tracks when users open the browser print dialog.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-print-intent-tracker.js
 
 - name: Copy tracker
   technical_name: copy_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-copy-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-copy-tracker.md
   description: Tracks when users copy text from a GOV.UK page.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-copy-tracker.js
 
 - name: Focus loss tracker
   technical_name: focus_loss_tracker
-  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/ga4-focus-loss-tracker.md
+  url: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-focus-loss-tracker.md
   description: Tracks when a user moves their browser focus away from an element with this tracker initialised on it.
   code: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-focus-loss-tracker.js
 


### PR DESCRIPTION
## What / why

Updates links to some GA4 analytics documentation following [changes in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/3963).

## Visual changes
None.

Trello card: https://trello.com/c/j2SEemPJ/195-extend-developer-documentation-to-help-developers-other-devs-use-ga4-tracking-on-govuk-components