### PR TITLE
Update references to ECR images

### DIFF
--- a/source/manual/access-to-licensing-for-third-parties.html.md
+++ b/source/manual/access-to-licensing-for-third-parties.html.md
@@ -37,7 +37,7 @@ When a PR is merged into main and that merge commit sucessful passes, the GitHub
 
 ## Building an image and deployment
 
-When a new Release is created, the GitHub Actions [`Deploy` workflow](https://github.com/alphagov/licensify/actions/workflows/deploy.yml) builds a new container image, pushes the image into a private AWS ECR (Elastic Container Registry) and triggers a deployment in the Kubernetes cluster.
+When a new Release is created, the GitHub Actions [`Deploy` workflow](https://github.com/alphagov/licensify/actions/workflows/deploy.yml) builds a new container image, pushes the image to GitHub Packages and triggers a deployment in the Kubernetes cluster.
 
 Every new release is automatically deployed to integration.
 

--- a/source/manual/deployments.html.md
+++ b/source/manual/deployments.html.md
@@ -42,16 +42,16 @@ This is an example deploying an application to integration:
 
 1. Developer merges a PR into main branch and it passes [CI](https://github.com/alphagov/whitehall/actions/workflows/ci.yml)
 1. Triggers the ["Deploy" workflow](https://github.com/alphagov/whitehall/actions/workflows/deploy.yml) in GitHub Actions
-    1. Builds and pushes an image to [AWS Elastic Container Registery (ECR)](https://aws.amazon.com/ecr/) in production
+    1. Builds and pushes an image to [GitHub Packages](https://github.com/orgs/alphagov/packages)
     1. Sends a webhook to [Argo Workflows in production](https://argo-workflows.eks.production.govuk.digital/workflows/apps)
 1. Triggers the ["deploy-image" workflow](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/argo-services/templates/workflows/deploy-image/workflow.yaml) in [Argo Workflows in production](https://argo-workflows.eks.production.govuk.digital/workflows/apps)
     1. Updates the image tag reference for integration in [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/image-tags) with a new commit
-    1. Adds a "deployed-to-<environment>" tag on the image in ECR
     1. Notifies the Release application of the deployment
 1. [Argo CD in integration](https://argo.eks.integration.govuk.digital/applications) polls [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts) and detects updated image tag reference
     1. Triggers sync of the [`app-config`](https://argo.eks.integration.govuk.digital/applications/cluster-services/app-config) ([app-of-apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern)) application in Argo CD
     1. Updates the Helm values for the deployed [app's Argo CD application resource](https://argo.eks.integration.govuk.digital/applications/cluster-services/whitehall-admin)
     1. Updates the Kubernetes deployment resource with the new image tag
+    1. Images are pulled-through [AWS Elastic Container Registery (ECR)](https://aws.amazon.com/ecr/) in production from GitHub Packages
 1. Kubernetes does a [rolling update of the pods](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/)
 1. Argo CD triggers the ["post-sync" workflow](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/argo-services/templates/workflows/post-sync/workflow.yaml) in [Argo Workflows in integration](https://argo-workflows.eks.integration.govuk.digital/workflows/apps)
     1. Runs smoke tests for the app

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -25,7 +25,7 @@ Run the following commands from the root directory of the repository.
 LOCAL_HEAD_SHA=$(git rev-parse HEAD)
 IMAGE_TAG="release-${LOCAL_HEAD_SHA}"
 REGISTRY="172025368201.dkr.ecr.eu-west-1.amazonaws.com"
-REPO=$(basename "$PWD")
+REPO="github/alphagov/govuk/$(basename $PWD)"
 ```
 
 1. Build the container image and tag it appropriately.
@@ -59,8 +59,8 @@ docker push $REGISTRY/$REPO:$IMAGE_TAG
 1. Repeat the steps above to turn off auto-sync for the application you wish to deploy.
 1. Close the `App details` sidebar, then select the Deploy object for the component of the application you'd like to redeploy. For example, to update the Sidekiq workers for Account API, you would open up the `account-api-worker` Deploy object.
 1. Go to `Live manifest` and select `Edit`.
-1. Find the `image:` field for the `app` container. It should look something like `172025368201.dkr.ecr.eu-west-1.amazonaws.com/<app-name>:release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
-1. Update the tag part of the `image:` value to the new image tag that you pushed to ECR. The part you are changing should look something like `release-2e902e3df274a00bbabba7ccf84cbef96ccc9b9e`.
+1. Find the `image:` field for the `app` container. It should look something like `172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/<app-name>:v123`.
+1. Update the tag part of the `image:` value to the new image tag that you pushed to ECR. The part you are changing should look something like `v123`.
 1. Click `Save`. Argo CD will start the deployment, which should complete in under ten minutes.
 
 When GitHub is available again (or when you've completed the above as part of a Technical 2nd Line drill), return things to normal by re-enabling the auto-sync:

--- a/source/manual/github.html.md
+++ b/source/manual/github.html.md
@@ -67,7 +67,6 @@ You'll then need to [plan and apply the GitHub workspace in Terraform Cloud](htt
 
 - This updates the collaborators to the [default teams and access levels](https://github.com/alphagov/govuk-infrastructure/blob/83ff43c4e55f3d3273644e80897b58fd351f566a/terraform/deployments/github/main.tf#L76-L112).
   - If your repository access is sensitive, it should be tagged with the [`govuk-sensitive-access`](https://github.com/search?q=topic:govuk-sensitive-access) topic to avoid this automation: you would then need to manually manage its collaborators.
-- It also gives permissions to push to the ECR registry, to repositories that have the [`container`](https://github.com/search?q=user%3Aalphagov+topic%3Acontainer&type=repositories) topic.
 
 Finally, you should run the ["Configure GitHub" action in govuk-saas-config](https://github.com/alphagov/govuk-saas-config/actions/workflows/configure-github.yml). This:
 


### PR DESCRIPTION
The ECR repositories are now set up as ghcr.io pull through caches, which has caused a name change.
