### PR TITLE
New documentation for document-collection emails

### DIFF
--- a/source/manual/document-collection-emails-a-special-case.html.md
+++ b/source/manual/document-collection-emails-a-special-case.html.md
@@ -1,0 +1,158 @@
+---
+owner_slack: "#govuk-developers"
+title: Document Collection emails - a special case
+section: Emails
+type: learn
+layout: manual_layout
+parent: "/manual.html"
+---
+
+[Document collections][document_collections_schema] are a type of GOV.UK page that is published by Whitehall, and rendered by [government-frontend][government-frontend]. This documentation seeks to explain how emails work on document collection pages, because at the time of writing, both the signup journey and the resulting email subscription for these pages are unique.
+
+[document_collections_schema]: /document-types/document_collection.html
+[government-frontend]: https://github.com/alphagov/government-frontend
+
+## Background: specialist topics retirement
+
+Prior to 2024, GOV.UK had three taxonomies:
+
+* Taxonomy Topics (`taxons`)
+* Mainstream Browse pages (`mainstream_browse_page`)
+* Specialist Topics (`topic`)
+
+In 2024, the Navigation team retired the Specialist Topic taxonomy. A result of this work was the roll out of two new email features that are present on document collection pages only.
+
+To understand why this complexity was needed, it's necessary to explain how specialist topics were retired, and the consequences of the retirement for email subscribers.
+
+### Specialist topic email subscriptions
+
+Like taxonomy topics, specialist topics supported email alerts i.e. it was possible for a user to subscribe to emails on a specialist topic page. As part of the retirement work, most specialist topic pages were archived and redirected to existing content on GOV.UK, and any email subscriptions were terminated.
+
+However around 50 high performing specialist topic pages were converted into document collections, and the original specialist topic page was redirected to the document collection conversion. For these pages, the migration of email subscribers from the specialist topic subscriber list, to the new document collection subscriber list was permitted.
+
+In the majority of these 50 pages, this is the action that was taken. However one department was concerned that a document collection email subscription was so different from a specialist topic email subscription, that the migration would not meet the needs of its existing and future email subscribers.
+
+It was necessary to address their concerns to unblock the retirement of specialist topics.
+
+### Key differences between specialist topic and document collection email subcriptions
+
+#### Breadth of subscription
+
+* A specialist topic email subscription would notify users when any content tagged to the specialist topic was updated and published as a major change. This meant that a specialist topic email subscription was very broad, because there was no limit to the number of pages that could be tagged to a specialist topic.
+
+* A document collection email subscription notifies users when either content listed on the document collection page, or the page itself, is updated and published as a major change. There is no technical limit to the number of links that can be added to a document collection, but sensible content design means that the number of linked content items on a document collection is far less than the number of pages that might be tagged to a specialist topic. For this reason a document collection email subscription is much narrower in scope.
+
+To address this difference, and unblock the retirement of specialist topics, a new feature was rolled out called a [Taxonomy topic email override][taxonomy-topic-section].
+
+This feature allows users to subscribe to a related taxonomy topic email list from a document collection page.
+
+A taxonomy topic email subscription is similar to a specialist topic subscription, because an email is triggered when changes are made to content tagged to the taxonomy topic. Provided all content that was previously tagged to the specialist topic, was now tagged to the related taxonomy topic, the email subscriptions created would be similar.
+
+[taxonomy-topic-section]: #what-is-a-taxonomy-topic-email-override
+
+#### Requirement for a GOV.UK Account
+
+* On Specialist topic pages, users subscribed to email alerts via the [Subscription links component][email-signup-subscription-links-heading]. This signup journey involved a user entering their email address and being sent a magic link to confirm their subscription. It was not necessary for the user to create or have an existing GOV.UK Account.
+
+* Document collection pages by contrast used the [Single page notification button component][email-signup-single-button-heading] as a route into the sign up journey. This journey was hardcoded to enfore the GOV.UK Account, in other words clicking the button took the user directly to the account signup/signin page. It was not possible to subscribe to email alerts without having or creating a GOV.UK Account.
+
+To address this difference, and unblock the retirement of specialist topics, a new variant of the single page notification button component was rolled out on document collection pages. This variant is configured to skip the GOV.UK Account, and sign the user up via a magic link instead. More information on how this feature works can be found on the [Email Signup Journeys documentation][email-signup-skip-account-heading] page.
+
+It's worth highlighting that although the single page notification button looks the same to the user, the page they are taken to after clicking the button on a document collection page is different to the page they are taken to when clicking the identical button on all other page types.
+
+[email-signup-subscription-links-heading]:/manual/email-signup-journeys.html#subscription-links-component
+[email-signup-single-button-heading]:/manual/email-signup-journeys.html#single-page-notification-button-component
+[email-signup-documentation]:/manual/email-signup-journeys.html
+[email-signup-skip-account-heading]:/manual/email-signup-journeys.html#how-does-the-skip-account-feature-work
+
+### What is a Taxonomy topic email override
+
+* A taxonomy_topic_email_overide is a type of link that [can only be added to document collections][document-collection-schema] **that have never previously been published**.
+* The field is set via a rake task in Whitehall.
+
+* The taxonomy_topic_email_overide stores the content_id of a taxonomy topic that a user will be subcribed to when signing up for emails on the document collection page.
+
+### How does the Taxonomy topic email override field work
+
+When rendering a document collection page, government frontend checks for the presence of a taxonomy_topic_email_override link in the content item.
+
+* If a link is found, the page is rendered with a [sign up link component][email-signup-documentation signup-link-heading] that will find or create a taxonomy topic email subscription for the topic stored in the field.
+
+* If no link is found, the page is rendered with a [single page notification button][email-signup-single-button-heading] that will sign the user up to a standard document collection email list instead.
+
+[document-collection-schema]: https://github.com/alphagov/publishing-api/blob/main/content_schemas/formats/document_collection.jsonnet#L69-L71
+
+[email-signup-documentation signup-link-heading]:/manual/email-signup-journeys.html#signup-link-component
+[email-signup-single-button-heading]:/manual/email-signup-journeys.html#single-page-notification-button-component
+[email-signup-subscription-link-heading]:/manual/email-signup-journeys.html#subscription-links-component
+[email-signup-subscription-link-heading]:/manual/email-signup-journeys.html#subscription-links-component
+[email_signup_component_guide]: https://components.publishing.service.gov.uk/component-guide/signup_link
+
+### How to set a taxonomy_topic_email_override
+
+**As mentioned above, it is only possible to set this field on document collections that have never been published before.**
+
+> Once a document is published with a taxonomy_topic_email_override, the field cannot be changed.
+
+#### Warning: Do not set this field unless you have an exceptionally good reason
+
+The following developer steps should **only** be taken if the request has comes from a content designer that has followed the guidance set out in [HMRC topic document collections: guidance for JCDs on 2nd line][content_documentation]. This is because once published, the field cannot be changed, so it's important that any government publisher requesting this feature has been talked through the risks and benefits before the override is set.
+
+[content_documentation]: https://docs.google.com/document/d/1MR5OaFG_DOCmWGL9o9MSGIPLMFe2mmSrV6Va-99cSzw/edit#heading=h.y6ckz26uo2lf
+
+#### 1. Find the id of the document collection
+
+* Log into the whitehall admin UI via signon.
+* The ID can be taken from the URL of the document collection. E.g. `12345` for a document_collection at URL `whitehall-admin.publishing.service.gov.uk/government/admin/collections/12345`
+
+#### 2.  Run the rake task
+
+The taxonomy_topic_email_override field can be set by running the following [rake task][whitehall_rake_task] from a Whitehall machine. This task runs in dry_run mode by default, unless a confirmation string is passed in. If the document collection has previously been published an error will be raised.
+
+DRY RUN:
+>`rake:set_taxonomy_topic_email_override[document_collection_id,taxon_content_id]`
+
+FOR REAL:
+>`rake:set_taxonomy_topic_email_override[document_collection_id,taxon_content_id,run_for_real]`
+
+[whitehall_rake_task]: https://github.com/alphagov/whitehall/blob/main/lib/tasks/set_taxonomy_topic_email_override.rake
+
+### What to do if you're asked to set or update a taxonomy topic email override field on a live page
+
+As mentioned above, it is not possible to set this field unless the document collection is new and never before published. However it is possible to create new content with a taxonomy topic email override, to replace the original.
+
+The steps to take depend on whether the original document collection was published with or without a taxonomy_topic_email_overide.
+
+#### Setting a taxonomy_topic_email_override on pages that have already been published without one
+
+#### Step one - create a replacement document collection
+
+1. The department must create a draft for a new document collection, that will replace the existing one.
+2. A developer sets a taxonomy topic email override on the replacement document by following the steps [above][how-to-set].
+3. The department confirms that the email override has been set to the correct taxonomy topic by checking the email notification tab on the document collection edit page in Whitehall. **The department must not publish the page until Step two below is complete.**
+4. Department publishes the page.
+5. Content designer unpublishes the original page and creates a redirect from the old document collection to the new document collection.
+
+[how-to-set]: #1-find-the-content-id-of-the-document-collection
+
+#### Step two - migrate any orphaned email subscribers
+
+As described [above][how-does-it-work], if the original page was published without a taxonomy_topic_email_override, the page would have displayed a single page notification button that subscribed users to a standard document collection email list.
+
+Those email subscribers can be bulk migrated to the appropriate taxonomy topic SubscriberList before the document collection page is unpublished and redirected.
+
+Run the `data_migration:move_all_subscribers` [rake task][bulk-migrate-rake] from an email-alert-api machine.
+
+[how-does-it-work]: #how-does-the-taxonomy-topic-email-override-field-work
+[bulk-migrate-rake]:https://github.com/alphagov/email-alert-api/blob/main/lib/tasks/data_migration.rake#L4-L11
+
+#### Overriding an existing taxonomy_topic_email_override for previously published pages
+
+In this case, we can create replacement content as described in [step one][step-one] above. However we cannot migrate any email subscribers that have signed up whilst the page was live.
+
+This is because if the original page was published with an override, the page would have displayed a [Sign up link][how-it-works] that subscribed users to a taxonomy topic email list.
+
+Email alert API does not store information about the page from which a user subscribed to a links-based list. So it is not possible to confidently identify the users that need to be migrated (as some could have signed up from the taxonomy page itself). This limitation/risk was acknowledged by both the department, and senior leadership when the feature was rolled out.
+
+[step-one]: #step-one---create-a-replacement-document-collection
+[how-it-works]: #how-does-the-taxonomy-topic-email-override-field-work

