### PR TITLE
Fix site search

### DIFF
--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,5 +1,5 @@
 //= require govuk_tech_docs
-//= require govuk_publishing_components/dependencies
+//= require dependencies
 //= require govuk_publishing_components/lib/trigger-event
 //= require govuk_publishing_components/lib/cookie-functions
 //= require govuk_publishing_components/lib/cookie-settings
@@ -7,72 +7,3 @@
 //= require govuk_publishing_components/components/tabs
 //= require govuk_publishing_components/load-analytics
 //= require filter-list
-
-// reworked version of modules.js from govuk_publishing_components
-// needed to manually start tech docs gem modules now that we're including
-// the modules code from govuk_publishing_components
-var devdocsModulesFind = function () {
-  container = document
-
-  var modules
-  var moduleSelector = '[data-module]'
-
-  modules = container.querySelectorAll(moduleSelector)
-  var modulesArray = []
-  // convert nodelist of modules to array
-  for (var i = 0; i < modules.length; i++) {
-    modulesArray.push(modules[i])
-  }
-
-  // Container could be a module too
-  if (container !== document && container.getAttribute('data-module')) {
-    modulesArray.push(container)
-  }
-  return modulesArray
-}
-
-var devdocsModulesStart = function () {
-  var GOVUK = window.GOVUK
-  var modules = devdocsModulesFind()
-
-  for (var i = 0, l = modules.length; i < l; i++) {
-    var element = modules[i]
-    var moduleNames = element.getAttribute('data-module').split(' ')
-
-    for (var j = 0, k = moduleNames.length; j < k; j++) {
-      var moduleName = camelCaseAndCapitalise(moduleNames[j])
-      var started = element.getAttribute('data-' + moduleNames[j] + '-module-started')
-      if (typeof GOVUK.Modules[moduleName] === 'function' && !started) {
-        try {
-          var module = new GOVUK.Modules[moduleName]
-          module.start($(element))
-          element.setAttribute('data-' + moduleNames[j] + '-module-started', true)
-        } catch (e) {
-          // if there's a problem with the module, catch the error to allow other modules to start
-          console.error('Error starting ' + moduleName + ' component JS: ' + e.message, window.location)
-        }
-      }
-    }
-  }
-
-  // eg selectable-table to SelectableTable
-  function camelCaseAndCapitalise (string) {
-    return capitaliseFirstLetter(camelCase(string))
-  }
-
-  // http://stackoverflow.com/questions/6660977/convert-hyphens-to-camel-case-camelcase
-  function camelCase (string) {
-    return string.replace(/-([a-z])/g, function (g) {
-      return g.charAt(1).toUpperCase()
-    })
-  }
-
-  // http://stackoverflow.com/questions/1026069/capitalize-the-first-letter-of-string-in-javascript
-  function capitaliseFirstLetter (string) {
-    return string.charAt(0).toUpperCase() + string.slice(1)
-  }
-}
-
-$(document).ready(function() {
-  devdocsModulesStart()
-})

--- a/source/javascripts/dependencies.js
+++ b/source/javascripts/dependencies.js
@@ -1,0 +1,24 @@
+/* eslint-env */
+
+// Copied without change from the govuk-publishing-components gem
+// to allow use of a custom modules.js with jQuery support
+
+// This adds in javascript that initialises components and dependencies
+// that are provided by Slimmer in public frontend applications.
+// = require ./modules.js
+
+$(document).ready(function() {
+  window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
+  window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {};
+
+  // if statements ensure these functions don't execute during testing
+  if (typeof window.GOVUK.loadAnalytics !== "undefined") {
+    window.GOVUK.loadAnalytics.loadExtraDomains();
+    if (typeof window.GOVUK.analyticsGa4.vars === "undefined") {
+      window.GOVUK.loadAnalytics.loadGa4();
+    }
+    if (typeof window.GOVUK.analyticsVars.gaProperty === "undefined") {
+      window.GOVUK.loadAnalytics.loadUa();
+    }
+  }
+});

