### PR TITLE
Update hosting for govspeak-preview

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -200,9 +200,8 @@
 
 - repo_name: govspeak-preview
   production_url: https://govspeak-preview.publishing.service.gov.uk
-  management_url: https://dashboard.heroku.com/apps/govspeak-preview
   team: "#govuk-publishing-platform"
-  production_hosted_on: heroku
+  production_hosted_on: eks
   type: Utilities
   sentry_url: false
 


### PR DESCRIPTION
This now runs on EKS, instead of Heroku, so updating the docs to reflect this.

[Trellon card](https://trello.com/c/dhgDqvBa)