### PR TITLE
(917) Add content modelling docs

### DIFF
--- a/app/repo_sidebar.rb
+++ b/app/repo_sidebar.rb
@@ -1,0 +1,53 @@
+class RepoSidebar
+  Item = Data.define(:path, :title, :children)
+
+  def initialize(repo_name)
+    @repo_name = repo_name
+  end
+
+  def items
+    format_tree(tree)
+  end
+
+private
+
+  attr_reader :repo_name
+
+  def format_tree(items)
+    items.map do |_, value|
+      Item.new(
+        value[:path],
+        value[:name],
+        format_tree(value[:children]),
+      )
+    end
+  end
+
+  def tree
+    @tree ||= begin
+      tree = {}
+
+      docs_to_import.each do |item|
+        path = item[:path].delete_prefix("/repos/#{repo_name}/")
+        parts = path.split("/")
+        current_level = tree
+
+        parts.each_with_index do |part, index|
+          current_level[part] ||= if index == parts.size - 1
+                                    # Assign title if available, otherwise use the file name
+                                    { name: item[:title] || part, path: item[:path], children: {} }
+                                  else
+                                    { name: part, path: parts[0..index].join("/"), children: {} }
+                                  end
+          current_level = current_level[part][:children]
+        end
+      end
+
+      tree
+    end
+  end
+
+  def docs_to_import
+    @docs_to_import ||= GitHubRepoFetcher.instance.docs(repo_name) || []
+  end
+end

--- a/data/dashboard.yml
+++ b/data/dashboard.yml
@@ -68,3 +68,6 @@
         - name: Document types
           url: /document-types.html
           description: The kinds of documents that are published on GOV.UK using one of the schemas.
+        - name: Content modelling
+          url: /content-modelling
+          description: Documentation for content modelling on GOV.UK

