### PR TITLE
Add GOV.UK mobile app backend repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -369,6 +369,16 @@
   team: "#govuk-apps-notifications"
   description: Services module for GOV.UK Android app
 
+- repo_name: govuk-mobile-backend
+  type: Mobile apps
+  team: "#govuk-apps-notifications"
+  description: Backend for GOV.UK mobile app
+
+- repo_name: govuk-mobile-backend-config
+  type: Mobile apps
+  team: "#govuk-apps-notifications"
+  description: Backend configuration for GOV.UK mobile app
+
 - repo_name: govuk-mobile-ios-app
   type: Mobile apps
   team: "#govuk-apps-notifications"


### PR DESCRIPTION
Adds GOV.UK mobile app backend repos to the repo owners list.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
