### PR TITLE
Add govuk_content_block_tools gem to repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -475,6 +475,11 @@
   type: Gems
   sentry_url: false
 
+- repo_name: govuk_content_block_tools
+  team: "#govuk-publishing-content-modelling-dev"
+  type: Gems
+  sentry_url: false
+
 - repo_name: govuk_document_types
   team: "#govuk-navigation-tech"
   type: Gems


### PR DESCRIPTION
This adds the newly-minted [govuk_content_block_tools](https://github.com/alphagov/govuk_content_block_tools) gem to the list of repos.