### PR TITLE
Add Android mobile module repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -347,6 +347,21 @@
   description: A simple Go program used by GOV.UK to populate mirrors hosted by AWS S3 and GCP Storage
   sentry_url: false
 
+- repo_name: govuk-mobile-android-homepage
+  type: Mobile apps
+  team: "#govuk-apps-notifications"
+  description: Homepage module for GOV.UK Android app
+
+- repo_name: govuk-mobile-android-onboarding
+  type: Mobile apps
+  team: "#govuk-apps-notifications"
+  description: Onboarding module for GOV.UK Android app
+
+- repo_name: govuk-mobile-android-services
+  type: Mobile apps
+  team: "#govuk-apps-notifications"
+  description: Services module for GOV.UK Android app
+
 - repo_name: govuk-mobile-ios-onboarding
   type: Mobile apps
   team: "#govuk-apps-notifications"


### PR DESCRIPTION
Adds the following repos - used by the mobile app development team:

-  govuk-mobile-android-homepage - [Jira](https://govukverify.atlassian.net/jira/software/projects/GOVAPP/boards/405?selectedIssue=GOVAPP-409) | [GitHub](https://github.com/alphagov/govuk-mobile-android-homepage)
-  govuk-mobile-android-onboarding - [Jira](https://govukverify.atlassian.net/jira/software/projects/GOVAPP/boards/405?selectedIssue=GOVAPP-395) | [GitHub](https://github.com/alphagov/govuk-mobile-android-onboarding)
-  govuk-mobile-android-services - [Jira](https://govukverify.atlassian.net/jira/software/projects/GOVAPP/boards/405?selectedIssue=GOVAPP-396) | [GitHub](https://github.com/alphagov/govuk-mobile-android-services)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
