### PR TITLE
Fix broken link to deployment docs

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -79,7 +79,7 @@ To grant access, the senior tech person should follow the steps in the ["GOV.UK 
 A new starter/engineer will be expected to work through the following checklist in order to 'qualify' for production admin access:
 
 - The different parts of the GOV.UK technical stack (CDN, frontends, publishing apps, etc). E.g. by attending an "Introduction to GOV.UK Technical Architecture" session (or watching the [recording](https://drive.google.com/file/d/1-az_Y_JeKJ2Xhqrc7VNVt1sKOTEpHbcM/view)).
-- The deployment pipeline - how code gets from your machine to running on production. E.g. by reading [the deployment docs](/manual/#deployment), and learning on the job.
+- The deployment pipeline - how code gets from your machine to running on production. E.g. by reading [the deployment docs](/manual#deployment), and learning on the job.
 - The incident management process. E.g. by reading through the [So, you're having an incident](/manual/incident-what-to-do) doc and completing the [incident preparedness quizzes](https://drive.google.com/drive/folders/1X9eGQMIl9ifb3X2jYcdjqrt01P9JYJzR).
 - Best practices around the principle of least privilege, how to safely debug production issues, and how to work with credentials and accounts. E.g. by pairing with another developer to [practise a drill](/manual/2nd-line-drills.html).
 


### PR DESCRIPTION
There's a slash that shouldn't be there, as this is linking to a section of the "manual" page.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
