### PR TITLE
Add a lead time to transition requests

### DIFF
--- a/source/manual/transition-a-site.html.md
+++ b/source/manual/transition-a-site.html.md
@@ -15,6 +15,10 @@ The [Transition][] app exists to allow old URLs to be mapped to pages
 on GOV.UK. These mappings are stored in a database and used by [Bouncer][] to
 handle requests to those old domains.
 
+Transitioning a site takes time and has to be prioritised. Please submit a
+request for your site to be transitioned at least two weeks before you need
+the site to be redirected.
+
 This page covers adding a site so that we can handle traffic to
 it, or changing the configuration of an existing site in the Transition app.
 


### PR DESCRIPTION
People keep requesting transition sites be added immediately which isn't really practicable.

Trello - https://trello.com/c/SOPCsAsD/1421-update-the-public-guidance-about-transition-to-include-a-lead-time

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
