### PR TITLE
Tweaks to Github docs

### DIFF
--- a/source/manual/github-new-repo.html.md
+++ b/source/manual/github-new-repo.html.md
@@ -1,0 +1,25 @@
+---
+owner_slack: "#govuk-developers"
+title: Configure a new GOV.UK repository
+parent: /manual.html
+layout: manual_layout
+section: GitHub
+type: learn
+---
+
+When creating a new GOV.UK repo in Github, you must:
+
+- make a well-written README (see [READMEs for GOV.UK applications](/manual/readmes.html), or the [GDS Way guidance](https://gds-way.digital.cabinet-office.gov.uk/manuals/readme-guidance.html#writing-readmes) for general repositories)
+- tag it with the [`govuk`](https://github.com/search?q=topic:govuk) topic
+- add [Dependency Review](/manual/dependency-review.html) and [CodeQL](/manual/codeql.html) scans to its CI pipeline
+- add it to the [repos.yml](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml) file
+- add it to [repos.yml in govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/repos.yml). This:
+  - applies [branch protection](https://help.github.com/articles/about-protected-branches) rules and configures PRs to be blocked on the outcome of the [GitHub Action CI](/manual/test-and-build-a-project-with-github-actions.html) workflow (if one exists)
+  - restricts the merging of PRs for continuously deployed apps, so that only those with Production Deploy or Production Admin access can merge
+  - enables vulnerability alerts and security fixes
+  - sets up the webhook for [GitHub Trello Poster](/repos/github-trello-poster.html)
+  - sets some other default repo settings (e.g. delete branch on merge)
+
+You'll then need to [plan and apply the GitHub workspace in Terraform Cloud](https://app.terraform.io/app/govuk/workspaces/GitHub/runs), which automatically updates the collaborators to the [default teams and access levels](https://github.com/alphagov/govuk-infrastructure/blob/83ff43c4e55f3d3273644e80897b58fd351f566a/terraform/deployments/github/main.tf#L76-L112).
+
+ > If your repository access is sensitive, tag it with the [`govuk-sensitive-access`](https://github.com/search?q=topic:govuk-sensitive-access) topic to avoid this automation: you would then need to manually manage its collaborators.

--- a/source/manual/github.html.md
+++ b/source/manual/github.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-developers"
-title: GitHub
+title: How GOV.UK uses GitHub
 parent: /manual.html
 layout: manual_layout
 section: GitHub
@@ -9,15 +9,17 @@ type: learn
 
 GOV.UK uses GitHub for version control, code deployments, authentication, CI, Dependabot and GitHub Pages. Read the "[GOV.UK reliance on GitHub features doc](https://docs.google.com/document/d/1KsYWCHSQZEwqB2NF1A7Z9rmP1s1azcZhEamaPsXAoxk/edit)" Google doc for more information.
 
-# GitHub organisation
+You must follow [these instructions when creating and configuring a new GOV.UK repository](/manual/github-new-repo).
 
-Our GitHub organisation is called [alphagov](https://github.com/alphagov). We (GOV.UK) share it with other teams in the Government Digital Service (GDS).
+## Our GitHub organisation
+
+Our GitHub organisation is called [alphagov](https://github.com/alphagov). GOV.UK shares it with other teams in the Government Digital Service (GDS).
 
 The organisation is on the Enterprise Cloud plan, which grants us access to GitHub's enterprise support. Only [people with enterprise permissions](https://github.com/orgs/alphagov/people/enterprise_owners) can access enterprise support ([limited to enterprise owners and up to 20 additional members](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-support-entitlements-for-your-enterprise)).
 
-[GDS GitHub Owners](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-github-owners) have superadmin access to alphagov. You can contact them to request changes to [organisation settings](https://docs.github.com/en/organizations/managing-organization-settings), or to request access to an inaccessible repository (e.g. one that was created by an ex-employee).
+[GDS GitHub Owners](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-github-owners) have superadmin access to alphagov. You need to contact them to request changes to [organisation settings](https://docs.github.com/en/organizations/managing-organization-settings), or to request access to an inaccessible repository (e.g. one that was created by an ex-employee).
 
-# GOV.UK teams
+## GOV.UK teams in Github
 
 There are several GOV.UK GitHub teams within alphagov, including:
 
@@ -34,46 +36,25 @@ There are several GOV.UK GitHub teams within alphagov, including:
   This team allows the user to create a branch in a GOV.UK repository and open a pull request, but only a developer can merge the request.
   Only content designers should be added to this team.
 
-# Getting access to GitHub
+## Getting access to GitHub
 
-Not everyone on GOV.UK requires GitHub access, as much of what we do is in the open. However, if your role requires it, you should be added to the org and the relevant team(s) through Terraform, in [govuk-user-reviewer][govuk-user-reviewer] - _not_ manually added through the GitHub UI itself, as this breaks the Terraform setup. Note that you will be sent an invitation email and will have to accept the invite before you are added to the organisation.
+If your role requires access to Github, you'll need to be added to the organisation and the relevant team(s) through Terraform, in [govuk-user-reviewer][govuk-user-reviewer] - _not_ manually added through the GitHub UI itself, as this breaks the Terraform setup. Note that you will have to accept the invite sent via email before you're added to the organisation.
 
-- If you're a content designer, ask for GitHub access via Zendesk (see [example ticket](https://govuk.zendesk.com/agent/tickets/5812930/events)). Ensure to include `govuk_platform_support` tag.
-- If you're an engineer or contractor, ask your tech lead to follow the instructions in [govuk-user-reviewer][govuk-user-reviewer] to add you.
-- If you don't have a tech lead, [ask someone in Senior Tech](/manual/ask-for-help.html#contact-senior-tech) to add you. You must state
-  - your role
-  - which team you're in
-  - your GitHub handle
-  - which GitHub team(s) you should join ([see list](#govuk-teams))
-  - why you need access
+- If you're an engineer or contractor, ask your tech lead to add you by following the instructions in [govuk-user-reviewer][govuk-user-reviewer].
+- If you don't have a tech lead, [ask someone in Senior Tech](/manual/ask-for-help.html#contact-senior-tech) to add you.
+- If you're a content designer, ask for GitHub access via Zendesk (see [example ticket](https://govuk.zendesk.com/agent/tickets/5812930)). Make sure you include the `govuk_platform_support` tag.
+
+In these last two cases, you must state:
+
+- your role
+- which team you're in
+- why you need access
+- your GitHub username
+- which GitHub team(s) you should join ([see list](#gov-uk-teams-in-github))
 
 ## Removing access to GitHub
 
 Users are removed from the GitHub organisation when their entry in [govuk-user-reviewer][govuk-user-reviewer] is deleted.
-
-# GOV.UK repos
-
-## Create and configure a new GOV.UK repo
-
-When creating a new GOV.UK repo, you must ensure it:
-
-- has a well-written README (see [READMEs for GOV.UK applications](/manual/readmes.html), or the [GDS Way guidance](https://gds-way.digital.cabinet-office.gov.uk/manuals/readme-guidance.html#writing-readmes) for general repositories)
-- is tagged with the [`govuk`](https://github.com/search?q=topic:govuk) topic
-- has [Dependency Review](/manual/dependency-review.html) and [CodeQL](/manual/codeql.html) scans in its CI pipeline
-- is added to the [repos.yml](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml) file in the Developer Docs.
-
-You should add repository to [repos.yml in govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/repos.yml). This:
-
-- Applies [branch protection](https://help.github.com/articles/about-protected-branches) rules and configures PRs to be blocked on the outcome of the [GitHub Action CI](/manual/test-and-build-a-project-with-github-actions.html) workflow (if one exists)
-- Restricts the merging of PRs for continuously deployed apps, so that only those with Production Deploy or Production Admin access can merge
-- Enables vulnerability alerts and security fixes
-- Sets up the webhook for [GitHub Trello Poster](/repos/github-trello-poster.html)
-- Sets some other default repo settings (e.g. delete branch on merge)
-
-You'll then need to [plan and apply the GitHub workspace in Terraform Cloud](https://app.terraform.io/app/govuk/workspaces/GitHub/runs):
-
-- This automatilcally updates the collaborators to the [default teams and access levels](https://github.com/alphagov/govuk-infrastructure/blob/83ff43c4e55f3d3273644e80897b58fd351f566a/terraform/deployments/github/main.tf#L76-L112).
-  - If your repository access is sensitive, it should be tagged with the [`govuk-sensitive-access`](https://github.com/search?q=topic:govuk-sensitive-access) topic to avoid this automation: you would then need to manually manage its collaborators.
 
 [govuk-user-reviewer]: https://github.com/alphagov/govuk-user-reviewer
 [team-govuk]: https://github.com/orgs/alphagov/teams/gov-uk


### PR DESCRIPTION
 A few smallish changes to:

- Try to make requirements for setting up a new GOV.UK repo clearer (some of these steps are regularly missed) by splitting this out into a separate page
- Fix heading structure
- Improve general readability and fix typos