### PR TITLE
Minor updates to Transition documentation

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -185,7 +185,7 @@ the day after.
 
 ### 9) Add the domain to Fastly
 
-Manually trigger govuk-fastly 'Plan and apply' run in [Terraform Cloud UI](https://app.terraform.io/app/govuk/workspaces/govuk-fastly/runs). Review the plan with changes to `module.bouncer-production.fastly_service_vcl.service` and apply the configuration.
+Manually trigger `govuk-fastly-bouncer-production` 'Plan and apply' run in [Terraform Cloud UI](https://app.terraform.io/app/govuk/workspaces/govuk-fastly-bouncer-production/runs). Review the plan with changes to `module.bouncer-production.fastly_service_vcl.service` and apply the configuration.
 
 ### 10) Point the domain at us
 

--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -187,6 +187,8 @@ the day after.
 
 Manually trigger `govuk-fastly-bouncer-production` 'Plan and apply' run in [Terraform Cloud UI](https://app.terraform.io/app/govuk/workspaces/govuk-fastly-bouncer-production/runs). Review the plan with changes to `module.bouncer-production.fastly_service_vcl.service` and apply the configuration.
 
+> If the domain currently has no DNS entries (e.g. it is brand new), this process will not set up the domain in Fastly (due to [this line of code](https://github.com/alphagov/transition/blob/8a532735ce8e61731986fd580a5d6ca1552e095f/app/controllers/hosts_controller.rb#L3C14-L3C49)). Instead you should request the domain's owner point the DNS to us (see next step) before running this project.
+
 ### 10) Point the domain at us
 
 Once the site has been imported successfully, the domain can be pointed


### PR DESCRIPTION
Updates the "Transition a site to GOV.UK" documentation to fix a broken link and clarify the process for new domains.

[Trello card](https://trello.com/c/PZ237KPX)