### PR TITLE
Documentation for likely dev tasks for site search autocomplete

### DIFF
--- a/source/manual/disable-autocomplete.html.md
+++ b/source/manual/disable-autocomplete.html.md
@@ -1,0 +1,22 @@
+---
+owner_slack: "#govuk-developers"
+title: Disable autocomplete
+section: GOV.UK Search
+layout: manual_layout
+parent: "/manual.html"
+---
+
+Autocomplete for GOV.UK site search is a feature that launched in December 2024, while it is a new feature there is a simple mechnanism to disable it.
+
+To disable the autocomplete functionality for GOV.UK site search for a GOV.UK environment:
+
+1. Open the appropriate `values-<environment>.yaml` file from [GOV.UK Helm Charts][], for example [values-production.yaml][]
+1. Find the `disableSearchAutocomplete` variable and set it to `true`
+1. Open a PR to apply the change
+1. Once merged the variable will propagate across apps
+
+As pages are [cached][] disabling this feature will not happen instantly and will apply to pages gradually as their cache times expire. It may take up-to 10 minutes for this to be applied to all pages of GOV.UK.
+
+[GOV.UK Helm Charts]: https://github.com/alphagov/govuk-helm-charts
+[values-production.yaml]: https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-production.yaml
+[cached]: https://docs.publishing.service.gov.uk/manual/architecture-shallow-dive.html#a-user-visits-a-gov-uk-webpage

--- a/source/manual/update-the-autocomplete-denylist.html.md
+++ b/source/manual/update-the-autocomplete-denylist.html.md
@@ -22,7 +22,10 @@ Then for each GOV.UK environment of integration, staging and production:
 1. [Authenticate][kube-auth] to the appropriate environment for Kubernetes
 1. Run the `rake autocomplete:update_denylist` [rake task][] for `search-api-v2` to import the file
 
+If there are problems updating the denylist we can consider [disabling the autocomplete feature][disable-autocomplete] temporarily to provide time to resolve the problem.
+
 [the spreadsheet]: https://docs.google.com/spreadsheets/d/1aA2JapqNt0nu-MiFraP7p9flSDvNQCm0QvSZi2Unw48/edit?gid=0#gid=0
 [Google Cloud]: /manual/google-cloud-platform-gcp.html#gcp-access
 [kube-auth]: /kubernetes/cheatsheet.html#prerequisites
 [rake task]: /manual/running-rake-tasks.html#run-a-rake-task-on-eks
+[disable-autocomplete]: /manual/disable-autocomplete.html

--- a/source/manual/update-the-autocomplete-denylist.html.md
+++ b/source/manual/update-the-autocomplete-denylist.html.md
@@ -1,0 +1,28 @@
+---
+owner_slack: "#govuk-developers"
+title: Update the autocomplete denylist
+section: GOV.UK Search
+layout: manual_layout
+parent: "/manual.html"
+---
+
+The autocomplete functionality for GOV.UK Site Search makes use of a denylist to avoid suggesting terms that are not suitable for GOV.UK.
+
+To update this list requires following a manual process:
+
+1. In a text editor create a new empty file, save this file as `denylist.jsonl`
+1. Access [the spreadsheet][] and apply the desired changes to the appropriate spreadsheet
+1. Copy and paste the contents from the "denylist" column from each spreadsheet into your created `denylist.jsonl` file
+
+Then for each GOV.UK environment of integration, staging and production:
+
+1. Log into [Google Cloud][] and access the `Search API V2 <environment>` project
+1. Access "Cloud Storage" > "Buckets" and find the `search-api-v2-<environment>_vais_artifacts` bucket
+1. Upload the `denylist.jsonl` file to the bucket, replacing the existing file
+1. [Authenticate][kube-auth] to the appropriate environment for Kubernetes
+1. Run the `rake autocomplete:update_denylist` [rake task][] for `search-api-v2` to import the file
+
+[the spreadsheet]: https://docs.google.com/spreadsheets/d/1aA2JapqNt0nu-MiFraP7p9flSDvNQCm0QvSZi2Unw48/edit?gid=0#gid=0
+[Google Cloud]: /manual/google-cloud-platform-gcp.html#gcp-access
+[kube-auth]: /kubernetes/cheatsheet.html#prerequisites
+[rake task]: /manual/running-rake-tasks.html#run-a-rake-task-on-eks


### PR DESCRIPTION
Draft - pending the merging of: https://github.com/alphagov/govuk-helm-charts/pull/2832 before these docs will fully apply.

We are looking to the roll out of autocomplete for GOV.UK site search. This will result in the search widget on every page of GOV.UK providing autocomplete suggestions. 

This documentation provides 2 guides:

1. How to follow a relatively manual process on how to update the denylist of terms that the GOV.UK autocomplete is not allowed to suggest (swear words, MP names, test data)
2. How to disable the autocomplete altogether

This information is added to the dev docs as there are concerns that there could be an urgent push to update the denylist if it is showing something undesirable and this could occur out of hours. The task to disable the autocomplete is provided as a quick means to be able to turn the feature off altogether should a problem occur and to allow time to fix it in office hours.