### PR TITLE
Replace govuk-chat repo name

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -263,7 +263,7 @@
 
 - repo_name: govuk-chat
   private_repo: true
-  team: "#ai-govuk"
+  team: "#dev-notifications-ai-govuk"
   type: AI apps
 
 - repo_name: govuk-content-api-docs


### PR DESCRIPTION
The team configuration for AI is based on the #dev-notifications-ai-govuk team name (see: https://github.com/alphagov/seal/blob/74724c9cd1f64e7cbbf18b3d756f864323440007/config/alphagov.yml#L28-L42) which is why we're not getting any notifications about PRs for this application from seal

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
