### PR TITLE
Create a new Monitoring and alerting section and move some docs to it

### DIFF
--- a/source/manual/alerts/RouterErrorRatioTooHigh.html.md
+++ b/source/manual/alerts/RouterErrorRatioTooHigh.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-2ndline-tech"
 title: Router error ratio too high
 parent: "/manual.html"
 layout: manual_layout
-section: Pagerduty alerts
+section: Monitoring and alerting
 ---
 
 You can find the router request error rates on this dashboard:

--- a/source/manual/alerts/chat-ai-alerts.html.md
+++ b/source/manual/alerts/chat-ai-alerts.html.md
@@ -3,7 +3,7 @@ owner_slack: "#dev-notifications-ai-govuk"
 title: GOV.UK Chat Alerts
 parent: "/manual.html"
 layout: manual_layout
-section: Alertmanager alerts
+section: Monitoring and alerting
 ---
 
 > **Note**

--- a/source/manual/alerts/email-alerts-travel-medical.html.md
+++ b/source/manual/alerts/email-alerts-travel-medical.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline-tech"
 title: Travel Advice or Drug and Medical Device email alerts not sent
-section: Pagerduty alerts
+section: Monitoring and alerting
 layout: manual_layout
 parent: "/manual.html"
 ---

--- a/source/manual/alerts/signon-api-user-token-expires-soon.html.md
+++ b/source/manual/alerts/signon-api-user-token-expires-soon.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-platform-engineering"
 title: Signon API user token expires soon
 parent: "/manual.html"
 layout: manual_layout
-section: Alertmanager alerts
+section: Monitoring and alerting
 ---
 
 One or more tokens for API Users are about to expire. You should rotate

--- a/source/manual/debug-underperforming-search.html.md
+++ b/source/manual/debug-underperforming-search.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-searchandnav"
 title: Debug underperforming search
-section: Monitoring
+section: Monitoring and alerting
 layout: manual_layout
 parent: "/manual.html"
 ---

--- a/source/manual/errors.html.md
+++ b/source/manual/errors.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: How we handle errors
-section: Monitoring
+section: Monitoring and alerting
 layout: manual_layout
 parent: "/manual.html"
 ---

--- a/source/manual/graphite-and-deployment-dashboards.html.md
+++ b/source/manual/graphite-and-deployment-dashboards.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Graphite and deployment dashboards
-section: Monitoring
+section: Monitoring and alerting
 type: learn
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/pagerduty.html.md
+++ b/source/manual/pagerduty.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline-tech"
 title: PagerDuty
-section: 2nd line
+section: Monitoring and alerting
 type: learn
 layout: manual_layout
 parent: "/manual.html"

--- a/source/manual/pingdom-bouncer-canary-check.html.md
+++ b/source/manual/pingdom-bouncer-canary-check.html.md
@@ -4,7 +4,7 @@ title: Pingdom Bouncer canary check
 parent: "/manual.html"
 layout: manual_layout
 type: learn
-section: Monitoring
+section: Monitoring and alerting
 ---
 
 This alert is raised by [Pingdom](/manual/pingdom.html) when it cannot

--- a/source/manual/pingdom.html.md
+++ b/source/manual/pingdom.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-developers"
 title: Pingdom
-section: Monitoring
+section: Monitoring and alerting
 layout: manual_layout
 parent: "/manual.html"
 ---

--- a/source/manual/screens.html.md
+++ b/source/manual/screens.html.md
@@ -4,7 +4,7 @@ title: Screens that we have in the office
 parent: "/manual.html"
 type: learn
 layout: manual_layout
-section: Monitoring
+section: Monitoring and alerting
 ---
 
 ## Technical 2nd Line screens

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-developers"
 title: Sentry
 parent: "/manual.html"
 layout: manual_layout
-section: Monitoring
+section: Monitoring and alerting
 type: learn
 ---
 

--- a/source/manual/sidekiq.html.md
+++ b/source/manual/sidekiq.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-developers"
 title: Sidekiq
 parent: "/manual.html"
 layout: manual_layout
-section: Monitoring
+section: Monitoring and alerting
 type: learn
 ---
 


### PR DESCRIPTION
As a fairly simple first step to getting some of these docs sorted out, I've consolidated these sections:

- `Alertmanager alerts`
- `Pagerduty alerts`
- `Pagerduty`
- `Monitoring`

into a single `Monitoring and alerting` section. 

Further work is still needed - part of https://github.com/alphagov/govuk-developer-docs/issues/4797 
