### PR TITLE
Allow alerts to be sent to a different channel for GOV.UK Publishing Platform

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -9,7 +9,7 @@ class Repo
     {
       app_name:, # beware renaming the key - it's used here: https://github.com/alphagov/seal/blob/36a897b099943713ea14fa2cfe1abff8b25a83a7/lib/team_builder.rb#L97
       team:,
-      dependencies_team:,
+      alerts_team:,
       shortname:,
       production_hosted_on:,
       links: {
@@ -141,9 +141,9 @@ class Repo
     repo_data["team"] || Repos::UNKNOWN
   end
 
-  def dependencies_team
+  def alerts_team
     repo_data
-      .fetch("dependencies_team", team)
+      .fetch("alerts_team", team)
   end
 
   def description

--- a/app/repos_csv.rb
+++ b/app/repos_csv.rb
@@ -15,7 +15,7 @@ class ReposCSV
         csv << [
           repo.repo_name,
           repo.team,
-          repo.dependencies_team,
+          repo.alerts_team,
           repo.html_url,
           repo.repo_url,
           repo.production_hosted_on,

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -10,17 +10,20 @@
 - repo_name: asset-manager
   type: APIs
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
 
 - repo_name: authenticating-proxy
   type: Supporting apps
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
   production_url: false
 
 - repo_name: bouncer
   type: Transition apps
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
   production_url: false
 
@@ -95,6 +98,7 @@
 - repo_name: content-store
   type: APIs
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
   production_url: https://www.gov.uk/api/content
   argo_cd_apps:
@@ -168,11 +172,13 @@
 
 - repo_name: gds-api-adapters
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   sentry_url: false
 
 - repo_name: gds-sso
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   description: OmniAuth adapter to allow apps to sign in via GOV.UK Signon.
   sentry_url: false
@@ -195,12 +201,14 @@
 
 - repo_name: govspeak
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   sentry_url: false
 
 - repo_name: govspeak-preview
   production_url: https://govspeak-preview.publishing.service.gov.uk
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
   type: Utilities
   sentry_url: false
@@ -243,6 +251,7 @@
 
 - repo_name: govuk-content-api-docs
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Utilities
 
 - repo_name: govuk-crd-library
@@ -434,6 +443,7 @@
 
 - repo_name: govuk-sli-collector
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Utilities
   production_hosted_on: eks
 
@@ -464,6 +474,7 @@
 
 - repo_name: govuk_message_queue_consumer
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   sentry_url: false
 
@@ -479,11 +490,13 @@
 
 - repo_name: govuk_schemas
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   sentry_url: false
 
 - repo_name: govuk_sidekiq
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   sentry_url: false
 
@@ -495,6 +508,7 @@
 - repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
 
 - repo_name: licensify
@@ -524,6 +538,7 @@
 - repo_name: link-checker-api
   type: APIs
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
 
 - repo_name: local-links-manager
@@ -556,6 +571,7 @@
 
 - repo_name: optic14n
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Gems
   sentry_url: false
 
@@ -587,6 +603,7 @@
 - repo_name: publishing-api
   type: APIs
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
 
 - repo_name: rack-logstasher
@@ -670,6 +687,7 @@
 - repo_name: signon
   type: Supporting apps
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
 
 - repo_name: siteimprove_api_client
@@ -721,6 +739,7 @@
 - repo_name: transition
   type: Transition apps
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"
   production_hosted_on: eks
   production_url: https://transition.publishing.service.gov.uk
 
@@ -742,3 +761,4 @@
 - repo_name: widdershins
   type: Gems
   team: "#govuk-publishing-platform"
+  alerts_team: "#govuk-publishing-platform-system-alerts"

--- a/source/partials/repo/_ownership.html.erb
+++ b/source/partials/repo/_ownership.html.erb
@@ -1,10 +1,10 @@
-<% if repo.team && repo.dependencies_team &&
-      repo.team != repo.dependencies_team %>
-  <strong><%= link_to repo.team, slack_url(repo.team) %></strong> owns the repo. <strong><%= links_to repo.dependencies_team, slack_url(repo.dependencies_team) %></strong> is responsible for updating its dependencies.
+<% if repo.team && repo.alerts_team &&
+      repo.team != repo.alerts_team %>
+  <strong><%= link_to repo.team, slack_url(repo.team) %></strong> owns the repo. <strong><%= links_to repo.alerts_team, slack_url(repo.alerts_team) %></strong> receives automated alerts for this repo.
 <% elsif repo.team %>
   <%= link_to repo.team, slack_url(repo.team) %>
-<% elsif repo.dependencies_team %>
-  <%= links_to repo.dependencies_team, slack_url(repo.dependencies_team) %>
+<% elsif repo.alerts_team %>
+  <%= links_to repo.alerts_team, slack_url(repo.alerts_team) %>
 <% else %>
   N/A
 <% end %>

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe Repo do
       app_details = {
         "repo_name" => "foo",
         "team" => "bar",
-        "dependencies_team" => "baz",
+        "alerts_team" => "baz",
         "production_hosted_on" => "aws",
       }
       payload = Repo.new(app_details).api_payload
       expect(payload[:app_name]).to eq(app_details["repo_name"])
       expect(payload[:team]).to eq(app_details["team"])
-      expect(payload[:dependencies_team]).to eq(app_details["dependencies_team"])
+      expect(payload[:alerts_team]).to eq(app_details["alerts_team"])
       expect(payload[:production_hosted_on]).to eq(app_details["production_hosted_on"])
       expect(payload[:links]).to include(:self, :html_url, :repo_url, :sentry_url)
     end


### PR DESCRIPTION
The `dependencies_team` value was [used by](https://github.com/alphagov/govuk-dependencies/blob/578a76784671cd0ca3070e15afb53ab3a09bd3dc/lib/gateways/team.rb#L27) the (now deprecated) `govuk-dependencies` application to allow dependabot alerts to be posted to channels other than the team's main channel.

It is currently unused by any application, but we would like to alert to a different channel in the release app.

Therefore renaming the field to make it more generic, so it can be used by all alerts, not just dependencies.

[Trello card](https://trello.com/c/NKbo84JK)