### PR TITLE
Update govsearch apps in repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -108,7 +108,7 @@
 
 - repo_name: data-community-tech-docs
   type: Utilities
-  team: "#data-products"
+  team: "#data-insights-team"
 
 - repo_name: datagovuk-tech-docs
   production_url: https://guidance.data.gov.uk/
@@ -217,7 +217,7 @@
 
 - repo_name: govuk-analytics-engineering
   private_repo: true
-  team: "#data-products"
+  team: "#data-insights-team"
   type: Data science
 
 - repo_name: govuk-aws
@@ -246,7 +246,7 @@
   type: Utilities
 
 - repo_name: govuk-data-science-workshop
-  team: "#data-products"
+  team: "#data-insights-team"
   type: Data science
 
 - repo_name: govuk-dependabot-merger
@@ -417,7 +417,7 @@
   sentry_url: false
 
 - repo_name: govuk-s3-mirror
-  team: "#data-products"
+  team: "#data-insights-team"
   type: Data science
   sentry_url: false
 

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -306,9 +306,17 @@
   type: Utilities
   team: "#govuk-platform-engineering"
 
-- repo_name: govuk-knowledge-graph-search
-  team: "#data-products"
+- repo_name: govuk-knowledge-graph-gcp
+  team: "#data-insights-team"
   type: Data science
+  description: GOV.UK content data and cloud infrastructure for the GovSearch app
+  production_hosted_on: gcp
+
+- repo_name: govuk-knowledge-graph-search
+  team: "#data-insights-team"
+  type: Data science
+  description: GovSearch web app allowing publishing users to search for content in the knowledge graph
+  production_hosted_on: gcp
 
 - repo_name: govuk-mirror
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
Adding `production_hosted_on` should cause these to show up in the list of "apps", rather than just repos.

I think #data-insights-team is a more accurate team name than #data-products

This should make it a little more difficult to forget that govsearch exists, which we should be careful not to do because the app meets an important need for publishing users that is otherwise not coverd by GOV.UK.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
