### PR TITLE
Fix Kibana links for Whitehall

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -114,15 +114,11 @@ class Repo
   end
 
   def kibana_url
-    return if repo_data["kibana_url"] == false
-
-    kibana_url_for(app: app_name, hours: 3)
+    repo_data["kibana_url"] || kibana_url_for(app: app_name, hours: 3)
   end
 
   def kibana_worker_url
-    return if repo_data["kibana_worker_url"] == false
-
-    kibana_url_for(app: "#{app_name}-worker", hours: 3, include: %w[level message])
+    repo_data["kibana_worker_url"] || kibana_url_for(app: "#{app_name}-worker", hours: 3, include: %w[level message])
   end
 
   def api_docs_url

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -739,6 +739,8 @@
   argo_cd_apps:
     - whitehall-admin
   production_hosted_on: eks
+  kibana_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,request,status,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:whitehall-admin),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:whitehall-admin)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())
+  kibana_worker_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:whitehall-admin-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:whitehall-admin-worker)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())
 
 - repo_name: widdershins
   type: Gems

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -105,6 +105,17 @@ RSpec.describe Repo do
 
       it { is_expected.to eql("https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,request,status,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:content-publisher),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:content-publisher)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())"), "Actual URL returned: #{kibana_url.inspect}" }
     end
+
+    describe "hosted on EKS but custom URL provided" do
+      let(:options) do
+        default_options.merge(
+          "production_hosted_on" => "eks",
+          "kibana_url" => "https://kibana.logit.io/custom-url",
+        )
+      end
+
+      it { is_expected.to eql("https://kibana.logit.io/custom-url") }
+    end
   end
 
   describe "kibana_worker_url" do
@@ -120,6 +131,17 @@ RSpec.describe Repo do
       let(:options) { default_options.merge("production_hosted_on" => "eks") }
 
       it { is_expected.to eql("https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:content-publisher-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:content-publisher-worker)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())"), "Actual URL returned: #{kibana_worker_url.inspect}" }
+    end
+
+    describe "hosted on EKS but custom URL provided" do
+      let(:options) do
+        default_options.merge(
+          "production_hosted_on" => "eks",
+          "kibana_worker_url" => "https://kibana.logit.io/custom-url",
+        )
+      end
+
+      it { is_expected.to eql("https://kibana.logit.io/custom-url") }
     end
   end
 end


### PR DESCRIPTION
Fixes the Kibana links on https://docs.publishing.service.gov.uk/repos/whitehall.html. See commits for details.

> <img alt="screenshot of whitehall doc page" src="https://github.com/user-attachments/assets/e29d606e-4cdd-4143-992f-f94b4e861065" width="400">
