### PR TITLE
Improve Implementation Guide page titles and meta descriptions

### DIFF
--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -1,10 +1,12 @@
 analytics:
   name: Google Analytics 4 implementation record
   desc: This site contains a record of the data implementation for Google Analytics 4 (GA4) on GOV.UK Publishing. It was built to aid developers on GOV.UK Publishing but is available to anyone who may find our approach useful.
+  metadesc: This site contains a record of the data implementation for Google Analytics 4 (GA4) on GOV.UK Publishing.
 
 data:
   name: Data
   desc: Details of our data schema, including event and attribute details.
+  metadesc: Details of our GA4 data schema, including event and attribute details.
   link_title: Browse data
   link: data.html
   subsections:
@@ -18,6 +20,7 @@ data:
 docs:
   name: Documentation
   desc: Documentation relevant to GOV.UK's dataLayer approach.
+  metadesc: Documentation relevant to GOV.UK's dataLayer approach.
   link_title: Browse documentation
   link: docs.html
   subsections:
@@ -35,23 +38,29 @@ docs:
 progress:
   name: Implementation progress
   desc: Shows current percentage of implemented events by priority.
+  metadesc: Our progress in implementing GA4 on GOV.UK Publishing.
   link: progress.html
 
 approach:
   name: Development approach
+  metadesc: Our development approach for implementing GA4 on GOV.UK Publishing.
 
 consent:
   name: Consent handling
+  metadesc: How we're doing cookie consent handling for GA4 on GOV.UK Publishing.
 
 pii:
   name: Personally Identifiable Information
+  metadesc: How we're handling Personally Identifiable Information in GA4 on GOV.UK Publishing.
 
 trackers:
   name: Trackers
   desc: Trackers are distinct JavaScripts that collect GA4 data in specific ways. Each works differently but produces and sends data to GA4 in the same way.
+  metadesc: Details of the JavaScript trackers we've written for GA4 on GOV.UK Publishing.
 
 further_docs:
   name: Further reading
+  metadesc: Further reading around GA4 on GOV.UK Publishing.
 
 attributes:
   name: Attributes
@@ -59,6 +68,7 @@ attributes:
     Attributes are the key value pairs of data inside events. Attributes are often used by more than one event.
 
     Events use the following attributes.
+  metadesc: Attributes are the key value pairs of data inside events. Attributes are often used by more than one event.
 
 events:
   name: Events by event name
@@ -66,10 +76,22 @@ events:
     Events are collections of data that are sent to a GA4 property when users do certain things, like opening an accordion or clicking a link.
 
     We use the following events.
+  metadesc: All of our GA4 events on GOV.UK Publishing.
+
 events_by_group:
   name: Events by group
+  metadesc: All of our GA4 events on GOV.UK Publishing, organised by group.
+
+event:
+  name: Event
+  metadesc: Details of the GA4 data sent for the event
+
+attribute:
+  name: Attribute
+  metadesc: Details of the GA4 data contained in the attribute
 
 schema:
   name: Data schemas
   desc: |
     This page shows our complete schemas for our different events.
+  metadesc: Details of the data schema in use for GA4 on GOV.UK Publishing.

--- a/data/analytics/navigation.yml
+++ b/data/analytics/navigation.yml
@@ -61,11 +61,13 @@ attributes:
     Events use the following attributes.
 
 events:
-  name: Events
+  name: Events by event name
   desc: |
     Events are collections of data that are sent to a GA4 property when users do certain things, like opening an accordion or clicking a link.
 
     We use the following events.
+events_by_group:
+  name: Events by group
 
 schema:
   name: Data schemas

--- a/source/analytics/approach.html.md.erb
+++ b/source/analytics/approach.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.approach.name) %>
+<% content_for :metadesc, data.analytics.navigation.approach.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.approach.name %>

--- a/source/analytics/attributes.html.md.erb
+++ b/source/analytics/attributes.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.attributes.name) %>
+<% content_for :metadesc, data.analytics.navigation.attributes.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.attributes.name %>

--- a/source/analytics/consent.html.md.erb
+++ b/source/analytics/consent.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.consent.name) %>
+<% content_for :metadesc, data.analytics.navigation.consent.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.consent.name %>

--- a/source/analytics/data.html.md.erb
+++ b/source/analytics/data.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.data.name) %>
+<% content_for :metadesc, data.analytics.navigation.data.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.data.name %>

