### PR TITLE
Add govuk_web_banners repo information

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -511,6 +511,11 @@
   type: Gems
   sentry_url: false
 
+- repo_name: govuk_web_banners
+  team: "#govuk-patterns-and-pages"
+  type: Gems
+  sentry_url: false
+
 - repo_name: hmrc-manuals-api
   type: APIs
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
