### PR TITLE
Document Whitehall retagging form

### DIFF
--- a/source/manual/government-changes.html.md.erb
+++ b/source/manual/government-changes.html.md.erb
@@ -130,12 +130,12 @@ In the meantime, follow the [working with CSVs on Kubernetes][running-csv-rake-t
 
 ### Bulk retagging documents
 
-There is a Rake task in Whitehall to change the lead and supporting
-organisations that a document is tagged to in bulk:
-[`data_hygiene:bulk_update_organisation[csv_file]`][whitehall-bulk-update-organisation].
+In **Whitehall**, there is a retagging form accessible from the "More" link in the menu:
+<https://whitehall-admin.publishing.service.gov.uk/government/admin/retagging>
 
-It accepts a CSV file which should have at least the following columns (in any
-order):
+The form allows anyone with the GDS Editor permission to change the lead and supporting
+organisations that a document is tagged to in bulk. It accepts CSV contents which should
+have at least the following columns (in any order):
 
 | Column Header | Description |
 | --- | --- |
@@ -144,11 +144,23 @@ order):
 | `New lead organisations` | The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations. |
 | `New supporting organisations` | The slugs of the new supporting organisations (separated by a comma). These will replace any existing organisations. |
 
-We should phase out CSV-reliant rake tasks now that we're on Kubernetes.
-In the meantime, follow the [working with CSVs on Kubernetes][running-csv-rake-tasks] instructions.
+In **Manuals Publisher**, there is a [rake task to change the organisations for a manual][manuals-bulk-update-organisation].
 
-In Publishing Api, the task responsible for retagging documents is
+For **Mainstream Publisher** documents, a data migration is required to change the organisations for documents.
+Depending on the requirements, we might need to replace all currently tagged organisations with the new one only,
+(example PR: [Migrate Publisher docs for replacing all tagged organisations][publisher-bulk-update-organisation-example])
+or just replace the old one with a new one, leaving other tagged organisations intact
+(example PR: [Migrate Publisher docs for replacing only the old organisation][publisher-bulk-update-preserving-multiple-organisations-example]).
+
+[manuals-bulk-update-organisation]: https://github.com/alphagov/manuals-publisher/blob/main/lib/tasks/update_manual_organisation.rake
+[publisher-bulk-update-organisation-example]: https://github.com/alphagov/publishing-api/pull/1981
+[publisher-bulk-update-preserving-multiple-organisations-example]: https://github.com/alphagov/publishing-api/pull/2827
+
+For anything else, in **Publishing Api**, the task responsible for retagging documents is
 [`data_hygiene:bulk_update_organisation[csv_file]`][publishing-api-bulk-update-organisation].
+*Note that you should always update via the Publishing apps themselves where possible - this rake task is a last resort.*
+Note also that the task depends on uploading a CSV file to Kubernetes, which is not ideal and should be phased out.
+In the meantime, follow the [working with CSVs on Kubernetes][running-csv-rake-tasks] instructions.
 It accepts a CSV file listing the document's slug and new associated organisations:
 
 | Column Header | Description |
@@ -156,18 +168,6 @@ It accepts a CSV file listing the document's slug and new associated organisatio
 | `path` | The slug of the document. |
 | `all organisations` | The slugs of the new organisations (separated by a comma). These will replace any existing organisations. |
 
-There is a similar [Rake task to change the organisations for Manuals][manuals-bulk-update-organisation].
-A data migration is required to change the organisations for (Mainstream) Publisher documents.
-Depending on the requirements, we might need to replace all currently tagged organisations with the new one only,
-(example PR: [Migrate Publisher docs for replacing all tagged organisations][publisher-bulk-update-organisation-example])
-or just replace the old one with a new one, leaving other tagged organisations intact
-(example PR: [Migrate Publisher docs for replacing only the old organisation][publisher-bulk-update-preserving-multiple-organisations-example]).
-
-[whitehall-bulk-update-organisation]: https://github.com/alphagov/whitehall/blob/main/lib/tasks/data_hygiene.rake
-[running-rake-tasks-on-the-command-line]: /manual/running-rake-tasks.html#run-rake-tasks-from-the-command-line
-[manuals-bulk-update-organisation]: https://github.com/alphagov/manuals-publisher/blob/main/lib/tasks/update_manual_organisation.rake
-[publisher-bulk-update-organisation-example]: https://github.com/alphagov/publishing-api/pull/1981
-[publisher-bulk-update-preserving-multiple-organisations-example]: https://github.com/alphagov/publishing-api/pull/2827
 [publishing-api-bulk-update-organisation]: https://github.com/alphagov/publishing-api/blob/b08fbe0a3f58d827f38403c714920b69826f608f/lib/tasks/data_hygiene.rake#L41
 
 ### Reorder ministers/peoples role titles


### PR DESCRIPTION
Also reorders the instructions for the other publishing apps, and brings the Publishing API rake task to the bottom of the list, since we should be making all changes in the publishing apps themselves where possible.

Trello: https://trello.com/c/o9iYyNxf/623-add-ui-for-re-tagging-organisations-to-content-in-bulk

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
