### PR TITLE
✨ Add a Platform Engineering Internal Ways of Working Document

### DIFF
--- a/source/kubernetes/internal-practices/ways-of-working.html.md
+++ b/source/kubernetes/internal-practices/ways-of-working.html.md
@@ -23,18 +23,18 @@ Status: 🧪 Experimental
 
 This session is dedicated to reviewing and improving how we collaborate, communicate, and deliver work. It focuses on our processes, tooling, and team interactions, so we can continually refine and adapt our approach.
 
-    - Frequency: Once per sprint (or after a major milestone/quarterly goal), to ensure regular reflection.
-    - Duration: 45–60 minutes.
-    - Attendees: Entire team (including any stakeholders or leadership who want to provide input).
-    - Goals:
-        - Discuss any proposed changes to our Ways of Working or new ideas (for example, adopting a new collaboration tool, revising sprint lengths).
-        - Review feedback and suggestions from previous sprints or retrospectives that might require broader team agreement or testing.
-        - Decide whether to formalise certain experiments or retire them if they’re no longer useful.
-    - Typical Agenda:
-        - Check-Ins (5 min): Quick team round-table on how our current processes are feeling (any major friction points?).
-        - Review Proposed Changes (15–20 min): Present any new or updated ideas for ways of working. Team discusses feasibility, potential benefits, and risks.
-        - Decision & Next Steps (15–20 min): Agree on any changes to pilot, document them in this guide (if accepted), and assign owners or next steps.
-        - Open Discussion (5–10 min): Any final thoughts or concerns before closing.
+  - Frequency: Once per sprint (or after a major milestone/quarterly goal), to ensure regular reflection.
+  - Duration: 45–60 minutes.
+  - Attendees: Entire team (including any stakeholders or leadership who want to provide input).
+  - Goals:
+      - Discuss any proposed changes to our Ways of Working or new ideas (for example, adopting a new collaboration tool, revising sprint lengths).
+      - Review feedback and suggestions from previous sprints or retrospectives that might require broader team agreement or testing.
+      - Decide whether to formalise certain experiments or retire them if they’re no longer useful.
+  - Typical Agenda:
+      - Check-Ins (5 min): Quick team round-table on how our current processes are feeling (any major friction points?).
+      - Review Proposed Changes (15–20 min): Present any new or updated ideas for ways of working. Team discusses feasibility, potential benefits, and risks.
+      - Decision & Next Steps (15–20 min): Agree on any changes to pilot, document them in this guide (if accepted), and assign owners or next steps.
+      - Open Discussion (5–10 min): Any final thoughts or concerns before closing.
 
 ### Infrastructure Weekly Attendance  
 

--- a/source/kubernetes/internal-practices/ways-of-working.html.md
+++ b/source/kubernetes/internal-practices/ways-of-working.html.md
@@ -1,0 +1,64 @@
+---
+title: Platform Engineering Ways of Working
+review_in: 3 months
+weight: 60
+layout: multipage_layout
+---
+
+# Platform Engineering Ways of Working
+
+This document is an internal Platform Engineering playbook. It outlines how we collaborate, plan, and deliver work, with a focus on continuous improvement. By following these guidelines, we can ensure consistency, clarity, and efficiency in our day-to-day tasks—enabling us to adapt quickly when needs change.
+
+Statuses:
+    ✅ Accepted
+    🧪 Experimenting
+    💡 New idea (waiting to be discussed by the team)
+    ⏸️ Paused (due to another active experiment)
+
+## Ceremonies
+
+### Ways of Engineering
+
+Status: 🧪 Experimental
+
+This session is dedicated to reviewing and improving how we collaborate, communicate, and deliver work. It focuses on our processes, tooling, and team interactions, so we can continually refine and adapt our approach.
+
+    - Frequency: Once per sprint (or after a major milestone/quarterly goal), to ensure regular reflection.
+    - Duration: 45–60 minutes.
+    - Attendees: Entire team (including any stakeholders or leadership who want to provide input).
+    - Goals:
+        - Discuss any proposed changes to our Ways of Working or new ideas (for example, adopting a new collaboration tool, revising sprint lengths).
+        - Review feedback and suggestions from previous sprints or retrospectives that might require broader team agreement or testing.
+        - Decide whether to formalise certain experiments or retire them if they’re no longer useful.
+    - Typical Agenda:
+        - Check-Ins (5 min): Quick team round-table on how our current processes are feeling (any major friction points?).
+        - Review Proposed Changes (15–20 min): Present any new or updated ideas for ways of working. Team discusses feasibility, potential benefits, and risks.
+        - Decision & Next Steps (15–20 min): Agree on any changes to pilot, document them in this guide (if accepted), and assign owners or next steps.
+        - Open Discussion (5–10 min): Any final thoughts or concerns before closing.
+
+### Infrastructure Weekly Attendance  
+
+**Status: 🧪 Experimental**
+
+We aim to have at least one member of the GOV.UK Platform Engineering team attend the weekly **Infrastructure Weekly** meeting. This meeting brings together all Site Reliability Engineering (SRE) staff to share updates and discuss current priorities. Our presence ensures visibility, facilitates collaboration, and highlights GOV.UK Platform needs or insights.
+
+- **Frequency**: Every week (day/time set by the SRE community and others)
+- **Duration**: Typically 30 minutes
+- **Attendees**: At least one GOV.UK Platform Engineering team representative; rotating volunteers or whoever is best placed to share current updates
+- **Goals**:
+  - Provide visibility on GOV.UK Platform initiatives and gather relevant feedback.
+  - Stay informed about broader infrastructure updates, issues, or roadmaps that could impact GOV.UK services.
+  - Represent GOV.UK Platform requirements, priorities, or concerns.
+  - Develop and maintain strong ties with the wider SRE community.
+
+We will assess the value of this attendance over time. If it proves consistently beneficial and fosters better alignment with the broader SRE community, we’ll consider making it a permanent practice rather than keeping it in an experimental status.
+
+## Adding/Adjusting Our Ways of Working
+
+To suggest a change or experiment, add an entry, with the relevant status, and then raise a Pull Request. You’re welcome to discuss your idea in Slack or at stand-up. At the latest, we’ll review the change during our retrospective.
+
+### Experimental Ways of Working
+
+We’re an innovative team, so we regularly test new methods and tools. We treat experiments as learning opportunities. If something doesn’t work, we reflect on lessons learned and decide whether to pivot, persevere, or pause.
+
+This internal document is living and will evolve as our team grows. Together, we ensure our processes stay transparent, collaborative, and well-suited to our unique platform engineering needs.

