### PR TITLE
Clearer instructions for removing assets originating from Whitehall

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -19,15 +19,23 @@ For example, for `https://assets.publishing.service.gov.uk/government/uploads/up
 
 ## Remove an asset
 
-> Where possible, you should delete the asset in the publishing application
-> that originally uploaded the file, for example Whitehall. Deleting an asset
-> from Asset Manager without removing the record from the publishing
-> application could cause problems if the asset is attempted to be re-published
-> again in the future.
+### Remove an asset via the originating publishing app
 
-If it isn't feasible to remove the asset in the publishing app, you can use
-these steps to remove the asset from `assets.publishing.service.gov.uk` in
-Asset Manager.
+Where possible, you should delete the asset in the publishing application that originally uploaded the file, for example Whitehall. Deleting an asset from Asset Manager without removing the record from the publishing application could cause problems if the asset is attempted to be re-published again in the future.
+
+For example, to delete a legacy Whitehall attachment of the form `/government/uploads/system/uploads/attachment_data/file/12345/foo.pdf`, you would:
+
+1. Open a Rails console in Whitehall
+
+1. Retrieve the content IDs (and some sense-checking attributes) of the attachments in Whitehall: `Attachment.where(attachment_data_id: 12345).pluck(:content_id, :deleted_at, :created_at)`
+
+1. Exit the Rails console
+
+1. For each attachment that is marked `deleted: false`, mark them as deleted via the dedicated rake task, i.e. `k exec deploy/whitehall-admin -- rake delete_attachment["<content id>"]`
+
+### Remove an asset directly in Asset Manager
+
+If it isn't feasible to remove the asset in the publishing app, you can use these steps to remove the asset from `assets.publishing.service.gov.uk` in Asset Manager.
 
 1. [Get the asset ID](/manual/manage-assets.html#get-an-assets-id).
 


### PR DESCRIPTION
This is by far the most common use case for following these instructions - so let's make it a bit less abstract.

Trello: https://trello.com/c/tKtV5zHj/3025-older-documents-are-appearing-in-google-search-results