### PR TITLE
Update links to Platform Engineering team.

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -197,3 +197,4 @@ redirects:
   /manual/user-management-in-aws.html: /manual/get-started.html
   /manual/welcome-to-2nd-line.html: /manual/2nd-line.html
   /manual/whitelist-site-in-transition.html: /manual/allowlist-site-in-transition.html
+  /platform-engineering: /kubernetes/contact-platform-engineering-team.html

--- a/source/kubernetes/contact-platform-engineering-team.html.md
+++ b/source/kubernetes/contact-platform-engineering-team.html.md
@@ -6,7 +6,7 @@ layout: multipage_layout
 
 # GOV.UK Platform Engineering team
 
-Platform Engineering team (previously known as Replatforming team) looks after the Kubernetes clusters, base services, build/release/rollout automation and Helm templates for hosting the GOV.UK website and content management system.
+Platform Engineering team (previously known as Replatforming team) looks after the Kubernetes clusters, base services, build/release/rollout automation (CI/CD) and Helm templates for hosting the GOV.UK website and content management system (CMS).
 
 ## Get in touch
 

--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -16,9 +16,9 @@ If you and your colleagues can’t resolve a technical issue, problem or questio
 
 You can ping `@govuk-senior-tech-people` on Slack, or email [govuk-senior-tech-members](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-senior-tech-members/members).
 
-## Contact Technical 2nd Line
+## Contact 2nd Line Technical Support
 
-The GOV.UK Technical 2nd Line team (#govuk-2ndline-tech):
+The GOV.UK 2nd Line Tech Support team ([#govuk-2ndline-tech])
 
 - monitors the GOV.UK hosting platform and applications, and works to fix any issues
 - calls on experienced members of other teams to assist in incidents
@@ -27,26 +27,32 @@ The GOV.UK Technical 2nd Line team (#govuk-2ndline-tech):
 
 ## Ask the developer communities
 
-The GOV.UK developer community (#govuk-developers):
+### The GOV.UK developer community ([#govuk-developers])
 
 - helps each other with specialised knowledge about specific areas of the platform
 - supports each other with issues deploying changes to GOV.UK
 - ensures missions are delivered technically in the best and most appropriate way
 
-The GOV.UK Platform Security and Reliability team (#govuk-platform-security-reliability-team):
+### GOV.UK Platform Security and Reliability team ([#govuk-platform-security-reliability-team])
 
 - works on long-term improvements to the reliability and security of GOV.UK
 - manages some access control automation such as govuk-user-reviewer
 - manages some AWS infrastructure that supports multiple teams (together with Platform Engineering team)
 
-The GOV.UK Platform Engineering team (#govuk-platform-engineering):
+### GOV.UK [Platform Engineering] team ([#govuk-platform-engineering])
 
-- manages the Kubernetes clusters and base images on which GOV.UK applications run
-- works on long-term improvements to the efficiency and reliability of GOV.UK
-- supports CI/CD (build, rollout, release) automation
+- manages the Kubernetes clusters and base images for running GOV.UK applications
+- works on long-term improvements to the efficiency, reliability and security of GOV.UK
+- supports CI/CD (build, release, rollout) automation
 - can offer advice on monitoring and alerting
 - can offer design reviews and advice to help build your application for
   reliability, robustness and low maintenance (especially at the early stages of
   the software lifecycle)
 - can offer advice and assistance with changes such as migrating from one
-  database to another as safely and efficiently as possible
+  database to another safely and efficiently
+
+[#govuk-2ndline-tech]: https://gds.slack.com/channels/govuk-2ndline-tech
+[#govuk-developers]: https://gds.slack.com/channels/govuk-developers
+[#govuk-platform-engineering]: https://gds.slack.com/channels/govuk-platform-engineering
+[#govuk-platform-security-reliability-team]: https://gds.slack.com/channels/govuk-platform-security-reliability-team
+[Platform Engineering]: /platform-engineering


### PR DESCRIPTION
- Add a redirect from /platform-engineering so we have a stable URL to use in other docs such as repo READMEs.
- Add some links to Slack channels for convenience.
- Minor edits for clarity.