### PR TITLE
Remove Default Admin Login instructions when logging into ArgoCD

### DIFF
--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -51,19 +51,13 @@ echo $IMAGE_TAG
 
 > ⚠️ This procedure will disable automatic deployments *for all applications*, not only in the environment you are working on but also in higher environments. For example, performing this procedure on integration will prevent all automatic deployments in integration, staging and production.
 
-1. Fetch the password for the Argo CD `admin` user. This varies by environment.
-
-    ```sh
-    kubectl -n cluster-services get secret argocd-initial-admin-secret -oyaml |yq .data.password |base64 -d
-    ```
-
-1. Log into Argo CD (for example in [integration](https://argo.eks.integration.govuk.digital/)).
+1. Log into Argo CD with your GitHub account (for example in [integration](https://argo.eks.integration.govuk.digital/)).
 1. Disable auto-sync for the `app-config` application:
     1. From the Applications page (the Argo CD homepage), choose the `app-config` application.
-    1. Press the `App Details` button near the top of the page.
+    1. Press the `Details` button near the top left hand side of the page.
     1. Scroll down to the bottom of the page and press `Disable auto-sync`. Argo will prompt you before actually disabling auto-sync.
 1. Repeat the steps above to turn off auto-sync for the application you wish to deploy.
-1. Close the `App details` sidebar, then select the Deploy object for the component of the application you'd like to redeploy. For example, to update the Sidekiq workers for Account API, you would open up the `account-api-worker` Deploy object.
+1. Close the `Details` sidebar, then select the Deploy object for the component of the application you'd like to redeploy. For example, to update the Sidekiq workers for Account API, you would open up the `account-api-worker` Deploy object.
 1. Go to `Live manifest` and select `Edit`.
 1. Find the `image:` field for the `app` container. It should look something like `172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/<app-name>:v123`.
 1. Update the tag part of the `image:` value to the new image tag that you pushed to ECR. The part you are changing should look something like `v123`.


### PR DESCRIPTION
The admin login was not needed, as when the drill was tested, the github permissions were sufficient. Fixed up a few minor details that might have changed since document was made.

https://trello.com/c/qRcySnzp/20-update-the-documentation-on-the-drills-for-the-shift

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