--- a/source/kubernetes/internal-practices/ways-of-working.html.md
+++ b/source/kubernetes/internal-practices/ways-of-working.html.md
@@ -19,7 +19,7 @@ Statuses:
 
 ### Ways of Engineering
 
-Status: 🧪 Experimental
+Status: 💡New idea**
 
 This session is dedicated to reviewing and improving how we collaborate, communicate, and deliver work. It focuses on our processes, tooling, and team interactions, so we can continually refine and adapt our approach.
 
@@ -38,7 +38,7 @@ This session is dedicated to reviewing and improving how we collaborate, communi
 
 ### Infrastructure Weekly Attendance  
 
-**Status: 🧪 Experimental**
+**Status: 💡New idea**
 
 We aim to have at least one member of the GOV.UK Platform Engineering team attend the weekly **Infrastructure Weekly** meeting. This meeting brings together all Site Reliability Engineering (SRE) staff to share updates and discuss current priorities. Our presence ensures visibility, facilitates collaboration, and highlights GOV.UK Platform needs or insights.
 

--- a/source/kubernetes/internal-practices/ways-of-working.html.md
+++ b/source/kubernetes/internal-practices/ways-of-working.html.md
@@ -17,7 +17,7 @@ Statuses:
 
 ## Ceremonies
 
-### Ways of Engineering
+### Ways of Working
 
 Status: 💡New idea**
 
@@ -25,7 +25,7 @@ This session is dedicated to reviewing and improving how we collaborate, communi
 
   - Frequency: Once per sprint (or after a major milestone/quarterly goal), to ensure regular reflection.
   - Duration: 45–60 minutes.
-  - Attendees: Entire team (including any stakeholders or leadership who want to provide input).
+  - Attendees: An optional attendance.
   - Goals:
       - Discuss any proposed changes to our Ways of Working or new ideas (for example, adopting a new collaboration tool, revising sprint lengths).
       - Review feedback and suggestions from previous sprints or retrospectives that might require broader team agreement or testing.

--- a/source/kubernetes/internal-practices/ways-of-working.html.md
+++ b/source/kubernetes/internal-practices/ways-of-working.html.md
@@ -19,7 +19,7 @@ Statuses:
 
 ### Ways of Working
 
-Status: 💡New idea**
+**Status: 💡New idea**
 
 This session is dedicated to reviewing and improving how we collaborate, communicate, and deliver work. It focuses on our processes, tooling, and team interactions, so we can continually refine and adapt our approach.
 


### PR DESCRIPTION
This pull request introduces a new internal playbook for the Platform Engineering team, outlining guidelines on collaboration, planning, and delivery practices. The document emphasizes continuous improvement and includes detailed sections on team ceremonies and processes.

Key changes include:

### New Internal Playbook

* Added a new document titled "Platform Engineering Ways of Working" that provides a structured approach to team collaboration and planning.

### Ceremonies

* Introduced the "Ways of Working" session, focusing on reviewing and improving team processes, tooling, and interactions.
* Established guidelines for "Infrastructure Weekly Attendance," ensuring regular participation in the broader Site Reliability Engineering (SRE) community meetings.

### Process for Changes

* Defined a process for suggesting and implementing changes or experiments in team practices, encouraging transparency and collaboration.