### PR TITLE
Remove `widdershins` from list of repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -798,8 +798,3 @@
   production_hosted_on: eks
   kibana_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,request,status,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:whitehall-admin),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:whitehall-admin)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())
   kibana_worker_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:whitehall-admin-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:whitehall-admin-worker)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())
-
-- repo_name: widdershins
-  type: Gems
-  team: "#govuk-publishing-platform"
-  alerts_team: "#govuk-publishing-platform-system-alerts"


### PR DESCRIPTION
Our fork of `widdershins` has been archived, since we no longer use it in any applications.

Depends on https://github.com/alphagov/govuk-content-api-docs/pull/152.

[Trello card](https://trello.com/c/7LqhcraV)