### PR TITLE
Add OpenAI rate limit alerts to Chat Alerts doc

### DIFF
--- a/source/manual/alerts/chat-ai-alerts.html.md
+++ b/source/manual/alerts/chat-ai-alerts.html.md
@@ -31,10 +31,14 @@ The 503 error code has been excluded from being alerted on, as that will be used
 - HighPodCPUWorker
 - HighPodMemoryFE
 - HighPodMemoryWorker
+- NearTokensRateLimit
+- NearRequestsRateLimit
 
 The `LongRequestDuration` alert indicates that a backend part of the service is not responding as expected, and as a result the user experience is severely impacted. For example, we have seen it fire when the RDS Postgres Database is offline.
 
 Any of the `High` alerts usually indicate that the service is under heavy load. In this situation, it may be necessary to increase the number of relevent pods running by modifying the `replicaCount` for FE or `workerReplicaCount` for Worker pods in the `govuk-chat` section of the relevant values Helm Chart file found [here].
+
+The `NearTokensRateLimit` and `NearRequestsRateLimit` alerts indicate that over 80% of the OpenAI limit for tokens or requests per minute has been used.
 
 [Integration]: https://grafana.eks.integration.govuk.digital/d/govuk-chat-techical
 [Staging]: https://grafana.eks.staging.govuk.digital/d/govuk-chat-techical


### PR DESCRIPTION
New Slack alerts have been created to warn when GOV.UK Chat is nearing the OpenAI rate limits for tokens or requests. This PR adds these alerts to the runbook. 