### PR TITLE
Change notes in manual publisher

### DIFF
--- a/source/manual/howto-remove-change-note.html.md
+++ b/source/manual/howto-remove-change-note.html.md
@@ -45,6 +45,12 @@ https://whitehall-admin.publishing.service.gov.uk/government/admin/editions/<edi
 1. If such an editorial remark is present, then destroy the `editorial_remark`
    and check that it is no longer displayed.
 
+## Manuals Publisher
+
+Removing change notes from manuals is now possible via the UI, for users with the `gds_editor` permission.
+
+See [this example document](https://manuals-publisher.integration.publishing.service.gov.uk/manuals/2606097c-e82a-4f5d-920a-5f360dcff626/change_history).
+
 ## Other apps
 
 **Note**


### PR DESCRIPTION
Add documentation on how to edit a change note in manuals publisher, via de UI.

[Trello card](https://trello.com/c/0o6xP2vR/2282-remove-change-notes-from-page-manuals-publisher)