### PR TITLE
Reduce the size of the gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           publish_dir: ./build
           cname: docs.publishing.service.gov.uk
           commit_message: ${{steps.commit_message_writer.outputs.commit_message}}
+          force_orphan: true
       - name: Notify failure
         uses: slackapi/slack-github-action@v1
         if: ${{ failure() }}


### PR DESCRIPTION
https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-force-orphan-force_orphan

> We can set the force_orphan: true option. This allows you to make your
> publish branch with only the latest commit.

On its own, this won't remove the gh-pages history, but once the branch is pointing at an orphaned commit we should be able to remove the references to the old gh-pages commits and garbage collect them.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
