### PR TITLE
♻️ Refactor platform index page to include user-guide and runbook sections

### DIFF
--- a/source/kubernetes/get-started/tutorials/app-update-deploy-monitor-logs/index.html.md
+++ b/source/kubernetes/get-started/tutorials/app-update-deploy-monitor-logs/index.html.md
@@ -1,10 +1,10 @@
 ---
-title: Deploy a new version of the example test app, check the deployment, monitor the app on Grafana and view application logs
+title: Update, Deploy and Monitor an Application
 weight: 20
 layout: multipage_layout
 ---
 
-# Deploy a new version of the example test app, check the deployment, monitor the app on Grafana and view application logs
+# Update, Deploy and Monitor an Application
 
 This tutorial will teach you how to deploy changes to an app and how to view application metrics and logs.
 

--- a/source/kubernetes/index.html.md
+++ b/source/kubernetes/index.html.md
@@ -20,31 +20,31 @@ It would also be helpful to hear how you've found this documentation. Did it hel
 
 ### Getting Started
 
-- [Gain access to a platform cluster](../../kubernetes/get-started/access-eks-cluster/index.html)
-- [Set up the recommended tools](../../kubernetes/get-started/set-up-tools/index.html)
-- [Understand how the platform works](../../kubernetes/how-platform-works/index.html)
+- [Gain access to a platform cluster](/kubernetes/get-started/access-eks-cluster/index.html)
+- [Set up the recommended tools](/kubernetes/get-started/set-up-tools/index.html)
+- [Understand how the platform works](/kubernetes/how-platform-works/index.html)
 
 ### Tutorials
 
