### PR TITLE
Add govuk_chat_private repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -508,6 +508,14 @@
   type: Gems
   sentry_url: false
 
+- repo_name: govuk_chat_private
+  private_repo: true
+  description: |
+    Private gem for storing code/config for GOV.UK Chat which isn't suitable
+    for open source.
+  team: "#dev-notifications-ai-govuk"
+  type: Gems
+
 - repo_name: govuk_content_block_tools
   team: "#govuk-publishing-content-modelling-dev"
   type: Gems


### PR DESCRIPTION
This is a private gem for the govuk-chat repo that is used to store parts of govuk-chat that were agreed to not be suitable for open sourcing.

While it's not a particularly interesting addition to the dev docs, being private, it is required for terraform handling of repo configuration.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
