### PR TITLE
[GOVUKAPP-495] Add new iOS repo to docs

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -405,6 +405,11 @@
   team: "#govuk-apps-notifications"
   description: Services module for GOV.UK iOS app
 
+- repo_name: govuk-mobile-ios-ui-components
+  type: Mobile apps
+  team: "#govuk-apps-notifications"
+  description: UI components library for GOV.UK iOS mobile app and modules
+
 - repo_name: govuk-pact-broker
   team: "#govuk-platform-security-reliability-team"
   production_url: https://govuk-pact-broker-6991351eca05.herokuapp.com/


### PR DESCRIPTION
https://github.com/alphagov/govuk-mobile-ios-ui-components

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
