### PR TITLE
Update PagerDuty drill time

### DIFF
--- a/source/manual/2nd-line.html.md
+++ b/source/manual/2nd-line.html.md
@@ -86,7 +86,7 @@ We use Grafana dashboards to monitor the health of our applications and service 
 
 ### PagerDuty
 
-Some alerts are urgent enough to warrant immediate attention, such as parts of the site becoming unavailable or large quantities of error pages being served. We use [PagerDuty][] to notify the primary and secondary engineers on Technical 2nd Line during office hours (9:30am to 5:30pm), and on-call engineers outside of office hours. We carry out a [Pagerduty drill](/manual/pagerduty.html#pagerduty-drill) every Wednesday morning at 10am UTC.
+Some alerts are urgent enough to warrant immediate attention, such as parts of the site becoming unavailable or large quantities of error pages being served. We use [PagerDuty][] to notify the primary and secondary engineers on Technical 2nd Line during office hours (9:30am to 5:30pm), and on-call engineers outside of office hours. We carry out a [Pagerduty drill](/manual/pagerduty.html#pagerduty-drill) every Wednesday morning at 10am UTC (11am BST).
 
 [Read more about PagerDuty](/manual/pagerduty.html).
 

--- a/source/manual/pagerduty.html.md
+++ b/source/manual/pagerduty.html.md
@@ -29,12 +29,12 @@ See the [Pagerduty documentation on how to schedule an override](https://support
 ## PagerDuty drill
 
 Every week we test PagerDuty to make sure it can phone to alert us to
-any issues. This happens every Wednesday morning at 10am BST.
+any issues. This happens every Wednesday morning at 10am UTC (11am BST).
 
 Prometheus is currently firing a constant `Watchdog` alert, which fires all the time so that
 developers can see the that prometheus is integrated with alertmanager. In the
 [alertmanager configs](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/cluster-services/templates/alertmanager-config.tpl#L79-L85)
-the pagerduty drill is set up to trigger when the the clocks hit a specified time frame, between 10am to 10:03am BST every Wednesday.
+the pagerduty drill is set up to trigger when the the clocks hit a specified time frame, between 10am to 10:03am UTC (11am to 11:03am BST) every Wednesday.
 
 You don't need to take any action for this alert. The primary in-office
 Technical 2nd Line developer should escalate the call to the secondary who should escalate


### PR DESCRIPTION
## What
This PR updates the documented time for the PagerDuty drill to address the difference in UTC and BST times.

## Why
The drill is documented as being triggered at 10am UTC and 10am BST (and should be 10am UTC and 11am BST).