### PR TITLE
Remove reference to now retired smart answer - marriage-abroad

### DIFF
--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -92,7 +92,6 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 
 This will update content from pages served by `smart-answers` such as:
 
-* <https://www.gov.uk/marriage-abroad>
 * <https://www.gov.uk/check-uk-visa>
 * <https://www.gov.uk/register-a-death/y/overseas>
 


### PR DESCRIPTION
Single reference removed as part of [retiring the smart answer for Get Married Abroad](https://trello.com/c/JQUKmEBh). The [old version](https://www.gov.uk/marriage-abroad) has been replaced with a [new version](https://www.gov.uk/marriages-civil-partnerships-abroad) which is now managed by FCDO. Therefore, the renaming countries process detailed here will no longer have an effect on the smart answer. 

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