--- a/source/content-modelling/index.html.md.erb
+++ b/source/content-modelling/index.html.md.erb
@@ -1,0 +1,40 @@
+---
+title: Content Modelling
+weight: 1
+layout: multipage_layout
+---
+
+# Content Modelling
+
+The aim of the Content Modelling team is to:
+
+> ... enable a single source of content truth, using modelled content across documents and channels, to promote efficiency and accuracy
+
+Within publishing, we do this via the [Content Block Manager](/repos/whitehall/content_block_manager.html) and
+functionality within Publishing API to process embed codes, which allow content to be embedded in documents and
+automatically update when the block changes.
+
+## Contact
+
+The Content Modelling Team are available via Slack at [#govuk-publishing-content-modelling-dev](https://gds.slack.com/archives/C0776B04EJU)
+
+## Related pages
+
+### Content Block Manager
+
+<ul>
+<% GitHubRepoFetcher.instance.docs("whitehall").select { |p| p[:path].start_with?("/repos/whitehall/content_block_manager") }.each do |page| %>
+  <li><a href="<%= page[:path] %>"><%= page[:title] %></a>
+<% end %>
+</ul>
+
+### Content Block Tools
+
+<ul>
+<li><a href="/repos/govuk_content_block_tools.html">README</a></li>
+<% (GitHubRepoFetcher.instance.docs("govuk_content_block_tools") || []).each do |page| %>
+  <li><a href="<%= page[:path] %>"><%= page[:title] %></a>
+<% end %>
+</ul>
+
+

--- a/source/layouts/multipage_layout.html.erb
+++ b/source/layouts/multipage_layout.html.erb
@@ -20,27 +20,5 @@
 
 <% wrap_layout :core do %>
   <%= html %>
-  <script>
-    /*
-      Manually trigger the styling of the 'current page' in the sidebar,
-      as it does not happen automatically because we are still technically
-      in single page mode.
-    */
-    (function () {
-      'use strict'
-      /*
-        Cannot use `$(document).ready` on next line as jQuery has not loaded
-        yet. But we can use jQuery in the callback.
-      */
-      window.addEventListener('load', function () {
-        try {
-          new GOVUK.Modules.InPageNavigation().start($("html"));
-        }
-        catch (error) {
-          /* Fail without causing other JS in the page to break */
-          console.log("Error calling GOVUK's InPageNavigation module", error);
-        }
-      })
-    }());
-  </script>
+  <%= partial("partials/in_page_navigation") %>
 <% end %>

--- a/source/layouts/repo_layout.html.erb
+++ b/source/layouts/repo_layout.html.erb
@@ -9,36 +9,7 @@
     </li>
     <li>
       <ul>
-        <%
-          unless repo.private_repo?
-            add_imported_docs = -> (docs_to_import) do
-              docs_subdirs = docs_to_import.map { |doc| doc[:path].split("/")[3..(doc[:path].split("/").count - 2)].join("/") }.uniq.reject(&:empty?)
-              docs_at_root_level = docs_to_import.reject do |doc|
-                docs_subdirs.any? { |subdir| doc[:path].include?(subdir) }
-              end
-              docs_at_root_level.each do |doc|
-        %>
-          <li><a href="<%= doc[:path] %>" rel="noopener" class="govuk-link"><%= doc[:title] %></a></li>
-          <%
-              end
-              docs_subdirs.each do |subdir|
-          %>
-          <li class="subdir__heading"><%= subdir %></li>
-          <ul class="subdir__menu">
-            <% docs_to_import.select { |doc| doc[:path].include?(subdir) }.each do |doc| %>
-              <li><a href="<%= doc[:path] %>" rel="noopener" class="govuk-link"><%= doc[:title] %></a></li>
-            <% end %>
-          </ul>
-        <%
-              end # end of `docs_subdirs` iteration
-            end # end of add_imported_docs lambda definition
-
-            imported_docs = GitHubRepoFetcher.instance.docs(repo.repo_name)
-            unless imported_docs.nil? || imported_docs.empty?
-              add_imported_docs.call(imported_docs)
-            end
-          end # end of 'private_repo?' check
-        %>
+        <%= partial("partials/repo/sidebar", locals: { items: RepoSidebar.new(repo.repo_name).items }) %>
       </ul>
     </li>
   </ul>

--- a/source/layouts/repo_layout.html.erb
+++ b/source/layouts/repo_layout.html.erb
@@ -27,4 +27,5 @@
   <%= partial 'partials/last_updated' if current_page.data.show_last_updated %>
   <%= partial 'partials/header' %>
   <%= yield %>
+  <%= partial("partials/in_page_navigation") %>
 <% end %>

--- a/source/partials/_in_page_navigation.html.erb
+++ b/source/partials/_in_page_navigation.html.erb
@@ -1,0 +1,23 @@
+<script>
+    /*
+      Manually trigger the styling of the 'current page' in the sidebar,
+      as it does not happen automatically because we are still technically
+      in single page mode.
+    */
+    (function () {
+        'use strict'
+        /*
+          Cannot use `$(document).ready` on next line as jQuery has not loaded
+          yet. But we can use jQuery in the callback.
+        */
+        window.addEventListener('load', function () {
+            try {
+                new GOVUK.Modules.InPageNavigation().start($("html"));
+            }
+            catch (error) {
+                /* Fail without causing other JS in the page to break */
+                console.log("Error calling GOVUK's InPageNavigation module", error);
+            }
+        })
+    }());
+</script>

--- a/source/partials/repo/_sidebar.html.erb
+++ b/source/partials/repo/_sidebar.html.erb
@@ -1,0 +1,10 @@
+<% items.each do |item| %>
+  <% if item.children.any? %>
+    <li class="subdir__heading"><%= item.title %></li>
+    <ul class="subdir__menu">
+      <%= partial("partials/repo/sidebar", locals: { items: item.children }) %>
+    </ul>
+  <% else %>
+    <li><a href="<%= item.path %>" rel="noopener" class="govuk-link"><%= item.title %></a></li>
+  <% end %>
+<% end %>

--- a/spec/app/repo_sidebar_spec.rb
+++ b/spec/app/repo_sidebar_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe RepoSidebar do
+  it "returns an ordered list of items" do
+    docs_to_import = [
+      {
+        path: "/repos/repo_name/base.html",
+        title: "Base",
+      },
+      {
+        path: "/repos/repo_name/something/in_a_sub_dir.html",
+        title: "Single level",
+      },
+      {
+        path: "/repos/repo_name/something/deeper/in_a_sub_dir.html",
+        title: "Double level",
+      },
+    ]
+
+    allow(GitHubRepoFetcher.instance).to receive(:docs)
+                                     .with("repo_name")
+                                     .and_return(docs_to_import)
+
+    result = RepoSidebar.new("repo_name").items
+
+    expect(result.count).to eq(2)
+
+    expect(result[0].title).to eq("Base")
+    expect(result[0].path).to eq("/repos/repo_name/base.html")
+    expect(result[0].children).to eq([])
+
+    expect(result[1].title).to eq("something")
+    expect(result[1].path).to eq("something")
+    expect(result[1].children.count).to eq(2)
+
+    expect(result[1].children[0].title).to eq("Single level")
+    expect(result[1].children[0].path).to eq("/repos/repo_name/something/in_a_sub_dir.html")
+
+    expect(result[1].children[1].title).to eq("deeper")
+    expect(result[1].children[1].path).to eq("something/deeper")
+    expect(result[1].children[1].children.count).to eq(1)
+
+    expect(result[1].children[1].children[0].title).to eq("Double level")
+    expect(result[1].children[1].children[0].path).to eq("/repos/repo_name/something/deeper/in_a_sub_dir.html")
+    expect(result[1].children[1].children[0].children).to eq([])
+  end
+end


### PR DESCRIPTION
This contains the beginnings of the content modelling documentation. Because we don't have a repo per se to refer to, I've added a new section, which then links out to the relevant documentation in the relevant repos. I've also done a bit of a refactor of a repo's navigation to support multiple levels of directories.