### PR TITLE
Document new Google group for Technical On-Call

### DIFF
--- a/source/manual/slack-unavailable.html.md
+++ b/source/manual/slack-unavailable.html.md
@@ -37,6 +37,6 @@ If your space is "Restricted", you'll need to invite every relevant person, as t
 - Members of the Google group will be able to discover your space using "Browse spaces".
 - This means you won't have to worry about keeping your list of team members in sync with your 'space'.
 
-## 2nd line Google Space
+## On-Call Google Space
 
-There is a persistent [Technical 2nd Line space](https://mail.google.com/mail/u/0/#chat/space/AAAAuQLSk78), to which the [Technical 2nd Line Support Google Group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/2nd-line-support) is invited as a member. Everyone on 2nd line should therefore be able to use the 2nd line space in the event of a Slack outage.
+There is a persistent [GOV.UK Technical On-Call - Google Space](https://mail.google.com/mail/u/0/#chat/space/AAAAuQLSk78), to which the [GOV.UK Technical On-Call Comms Google Group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gov-uk-technical-oncall-comms) is invited as a member. Everyone on call should therefore be able to use the Google space in the event of a Slack outage.

--- a/source/manual/terraform-cloud.html.md
+++ b/source/manual/terraform-cloud.html.md
@@ -11,7 +11,7 @@ GOV.UK uses Terraform Cloud as a centralised interface for running Terraform.
 
 ## Getting Terraform Cloud access
 
-You can sign up for Terraform Cloud and join the GOV.UK organisation yourself. You will need to be a member of the [Technical 2nd Line Support](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/2nd-line-support) Google Group, or the [GOV.UK Terraform Cloud Access](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/GOV.UK_Terraform_Cloud_Access/members) group.
+You can sign up for Terraform Cloud and join the GOV.UK organisation yourself. You will need to be a member of the [GOV.UK Terraform Cloud Access](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/GOV.UK_Terraform_Cloud_Access/members) group (or of a group that is a member of that group, such as [GOV.UK Technical On-Call Comms](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gov-uk-technical-oncall-comms)).
 
 1. Follow this link to [join the GOV.UK Terraform Cloud organisation](https://accounts.google.com/o/saml2/initsso?idpid=C01ppujwc&spid=738388265440&forceauthn=false). By connecting your digital.cabinet-office.gov.uk Google account, you'll be granted access to the GOV.UK organisation.
 2. After connecting Google, you'll be asked to create a Terraform Cloud account (or sign in if you already have one), as [SSO does not automatically provision Terraform Cloud user accounts](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#sso-identities-and-terraform-cloud-user-accounts). You'll need to set an account password, however, once the SSO identity is linked, you'll only log in to the GOV.UK organization using the linked (Google) account.


### PR DESCRIPTION
2nd-line-support is deprecated.

Trello: https://trello.com/c/348IuAYs/259-set-up-new-govuk-technical-oncall-comms-google-group-to-replace-2nd-line-support

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
