### PR TITLE
Document that the responsibility for owning drills is now in teams

### DIFF
--- a/source/manual/ownership-meaning.html.md
+++ b/source/manual/ownership-meaning.html.md
@@ -17,6 +17,7 @@ The owner of an application is responsible for:
 - monitoring performance, including setting any Service Level Objectives/Indicators or similar measures
 - maintaining and prioritising a backlog, to include improvements and bug-fixing
 - dealing with any security issues arising from IT healthchecks etc
+- ensuring that any application-related workflows that may be required during an incident or high profile event, are sufficiently documented and regularly tested (which could mean an automated test, a manual drill, or something else)
 - actions arising from incident reviews (the Tech Lead and/or Product Manager should attend any incident review relating to the application)
 - making lifecycle decisions about the application, including if it should be retired. An application only exists to serve a purpose, and teams should feel empowered to create and retire them as needed
 - strategic thinking and planning around the application and how it fits with others

--- a/source/manual/tech-lead-responsibilities.html.md
+++ b/source/manual/tech-lead-responsibilities.html.md
@@ -60,6 +60,12 @@ As tech lead you have the opportunity to champion good developer practice in ter
 
 Essentially a tech lead’s role is to be the face that represents all the standards and principles by which developers need to work with.
 
+## Being prepared for incidents and high profile events
+
+The sorts of things that used to be drilled on Technical 2nd Line are [now the responsibility of the product teams](https://docs.google.com/document/d/1I4o4hLjpjUMthTOXEbmecBqpHvms2HV3EXKCHSCAK3U/edit). In other words, processes like "drilling deploying the emergency banner" are now the responsibility of the publishing teams.
+
+In practice, this means all of the tech leads in the publishing space (in this example) should collaborate on a plan for replacing the old drill process. This might mean running the drill within a publishing team, or perhaps replacing the drill with an automated test. It is also the responsibility of the tech leads to disseminate any information necessary (e.g. via Tech Fortnightly) such that whoever is on-call is confidently able to deal with related incidents.
+
 ## Attending tech lead stand up and writing the weeknote
 
 Every week there’s a GOV.UK tech lead stand up where each tech lead will talk about the work their team did in the last week, and let other tech leads become aware of anything that might affect them. At the same time, this is a good opportunity to share things that you’ve found out with the rest of your team so they’re aware of wider changes happening on GOV.UK.

--- a/source/manual/tech-lead-responsibilities.html.md
+++ b/source/manual/tech-lead-responsibilities.html.md
@@ -62,7 +62,7 @@ Essentially a tech lead’s role is to be the face that represents all the stand
 
 ## Being prepared for incidents and high profile events
 
-The sorts of things that used to be drilled on Technical 2nd Line are [now the responsibility of the product teams](https://docs.google.com/document/d/1I4o4hLjpjUMthTOXEbmecBqpHvms2HV3EXKCHSCAK3U/edit). In other words, processes like "drilling deploying the emergency banner" are now the responsibility of the publishing teams.
+The sorts of things that used to be drilled on Technical 2nd Line are [now the responsibility of product teams](https://docs.google.com/document/d/1I4o4hLjpjUMthTOXEbmecBqpHvms2HV3EXKCHSCAK3U/edit). For example, a process like "drilling deploying the emergency banner" is now the responsibility of the publishing teams.
 
 In practice, this means all of the tech leads in the publishing space (in this example) should collaborate on a plan for replacing the old drill process. This might mean running the drill within a publishing team, or perhaps replacing the drill with an automated test. It is also the responsibility of the tech leads to disseminate any information necessary (e.g. via Tech Fortnightly) such that whoever is on-call is confidently able to deal with related incidents.
 


### PR DESCRIPTION
Effectively a TLDR of
https://docs.google.com/document/d/1I4o4hLjpjUMthTOXEbmecBqpHvms2HV3EXKCHSCAK3U/edit, which has already been accepted and implemented.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
