### PR TITLE
Update some links to Kubernetes pages

### DIFF
--- a/source/kubernetes/fix-app/index.html.md
+++ b/source/kubernetes/fix-app/index.html.md
@@ -32,7 +32,7 @@ kubectl -n apps exec deploy/<APPNAME> -c app -- env
 
 To change a plain text environment variable, edit the value in the `values-<ENVIRONMENT>.yaml` file.
 
-To change a Kubernetes secret, see the [Add secrets to your app documentation](/manage-app/manage-secrets).
+To change a Kubernetes secret, see the [Add secrets to your app documentation](/kubernetes/manage-app/manage-secrets).
 
 When you change a Kubernetes secret, run the following in the command line to restart your app so that the change takes effect:
 
@@ -50,7 +50,7 @@ To check why a container or pod has crashed, run `describe pods` in the command 
 kubectl -n apps describe pods -l=app=<APPNAME>
 ```
 
-If the pod or container crashes because of a lack of resources, you should [scale your app's resources](/manage-app/scale-app/).
+If the pod or container crashes because of a lack of resources, you should [scale your app's resources](/kubernetes/manage-app/scale-app/).
 
 You can monitor the pod resource usage of an app in the `General/Kubernetes/Compute Resources/Pod` Grafana dashboard for the appropriate environment.
 
@@ -68,7 +68,7 @@ To open the security groups to the worker nodes, make terraform changes to the [
 
 Use this [example pull request in the `govuk-infrastructure` repo](https://github.com/alphagov/govuk-infrastructure/pull/584/files) as a guide to making the necessary changes.
 
-Once you have made these changes, apply them by [deploying the `cluster-infrastructure` module](/manage-app/create-new-env/#2-deploy-the-cluster-infrastructure-module).
+Once you have made these changes, apply them by [deploying the `cluster-infrastructure` module](/kubernetes/manage-app/create-new-env/#2-deploy-the-cluster-infrastructure-module).
 
 ## If you suspect a problem with the cluster itself
 
@@ -84,7 +84,7 @@ If you suspect a problem with the cluster, [contact Platform Engineering team](/
 
 ### Getting logs for your apps
 
-To get logs for your apps, follow the [viewing app logs documentation](/manage-app/get-app-info/#view-app-logs).
+To get logs for your apps, follow the [viewing app logs documentation](/kubernetes/manage-app/get-app-info/#view-app-logs).
 
 ### Creating a shell inside a running container
 

--- a/source/kubernetes/manage-app/release-new-version/index.html.md
+++ b/source/kubernetes/manage-app/release-new-version/index.html.md
@@ -9,6 +9,6 @@ layout: multipage_layout
 A new release of an app automatically occurs when:
 
 - a user merges a PR to the main branch of an app's GitHub repo
-- the merge commit passes all [pre-release tests](/manage-app/access-ci-cd/#continuous-deployment-of-a-release-of-a-gov-uk-app)
+- the merge commit passes all [pre-release tests](/kubernetes/manage-app/access-ci-cd/#continuous-deployment-of-a-release-of-a-gov-uk-app)
 
 The [`release.yml` shared workflow](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/release.yml) runs automatically in GitHub Actions and adds a Git tag for the release. Release tags are of the form `v` followed by a sequential number.

--- a/source/kubernetes/manage-app/roll-back-app/index.html.md
+++ b/source/kubernetes/manage-app/roll-back-app/index.html.md
@@ -26,7 +26,7 @@ You can roll back your app by:
 
 1. Create a pull request and merge the change into the main branch.
 
-Once you have merged your pull request, [Argo CD automatically deploys the older version of the app to production](/manage-app/access-ci-cd/#deploying-a-release-of-a-gov-uk-app).
+Once you have merged your pull request, [Argo CD automatically deploys the older version of the app to production](/kubernetes/manage-app/access-ci-cd/#deploying-a-release-of-a-gov-uk-app).
 
 ## Triggering the deploy GitHub Action to deploy an older release
 


### PR DESCRIPTION
It looks like the `/kubernetes` prefix was added to these pages at some
point, but a couple of links got missed.