### PR TITLE
Add note about cronjob

### DIFF
--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -13,6 +13,10 @@ expiring tokens to ensure the associated application keeps working.
 
 > 🪨 This procedure is [toil](https://sre.google/workbook/eliminating-toil/) and should be eliminated or automated away. For now, it's unfortunately still a manual process.
 
+Note that the overnight token sync cronjob will over-write any changes made in the Staging environment to match those in the Production environment so this procedure need only be followed for the Production and Integration environments. Any alerts relating to the Staging environment can be safely ignored.
+
+The Integration environment should also be updated overnight but this is not happening currently. It is a known issue that when fixed will mean this procedure will need only to be followed for the Production environment.
+
 ### Special cases
 
 If the token is for `Trade Tariff Admin` or `Trade Tariff Backend`, see [Trade Tariff Admin on the Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/3155099649/Trade+Tariff+Admin)


### PR DESCRIPTION
This change adds a note to the "Signon API user token expires soon" section to the effect that any alerts relating to Staging (currently) and Integration (in the future) do not need any action. This is because the overnight cronjob updates the token in this environment to match any changes made in Production.  The change is shown in the screenshot below. 

|Current|Updated|
|-|-|
|![Screenshot 2024-05-17 at 12 30 47](https://github.com/alphagov/govuk-developer-docs/assets/6080548/ebff6929-1ee9-47a0-a8e4-f8ef629c9c0f)|![Screenshot 2024-05-17 at 12 30 18](https://github.com/alphagov/govuk-developer-docs/assets/6080548/279a6987-dd7b-4bab-aa02-633e8db178bb)|

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
