### PR TITLE
Add GOV.UK mobile section

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos-types (1.14.0)
       google-protobuf (~> 3.18)
@@ -325,6 +326,8 @@ GEM
       net-protocol
     nio4r (2.7.3)
     nokogiri (1.16.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
@@ -709,6 +712,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/config.rb
+++ b/config.rb
@@ -77,3 +77,8 @@ data.analytics.trackers.each do |tracker|
   tracker_name = tracker["name"].downcase.gsub(" ", "_")
   proxy "analytics/tracker_#{tracker_name}.html", "analytics/templates/tracker.html", locals: { tracker: }
 end
+
+# Configuration for Mobile pages
+ignore "mobile/templates/*"
+
+page "mobile/*", layout: :mobile_layout

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -65,3 +65,8 @@
         - name: Document types
           url: /document-types.html
           description: The kinds of documents that are published on GOV.UK using one of the schemas.
+    - name: GOV.UK mobile
+      sites:
+        - name: GOV.UK mobile
+          url: /mobile/
+          description: Documentation related to the GOV.UK mobile app and it's development.

--- a/data/mobile/navigation.yml
+++ b/data/mobile/navigation.yml
@@ -1,0 +1,21 @@
+mobile:
+  name: GOV.UK mobile application
+  desc: This site contains documentation relating to the GOV.UK mobile application. It exists to aid developers on the GOV.UK mobile team, but is available to anyone who may find our approach useful.
+
+general:
+  name: General
+  desc: Documentation relating to general mobile application topics that are not specific to either the Android or iOS platforms.
+  link_title: View
+  link: /mobile/general/
+
+android:
+  name: Android
+  desc: Documentation relating to Android specific topics.
+  link_title: View
+  link: /mobile/android/
+
+ios:
+  name: iOS
+  desc: Documentation relating to iOS specific topics.
+  link_title: View
+  link: /mobile/ios/

--- a/source/layouts/mobile_layout.html.erb
+++ b/source/layouts/mobile_layout.html.erb
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+
+<head>
+  <meta charset="utf-8">
+  <title><%= yield_content(:title) || create_page_title(false) %></title>
+  <link rel="stylesheet" type="text/css" href="/stylesheets/screen.css"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0c0c">
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <% meta_tags.tags.each do |name, content| %>
+    <%= tag :meta, name: name, content: content %>
+  <% end %>
+
+  <% meta_tags.opengraph_tags.each do |property, content| %>
+    <%= tag :meta, property: property, content: content %>
+  <% end %>
+  <%= partial 'partials/cookie_wrapper' %>
+</head>
+
+<body class="govuk-template__body ">
+  <script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+
+  <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+  <header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container">
+      <div class="govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/mobile/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <a href="/mobile/" class="govuk-header__link govuk-header__service-name">
+            GOV.UK mobile
+          </a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="govuk-width-container ">
+    <main class="govuk-main-wrapper">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <ul class="govuk-list">
+            <li>
+              <%= link_to "GOV.UK Developer docs", "/", class: "govuk-link" %>
+            </li>
+          </ul>
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          <ul class="govuk-list">
+            <li>
+              <%= link_to "GOV.UK mobile", "/mobile/", class: "govuk-link" %>
+            </li>
+          </ul>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>
+              <%= link_to data.mobile.navigation.general.name, data.mobile.navigation.general.link, class: "govuk-link" %>
+            </li>
+            <li>
+              <%= link_to data.mobile.navigation.android.name, data.mobile.navigation.android.link, class: "govuk-link" %>
+            </li>
+            <li>
+              <%= link_to data.mobile.navigation.ios.name, data.mobile.navigation.ios.link, class: "govuk-link" %>
+            </li>
+          </ul>
+        </div>
+
+        <div class="govuk-grid-column-two-thirds" id="main-content" role="main">
+          <%= yield %>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          <ul class="govuk-footer__inline-list">
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/cookies.html">
+                Cookies
+              </a>
+            </li>
+          </ul>
+          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+          </svg>
+          <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+        </div>
+        <div class="govuk-footer__meta-item">
+          <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/javascripts/application.js"></script>
+  <script>
+    window.GOVUKFrontend.initAll()
+  </script>
+</body>
+</html>

--- a/source/mobile/android/index.html.md.erb
+++ b/source/mobile/android/index.html.md.erb
@@ -1,0 +1,17 @@
+<% content_for :title, create_page_title(data.mobile.navigation.android.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.mobile.navigation.android.name %>
+</h1>
+
+<p class="govuk-body"><%= data.mobile.navigation.android.desc %></p>
+
+<% if data.mobile.navigation.android.subsections %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% data.mobile.navigation.android.subsections.each do |subsection| %>
+      <li>
+        <%= link_to subsection.name, subsection.link, class: "govuk-link" %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/source/mobile/general/architecture.html.md.erb
+++ b/source/mobile/general/architecture.html.md.erb
@@ -1,0 +1,3 @@
+<% content_for :title, create_page_title(data.mobile.navigation.general.name) %>
+
+<h1 class="govuk-heading-l">Architecture</h1>

--- a/source/mobile/general/index.html.md.erb
+++ b/source/mobile/general/index.html.md.erb
@@ -1,0 +1,17 @@
+<% content_for :title, create_page_title(data.mobile.navigation.general.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.mobile.navigation.general.name %>
+</h1>
+
+<p class="govuk-body"><%= data.mobile.navigation.general.desc %></p>
+
+<% if data.mobile.navigation.general.subsections %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% data.mobile.navigation.general.subsections.each do |subsection| %>
+      <li>
+        <%= link_to subsection.name, subsection.link, class: "govuk-link" %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/source/mobile/index.html.md.erb
+++ b/source/mobile/index.html.md.erb
@@ -1,0 +1,57 @@
+<h1 class="govuk-heading-l">
+  <%= data.mobile.navigation.mobile.name %>
+</h1>
+
+<p class="govuk-body">
+  <%= data.mobile.navigation.mobile.desc %>
+</p>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-7">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">
+      <%= data.mobile.navigation.general.name %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= data.mobile.navigation.general.desc %>
+    </p>
+
+    <p class="govuk-body">
+      <a href="<%= data.mobile.navigation.general.link %>" class="govuk-link">
+        <%= data.mobile.navigation.general.link_title %>
+      </a>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">
+      <%= data.mobile.navigation.android.name %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= data.mobile.navigation.android.desc %>
+    </p>
+
+    <p class="govuk-body">
+      <a href="<%= data.mobile.navigation.android.link %>" class="govuk-link">
+        <%= data.mobile.navigation.android.link_title %>
+      </a>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">
+      <%= data.mobile.navigation.ios.name %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= data.mobile.navigation.ios.desc %>
+    </p>
+
+    <p class="govuk-body">
+      <a href="<%= data.mobile.navigation.ios.link %>" class="govuk-link">
+        <%= data.mobile.navigation.ios.link_title %>
+      </a>
+    </p>
+  </div>
+</div>

--- a/source/mobile/ios/index.html.md.erb
+++ b/source/mobile/ios/index.html.md.erb
@@ -1,0 +1,17 @@
+<% content_for :title, create_page_title(data.mobile.navigation.ios.name) %>
+
+<h1 class="govuk-heading-l">
+  <%= data.mobile.navigation.ios.name %>
+</h1>
+
+<p class="govuk-body"><%= data.mobile.navigation.ios.desc %></p>
+
+<% if data.mobile.navigation.ios.subsections %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% data.mobile.navigation.ios.subsections.each do |subsection| %>
+      <li>
+        <%= link_to subsection.name, subsection.link, class: "govuk-link" %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
This change adds a new section (similar in style to the Analytics section) for the GOV.UK mobile application. 

We do not introduce too much by way of document structure at this point, preferring to leave those decisions for later. However, as the application itself is mobile native - i.e. built in iOS and Android - it does give a broad set of initial sections: 

- iOS - for iOS specific documentation
- Android - for Android specific documentation
- General - for documentation that is either the same for both iOS and Android, or documents that describe more general and architectural elements of the system and its development. 

Actual documentation will of course, come later.


| Screenshots |
| --- |
| ![Screenshot 2024-05-08 at 15 08 11](https://github.com/alphagov/govuk-developer-docs/assets/44037625/4366c21e-66d7-4bd7-b840-afe04cbe7ef4) |
| ![Screenshot 2024-05-08 at 15 08 35](https://github.com/alphagov/govuk-developer-docs/assets/44037625/3d00bc34-d2dd-4498-81d6-75924974675c) |

