### PR TITLE
Document Rails secret approach post Rails 7.1 deprecations

### DIFF
--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -281,19 +281,18 @@ Rails application with practices such as:
 
 ### Inject secrets with environment variables
 
-The conventional place to store secrets for a GOV.UK Rails application is
-`config/secrets.yml`. All production secrets should be populated with an
-environment variable; for dev and test environments it's preferred to leave
-a usable placeholder default if an actual secret isn't needed
-([example][secrets-example]).
-
-We haven't migrated to using the [encrypted `config/credentials.yml.enc`
-introduced in Rails 5.2][rails-credentials]. This approach presents us
-with a few problems, most notably that we run our apps in Rails
-"production" environment in numerous places (integration, staging,
+We don't make use of [Rails encrypted credentials][rails-credentials],
+preferring instead to use environment variables. Using Rails credentials
+would present us with numerous challenges, most notably that we run our
+apps in Rails "production" environment in numerous places (integration, staging,
 production) and need different secrets for them.
 
-[secrets-example]: https://github.com/alphagov/content-publisher/blob/654d1885dd94e347e236be73d20f2304913bc906/config/secrets.yml
+If you need to make dummy secrets available to dev and test environments
+configure these in the respective `config/environments/*.rb` configuration files.
+
+Applications should no longer make use of `config/secrets.yml` as this
+[is deprecated](https://github.com/rails/rails/pull/48472).
+
 [rails-credentials]: https://edgeguides.rubyonrails.org/security.html#custom-credentials
 
 ### Specify London as the timezone


### PR DESCRIPTION
This updates our conventions to reflect the demise of Rails.application.secrets which will be removed in Rails 7.2.

It reflects the view that Rails.credentials is not suitable for our use case and that really we don't need anything special since we're just using env vars and can just reference secrets in our config files since they come from env vars.

A thing to note is that for apps migrating from config/secrets.yml they will not need to set anything up for secret_key_base. Rails automatically generates secret_key_base values in dev and test environments and automatically reads the ENV["SECRET_KEY_BASE"] env var [1]. So if this is all in app has in secrets.yml then the file can just be deleted.

[1]: https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
