### PR TITLE
Fix licensify port forward proxy

### DIFF
--- a/source/manual/licensing.html.md
+++ b/source/manual/licensing.html.md
@@ -58,7 +58,7 @@ You can give the application reference to Kibana in the relevant environment to 
 The Feeds application has a UI, but that isn't exposed publicly, so you need proxy to the service:
 
 ```bash
-kubectl -n apps port-forward svc/licensify-feed 9400:80
+kubectl -n licensify port-forward svc/licensify-feed 9400:80
 ```
 
 Once the tunnel above has been set up, the following pages are available:


### PR DESCRIPTION
Description:
- Licensify lives in the `licensify` namespace not the `app` namespace

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
