### PR TITLE
Rename Licensify apps

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -496,7 +496,7 @@
   production_hosted_on: eks
 
 - repo_name: licensify
-  app_name: licensify
+  app_name: licensify-backend
   private_repo: true
   type: Licensing apps
   production_hosted_on: eks
@@ -504,7 +504,7 @@
   description: GOV.UK Licensing (formerly ELMS, Licence Application Tool, & Licensify)
 
 - repo_name: licensify
-  app_name: licensify-admin
+  app_name: licensify-frontend
   private_repo: true
   type: Licensing apps
   production_hosted_on: eks


### PR DESCRIPTION
Licensify consists of three different apps in a single repo. The app names in the docs should match the actual app names.