### PR TITLE
Add warning about Sass compilation

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,4 +1,8 @@
 @import "govuk_tech_docs";
+// govuk_publishing_components uses dart-sass, dev docs (through Middleman)
+// does not, fortunately dev docs doesn't import the sass that would break
+// compilation, specifically _search.scss, _step-by-step-nav.scss, _grid-helper.scss
+// see https://github.com/alphagov/govuk_publishing_components/pull/4106
 @import "govuk_publishing_components/components/_summary-list";
 @import "govuk_publishing_components/components/_breadcrumbs";
 @import "govuk_publishing_components/components/_cookie-banner";


### PR DESCRIPTION
## What / why
Adds a warning to the main sass file about a compilation problem. In a nutshell:

- https://github.com/alphagov/govuk_publishing_components/pull/4106 fixes some Sass compilation warnings, but only when compiled using `dart-sass`, which most of our applications have been migrated to
- dev docs doesn't use `dart-sass` yet, because it relies on `Middleman` for sass compilation, and we can't upgrade that
- fortunately, none of the changed Sass files in the PR above are included in the dev docs, so currently this isn't a problem
- however it seems sensible to add this warning to future devs if and when they encounter this problem (sorry future devs)

## Visual changes
None.

Trello card: https://trello.com/c/gW2NW1sB/142-fix-sass-compilation-warnings