-- [Create a new application](../../kubernetes/create-app/index.html)
-- [Update an application's environment in Helm charts](../../kubernetes/get-started/tutorials/app-config-deploy-helm-chart/index.html)
-- [Update, deploy, and monitor an application](../../kubernetes/get-started/tutorials/app-update-deploy-monitor-logs/index.html)
-- [Set or change an environment variable](../../kubernetes/manage-app/set-env-var/index.html)
-- [Add secrets to your application](../../kubernetes/manage-app/manage-secrets/index.html)
-- [Horizontally and vertically scale your application](../../kubernetes/manage-app/scale-app/index.html)
-- [Roll back applications](../../kubernetes/manage-app/roll-back-app/index.html)
-- [Fix your application when something goes wrong](../../kubernetes/fix-app/index.html)
-- [View your application and inspect Kubernetes using the command line](../../kubernetes/manage-app/get-app-info/index.html)
-- [Troubleshoot failed deployments](../../kubernetes/manage-app/manage-state/index.html)
+- [Create a new application](/kubernetes/create-app/index.html)
+- [Update an application's environment in Helm charts](/kubernetes/get-started/tutorials/app-config-deploy-helm-chart/index.html)
+- [Update, deploy, and monitor an application](/kubernetes/get-started/tutorials/app-update-deploy-monitor-logs/index.html)
+- [Set or change an environment variable](/kubernetes/manage-app/set-env-var/index.html)
+- [Add secrets to your application](/kubernetes/manage-app/manage-secrets/index.html)
+- [Horizontally and vertically scale your application](/kubernetes/manage-app/scale-app/index.html)
+- [Roll back applications](/kubernetes/manage-app/roll-back-app/index.html)
+- [Fix your application when something goes wrong](/kubernetes/fix-app/index.html)
+- [View your application and inspect Kubernetes using the command line](/kubernetes/manage-app/get-app-info/index.html)
+- [Troubleshoot failed deployments](/kubernetes/manage-app/manage-state/index.html)
 
 ### Concepts
 
-- [How we release a new version of your app](../../kubernetes/manage-app/release-new-version/index.html)
-- [How applications are deployed](../../kubernetes/manage-app/access-ci-cd/index.html)
+- [How we release a new version of your app](/kubernetes/manage-app/release-new-version/index.html)
+- [How applications are deployed](/kubernetes/manage-app/access-ci-cd/index.html)
 
 ### Cheatsheet
 
-Quickly reference common commands and workflows in the [cheatsheet](../../kubernetes/cheatsheet.html).
+Quickly reference common commands and workflows in the [cheatsheet](/kubernetes/cheatsheet.html).
 
 ## Runbooks
 
@@ -52,8 +52,8 @@ This section is for **platform engineers and administrators**. It serves as a ce
 
 ### Common tasks
 
-- [Create new environments](../../kubernetes/manage-app/create-new-env/index.html)
+- [Create new environments](/kubernetes/manage-app/create-new-env/index.html)
 
 ## Contact the Platform Engineering Team
 
-Need help? Visit [Contact the Platform Engineering Team](../../kubernetes/contact-platform-engineering-team.html) for support options.
+Need help? Visit [Contact the Platform Engineering Team](/kubernetes/contact-platform-engineering-team.html) for support options.

--- a/source/kubernetes/index.html.md
+++ b/source/kubernetes/index.html.md
@@ -4,9 +4,9 @@ weight: 1
 layout: multipage_layout
 ---
 
-# GOV.UK Internal Developer Platform
+# GOV.UK Internal Platform
 
-The GOV.UK Internal Developer Platform is a centralised platform where teams can build, deploy, and manage applications in a reliable and secure environment.
+The GOV.UK Internal Platform is a centralised platform where teams can build, deploy, and manage applications in a reliable and secure environment.
 
 This documentation is for both platform users and internal team members. It provides guides, tools, and best practices to help onboard, manage, and troubleshoot applications efficiently.
 

--- a/source/kubernetes/index.html.md
+++ b/source/kubernetes/index.html.md
@@ -10,22 +10,17 @@ The GOV.UK Internal Developer Platform is a centralised platform where teams can
 
 This documentation is for both platform users and internal team members. It provides guides, tools, and best practices to help onboard, manage, and troubleshoot applications efficiently.
 
-## Who this guide is for
-
-This documentation is for:
-
-- **Developers and engineers**: Deploying and managing applications on the platform.
-- **Platform engineers and administrators**: Maintaining and extending the platform.
-
 ## User Guide
 
-This section is for application developers using the platform. The platform reduces cognitive load by abstracting infrastructure complexity and providing tools, guides, and automated workflows.
+This section is for application developers using the platform. The platform intends to reduce cognitive load by abstracting infrastructure complexity and providing tools, guides, and automated workflows.
 
 If something is missing, let us know, and we’ll add an article. If you're comfortable contributing, pull requests (PRs) are welcome.
 
+It would also be helpful to hear how you've found this documentation. Did it help or hinder? Let us know using the contact us links below.
+
 ### Getting Started
 
-- [Gain access to a platform EKS cluster](../../kubernetes/get-started/access-eks-cluster/index.html)
+- [Gain access to a platform cluster](../../kubernetes/get-started/access-eks-cluster/index.html)
 - [Set up the recommended tools](../../kubernetes/get-started/set-up-tools/index.html)
 - [Understand how the platform works](../../kubernetes/how-platform-works/index.html)
 
@@ -47,6 +42,10 @@ If something is missing, let us know, and we’ll add an article. If you're comf
 - [How we release a new version of your app](../../kubernetes/manage-app/release-new-version/index.html)
 - [How applications are deployed](../../kubernetes/manage-app/access-ci-cd/index.html)
 
+### Cheatsheet
+
+Quickly reference common commands and workflows in the [cheatsheet](../../kubernetes/cheatsheet.html).
+
 ## Runbooks
 
 This section is for **platform engineers and administrators**. It serves as a central place for capturing knowledge and documenting ways of working.
@@ -54,10 +53,6 @@ This section is for **platform engineers and administrators**. It serves as a ce
 ### Common tasks
 
 - [Create new environments](../../kubernetes/manage-app/create-new-env/index.html)
-
-## Cheatsheet
-
-Quickly reference common commands and workflows in the [cheatsheet](../../kubernetes/cheatsheet.html).
 
 ## Contact the Platform Engineering Team
 

--- a/source/kubernetes/index.html.md
+++ b/source/kubernetes/index.html.md
@@ -8,59 +8,57 @@ layout: multipage_layout
 
 The GOV.UK Internal Developer Platform is a centralised platform where teams can build, deploy, and manage applications in a reliable and secure environment.
 
-This documentation is designed for both platform users and internal team members, providing guides, tools, and best practices to onboard, manage, and troubleshoot your applications effectively.
+This documentation is for both platform users and internal team members. It provides guides, tools, and best practices to help onboard, manage, and troubleshoot applications efficiently.
 
-## Who is this for?
+## Who this guide is for
 
 This documentation is for:
 
-- Developers, engineers, and stakeholders deploying and managing applications on the platform.
-
-- Platform engineers and administrators responsible for maintaining and extending the platform.
+- **Developers and engineers**: Deploying and managing applications on the platform.
+- **Platform engineers and administrators**: Maintaining and extending the platform.
 
 ## User Guide
 
-This section is specifically for application developers using the platform. The platform is designed to reduce cognitive load for developers by abstracting away infrastructure complexity and providing tools, guides, and automated workflows. 
+This section is for application developers using the platform. The platform reduces cognitive load by abstracting infrastructure complexity and providing tools, guides, and automated workflows.
 
-If there’s something missing, please either let us know and we’ll add a new article, or if you’re comfortable writing one yourself, PRs will be gratefully received.
+If something is missing, let us know, and we’ll add an article. If you're comfortable contributing, pull requests (PRs) are welcome.
 
 ### Getting Started
 
-- [Gain access to a platform EKS Cluster](../../kubernetes/get-started/access-eks-cluster/index.html)
+- [Gain access to a platform EKS cluster](../../kubernetes/get-started/access-eks-cluster/index.html)
 - [Set up the recommended tools](../../kubernetes/get-started/set-up-tools/index.html)
 - [Understand how the platform works](../../kubernetes/how-platform-works/index.html)
 
 ### Tutorials
 
 - [Create a new application](../../kubernetes/create-app/index.html)
-- [Update an application's environment in our Helm charts](../../kubernetes/get-started/tutorials/app-config-deploy-helm-chart/index.html)
+- [Update an application's environment in Helm charts](../../kubernetes/get-started/tutorials/app-config-deploy-helm-chart/index.html)
 - [Update, deploy, and monitor an application](../../kubernetes/get-started/tutorials/app-update-deploy-monitor-logs/index.html)
-- [Set or change an environment variable in your application](../../kubernetes/manage-app/set-env-var/index.html)
+- [Set or change an environment variable](../../kubernetes/manage-app/set-env-var/index.html)
 - [Add secrets to your application](../../kubernetes/manage-app/manage-secrets/index.html)
 - [Horizontally and vertically scale your application](../../kubernetes/manage-app/scale-app/index.html)
-- [Rolling Back Applications](../../kubernetes/manage-app/roll-back-app/index.html)
-- [Fix your application when something's gone wrong](../../kubernetes/fix-app/index.html)
-- [View your application and inspect Kubernetes via the command-line](../../kubernetes/manage-app/get-app-info/index.html)
-- [Troubleshoot your failed deployment](../../kubernetes/manage-app/manage-state/index.html)
+- [Roll back applications](../../kubernetes/manage-app/roll-back-app/index.html)
+- [Fix your application when something goes wrong](../../kubernetes/fix-app/index.html)
+- [View your application and inspect Kubernetes using the command line](../../kubernetes/manage-app/get-app-info/index.html)
+- [Troubleshoot failed deployments](../../kubernetes/manage-app/manage-state/index.html)
 
 ### Concepts
 
 - [How we release a new version of your app](../../kubernetes/manage-app/release-new-version/index.html)
-- [How is your application deployed](../../kubernetes/manage-app/access-ci-cd/index.html)
+- [How applications are deployed](../../kubernetes/manage-app/access-ci-cd/index.html)
 
 ## Runbooks
 
-This section is specifically for platform engineers and administrators and should act as a place for knowledge capture and ways of working practices.
+This section is for **platform engineers and administrators**. It serves as a central place for capturing knowledge and documenting ways of working.
 
 ### Common tasks
 
-- [Create New Environments](../../kubernetes/manage-app/create-new-env/index.html)
+- [Create new environments](../../kubernetes/manage-app/create-new-env/index.html)
 
 ## Cheatsheet
 
-Quickly reference common commands and workflows in the [Cheatsheet](../../kubernetes/cheatsheet.html).
+Quickly reference common commands and workflows in the [cheatsheet](../../kubernetes/cheatsheet.html).
 
 ## Contact the Platform Engineering Team
 
 Need help? Visit [Contact the Platform Engineering Team](../../kubernetes/contact-platform-engineering-team.html) for support options.
-

--- a/source/kubernetes/index.html.md
+++ b/source/kubernetes/index.html.md
@@ -1,31 +1,66 @@
 ---
-title: GOV.UK Kubernetes cluster documentation for developers
+title: GOV.UK Internal Developer Platform
 weight: 1
 layout: multipage_layout
 ---
 
-# GOV.UK Kubernetes cluster documentation for developers
+# GOV.UK Internal Developer Platform
 
-Use this documentation to find out how to:
+The GOV.UK Internal Developer Platform is a centralised platform where teams can build, deploy, and manage applications in a reliable and secure environment.
 
-- start using the GOV.UK Kubernetes clusters
-- manage your GOV.UK app on Kubernetes
+This documentation is designed for both platform users and internal team members, providing guides, tools, and best practices to onboard, manage, and troubleshoot your applications effectively.
 
-## Introduction
+## Who is this for?
 
-The GOV.UK website and content management system (known internally as the publishing platform) are hosted on [Kubernetes](https://kubernetes.io/) clusters on Amazon Web Services (AWS), using [Elastic Kubernetes Service](https://aws.amazon.com/eks/) (EKS).
+This documentation is for:
 
-Kubernetes is a widely-used, open-source [container orchestration system](https://cloud.google.com/discover/what-is-container-orchestration) for managing containerised workloads such as GOV.UK's.
+- Developers, engineers, and stakeholders deploying and managing applications on the platform.
 
-Kubernetes is designed for automation and emphasises [declarative configuration](https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/declarative-application-management.md#declarative-configuration) and [immutable infrastructure](https://thenewstack.io/a-brief-look-at-immutable-infrastructure-and-why-it-is-such-a-quest/). It provides mechanisms for:
+- Platform engineers and administrators responsible for maintaining and extending the platform.
 
-- efficiently and automatically fitting workloads into available compute resources
-- resilient, "self-healing" deployments
-- service discovery and load balancing
-- automated rollouts and rollbacks
-- quotas and isolation of compute resources between workloads
-- authentication, authorisation and audit logging
-- secrets and configuration management
-- managing persistent storage
+## User Guide
 
-See the official [Kubernetes overview documentation](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) for more information about Kubernetes.
+This section is specifically for application developers using the platform. The platform is designed to reduce cognitive load for developers by abstracting away infrastructure complexity and providing tools, guides, and automated workflows. 
+
+If there’s something missing, please either let us know and we’ll add a new article, or if you’re comfortable writing one yourself, PRs will be gratefully received.
+
+### Getting Started
+
+- [Gain access to a platform EKS Cluster](../../kubernetes/get-started/access-eks-cluster/index.html)
+- [Set up the recommended tools](../../kubernetes/get-started/set-up-tools/index.html)
+- [Understand how the platform works](../../kubernetes/how-platform-works/index.html)
+
+### Tutorials
+
+- [Create a new application](../../kubernetes/create-app/index.html)
+- [Update an application's environment in our Helm charts](../../kubernetes/get-started/tutorials/app-config-deploy-helm-chart/index.html)
+- [Update, deploy, and monitor an application](../../kubernetes/get-started/tutorials/app-update-deploy-monitor-logs/index.html)
+- [Set or change an environment variable in your application](../../kubernetes/manage-app/set-env-var/index.html)
+- [Add secrets to your application](../../kubernetes/manage-app/manage-secrets/index.html)
+- [Horizontally and vertically scale your application](../../kubernetes/manage-app/scale-app/index.html)
+- [Rolling Back Applications](../../kubernetes/manage-app/roll-back-app/index.html)
+- [Fix your application when something's gone wrong](../../kubernetes/fix-app/index.html)
+- [View your application and inspect Kubernetes via the command-line](../../kubernetes/manage-app/get-app-info/index.html)
+- [Troubleshoot your failed deployment](../../kubernetes/manage-app/manage-state/index.html)
+
+### Concepts
+
+- [How we release a new version of your app](../../kubernetes/manage-app/release-new-version/index.html)
+- [How is your application deployed](../../kubernetes/manage-app/access-ci-cd/index.html)
+
+## Runbooks
+
+This section is specifically for platform engineers and administrators and should act as a place for knowledge capture and ways of working practices.
+
+### Common tasks
+
+- [Create New Environments](../../kubernetes/manage-app/create-new-env/index.html)
+
+## Cheatsheet
+
+Quickly reference common commands and workflows in the [Cheatsheet](../../kubernetes/cheatsheet.html).
+
+## Contact the Platform Engineering Team
+
+Need help? Visit [Contact the Platform Engineering Team](../../kubernetes/contact-platform-engineering-team.html) for support options.
+


### PR DESCRIPTION
## 👀 Purpose

- While working on platform documentation, I realised how awkward linking from the index page is. I believe this is partly because the index page does a fine job of describing the platform to someone who already knows what a platform is, but is terrible at guiding users through using our platform from scratch or even as a refresher.
- I hope the changes in this PR make linking more manageable and create a framework for good user engagement. 
- I also hope that the team can start to publish some of its practices and ways of working.

## ♻️ What's changed

- The index page is heavily refactored and now includes two paths:
      -- A developer path: for a tenant using the platform, which comes under the guise of "user-guide"
      -- A platform engineer path: for the operators and engineers of the platform, intended for internal team use.

## 📝 Notes

- You can follow the instructions in the readme for a better look at the refactor, but I'll include screenshots below:

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/eaa41360-212b-4de3-8f99-4f572e77a72f" />

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/239f52c0-595c-4445-84ea-67ff3736456d" />

<img width="1494" alt="Screenshot 2025-01-28 at 15 55 06" src="https://github.com/user-attachments/assets/1cb42df9-ad57-44c4-84fd-c2105101a76d" />