--- a/source/manual/email-signup-journeys.html.md
+++ b/source/manual/email-signup-journeys.html.md
@@ -1,0 +1,73 @@
+---
+owner_slack: "#govuk-notifications"
+title: "Email signup journeys and email subscriptions across GOV.UK"
+section: Emails
+type: learn
+layout: manual_layout
+parent: "/manual.html"
+---
+
+There are a number of different ways that a user can subscribe to email notifications on GOV.UK. This documentation seeks to explain the different signup journeys, and types of subscription that are created.
+
+## Email sign up entry points
+
+### Single page notification button component
+
+[The single page notification button component][single-page-notification-button] was rolled out in early 2022, and is present on many pages types including Call for evidence, Consultations, Detailed guides, Document collections and Publications. This signup flow subscribes users to a [content-id based][email-alert-api-documentation-content-id] email subscription.
+
+The button was designed to enforce the GOV.UK account, in other words the user would be forced to sign-in or create an account to be able to complete their subscription journey. This tight coupling with the account was by design, to help increase the number of users signing up to the new GOV.UK account.
+
+Since its initial roll out, the component has been extended so that it can now be [configured][skip-account-documentation] to skip the account sign up flow, and allow users to sign up via a magic link instead. At the time of writing, this customisation has only been implemented on Document collection pages. You can read about the reasons for this feature here: [Document Collection emails - a special case][document-collection-emails-documenation]
+
+[document-collection-emails-documenation]: /manual/document-collection-emails-a-special-case.html.md
+
+#### How does the skip account feature work?
+
+- By default, the button will post to `/email/subscriptions/single-page/new?topic_id=slug` which is served by email-alert-frontend's [govuk_account_signups controller][email-alert-frontend-account-controller]. This route enforces the GOV.UK account.
+- If the [skip_account paramater is present][govuk-publishing-components-present], the button will post to `/email-signup/?link=/slug` which is served by email-alert-frontend's [content_item_signups controller][email-alert-frontend-content-item-controller]. This route signs the user up by magic link.
+
+[single-page-notification-button]: https://components.publishing.service.gov.uk/component-guide/single_page_notification_button
+[skip-account-documentation]: https://components.publishing.service.gov.uk/component-guide/single_page_notification_button/with_skip_account
+[email-alert-api-documentation-content-id]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md#uuid-field
+[email-alert-frontend-account-controller]:https://github.com/alphagov/email-alert-frontend/blob/main/config/routes.rb#L39
+[govuk-publishing-components-present]: https://github.com/alphagov/govuk_publishing_components/blob/main/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb#L64-L66
+
+### Sign up link component
+
+[The Sign up link component][sign-up-link] predates the single page notification button, and is present on taxonomy topic pages only (see [here][taxonomy-topic-example] for an example). When subscribing to a topic that has subtopics, a checkbox form allows users to select which subtopics they would like to receive alerts about.
+
+This component posts to `/email-signup/?link=/slug` which is served by email-alert-frontend's [content_item_signups controller][email-alert-frontend-content-item-controller]. This controller makes a request to Email Alert API for a [links-based][email-alert-api-documentation-links] email subscription.
+
+The signup journey does not enforce the GOV.UK account, the user must enter an email address and is sent a magic link to confirm their subscription.
+
+[sign-up-link]: https://components.publishing.service.gov.uk/component-guide/signup_link
+[taxonomy-topic-example]: https://www.gov.uk/education
+[email-alert-api-documentation-links]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md#json-fields
+[email-alert-frontend-content-item-controller]: https://github.com/alphagov/email-alert-frontend/blob/main/config/routes.rb#L11
+
+### Subscription links component
+
+[The Subscription links component][subscription-links] is used on many pages, including:
+
+- the announcements section of some [people pages][people-finder] (there's an example [here][rishi-sunak-page])
+- organisation pages
+- service manual pages
+- specialist finders
+- topical event pages
+- travel advice pages
+- world location news pages
+- world wide taxon pages
+
+The signup journey does not enforce the GOV.UK account, the user must enter an email address and is sent a magic link to confirm their subscription.
+
+On Travel advice pages, the component posts to `/email/subscriptions/new?frequency=whatever&topic_id=slug` which is served by email-alert-frontend's [subscriptions controller][email-alert-frontend-subscriptions-controller]. This signup flow is the only place that the legacy [email_alert_signup][email-alert-schema] schema is currently used. The subscription that is created is [tag-based][email-alert-api-documentation-links].
+
+You can read more about how email subscriptions work on specialist finders and the other page types mentioned above [here][finder-frontend-docs]
+
+[subscription-links]: https://components.publishing.service.gov.uk/component-guide/subscription_links
+[people-finder]: https://www.gov.uk/government/people
+[rishi-sunak-page]: https://www.gov.uk/government/people/rishi-sunak
+[email-alert-frontend-subscriptions-controller]:https://github.com/alphagov/email-alert-frontend/blob/main/config/routes.rb#L35
+[finder-frontend-docs]https://github.com/alphagov/finder-frontend/blob/main/docs/finder-email-alerts.md
+[email-alert-schema]: https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+[email-alert-api-documentation-links]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md#json-fields

--- a/source/manual/email-signup-journeys.html.md
+++ b/source/manual/email-signup-journeys.html.md
@@ -24,12 +24,12 @@ Since its initial roll out, the component has been extended so that it can now b
 #### How does the skip account feature work?
 
 - By default, the button will post to `/email/subscriptions/single-page/new?topic_id=slug` which is served by email-alert-frontend's [govuk_account_signups controller][email-alert-frontend-account-controller]. This route enforces the GOV.UK account.
-- If the [skip_account paramater is present][govuk-publishing-components-present], the button will post to `/email-signup/?link=/slug` which is served by email-alert-frontend's [content_item_signups controller][email-alert-frontend-content-item-controller]. This route signs the user up by magic link.
+- If the [skip_account parameter is present][govuk-publishing-components-present], the button will post to `/email-signup/?link=/slug` which is served by email-alert-frontend's [content_item_signups controller][email-alert-frontend-content-item-controller]. This route signs the user up by magic link.
 
 [single-page-notification-button]: https://components.publishing.service.gov.uk/component-guide/single_page_notification_button
 [skip-account-documentation]: https://components.publishing.service.gov.uk/component-guide/single_page_notification_button/with_skip_account
 [email-alert-api-documentation-content-id]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md#uuid-field
-[email-alert-frontend-account-controller]:https://github.com/alphagov/email-alert-frontend/blob/main/config/routes.rb#L39
+[email-alert-frontend-account-controller]:https://github.com/alphagov/email-alert-frontend/blob/810f3bd43dde903ca85cbf99c073c61bf037ca16/config/routes.rb#L39
 [govuk-publishing-components-present]: https://github.com/alphagov/govuk_publishing_components/blob/main/lib/govuk_publishing_components/presenters/single_page_notification_button_helper.rb#L64-L66
 
 ### Sign up link component
@@ -43,7 +43,7 @@ The signup journey does not enforce the GOV.UK account, the user must enter an e
 [sign-up-link]: https://components.publishing.service.gov.uk/component-guide/signup_link
 [taxonomy-topic-example]: https://www.gov.uk/education
 [email-alert-api-documentation-links]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md#json-fields
-[email-alert-frontend-content-item-controller]: https://github.com/alphagov/email-alert-frontend/blob/main/config/routes.rb#L11
+[email-alert-frontend-content-item-controller]: https://github.com/alphagov/email-alert-frontend/blob/810f3bd43dde903ca85cbf99c073c61bf037ca16/config/routes.rb#L11
 
 ### Subscription links component
 


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

Add documentation to explain the taxonomy_topic_email_override feature present on some document collection pages.

- [Rendered page 1](https://github.com/alphagov/govuk-developer-docs/blob/b2b5ac2b940efea67bf8ad41de5db134fb45ec01/source/manual/document-collection-emails-a-special-case.html.md)
- [Rendered page 2](https://github.com/alphagov/govuk-developer-docs/blob/b2b5ac2b940efea67bf8ad41de5db134fb45ec01/source/manual/email-signup-journeys.html.md)
- Trello cards: 
https://trello.com/c/OSr529Am/2080-workflow-to-manage-future-requests-from-hmrc-to-set-topic-level-email-notifications-on-new-not-yet-published-document-collection
https://trello.com/c/apWwP9dh/2554-complete-any-gaps-in-our-technical-documentation-for-specialist-topic-retirement