### PR TITLE
Remove space from rake task

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -41,7 +41,7 @@ Asset Manager.
 
    To delete all traces of the asset (including the file from cloud storage), run:
 
-   <%= RunRakeTask.links("asset-manager", "assets:delete[ASSET_ID, true]") %>
+   <%= RunRakeTask.links("asset-manager", "assets:delete[ASSET_ID,true]") %>
 
    For "Whitehall" Assets (paths starting with `/government/uploads/system`), use the [`assets:whitehall_delete` Rake task](https://github.com/alphagov/asset-manager/blob/796eb36/lib/tasks/assets.rake#L9-L13) instead:
 


### PR DESCRIPTION
Otherwise we get `zsh: bad pattern: assets:delete[content_id,` in the output and the task fails to run.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
