### PR TITLE
Fix for "LoadError: cannot load such file -- sassc" error

### DIFF
--- a/source/manual/migrate-to-dart-sass-from-libsass.html.md
+++ b/source/manual/migrate-to-dart-sass-from-libsass.html.md
@@ -191,7 +191,13 @@ See [3.2 Turning Digests Off - The Asset Pipeline — Ruby on Rails Guides](http
 
 ## Troubleshooting
 
-See [common issues](https://github.com/rails/dartsass-rails#troubleshooting).
+If you see `LoadError: cannot load such file -- sassc` (e.g. when attempting to run tests), try running:
+
+```
+govuk-docker-run rails assets:precompile
+```
+
+If that doesn't work, read the [rails/dartsass-rails troubleshooting guide](https://github.com/rails/dartsass-rails#troubleshooting).
 
 ### Other issues
 


### PR DESCRIPTION
Searching for "sassc" quickly brought up this page in the docs, which has a lot of useful info about the migration from LibSass to Dart Sass, but didn't specifically explain how to fix this issue. Hopefully it helps a future dev.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
