### PR TITLE
Update pagerduty drill docs

### DIFF
--- a/source/manual/pagerduty.html.md
+++ b/source/manual/pagerduty.html.md
@@ -34,7 +34,7 @@ any issues. This happens every Monday morning at 10am UTC (11am BST).
 Prometheus is currently firing a constant `Watchdog` alert, which fires all the time so that
 developers can see the that prometheus is integrated with alertmanager. In the
 [alertmanager configs](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/cluster-services/templates/alertmanager-config.tpl#L79-L85)
-the pagerduty drill is set up to trigger when the the clocks hit a specified time frame, between 10am to 10:03am UTC (11am to 11:03am BST) every Wednesday.
+the pagerduty drill is set up to trigger when the the clocks hit a specified time frame, between 10am to 10:03am UTC (11am to 11:03am BST) every Monday.
 
 You don't need to take any action for this alert. The primary in-office
 Technical 2nd Line developer should escalate the call to the secondary who should escalate


### PR DESCRIPTION
The PagerDuty drill now runs on a Monday rather than a Wednesday so I've updated the docs to reflect this.
