### PR TITLE
Redirected paths have to end in `.html`.

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -197,4 +197,4 @@ redirects:
   /manual/user-management-in-aws.html: /manual/get-started.html
   /manual/welcome-to-2nd-line.html: /manual/2nd-line.html
   /manual/whitelist-site-in-transition.html: /manual/allowlist-site-in-transition.html
-  /platform-engineering: /kubernetes/contact-platform-engineering-team.html
+  /platform-engineering.html: /kubernetes/contact-platform-engineering-team.html

--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -55,4 +55,4 @@ The GOV.UK 2nd Line Tech Support team ([#govuk-2ndline-tech])
 [#govuk-developers]: https://gds.slack.com/channels/govuk-developers
 [#govuk-platform-engineering]: https://gds.slack.com/channels/govuk-platform-engineering
 [#govuk-platform-security-reliability-team]: https://gds.slack.com/channels/govuk-platform-security-reliability-team
-[Platform Engineering]: /platform-engineering
+[Platform Engineering]: /platform-engineering.html


### PR DESCRIPTION
AFAICT the only way to influence [content-type/disposition in GitHub Pages] is by making the filename of the resource [match the desired MIME type].

[content-type/disposition in GitHub Pages]: https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#mime-types-on-github-pages
[match the desired MIME type]: https://github.com/jshttp/mime-db/blob/master/db.json