### PR TITLE
Remove search-analytics

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -125,7 +125,6 @@ redirects:
   /apps/router-api.html: /repos/router-api.html
   /apps/seal.html: /repos/seal.html
   /apps/search-admin.html: /repos/search-admin.html
-  /apps/search-analytics.html: /repos/search-analytics.html
   /apps/search-api.html: /repos/search-api.html
   /apps/service-manual-publisher.html: /repos/service-manual-publisher.html
   /apps/short-url-manager.html: /repos/short-url-manager.html

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -648,10 +648,6 @@
   team: "#govuk-search-improvement"
   production_hosted_on: eks
 
-- repo_name: search-analytics
-  type: Services
-  team: "#dev-notifications-ai-govuk"
-
 - repo_name: search-api
   type: APIs
   team: "#dev-notifications-ai-govuk"


### PR DESCRIPTION
Search Analytics has been archived as it is no longer functional following the retirement of Google Universal Analytics.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
