### PR TITLE
Update Chat Grafana dashboard title

### DIFF
--- a/source/manual/alerts/chat-ai-alerts.html.md
+++ b/source/manual/alerts/chat-ai-alerts.html.md
@@ -17,7 +17,7 @@ section: Alertmanager alerts
 - High5xxRate
 - LongRequestDuration
 
-These alerts indicate that a part of the service is not responding as expected, and as a result the user experience is severely impacted. For example, we have seen `LongRequestDuration` fire when the RDS Postgres Database is offline. For these alerts, it is worth checking the Grafana Dashboard `Chat AI Dashboard` to see if any of the backend services are showing signs of an issue.
+These alerts indicate that a part of the service is not responding as expected, and as a result the user experience is severely impacted. For example, we have seen `LongRequestDuration` fire when the RDS Postgres Database is offline. For these alerts, it is worth checking the Grafana Dashboard `GOV.UK Chat Technical` to see if any of the backend services are showing signs of an issue.
 
 ### Slack Alerts
 


### PR DESCRIPTION
We recently renamed this dashboard to "GOV.UK Chat Technical". This was missed as part of the rename.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
