### PR TITLE
Update email notifcation docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
       faraday (~> 1.0)
     fast_blank (1.0.1)
     fastimage (2.3.1)
+    ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
@@ -162,6 +163,9 @@ GEM
       rchardet (~> 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.27.5-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.27.5-arm64-darwin)
       bigdecimal
       rake (>= 13)
@@ -334,6 +338,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.8-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.8-x86_64-darwin)
@@ -712,6 +718,7 @@ GEM
     zeitwerk (2.6.17)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   x86_64-darwin-23
   x86_64-linux

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -11,8 +11,6 @@ parent: "/manual.html"
 
 The purpose of the email notifications system is to inform users when content they are interested in is added to or changed on GOV.UK. Users can subscribe to receive updates for an area of interest, such as a topic, government department, or a set of search results. Current subscriptions to individual content items are not supported.
 
-**Update September 2019:** the email system also now supports highly customised subscriptions for users completing the [Brexit Checker][brexit-checker], which operates in isolation from the rest of GOV.UK, and specifies its own notifications. More information can be found in [the ADR][message-adr] for these changes.
-
 ## Types of email
 
 The email notification system generates 3 different types of email. These are transactional, immediate and digest.

--- a/source/manual/email-notifications-how-they-work.html.md
+++ b/source/manual/email-notifications-how-they-work.html.md
@@ -11,6 +11,10 @@ parent: "/manual.html"
 
 The purpose of the email notifications system is to inform users when content they are interested in is added to or changed on GOV.UK. Users can subscribe to receive updates for an area of interest, such as a topic, government department, or a set of search results. Current subscriptions to individual content items are not supported.
 
+## Language support
+
+The email notification system will only alert uses to [content changes on pages published in English][email-alert-service-code-link].
+
 ## Types of email
 
 The email notification system generates 3 different types of email. These are transactional, immediate and digest.
@@ -55,6 +59,7 @@ The email notification system generates 3 different types of email. These are tr
 
 Communication from Email Alert API to Notify is done via a HTTP API which is authenticated by [an API key][notify-api-key]. Communication from Notify to Email Alert API is [authenticated][email-spam-auth] with Signon and a bearer token.  Email Alert API is an internal application, so to enable callbacks two endpoints are [exposed][email-spam-public] publicly through <https://email-alert-api-public.publishing.service.gov.uk> (similarly for Integration and Staging).
 
+[email-alert-service-code-link]: https://github.com/alphagov/email-alert-service/blob/main/email_alert_service/models/major_change_message_processor.rb#L23-L26
 [finder-frontend-email]: https://github.com/alphagov/finder-frontend/blob/main/app/controllers/email_alert_subscriptions_controller.rb
 [email-frontend-readme]: https://github.com/alphagov/email-alert-frontend
 [Specialist Publisher]: /repos/specialist-publisher.html

--- a/source/manual/email-signup-journeys.html.md
+++ b/source/manual/email-signup-journeys.html.md
@@ -71,3 +71,13 @@ The button is configured similarly on the other page types mentioned aboves, inc
 [finder-frontend-docs]: https://github.com/alphagov/finder-frontend/blob/main/docs/finder-email-alerts.md
 [email-alert-schema]: https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/email_alert_signup/notification/schema.json
 [email-alert-api-documentation-links]: https://github.com/alphagov/email-alert-api/blob/main/docs/matching-content-to-subscriber-lists.md#json-fields
+
+## Email sign up from content published in a foreign language
+
+Whilst there is translated content on GOV.UK, the email notification system only supports subscriptions to English language pages. Unfortunately there are three different approaches we take to prevent users from signing up to foreign language emails on GOV.UK. This lack of constistency is a result of there being multiple email sign up entry points. It is also a result of there being two different ways that translated content is published to GOV.UK: Whitehall content has a link to the English equivalent, but translated mainstream content does not.
+
+Code links to illustrate the different approaches can be found [here][organisation-page-emails], [here][single-page-notification-emails] and [here][world-location-news-page-email].
+
+[organisation-page-emails]: https://github.com/alphagov/collections/pull/3489
+[single-page-notification-emails]: https://github.com/alphagov/government-frontend/pull/3467
+[world-location-news-page-email]:https://github.com/alphagov/collections/blob/ea307473313aa5138e6db6dd16eb26f1bf453bfd/app/views/world_location_news/show.html.erb#L56-L86


### PR DESCRIPTION
Update email notification documentation to cover lack of support for foreign language publications. 

[Trello](https://trello.com/c/24HBupfM/3107-hide-single-page-notification-button-on-welsh-pages)