### PR TITLE
Change some pages from"Learn" to "How to"

### DIFF
--- a/source/manual/configure-linting.html.md
+++ b/source/manual/configure-linting.html.md
@@ -2,7 +2,6 @@
 owner_slack: "#govuk-developers"
 title: Configure linting
 section: Applications
-type: learn
 layout: manual_layout
 parent: "/manual.html"
 ---

--- a/source/manual/find-a-rails-template-based-on-a-govuk-url.html.md
+++ b/source/manual/find-a-rails-template-based-on-a-govuk-url.html.md
@@ -3,7 +3,6 @@ owner_slack: "#govuk-developers"
 title: Find a rails template based on a GOV.UK URL or vice verca
 section: Frontend
 layout: manual_layout
-type: learn
 parent: "/manual.html"
 ---
 When making changes to a template in one of our frontend apps it's often beneficial to see a rendered page with your change so that you can effectively test it. This can be difficult when developing within gov.uk as we have several frontend apps which control different parts of the site, sometimes overlapping in sections that they take responsibility for. This document details ways in which you can bypass this issue.

--- a/source/manual/github-new-repo.html.md
+++ b/source/manual/github-new-repo.html.md
@@ -4,7 +4,6 @@ title: Configure a new GOV.UK repository
 parent: /manual.html
 layout: manual_layout
 section: GitHub
-type: learn
 ---
 
 When creating a new GOV.UK repo in Github, you must:

--- a/source/manual/how-to-escalate-to-AWS-support.html.md
+++ b/source/manual/how-to-escalate-to-AWS-support.html.md
@@ -1,10 +1,8 @@
 ---
 owner_slack: "#govuk-developers"
 title: How to raise a support ticket with AWS
-
 section: AWS
 layout: manual_layout
-type: learn
 parent: "/manual.html"
 ---
 

--- a/source/manual/slack-integrations.html.md
+++ b/source/manual/slack-integrations.html.md
@@ -3,7 +3,6 @@ owner_slack: "#govuk-developers"
 title: How to add popular GOV.UK Slack integrations
 section: Team tools
 layout: manual_layout
-type: learn
 parent: "/manual.html"
 ---
 


### PR DESCRIPTION
Slightly pedantic, but this changes how the pages are displayed on https://docs.publishing.service.gov.uk/manual.html, and how related links are displayed at the bottom of pages. 
Several pages were incorrectly marked as "Learn" when actually they're guides for how to do something. 
