### PR TITLE
Retire 'gds_zendesk' gem

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -177,10 +177,6 @@
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
   sentry_url: false
 
-- repo_name: gds_zendesk
-  team: "#govuk-platform-engineering"
-  type: Gems
-
 - repo_name: github-trello-poster
   team: "#govuk-platform-engineering"
   management_url: https://dashboard.heroku.com/apps/govuk-github-trello-poster


### PR DESCRIPTION
This functionality was ported to Support API: /support-tickets endpoint [^1] is exposed via GDA API Adapters's [^2].

We want to consolidate onto one centralised way of raising support tickets. This will minimise the maintenance overhead if we ever switch away from Zendesk (rumoured to be happening in 2024) and will make the process more vendor agnostic.

https://github.com/alphagov/gds_zendesk/issues/108

[^1]: https://github.com/alphagov/support-api/blob/c0b6ca3587f6673c9512573deeecd66a2aaa0d98/app/controllers/support_tickets_controller.rb
[^2]: https://github.com/alphagov/gds-api-adapters/blob/9aabf9d/lib/gds_api/support_api.rb#L25-L39

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
