### PR TITLE
Move data sync page to Backups section

### DIFF
--- a/source/manual/govuk-env-sync.html.md
+++ b/source/manual/govuk-env-sync.html.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#govuk-2ndline-tech"
 title: Environment data sync
-section: Monitoring
+section: Backups
 type: learn
 layout: manual_layout
 parent: "/manual.html"


### PR DESCRIPTION
This feels like a better place for the data sync docs, and it was the last thing in the now-superseded `Monitoring` section. 

I somehow missed this in https://github.com/alphagov/govuk-developer-docs/pull/4863 
