### PR TITLE
repos: add "govuk-display-screen" repo to the repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -283,7 +283,7 @@
   team: "#govuk-insights-and-analytics"
   management_url: https://govuk-display-screen-20e334eeb1ba.herokuapp.com/
   production_hosted_on: heroku
-  description: Webapp to display essential gov.uk content analytics on the office TVs
+  description: Provides realtime GOV.UK content analytics for digital signage
 
 - repo_name: govuk-dns-tf
   private_repo: true

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -278,6 +278,13 @@
   type: Utilities
   sentry_url: false
 
+- repo_name: govuk-display-screen
+  type: Utilities
+  team: "#govuk-insights-and-analytics"
+  management_url: https://govuk-display-screen-20e334eeb1ba.herokuapp.com/
+  production_hosted_on: heroku
+  description: Webapp to display essential gov.uk content analytics on the office TVs
+
 - repo_name: govuk-dns-tf
   private_repo: true
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
# Context

Our team has recently revived and taken over the `govuk-display-screen` application.
This PR adds our team as owner of the repository.


# Question:

Is the `team` value supposed to be our team's channel name in Slack? Or something else?