### PR TITLE
Update remaining references to the Platform Security and Reliability team

### DIFF
--- a/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
+++ b/source/manual/alerts/content-data-api-app-healthcheck-not-ok.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-security-reliability-team"
+owner_slack: "#govuk-platform-engineering"
 title: content-data-api app healthcheck not ok
 section: Icinga alerts
 layout: manual_layout

--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-security-reliability-team"
+owner_slack: "#govuk-platform-engineering"
 title: Ask for help
 parent: "/manual.html"
 layout: manual_layout
@@ -33,17 +33,12 @@ The GOV.UK 2nd Line Tech Support team ([#govuk-2ndline-tech])
 - supports each other with issues deploying changes to GOV.UK
 - ensures missions are delivered technically in the best and most appropriate way
 
-### GOV.UK Platform Security and Reliability team ([#govuk-platform-security-reliability-team])
-
-- works on long-term improvements to the reliability and security of GOV.UK
-- manages some access control automation such as govuk-user-reviewer
-- manages some AWS infrastructure that supports multiple teams (together with Platform Engineering team)
-
 ### GOV.UK [Platform Engineering] team ([#govuk-platform-engineering])
 
 - manages the Kubernetes clusters and base images for running GOV.UK applications
 - works on long-term improvements to the efficiency, reliability and security of GOV.UK
 - supports CI/CD (build, release, rollout) automation
+- manages some access control automation such as govuk-user-reviewer
 - can offer advice on monitoring and alerting
 - can offer design reviews and advice to help build your application for
   reliability, robustness and low maintenance (especially at the early stages of
@@ -54,5 +49,4 @@ The GOV.UK 2nd Line Tech Support team ([#govuk-2ndline-tech])
 [#govuk-2ndline-tech]: https://gds.slack.com/channels/govuk-2ndline-tech
 [#govuk-developers]: https://gds.slack.com/channels/govuk-developers
 [#govuk-platform-engineering]: https://gds.slack.com/channels/govuk-platform-engineering
-[#govuk-platform-security-reliability-team]: https://gds.slack.com/channels/govuk-platform-security-reliability-team
 [Platform Engineering]: /platform-engineering.html

--- a/source/manual/content-data-architecture.html.md
+++ b/source/manual/content-data-architecture.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-platform-security-reliability-team"
+owner_slack: "#govuk-platform-engineering"
 title: Content Data architecture
 section: Content Data
 type: learn

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -218,9 +218,8 @@ errors to risk breaching our account limit. These limits are configured on the
 
 ## Slack alerts
 
-You can configure Sentry to notify a Slack channel when a notable condition is
-satisfied. For example, the `#govuk-platform-security-reliability-team` channel gets notified when
-any issue records 100 or more errors in a 1 hour period.
+You can configure Sentry to notify a Slack channel when a condition is
+satisfied, such as when any issue records 100 or more errors in a 1 hour period.
 
 To set up an alert, visit the [Alerts panel][], select the project the alert
 should apply to (e.g. `app-whitehall`), and then click "Create Alert Rule". It is


### PR DESCRIPTION

The team is now merged with Platform Engineering and no longer has its own Slack channel.