### PR TITLE
Add govuk-dns-ui repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -305,6 +305,12 @@
   type: Utilities
   description: Terraform configuration for managing DNS records
 
+- repo_name: govuk-dns-ui
+  private_repo: true
+  team: "#govuk-platform-engineering"
+  type: Utilities
+  description: Simple UI to help with management of GOV.UK DNS records
+
 - repo_name: govuk-docker
   team: "#govuk-platform-security-reliability-team"
   type: Utilities


### PR DESCRIPTION
Repo is excluded from CI checks for now:  https://github.com/alphagov/seal/commit/69efdbeff1e6b139b7420cc87ae57c2d4f000001

I'll add `govuk` tag/topic once the PR is merged.