### PR TITLE
Remove `search-v2-evaluator`

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -329,7 +329,7 @@
   type: Utilities
   team: "#govuk-platform-engineering"
   private_repo: true
-  
+
 - repo_name: govuk-knowledge-graph-gcp
   team: "#data-engineering"
   type: Data science
@@ -667,12 +667,6 @@
 
 - repo_name: search-api-v2
   type: APIs
-  team: "#govuk-search-improvement"
-  production_hosted_on: eks
-
-- repo_name: search-v2-evaluator
-  type: Supporting apps
-  description: Internal semi-temporary tool to evaluate results from search-api-v2
   team: "#govuk-search-improvement"
   production_hosted_on: eks
 


### PR DESCRIPTION
This repo is being retired, and it's not worth keeping around as retired in the repo list as there isn't really broad awareness of it, or dependencies on it, outside our team.