### PR TITLE
Update government changes documentation

### DIFF
--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -71,9 +71,14 @@ be set manually.
 #### Reindexing political content in search
 
 There is a Rake task to reindex all political content in search. This must be
-done after a government is closed.
+done after a government is closed, but can be done before the publishing-api queues
+have completed their processing.
+
+This is necessary because [search is populated by whitehall][], which is a piece of technical debt.
 
 <%= RunRakeTask.links("whitehall-admin", "search:political") %>
+
+[search is populated by whitehall]: https://trello.com/c/vnrBGTvr/26-search-is-populated-by-whitehall-sending-data?filter=search
 
 ### Backdating
 

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -23,7 +23,7 @@ Governments are listed at the [government path of Whitehall Admin][].
 
 1. Select the current government, and click the `Prepare to close this
    government` link.
-2. Close the government.
+2. Close the government - note that this may take some time, be patient after clicking the button
 
 This will close the current government and remove all [ministerial
 appointments][].
@@ -31,7 +31,7 @@ appointments][].
 This will cause a high number of documents to be represented by the Publishing
 API which might mean some delays on content being up to date on the website.
 Previous tests have shown that it takes around 3.5 hours for the queues to
-clear in integration.
+clear in integration / staging.
 
 Grafana monitoring for:
 

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -48,11 +48,6 @@ Grafana monitoring for the Publishing API queues:
 This will instantly create a new government. Changes can be seen in the Rails
 console by running `Government.current`.
 
-The new government should also instantly appear in the response from
-[/api/governments][].
-
-[/api/governments]: https://www.integration.publishing.service.gov.uk/api/governments
-
 ### Applying a banner to political content published by the previous government
 
 Content in Whitehall can be marked as political. Political content which was

--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -33,14 +33,11 @@ API which might mean some delays on content being up to date on the website.
 Previous tests have shown that it takes around 3.5 hours for the queues to
 clear in integration / staging.
 
-Grafana monitoring for:
+Grafana monitoring for the Publishing API queues:
 
-- [Publishing API in Integration](https://grafana.integration.publishing.service.gov.uk/dashboard/file/publishing-api.json?refresh=5s&orgId=1)
-- [Publishing API in Staging](https://grafana.staging.govuk.digital/dashboard/file/publishing-api.json?refresh=5s&orgId=1)
-- [⚠️ Publishing API in Production ⚠️](https://grafana.production.govuk.digital/dashboard/file/publishing-api.json?refresh=5s&orgId=1)
-- [Sidekiq in Integration](https://grafana.integration.publishing.service.gov.uk/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=publishing-api&var-Aggregation=$__auto_interval)
-- [Sidekiq in Staging](https://grafana.staging.publishing.service.gov.uk/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=publishing-api&var-Aggregation=$__auto_interval)
-- [⚠️ Sidekiq in Production ⚠️](https://grafana.production.publishing.service.gov.uk/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=publishing-api&var-Aggregation=$__auto_interval)
+- [Integration](https://grafana.eks.integration.govuk.digital/d/sidekiq-queues/sidekiq3a-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=publishing-api-worker)
+- [Staging](https://grafana.eks.staging.govuk.digital/d/sidekiq-queues/sidekiq3a-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=publishing-api-worker)
+- [Production](https://grafana.eks.production.govuk.digital/d/sidekiq-queues/sidekiq3a-queue-length-max-delay?orgId=1&var-namespace=apps&var-app=publishing-api-worker)
 
 [ministerial appointments]: https://www.integration.publishing.service.gov.uk/government/ministers
 


### PR DESCRIPTION
I found a few problems with this documentation when I drilled closing the government in staging.

- It takes a long time after clicking the close governments button for anything to happen (around 1 minute, although I think [this PR](https://github.com/alphagov/whitehall/pull/9188) should speed that up)
- The links to grafana were broken 😪 
- The /api/governments endpoint is [no longer a thing](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-159-switch-off-whitehall-apis.md)
- It wasn't clear to me when I could run the search reindexing task, but I'm pretty sure the answer is "straight away, once the government is closed". Which makes me wonder why it isn't just kicked off automatically? But anyway.