### PR TITLE
Remove govuk-infrastructure-sensitive repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -325,11 +325,6 @@
   type: Utilities
   team: "#govuk-platform-engineering"
 
-- repo_name: govuk-infrastructure-sensitive
-  type: Utilities
-  team: "#govuk-platform-engineering"
-  private_repo: true
-
 - repo_name: govuk-knowledge-graph-gcp
   team: "#data-engineering"
   type: Data science


### PR DESCRIPTION
This repo was deleted as we no longer need to store sensitive information there