### PR TITLE
Clarify the wording in 'When you get Production Deploy access'

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -41,7 +41,7 @@ any access issues.
 
 #### When you get Production Deploy access
 
-Access can be granted to both civil servants and contractors as needed, at the discretion of a "sponsor": either the engineer's (civil servant) tech lead, or a GOV.UK Senior Technologist.
+Access can be granted to both civil servants and contractors as needed, at the discretion of a "sponsor": either the engineer's (civil servant) tech lead, or a [GOV.UK Senior Tech member](/manual/ask-for-help.html#contact-senior-tech).
 
 Before approving access, the sponsor should ensure that the engineer:
 


### PR DESCRIPTION
The term “Senior Technologist” can be ambiguous as it can be interpreted as referring to any Senior Developers/SRE/Technical Architects. Also later in the doc “Apprentice Technologist” is used.

We commonly use phrase “Senior Tech” to describe the group of Lead Developers/SRE/Technical Architects. This change makes is consistent with other manuals.

This also adds a link to the doc describing how to contact that group.
