### PR TITLE
update links in doc

### DIFF
--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -24,13 +24,15 @@ Renaming a country affects these pages:
 
 This will update www.gov.uk/foreign-travel-advice/`<country_slug>` to www.gov.uk/foreign-travel-advice/`<new_country_slug>`.
 
-1. Change the relevant name and slug in the `lib/data/countries.yml` file. Keep `content_id` and `email_signup_content_id` the same, and ensure the alphabetical order of the list is respected. [Example](https://github.com/alphagov/travel-advice-publisher/pull/539/files#diff-e7c0733c6cf5a1d6fc1f2589a6d9f0f7)
+1. Change the relevant name and slug in the `lib/data/countries.yml` file. Keep `content_id` and `email_signup_content_id` the same, and ensure the alphabetical order of the list is respected. [Example](https://github.com/alphagov/travel-advice-publisher/pull/1876/files)
 
 2. Deploy Travel Advice Publisher
-   * Once the above pull request is ready, [deploy](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/parambuild/?TARGET_APPLICATION=travel-advice-publisher&DEPLOY_TASK=deploy:with_hard_restart) Travel Advice Publisher with a hard restart to update the countries YAML file.
+   * Once the above pull request is ready, [deploy](https://github.com/alphagov/travel-advice-publisher/actions/workflows/deploy.yml) Travel Advice Publisher to update the countries YAML file.
    * You will see the country has updated in the list in [Travel Advice Publisher](https://travel-advice-publisher.integration.publishing.service.gov.uk/admin)
 
 3. Run Rake tasks
+
+   kubectl exec deploy/travel-advice-publisher  -- rake
    * Run `country:rename[old_country_slug,new_country_slug]` to update the `TravelAdviceEdition`s.
    * Run `publishing_api:republish_edition[new_country_slug]` to update the Publishing API.
    * Run `publishing_api:republish_email_signups:country_edition[country-slug]` to update email subscriptions at `/foreign-travel-advice/<country_slug>/email-signup`
@@ -42,13 +44,13 @@ This will update www.gov.uk/foreign-travel-advice/`<country_slug>` to www.gov.uk
 
 ### 2. Update Worldwide Taxons
 
-**Example pull request:** [https://github.com/alphagov/search-api/pull/1436](https://github.com/alphagov/search-api/pull/1436)
+**Example pull request:** [https://github.com/alphagov/search-api/pull/2884/files](https://github.com/alphagov/search-api/pull/2884/files)
 
 This will update `www.gov.uk/world/<country_slug>` to `www.gov.uk/world/<new_country_slug>`.
 
 In [Search API](https://github.com/alphagov/search-api):
 
-1. Create a [pull request](https://github.com/alphagov/search-api/pull/1436) with a change to the relevant country taxon in `config/govuk_index/migrated_formats.yaml`
+1. Create a [pull request](https://github.com/alphagov/search-api/pull/2884/files) with a change to the relevant country taxon in `config/govuk_index/migrated_formats.yaml`
 2. Deploy Search API
 
 In [Content Tagger](https://content-tagger.integration.publishing.service.gov.uk/):
@@ -65,13 +67,13 @@ The old slug might still appear as a duplicate in our internal GOV.UK search,
 
 ### 3. Update Whitehall
 
-**Example pull request:** [https://github.com/alphagov/whitehall/pull/4643](https://github.com/alphagov/whitehall/pull/4643)
+**Example pull request:** [https://github.com/alphagov/whitehall/pull/8963](https://github.com/alphagov/whitehall/pull/8963)
 
 This will update `www.gov.uk/world/<country_slug>/news`.
 
 In [Whitehall](https://github.com/alphagov/whitehall):
 
-1. Create a [data migration](https://github.com/alphagov/whitehall/pull/4643/files) to update the `slug` and `name` fields of the `WorldLocation` table.
+1. Create a [data migration](https://github.com/alphagov/whitehall/pull/8963/files) to update the `slug` and `name` fields of the `WorldLocation` table.
 
 2. Deploy the changes
 
@@ -82,7 +84,7 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 
 ### 4. Update Smart-answers
 
-**Example pull request:** [https://github.com/alphagov/smart-answers/pull/3899/](https://github.com/alphagov/smart-answers/pull/3899/)
+**Example pull request:** [https://github.com/alphagov/smart-answers/pull/6755](https://github.com/alphagov/smart-answers/pull/6755)
 
 > **Note**
 >
@@ -96,7 +98,7 @@ This will update content from pages served by `smart-answers` such as:
 
 In [Smart-answers](https://github.com/alphagov/smart-answers):
 
-1. Create a [pull request](https://github.com/alphagov/smart-answers/pull/3899/) that replaces all instances of `country_name` with `new_country_name`.
+1. Create a [pull request](https://github.com/alphagov/smart-answers/pull/6755) that replaces all instances of `country_name` with `new_country_name`.
 
 2. Check changes are reflected in the affected smart answers
 
@@ -123,13 +125,13 @@ Each subscriber list also has a "slug", which appears in the query params of the
 
 ### 6. Remove duplicate search results
 
-In [Whitehall](https://github.com/alphagov/whitehall) run `SearchIndexDeleteWorker.perform_async(instance.search_index['slug'], instance.rummager_index)`
+In [Whitehall](https://github.com/alphagov/whitehall) run `SearchIndexDeleteWorker.perform_async(link, index)`
 
-Failing this, there is a [rake task](https://github.com/alphagov/search-api/blob/4f106e40f2c1690d631f699bf8fc63dc39268866/lib/tasks/delete.rake#L9) that takes care of this.
+For example `SearchIndexDeleteWorker.perform_async('/world/micronesia/news', 'government')`
 
 ### 7. Update Specialist Publisher
 
-1. Create and deploy pull requests for schemas in publishing api  ([example](https://github.com/alphagov/govuk-content-schemas/pull/1014)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1722/commits/79c10d173f8294fef25b07678a7e74213e78e424)) to support both countries temporarily (during the data migration). Note that the schema example PR given here is for the archived govuk-content-schemas repo - please update with a publishing api PR when this is available.
+1. Create and deploy pull requests for schemas in publishing api ([example](https://github.com/alphagov/publishing-api/pull/2712)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/2592)) to support both countries temporarily (during the data migration).
 
 2. Run the rake task `publishing_api:publish_finder[finder]` to republish the updated finders:
    * `export_health_certificates`
@@ -138,10 +140,10 @@ Failing this, there is a [rake task](https://github.com/alphagov/search-api/blob
 3. Run the rake task `rename_country:all[country_slug,new_country_slug]` to republish all the relevant documents.
 
 4. Check the country filter options have updated and documents appear with the new country filter set. This could take a few minutes due to the time it takes to republish the finder and all its associated documents.
-   * [Export Health Certificates](https://www-origin.integration.publishing.service.gov.uk/export-health-certificates?cachebust=123).
-   * [International Development Funds](https://www-origin.integration.publishing.service.gov.uk/international-development-funding?cachebust=123).
+   * [Export Health Certificates](https://www.integration.publishing.service.gov.uk/export-health-certificates?cachebust=123).
+   * [International Development Funds](https://www.integration.publishing.service.gov.uk/international-development-funding?cachebust=123).
 
-5. Create and deploy another pull request for content schemas in publishing api ([example](https://github.com/alphagov/govuk-content-schemas/pull/1015)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/1724)) to remove support for the old country. Note that the schema example PR given here is for the archived govuk-content-schemas repo - please update with a publishing api PR when this is available.
+5. Create and deploy another pull request for content schemas in publishing api ([example](https://github.com/alphagov/publishing-api/pull/2713)) and Specialist Publisher ([example](https://github.com/alphagov/specialist-publisher/pull/2593)) to remove support for the old country.
 
 6. Re-publish the finders again, as above.
 


### PR DESCRIPTION
Updating the documentation for renaming a country following the recent change made to Micronesia. The old documentation was quite old, so a lot of the links no longer worked. This PR updates the links and makes minor changes to reflect the current way of doing things. 

[Trello](https://trello.com/c/BjZeFZvx/2531-update-govuk-developer-docs-to-reflect-current-process-for-updating-the-name-of-a-country)


<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
