### PR TITLE
Update Getting access to GitHub

### DIFF
--- a/source/manual/github.html.md
+++ b/source/manual/github.html.md
@@ -38,7 +38,7 @@ There are several GOV.UK GitHub teams within alphagov, including:
 
 Not everyone on GOV.UK requires GitHub access, as much of what we do is in the open. However, if your role requires it, you should be added to the org and the relevant team(s) through Terraform, in [govuk-user-reviewer][govuk-user-reviewer] - _not_ manually added through the GitHub UI itself, as this breaks the Terraform setup. Note that you will be sent an invitation email and will have to accept the invite before you are added to the organisation.
 
-- If you're a content designer, ask for GitHub access via Zendesk (see [example ticket](https://govuk.zendesk.com/agent/tickets/5297731/events))
+- If you're a content designer, ask for GitHub access via Zendesk (see [example ticket](https://govuk.zendesk.com/agent/tickets/5812930/events)). Ensure to include `govuk_platform_support` tag.
 - If you're an engineer or contractor, ask your tech lead to follow the instructions in [govuk-user-reviewer][govuk-user-reviewer] to add you.
 - If you don't have a tech lead, [ask someone in Senior Tech](/manual/ask-for-help.html#contact-senior-tech) to add you. You must state
   - your role


### PR DESCRIPTION
The ticket should be tagged with `govuk_platform_support` so it's triaged to appropriate view.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
