### PR TITLE
Remove UA code

### DIFF
--- a/source/javascripts/dependencies.js
+++ b/source/javascripts/dependencies.js
@@ -9,16 +9,12 @@
 
 $(document).ready(function() {
   window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {};
-  window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {};
 
   // if statements ensure these functions don't execute during testing
   if (typeof window.GOVUK.loadAnalytics !== "undefined") {
     window.GOVUK.loadAnalytics.loadExtraDomains();
     if (typeof window.GOVUK.analyticsGa4.vars === "undefined") {
       window.GOVUK.loadAnalytics.loadGa4();
-    }
-    if (typeof window.GOVUK.analyticsVars.gaProperty === "undefined") {
-      window.GOVUK.loadAnalytics.loadUa();
     }
   }
 });


### PR DESCRIPTION
## What
Removes the initialisation of Universal Analytics, which has now been turned off and replaced with Google Analytics 4.

## Why
Not needed, plus was causing an error in the console that's been happening since upgrading to the version of `govuk_publishing_components` that removed the UA code that was being called here.

```
application.js:3 Uncaught TypeError: window.GOVUK.loadAnalytics.loadUa is not a function
    at HTMLDocument.<anonymous> (application.js:13:12775)
    at d (application.js:3:7048)
    at h (application.js:3:7351)
```

## Visual changes
None.

Trello card: https://trello.com/c/fKGle0gD/187-remove-ua-code-from-applications

