### PR TITLE
Remove puppet steps from retiring an app

### DIFF
--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -6,52 +6,20 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-Note: Now that we've moved most of the applications to EKS, some of these
-steps are only necessary for the handful of apps being deployed by Puppet.
-The step titles now indicate whether a step is only required for Puppet or
-EKS-deployed apps.
-
-## 1. (PUPPET APPS ONLY) Remove app from puppet
-
-Configure Puppet to remove the app from all servers. Change the app resource,
-and any database resources to `ensure => absent`, remove any host and
-load-balancer entries, but leave the hieradata entries.
-
-See this pull request for an example:
-
-- <https://github.com/alphagov/govuk-puppet/pull/5496>
-
-After this has been deployed, remove it entirely. For example:
-
-- <https://github.com/alphagov/govuk-puppet/pull/5507>
-
-## 2. Remove smoke tests
+## 1. Remove smoke tests
 
 Remove any [smokey tests][smokey] specific to the application.
 
 [smokey]: https://github.com/alphagov/smokey
 
-## 3. (PUPPET APPS ONLY) Remove deploy scripts
-
-Remove necessary scripts from [govuk-app-deployment][govuk-app-deployment].
-
-[govuk-app-deployment]: https://github.com/alphagov/govuk-app-deployment
-
-## 4. Update Release app
+## 2. Update Release app
 
 Mark the application as archived in the Release app.
 
 Edit the application in the release app (you'll need the `deploy` permission to
 do this), and check the `archived` checkbox. This will hide it from the UI.
 
-## 5. (PUPPET APPS ONLY) Remove from deploy Jenkins
-
-Remove entry from the deploy Jenkinses. This is managed
-[through govuk-puppet][common] in the `common.yml`.
-
-[common]: https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/common.yaml
-
-## 6. Update Signon
+## 3. Update Signon
 
 Mark the application as "retired" in signon, if it used it.
 
@@ -59,7 +27,7 @@ Click on the Applications tab. Find the application that is being retired and
 click the "edit" button. Tick the box that says "This application is being
 retired", then save your changes.
 
-## 7. Remove from GOV.UK Docker
+## 4. Remove from GOV.UK Docker
 
 Remove from the [projects directory] and any references
 in [docker compose] or throughout the repo.
@@ -67,7 +35,7 @@ in [docker compose] or throughout the repo.
 [projects directory]: https://github.com/alphagov/govuk-docker/tree/master/projects
 [docker compose]: https://github.com/alphagov/govuk-docker/blob/master/docker-compose.yml
 
-## 8. Update DNS
+## 5. Update DNS
 
 Request any public DNS entries be removed. If the app had an admin UI, it will
 have had public DNS entries in the `publishing.service.gov.uk` domain.
@@ -77,36 +45,30 @@ these.
 
 [dns-changes]: /manual/dns.html#dns-for-the-publishingservicegovuk-domain
 
-## 9. Remove the GOV.UK architecture diagram
+## 6. Remove from the GOV.UK architecture diagram
 
 - Remove the application from the [GOV.UK architecture diagram](/manual/architecture.html)
 
-## 10. Drop database
+## 7. Drop database
 
-If Puppet hasn't done it (eg for MongoDB databases), drop the database.
+Drop the database, if present - note that this might be in RDS, but it might also exist
+as a MongoDB or DocumentDB database.
 
-## 11. (PUPPET APPS ONLY) Remove jobs in CI
-
-If tests were set up, go to [CI] and choose "Delete Repository" for your
-project.
-
-[CI]: https://ci.integration.publishing.service.gov.uk/
-
-## 12. Unpublish routes
+## 8. Unpublish routes
 
 Some applications are responsible for publishing certain routes. If you're
 retiring a publishing application, make sure you check if any of its content
 items need to be unpublished and do it via the Publishing API.
 
-## 13. Remove from Sentry
+## 9. Remove from Sentry
 
 Since the application has been retired, it shouldn't be tracked in Sentry.
 
-## 14. Remove from Heroku
+## 10. Remove from Heroku
 
 If relevant (e.g. if Heroku was used for previews).
 
-## 15. (EKS APPS ONLY) Remove from govuk-helm-charts
+## 11. Remove from govuk-helm-charts
 
 Remove the app's entry in [govuk-helm-charts] from:
 
@@ -122,7 +84,7 @@ Once the PR is merged ([Example PR][]), the app pods will automatically be remov
 [govuk-helm-charts] (https://github.com/alphagov/govuk-helm-charts/)
 [Example PR] (https://github.com/alphagov/govuk-helm-charts/pull/1236)
 
-## 17. Delete the app's Kubernetes resources (if applicable)
+## 12. Delete the app's Kubernetes resources (if applicable)
 
 In the staging and production environments, deleting an Argo CD app will not [automatically delete](https://github.com/alphagov/govuk-helm-charts/blob/c55a034/charts/app-config/templates/govuk-application.yaml#L10) the Kubernetes resources that it manages, such as `deployments`, `services`, `jobs` and `cronjobs`.
 
@@ -134,6 +96,6 @@ You will need to list and delete these resources yourself, for example:
   kubectl delete deploy/<app-name> svc/<app-name> job/<app-name>-upload-assets
 ```
 
-## 18. Archive the repo
+## 13. Archive the repo
 
 Follow the steps at [Retire a repo](/manual/retiring-a-repo.html).


### PR DESCRIPTION
Puppet isn't used any more, so it's not necessary to differentiate Puppet/EKS steps in retiring an app.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
