### PR TITLE
Set ckan-functional-tests to retire

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -45,6 +45,7 @@
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
   sentry_url: false
+  retired: true
 
 - repo_name: ckan-helm
   type: Utilities


### PR DESCRIPTION
This repo was useful as part of the python 2 to 3 upgrade and replatforming but as those have now been completed it has been retired.

