### PR TITLE
Include worker process in secret env var steps

### DIFF
--- a/source/kubernetes/manage-app/set-env-var/index.html.md
+++ b/source/kubernetes/manage-app/set-env-var/index.html.md
@@ -62,10 +62,19 @@ To update an existing secret:
     k delete secret foo-app-api-key
     ```
 
-3. Do a rolling restart of the affected app:
+3. Do a rolling restart of the affected app and any worker processes
+
+    Restart the app:
 
     ```sh
     k rollout restart deploy/foo-app
+    k rollout status !$
+    ```
+
+    If the app has worker processes:
+
+    ```sh
+    k rollout restart deploy/foo-app-worker
     k rollout status !$
     ```
 


### PR DESCRIPTION
Worker processes also need a rolling restart to set the env var.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
