### PR TITLE
Update repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -36,18 +36,6 @@
   description: For bulk merging Pull Requests for GOV.UK repos.
   sentry_url: false
 
-- repo_name: ckan
-  retired: true
-  type: data.gov.uk apps
-  team: "#govuk-datagovuk"
-  sentry_url: false
-
-- repo_name: ckan-functional-tests
-  type: data.gov.uk apps
-  team: "#govuk-datagovuk"
-  sentry_url: false
-  retired: true
-
 - repo_name: ckan-helm
   type: Utilities
   team: "#govuk-platform-engineering"
@@ -138,12 +126,6 @@
   type: data.gov.uk apps
   team: "#govuk-datagovuk"
   sentry_url: false
-
-- repo_name: datagovuk-visual-regression-tests
-  type: data.gov.uk apps
-  team: "#govuk-datagovuk"
-  sentry_url: false
-  retired: true
 
 - repo_name: datagovuk_find
   type: data.gov.uk apps
@@ -521,12 +503,6 @@
 - repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-publishing-platform"
-  production_hosted_on: eks
-
-- repo_name: info-frontend
-  retired: true
-  type: Frontend apps
-  team: "#govuk-navigation-tech"
   production_hosted_on: eks
 
 - repo_name: licensify


### PR DESCRIPTION
Remove retired repos. They will keep showing up in the search if we don't do this.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
