### PR TITLE
Fix link in get-started.html.md

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -104,7 +104,7 @@ Ask your tech lead to follow the [instructions] in govuk-user-reviewer to grant 
 [Sentry]: /manual/sentry.html
 [Pagerduty]: /manual/pagerduty.html
 [govuk-user-reviewer]: https://github.com/alphagov/govuk-user-reviewer
-[instructions]: https://github.com/alphagov/govuk-user-reviewer#addingremoving-users
+[instructions]: https://github.com/alphagov/govuk-user-reviewer#adding-users
 
 ## 7. Install and configure the GDS CLI
 


### PR DESCRIPTION
The link to the instructions in govuk-user-reviewer for adding a user was broken (the referenced section within the page doesn't exist)—update the link to point to the correct section of the document.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
