### PR TITLE
Remove special-route-publisher from docs

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -131,7 +131,6 @@ redirects:
   /apps/signon.html: /repos/signon.html
   /apps/slimmer.html: /repos/slimmer.html
   /apps/smart-answers.html: /repos/smart-answers.html
-  /apps/special-route-publisher.html: /repos/special-route-publisher.html
   /apps/specialist-publisher.html: /repos/specialist-publisher.html
   /apps/static.html: /repos/static.html
   /apps/support.html: /repos/support.html

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -696,11 +696,6 @@
   production_hosted_on: eks
   sentry_url: false
 
-- repo_name: special-route-publisher
-  team: "#govuk-whitehall-experience-tech"
-  type: Utilities
-  sentry_url: false
-
 - repo_name: specialist-publisher
   type: Publishing apps
   team: "#govuk-whitehall-experience-tech"

--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -8,6 +8,6 @@ old_paths:
  - /manual/publish_special_routes.html
 ---
 
-[Special Route Publisher](https://github.com/alphagov/special-route-publisher) is a tool for loading a set of routes (a map of URL path to a rendering app and content ID) from a YAML file into Publishing API.
+[Publishing API](https://github.com/alphagov/publishing-api) has a set of rake tasks for loading routes (a map of URL path to a rendering app and content ID) from a YAML file into Publishing API.
 
-See [Publishing routes on EKS](https://github.com/alphagov/special-route-publisher#publishing-routes-on-eks) for usage.
+See [Publishing special routes](https://github.com/alphagov/publishing-api/blob/main/docs/admin-tasks.md#publishing-special-routes) for usage.


### PR DESCRIPTION
Preparation for retiring the repo (rake tasks now moved to publishing-api as of https://github.com/alphagov/publishing-api/pull/2881)

- point publish-special-routes docs at publishing-api

https://trello.com/c/9rOxWNnD/396-retire-special-route-publisher

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
