### PR TITLE
Update .govuk_dependabot_merger.yml to v2

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,28 +1,7 @@
-api_version: 1
-auto_merge:
-  - dependency: govuk_app_config
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_personalisation
-    allowed_semver_bumps:
-      - patch
-  - dependency: govuk_publishing_components
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_schemas
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_tech_docs
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: middleman-search-gds
-    allowed_semver_bumps:
-      - patch
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+api_version: 2
+defaults:
+  allowed_semver_bumps:
+    - patch
+    - minor
+  auto_merge: true
+  update_external_dependencies: false


### PR DESCRIPTION
Auto-merge all internal dependencies that are patch/minor. Could potentially enable external dependencies too, but haven't had time to investigate the code coverage in govuk-developer-docs yet, so keeping it as `false` for now as a precaution.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
