### PR TITLE
Update bulk republishable types

### DIFF
--- a/source/manual/republishing-content.html.md.erb
+++ b/source/manual/republishing-content.html.md.erb
@@ -42,6 +42,7 @@ documented below.
 
 To republish all instances of the following document types, run the following rake task.
 
+- CallForEvidence
 - CaseStudy
 - Consultation
 - Contact
@@ -50,6 +51,7 @@ To republish all instances of the following document types, run the following ra
 - DocumentCollection
 - FatalityNotice
 - Government
+- HistoricalAccount
 - NewsArticle
 - OperationalField
 - Organisation
@@ -64,7 +66,6 @@ To republish all instances of the following document types, run the following ra
 - TakePartPage
 - TopicalEvent
 - TopicalEventAboutPage
-- WorldLocation
 - WorldLocationNews
 - WorldwideOffice
 - WorldwideOrganisation


### PR DESCRIPTION
[Trello](https://trello.com/c/2nRbOaFp/1200-add-a-user-interface-for-whitehalls-bulk-republishing-documents-by-type-rake-task)

These were a little wrong/out of date. This list has been generated by finding models that match either of the following criteria:
- `ApplicationRecord` subclasses that include `PublishesToPublishingApi`
- `Edition` descendants with no descendants of their own

`EditionableWorldwideOrganisation` also meets the second criteria, but the feature is not yet turned on

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
