### PR TITLE
Add GOV.UK mobile section

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos-types (1.14.0)
       google-protobuf (~> 3.18)
@@ -327,6 +328,8 @@ GEM
       net-protocol
     nio4r (2.7.3)
     nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
@@ -712,6 +715,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,6 +16,7 @@ header_links:
   Kubernetes: /kubernetes/
   Apps: /apps.html
   Repos: /repos.html
+  Mobile: /mobile/
   Schemas: /content-schemas.html
   Document types: /document-types.html
 

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -52,6 +52,9 @@
         - name: GOV.UK Kubernetes manual
           url: /kubernetes/
           description: The developer manuals for GOV.UK's Kubernetes clusters.
+        - name: GOV.UK mobile manual
+          url: /mobile/
+          description: The developer manuals for GOV.UK's mobile app.
     - name: GOV.UK analytics
       sites:
         - name: Analytics

--- a/source/mobile/android/index.html.md.erb
+++ b/source/mobile/android/index.html.md.erb
@@ -1,0 +1,11 @@
+---
+title: Android
+weight: 30
+layout: multipage_layout
+---
+
+# Android
+
+## GitHub repositories
+
+<%= partial "partials/repo/mobile", locals: { os: "android" } %>

--- a/source/mobile/general/index.html.md
+++ b/source/mobile/general/index.html.md
@@ -1,0 +1,7 @@
+---
+title: General
+weight: 20
+layout: multipage_layout
+---
+
+# General

--- a/source/mobile/index.html.md
+++ b/source/mobile/index.html.md
@@ -1,0 +1,22 @@
+---
+title: GOV.UK mobile app documentation for developers
+weight: 1
+layout: multipage_layout
+---
+
+<div class="govuk-notification-banner govuk-!-margin-top-6 govuk-!-margin-bottom-6" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      The mobile app is a work in progress and not currently live.
+    </p>
+  </div>
+</div>
+
+# GOV.UK mobile app documentation for developers
+
+Use this documentation to find technical information about the GOV.UK mobile app. It will cover iOS, Android and general information relating to both versions.

--- a/source/mobile/ios/index.html.md.erb
+++ b/source/mobile/ios/index.html.md.erb
@@ -1,0 +1,11 @@
+---
+title: iOS
+weight: 30
+layout: multipage_layout
+---
+
+# iOS
+
+## GitHub repositories
+
+<%= partial "partials/repo/mobile", locals: { os: "ios" } %>

--- a/source/partials/repo/_mobile.html.erb
+++ b/source/partials/repo/_mobile.html.erb
@@ -1,0 +1,15 @@
+<%
+  mobile_repos = data["repos"].to_a.map do |repo|
+    if repo.type == "Mobile apps" && repo.repo_name.include?(os)
+      "<a href=\"https://github.com/alphagov/#{repo.repo_name}\" class=\"govuk-link\"
+      rel=\"noreferrer noopener\" target=\"_blank\">#{repo.repo_name}:</a> #{repo.description}"
+    end
+  end
+%>
+
+<%=
+  GovukPublishingComponents.render(
+    "govuk_publishing_components/components/list",
+    items: mobile_repos.compact
+  )
+%>


### PR DESCRIPTION
This change adds a new section for the GOV.UK mobile app documentation. 

We do not introduce too much by way of document structure at this point, preferring to leave those decisions for later. However, as the app itself is mobile native - i.e. is built in iOS and Android - it does naturally suggest a broad set of initial sections: 

- iOS - for iOS specific documentation
- Android - for Android specific documentation
- General - for documentation that is either the same for both iOS and Android, or documents that describe more general and architectural elements of the system and its development. 

GitHub repository links have been added for iOS and Android.

A [Notification banner](https://design-system.service.gov.uk/components/notification-banner/) has also been added to the `/mobile` page indicating that the mobile app (and therefore the documentation) is a work in progress.

| Screenshots |
| --- |
| ![Screenshot 2024-05-10 at 15 42 48](https://github.com/alphagov/govuk-developer-docs/assets/44037625/810820c9-5100-496f-b809-b95efc0a4c4b) |
| ![Screenshot 2024-05-10 at 15 42 23](https://github.com/alphagov/govuk-developer-docs/assets/44037625/14ab68f2-52f5-4ef3-b699-5f00cd5d30c8) |
| ![Screenshot 2024-05-10 at 15 43 25](https://github.com/alphagov/govuk-developer-docs/assets/44037625/e57f50e3-abd5-4a4f-a39f-96dc39a0557d) |
| ![Screenshot 2024-05-10 at 15 43 07](https://github.com/alphagov/govuk-developer-docs/assets/44037625/8fd51c2d-1354-4fb6-97ed-5a34b6909d30) |

[Jira GOVAPP-453](https://govukverify.atlassian.net/jira/software/projects/GOVAPP/boards/405?selectedIssue=GOVAPP-453)