### PR TITLE
Fetch the content schemas from Publishing API's main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
-          ref: deployed-to-production
+          ref: main
           path: tmp/publishing-api
           show-progress: false
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The deployed-to-production branch no longer exists in the Publishing API repository. It has not been used for some time, as far as we are aware.
