### PR TITLE
Remove retired repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -206,10 +206,6 @@
   team: "#govuk-platform-security-reliability-team"
   type: Gems
 
-- repo_name: gem-release-alert
-  team: "#govuk-platform-security-reliability-team"
-  type: Utilities
-
 - repo_name: github-trello-poster
   team: "#govuk-platform-security-reliability-team"
   management_url: https://dashboard.heroku.com/apps/govuk-github-trello-poster


### PR DESCRIPTION
https://trello.com/c/6GdfNb6n/3482-move-gem-alerts-into-seal-and-retire-gem-release-alert-repo