### PR TITLE
Update instructions for load testing

### DIFF
--- a/source/manual/load-test.html.md
+++ b/source/manual/load-test.html.md
@@ -31,7 +31,7 @@ These instructions are based on [this blog post](https://grafana.com/blog/2022/0
 1. Clone the `k6-operator` repo and make this:
 
     ```sh
-    git clone git@github.com:grafana/k6-operator.git && cd k6-operator
+    git clone git@github.com:grafana/k6-operator.git && cd k6-operator && git checkout v0.0.18
     make deploy
     ```
 

--- a/source/manual/load-test.html.md
+++ b/source/manual/load-test.html.md
@@ -121,4 +121,5 @@ These instructions are based on [this blog post](https://grafana.com/blog/2022/0
 
     ```sh
     kubectl delete -f /path/to/our/k6/custom-resource.yml
+    kubectl delete configmap my-test-name
     ```


### PR DESCRIPTION
The instructions missed the step to remove the configmap file.  Not removing this can result in an error (because of duplicated names) when running another load test.

Also we need to use a stable version of `k6-operator` (rather than the main branch).  Therefore pinning this to the version that was used when writing these instructions.

[Trello card](https://trello.com/c/sVW4QFue)