### PR TITLE
Remove mention of auto-rotating tokens.

### DIFF
--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -21,8 +21,6 @@ The Integration environment should also be updated overnight but this is not hap
 
 If the token is for `Trade Tariff Admin` or `Trade Tariff Backend`, see [Trade Tariff Admin on the Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/3155099649/Trade+Tariff+Admin)
 
-If the token is for `Signon API Client (permission and suspension updater)` then the key will rotate automatically and the alert can be ignored.
-
 ### 1. Issue a new token
 
 1. Go to the [APIs page](https://signon.publishing.service.gov.uk/api_users) in Signon.


### PR DESCRIPTION
This behaviour was removed with [this PR](https://github.com/alphagov/signon/pull/2294)

Trello: https://trello.com/c/l6JLGp25/1381-spike-how-and-when-do-auto-rotating-api-tokens-rotate

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
