### PR TITLE
Fix broken incident management link

### DIFF
--- a/source/manual/post-a-statuspage-message.html.md
+++ b/source/manual/post-a-statuspage-message.html.md
@@ -121,7 +121,7 @@ Example message:
 
 > On 30 to 31 May 2022 users of GOV.UK were unable to subscribe and unsubscribe from email alerts to page changes.
 
-[inc]: /manual/incident-management-guidance.html
+[inc]: /manual.html#incident-management
 [status]: https://status.publishing.service.gov.uk
 [sp]: https://statuspage.io
 [man]: https://manage.statuspage.io


### PR DESCRIPTION
## What

Updated the "Incident Management" linked on the Status Page.

## Why

The previous link would result in a 404 error.