### PR TITLE
Update documentation for rotating an expiring token

### DIFF
--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -41,55 +41,55 @@ If the token is for `Signon API Client (permission and suspension updater)` then
 
 1. Choose **Create access token**.
 
-The nightly `signon-sync-token-secrets-to-k8s` cronjob will update the token in the Kubernetes secret that the application uses.
+1. Take one of the following actions:
 
-### 2. Check that the client application works with the new token
+    * For a token used in an application outside of GOV.UK (e.g. by HMRC): securely send the token to the consumer.
 
-1. Trigger the token sync cronjob to run now (or wait until the next day).
+    * For a token used by another GOV.UK application: follow the steps in the section below.
 
-    ```sh
-    k create job --from cronjob/signon-sync-token-secrets-to-k8s signon-token-sync-$USER
-    ```
+### 2. Update the token in the secrets used by the consuming application
 
-   The job should finish within a few seconds. You can view the job's output to check that it succeeded:
+> This only applies for tokens used by internal GOV.UK applications.
 
-    ```sh
-    k logs -f job/signon-token-sync-$USER
-    ```
+1. Update the token in the Kubernetes secret:
 
-    Alternatively, this job can be triggered through the ArgoCD user interface. Navigate to the [console for Signon](https://argo.eks.production.govuk.digital/applications/cluster-services/signon?view=tree&orphaned=false&resource=), click the "signon-sync-token-secrets-to-k8s" cron job, then press the three dots in the top right, then "Create Job". The logs can be viewed by clicking the newly created job.
+    1. Go to the Argo interface for the envrionment: [integration](https://argo.eks.integration.govuk.digital/applications/cluster-services/signon?view=tree&orphaned=false&resource=), [staging](https://argo.eks.staging.govuk.digital/applications/cluster-services/signon?view=tree&orphaned=false&resource=) or [production](https://argo.eks.production.govuk.digital/applications/cluster-services/signon?view=tree&orphaned=false&resource=).
 
-1. Open a Rails console on the client app. For example, if the `api_user` is `short-url-manager@alphagov.co.uk`, open a console on `short-url-manager`.
+    1. Locate the `signon-sync-app-secrets-to-k8s` cron job.
 
-    ```sh
-    k exec -it deploy/short-url-manager -- rails c
-    ```
+    1. Click the three dots on this cron job and click **Create job**.
 
-1. Fetch the environment variable that contains the token. The variable name refers to the server (destination) application, which is the same as the `application` field in the alert. For example, for short-url-manager (client) talking to publishing-api (server):
+    1. Wait for the job to complete. A sucessful run will be labelled with a green checkmark and a label such as `Healthy 1 pods`. The logs can also be choosing the **Logs** option for the most recent run.
 
-    ```ruby
-    ENV["PUBLISHING_API_BEARER_TOKEN"]
-    ```
+1. Check that the client application works with the new token:
 
-    Check that the result matches the new token in Signon and not the old one.
+    1. Open a Rails console on the client app. For example, if the `api_user` is `short-url-manager@alphagov.co.uk`, open a console on `short-url-manager`.
 
-1. You can also check that the token works by making an API call yourself from the client app's Rails console. For example, to check that Short URL Manager can talk to Publishing API, you could:
-
-    1. Choose a method from the publishing-api client library in [gds-api-adaptors](https://github.com/alphagov/gds-api-adapters/tree/main/lib/gds_api).
-    1. Call the method from short-url-manager's Rails console:
-
-        ```ruby
-        client = GdsApi::PublishingApi.new(
-          Plek.new.find("publishing-api"),
-          bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"]
-        )
-        client.lookup_content_id(base_path: "/")
+        ```sh
+        k exec -it deploy/short-url-manager -- rails c
         ```
 
-        The call should return some result and not raise an exception.
+    1. Fetch the environment variable that contains the token. The variable name refers to the server (destination) application, which is the same as the `application` field in the alert. For example, for short-url-manager (client) talking to publishing-api (server):
 
-### 3. Revoke the old token
+        ```ruby
+        ENV["PUBLISHING_API_BEARER_TOKEN"]
+        ```
 
-Once you have confirmed that the application is working with the new token, go back to Signon and revoke the old token.
+        Check that the result matches the new token in Signon and not the old one.
 
-1. On the **Manage tokens** page, choose the **Revoke** link for the old token.
+    1. You can also check that the token works by making an API call yourself from the client app's Rails console. For example, to check that Short URL Manager can talk to Publishing API, you could:
+
+        1. Choose a method from the publishing-api client library in [gds-api-adaptors](https://github.com/alphagov/gds-api-adapters/tree/main/lib/gds_api).
+        1. Call the method from short-url-manager's Rails console:
+
+            ```ruby
+            client = GdsApi::PublishingApi.new(
+              Plek.new.find("publishing-api"),
+              bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"]
+            )
+            client.lookup_content_id(base_path: "/")
+            ```
+
+            The call should return some result and not raise an exception.
+
+1. Once you have confirmed that the application is working with the new token, go back to Signon and revoke the old token. On the **Manage tokens** page, choose the **Revoke** link for the old token.


### PR DESCRIPTION
This makes the following changes:
- removes the need to wait overnight or execute the cron job on a command line
- makes it clear that tokens used outside GOV.UK need to be dealt with differently

[Trello card](https://trello.com/c/ciBHfk6a)