### PR TITLE
Add exception for 'deprecated repos'

### DIFF
--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -67,3 +67,8 @@ New versions of Ruby bring us improved performance and nicer syntax for certain 
 See [Add a new Ruby version][] for a guide on how to install a new version of Ruby.
 
 [Add a new Ruby version]: /manual/ruby.html
+
+### Deprecated repos
+
+There is little point in spending developer time on keeping a repository's dependencies fully up to date, if that repository is planned to be retired.
+These repositories can be configured to receive security updates only (see [example](https://github.com/alphagov/content-publisher/pull/3287)).


### PR DESCRIPTION
We currently spend an unacceptable amount of time patching all of our repos to the very latest versions of all dependencies, when actually we have some repos that are barely used and are already marked for retirement.

In these cases, the risk of loosening our Dependabot policy for deprecated repos should be very low. In fact, the risk of accidentally breaking something in the deprecated repo - through bumping a dependency - is moderately high, as we'd be relying purely on tests to catch any regressions. (There may be too little user activity for it to be noticed otherwise).

Security updates should still be applied.

See https://docs.google.com/document/d/1qcnGDzw5PKKg97c3ivDpBtmbbutsUcIfk5GZxqLqFjg/edit for more.

Trello: https://trello.com/c/kpf7rWEq/2979-change-dependabot-configs-for-content-publisher-and-maslow

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