--- a/source/javascripts/modules.js
+++ b/source/javascripts/modules.js
@@ -1,0 +1,85 @@
+// reworked version of modules.js from govuk_publishing_components to support jQuery
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.modules = {
+    find: function (container) {
+      container = container || document
+
+      var modules
+      var moduleSelector = '[data-module]'
+
+      modules = container.querySelectorAll(moduleSelector)
+      var modulesArray = []
+      // convert nodelist of modules to array
+      for (var i = 0; i < modules.length; i++) {
+        modulesArray.push(modules[i])
+      }
+
+      // Container could be a module too
+      if (container !== document && container.getAttribute('data-module')) {
+        modulesArray.push(container)
+      }
+      return modulesArray
+    },
+
+    start: function (container) {
+      var modules = this.find(container)
+
+      for (var i = 0, l = modules.length; i < l; i++) {
+        var element = modules[i]
+        var moduleNames = element.getAttribute('data-module').split(' ')
+
+        for (var j = 0, k = moduleNames.length; j < k; j++) {
+          var moduleName = camelCaseAndCapitalise(moduleNames[j])
+          var started = element.getAttribute('data-' + moduleNames[j] + '-module-started')
+          if (typeof GOVUK.Modules[moduleName] === 'function' && !started) {
+            try {
+              if (GOVUK.Modules[moduleName].prototype.init) {
+                // Vanilla JavaScript GOV.UK Modules and GOV.UK Frontend V4 Modules
+                new GOVUK.Modules[moduleName](element).init()
+              } else {
+                // GOV.UK Frontend V5 Modules - removed component init() methods and initialise in constructor
+                // https://github.com/alphagov/govuk-design-system-architecture/blob/main/decision-records/010-remove-init-method.md
+                /* eslint-disable no-new */
+                var module = new GOVUK.Modules[moduleName](element)
+
+                // Support jQuery modules
+                // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/javascript-modules.md
+                if (module.start) {
+                  module.start($(element))
+                }
+              }
+              element.setAttribute('data-' + moduleNames[j] + '-module-started', true)
+            } catch (e) {
+              // if there's a problem with the module, catch the error to allow other modules to start
+              console.error('Error starting ' + moduleName + ' component JS: ', e, window.location)
+            }
+          }
+        }
+      }
+
+      // eg selectable-table to SelectableTable
+      function camelCaseAndCapitalise (string) {
+        return capitaliseFirstLetter(camelCase(string))
+      }
+
+      // http://stackoverflow.com/questions/6660977/convert-hyphens-to-camel-case-camelcase
+      function camelCase (string) {
+        return string.replace(/-([a-z])/g, function (g) {
+          return g.charAt(1).toUpperCase()
+        })
+      }
+
+      // http://stackoverflow.com/questions/1026069/capitalize-the-first-letter-of-string-in-javascript
+      function capitaliseFirstLetter (string) {
+        return string.charAt(0).toUpperCase() + string.slice(1)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)


### PR DESCRIPTION
## What

- Copy over `modules.js` and `dependencies.js` from the publishing components gem.
- Update developer docs version of `modules.js` to add support for initialising modules from the tech-docs gem that rely on jQuery

Although it would be possible to update `modules.js` in the publishing components gem to avoid copying over from the gem, we would likely need to include some checks for jQuery which doesn't feel like quite the right approach as it could send the wrong message for jQuery support in the govuk-publishing-components gem.

## Why

Site search in the developer docs was defaulting to use Google search following a recent update in `modules.js` in the publishing-components-gem - https://github.com/alphagov/govuk-developer-docs/pull/4664

It appears this was conflicting with the approach used in the developer docs where jQuery is still used, and modules.js would initialise all modules on the page, even where jQuery is used.

[Trello card](https://trello.com/c/TXRwnlvj/2621-fix-site-search-in-developer-docs-s)

## Further info

There appears to be a console error when testing locally, this error was present before the update to 38.4.0 and may need to be investigated further.

```
Error starting Search component JS: window.stripPIIFromString is not a function
```
