### PR TITLE
Update Kubernetes documentation for PSS restricted

### DIFF
--- a/source/kubernetes/manage-app/index.html.md
+++ b/source/kubernetes/manage-app/index.html.md
@@ -13,5 +13,5 @@ You can:
 - scale your app up or down
 - release a new version of your app
 - roll back your app
-- set access permissions for your app
+- set security restrictions for your app
 - manage secrets in your app

--- a/source/kubernetes/manage-app/set-permissions/index.html.md
+++ b/source/kubernetes/manage-app/set-permissions/index.html.md
@@ -1,7 +1,23 @@
 ---
-title: Set access permissions for your app
+title: Set security restrictions for your app
 weight: 47
 layout: multipage_layout
 ---
 
-# Set access permissions for your app
+# Set security restrictions for your app
+
+Our current workloads in our Kubernetes clusters conform to the [restricted profile](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) of pod security standards (PSS).
+A pod that fails to meet this criteria will error on creation:
+
+```
+Warning: would violate PodSecurity "restricted:latest":
+allowPrivilegeEscalation != false (container "nginx" must set securityContext.allowPrivilegeEscalation=false),
+unrestricted capabilities (container "nginx" must set securityContext.capabilities.drop=["ALL"]),
+runAsNonRoot != true (pod or container "nginx" must set securityContext.runAsNonRoot=true),
+seccompProfile (pod or container "nginx" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
+deployment.apps/nginx created
+```
+
+To fix this add the appropriate key-value pairs.
+
+The [generic-govuk-app](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/generic-govuk-app/templates/deployment.yaml) is an example of a deployment that conforms to the restricted profile of PSS.


### PR DESCRIPTION
Description:
- Describe the error that occurs when a deployment doesn't conform to PSS restricted
- Closes https://github.com/alphagov/govuk-helm-charts/issues/1883

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
