### PR TITLE
Remove secrets from Brakeman workflow example

### DIFF
--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -24,7 +24,6 @@ To use the Brakeman reusable workflow, add the following job to the `jobs` secti
 security-analysis:
   name: Security Analysis
   uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
-  secrets: inherit
   permissions:
     contents: read
     security-events: write


### PR DESCRIPTION

The reusable workflow for running Brakeman[1] doesn't rely on any
secrets, so there's no need to pass `secrets: inherit` when calling the
workflow.

[1] https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/brakeman.yml
