### PR TITLE
Fix typo in `link_to` method call

### DIFF
--- a/source/partials/repo/_ownership.html.erb
+++ b/source/partials/repo/_ownership.html.erb
@@ -1,6 +1,6 @@
 <% if repo.team && repo.alerts_team &&
       repo.team != repo.alerts_team %>
-  <strong><%= link_to repo.team, slack_url(repo.team) %></strong> owns the repo. <strong><%= links_to repo.alerts_team, slack_url(repo.alerts_team) %></strong> receives automated alerts for this repo.
+  <strong><%= link_to repo.team, slack_url(repo.team) %></strong> owns the repo. <strong><%= link_to repo.alerts_team, slack_url(repo.alerts_team) %></strong> receives automated alerts for this repo.
 <% elsif repo.team %>
   <%= link_to repo.team, slack_url(repo.team) %>
 <% elsif repo.alerts_team %>


### PR DESCRIPTION
It appears this code has never been executed before, so the long-standing typo has never been discovered.

[Trello card](https://trello.com/c/NKbo84JK)