### PR TITLE
Remove archived repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -133,13 +133,6 @@
   sentry_url: https://sentry.io/govuk/find-data
   dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
 
-- repo_name: datagovuk_publish
-  type: data.gov.uk apps
-  team: "#govuk-datagovuk"
-  production_hosted_on: eks
-  sentry_url: https://sentry.io/govuk/publish-data
-  dashboard_url: https://grafana-paas.cloudapps.digital/d/xonj40imk/data-gov-uk?refresh=1m&orgId=1
-
 - repo_name: email-alert-api
   type: APIs
   team: "#govuk-patterns-and-pages"
@@ -713,10 +706,6 @@
   type: APIs
   team: "#govuk-search-improvement"
   production_hosted_on: eks
-
-- repo_name: search-v2-infrastructure
-  type: Utilities
-  team: "#govuk-search-improvement"
 
 - repo_name: service-manual-publisher
   type: Publishing apps


### PR DESCRIPTION
Both of these were archived in the last couple of days and need to be removed from the dev docs to stop terraform trying to write to them (terraform tries to unarchive them but mercifully fails)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