--- a/source/analytics/docs.html.md.erb
+++ b/source/analytics/docs.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.docs.name) %>
+<% content_for :metadesc, data.analytics.navigation.docs.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.docs.name %>

--- a/source/analytics/events.html.md.erb
+++ b/source/analytics/events.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.events.name) %>
+<% content_for :metadesc, data.analytics.navigation.events.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.events.name %>

--- a/source/analytics/events_by_group.html.erb
+++ b/source/analytics/events_by_group.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, create_page_title(data.analytics.navigation.events.name) %>
+<% content_for :title, create_page_title(data.analytics.navigation.events_by_group.name) %>
 
 <h1 class="govuk-heading-l">
-  <%= data.analytics.navigation.events.name %>
+  <%= data.analytics.navigation.events_by_group.name %>
 </h1>
 
 <p class="govuk-body">

--- a/source/analytics/events_by_group.html.erb
+++ b/source/analytics/events_by_group.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.events_by_group.name) %>
+<% content_for :metadesc, data.analytics.navigation.events_by_group.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.events_by_group.name %>

--- a/source/analytics/further_docs.html.erb
+++ b/source/analytics/further_docs.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.further_docs.name) %>
+<% content_for :metadesc, data.analytics.navigation.further_docs.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.further_docs.name %>

--- a/source/analytics/pii.html.md.erb
+++ b/source/analytics/pii.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.pii.name) %>
+<% content_for :metadesc, data.analytics.navigation.pii.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.pii.name %>

--- a/source/analytics/progress.html.md.erb
+++ b/source/analytics/progress.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.progress.name) %>
+<% content_for :metadesc, data.analytics.navigation.progress.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.progress.name %>

--- a/source/analytics/schema.html.md.erb
+++ b/source/analytics/schema.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.schema.name) %>
+<% content_for :metadesc, data.analytics.navigation.schema.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.schema.name %>

--- a/source/analytics/templates/attribute.html.erb
+++ b/source/analytics/templates/attribute.html.erb
@@ -1,10 +1,12 @@
-<% content_for :title, create_page_title("#{attribute.name.capitalize} attribute data") %>
 <%
+  content_for :title, create_page_title("#{attribute.name.capitalize} attribute data")
   attribute_name = attribute.name
   attribute_name = attribute.name + " (#{variant.event_name})" if variant
+  content_for :metadesc, "#{data.analytics.navigation.attribute.metadesc} '#{attribute_name}'"
 %>
+
 <h1 class="govuk-heading-l">
-  <span class="govuk-caption-l">Attribute</span>
+  <span class="govuk-caption-l"><%= data.analytics.navigation.attribute.name %></span>
   <%= attribute_name %>
 </h1>
 

--- a/source/analytics/templates/event.html.erb
+++ b/source/analytics/templates/event.html.erb
@@ -1,7 +1,8 @@
 <% content_for :title, create_page_title("#{event.name.capitalize} event data") %>
+<% content_for :metadesc, "#{data.analytics.navigation.event.metadesc} '#{event.name}'" %>
 
 <h1 class="govuk-heading-l analytics-heading">
-  <span class="govuk-caption-l">Event</span>
+  <span class="govuk-caption-l"><%= data.analytics.navigation.event.name %></span>
   <%= event.name %>
 </h1>
 

--- a/source/analytics/trackers.html.md.erb
+++ b/source/analytics/trackers.html.md.erb
@@ -1,4 +1,5 @@
 <% content_for :title, create_page_title(data.analytics.navigation.trackers.name) %>
+<% content_for :metadesc, data.analytics.navigation.trackers.metadesc %>
 
 <h1 class="govuk-heading-l">
   <%= data.analytics.navigation.trackers.name %>

--- a/source/layouts/analytics_layout.html.erb
+++ b/source/layouts/analytics_layout.html.erb
@@ -17,6 +17,7 @@
   <% meta_tags.opengraph_tags.each do |property, content| %>
     <%= tag :meta, property: property, content: content %>
   <% end %>
+  <meta name="description" content="<%= yield_content(:metadesc) %>">
   <%= partial 'partials/cookie_wrapper' %>
 </head>
 


### PR DESCRIPTION
## What
Improves page titles and adds metadata descriptions for the [analytics section of the dev docs](https://docs.publishing.service.gov.uk/analytics/).

## Why
Previously no meta descriptions, so sharing pages didn't provide enough information.

## Visual changes
None.

Trello: https://trello.com/c/PmI26YFF/839-update-ga4-implementation-record-page-titles
