### PR TITLE
Add skip_docs option, and skip siteimprove docs

### DIFF
--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -9,7 +9,7 @@ class ProxyPages
   end
 
   def self.repo_docs
-    docs = Repos.active_public.map do |repo|
+    docs = Repos.with_docs.map do |repo|
       docs_for_repo = GitHubRepoFetcher.instance.docs(repo.repo_name) || []
       docs_for_repo.map do |page|
         {

--- a/app/repo.rb
+++ b/app/repo.rb
@@ -160,6 +160,10 @@ class Repo
     github_readme
   end
 
+  def skip_docs?
+    repo_data.fetch("skip_docs", false)
+  end
+
 private
 
   def kibana_url_for(app:, hours: 3, include: %w[level request status message])

--- a/app/repos.rb
+++ b/app/repos.rb
@@ -24,6 +24,10 @@ class Repos
     Repos.active.reject(&:private_repo?)
   end
 
+  def self.with_docs
+    Repos.active_public.reject(&:skip_docs?)
+  end
+
   def self.active_apps
     Repos.all.reject(&:retired?).select(&:is_app?)
   end

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -749,6 +749,7 @@
   sentry_url: false
   description: |
     Used by content-data-admin Siteimprove integration.
+  skip_docs: true
 
 - repo_name: slimmer
   team: "#govuk-navigation-tech"

--- a/spec/app/proxy_pages_spec.rb
+++ b/spec/app/proxy_pages_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ProxyPages do
   before do
     allow(Repos).to receive(:all)
-      .and_return([double("Repo", app_name: "", repo_name: "", page_title: "", description: "", private_repo?: false, retired?: false)])
+      .and_return([double("Repo", app_name: "", repo_name: "", page_title: "", description: "", skip_docs?: false, private_repo?: false, retired?: false)])
     allow(DocumentTypes).to receive(:pages)
       .and_return([double("Page", name: "")])
     allow(Supertypes).to receive(:all)

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe Repo do
     end
   end
 
+  describe "skip_docs?" do
+    it "returns false if 'skip_docs' is omitted" do
+      expect(Repo.new({}).skip_docs?).to be(false)
+    end
+
+    it "returns true if 'skip_docs' is true" do
+      expect(Repo.new({ "skip_docs" => true }).skip_docs?).to be(true)
+    end
+  end
+
   describe "api_payload" do
     it "returns a hash of keys describing the app" do
       app_details = {


### PR DESCRIPTION
The siteimprove client includes [extensive auto-generated API documentation](https://docs.publishing.service.gov.uk/repos/siteimprove_api_client.html), which doesn't need to be mirrored to the developer docs.

If someone wants to read this documentation while working with the siteimprove client, they can still read it in GitHub.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
