### PR TITLE
Update 'Drill updating homepage popular links' docs

### DIFF
--- a/source/manual/2nd-line-drills.html.md
+++ b/source/manual/2nd-line-drills.html.md
@@ -146,13 +146,7 @@ You can also try deleting the change note. Again, ensure you do this on Staging 
 On Integration or Staging, follow [Modify a change note in Publishing API](/manual/howto-modify-change-note.html#publishing-api) using [this document](https://www.staging.publishing.service.gov.uk/guidance/deer-keepers-tagging-deer-and-reporting-their-movements) or one of your choice.
 Once you have successfully updated the change note you can drill [removing a change note in Publishing API](/manual/howto-remove-change-note.html#other-apps).
 
-## Drill making changes to the homepage
-
-### Drill updating homepage popular links
-
-Change the homepage popular links following [Update popular links](/manual/update_popular_links.html). Open a draft PR, and deploy your branch to integration. Once deployed, check your change and redeploy the previous branch to integration.
-
-### Drill updating homepage promotion slots
+## Drill updating homepage promotion slots
 
 Follow the [Update homepage promotion slots](/repos/frontend/update-homepage-promotion-slots.html) instructions, using an appropriate image and text.
 Open a draft PR, and [deploy your branch to integration](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/).


### PR DESCRIPTION
## What

Update 'Drill making changes to the homepage' docs

## Why

It is no longer necessary to drill into updating popular links on the homepage, as this can now be managed through Signon / Homepage. Therefore, I have removed that section.