### PR TITLE
We no longer show popular links in the the dropdown, so remove that from the drill

### DIFF
--- a/source/manual/update_popular_links.html.md
+++ b/source/manual/update_popular_links.html.md
@@ -6,22 +6,12 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-Popular links on GOV.UK are shown in two places on the home page and in the search bar.
+Popular links on GOV.UK are shown on the home page.
 
 ![Image of the popular links on the GOV.UK homepage](images/popular-links-on-homepage.jpeg)
-
-![Image of the popular links in the search drop down](images/popular-links-in-search-dropdown.jpeg)
 
 ## Updating the popular links on the homepage
 
 Popular links can be found in [config/locales/en.yml on frontend](https://github.com/alphagov/frontend/blob/80ec5cb2840086e7f073ceeba89d5c07d581a02d/config/locales/en.yml#L363-L373)
 
 [Example PR](https://github.com/alphagov/frontend/pull/3155)
-
-## Updating the popular links in the search drop down
-
-These links are set in the [GOV.UK publishing components](https://github.com/alphagov/govuk_publishing_components/blob/d05b3369b7426e32ad49b5898096b9752df7e410/config/locales/en.yml#L179-L189)
-
-[Example PR](https://github.com/alphagov/govuk_publishing_components/pull/2660)
-
-The GOV.UK publishing components gem will then need to be released, and [static](https://github.com/alphagov/static) will have to be updated to use the latest GOV.UK publishing components gem for these changes to take effect.


### PR DESCRIPTION

https://trello.com/c/KxCmWZAB/2342-2nd-line-drill

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
