### PR TITLE
Update renamed channel

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -529,7 +529,7 @@
   type: Gems
 
 - repo_name: govuk_publishing_components
-  team: "#govuk-frontenders"
+  team: "#govuk-ruby-frontenders"
   type: Gems
   production_url: https://components.publishing.service.gov.uk
   sentry_url: false


### PR DESCRIPTION
This updates the channel govuk-frontenders to govuk-ruby-frontenders as it has been renamed for clarity now that the Design System frontenders are also in the GOV.UK programme
