### PR TITLE
Add note about auto rotation

### DIFF
--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -17,7 +17,7 @@ expiring tokens to ensure the associated application keeps working.
 
 If the token is for `Trade Tariff Admin` or `Trade Tariff Backend`, see [Trade Tariff Admin on the Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/3155099649/Trade+Tariff+Admin)
 
-If the token is for `Signon API Client (permission and suspension updater)`, talk with the [Publishing Platform team](https://gds.slack.com/channels/govuk-publishing-platform).
+If the token is for `Signon API Client (permission and suspension updater)` then the key will rotate automatically and the alert can be ignored.
 
 ### 1. Issue a new token
 


### PR DESCRIPTION
These keys auto rotate, so just adding a note about it until we can axe that alert for that api user

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
