### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                     "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/.github/workflows/deploy.yml|Developer Docs deployment script> failed.",
+                     "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/.github/workflows/deploy.yml|Developer Docs deployment script> failed."
                   },
                   "accessory": {
                     "type": "button",

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ end
 namespace :assets do
   desc "Build the static site"
   task :precompile do
-    sh "rm -rf /tmp/govuk-content-schemas; git clone https://github.com/alphagov/publishing-api.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas/content_schemas middleman build"
+    sh "rm -rf /tmp/govuk-content-schemas; git clone https://github.com/alphagov/publishing-api.git /tmp/govuk-content-schemas --depth=1 && NO_CONTRACTS=true GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas/content_schemas middleman build --verbose --bail"
   end
 end
 


### PR DESCRIPTION
The build is [currently failing](https://github.com/alphagov/govuk-developer-docs/actions/runs/13657932250/job/38181773085), but it's difficult to see why. This PR adds verbose logging as well as failing fast so the build bails at the first error, so we can see what's going on a bit more easily. I've also fixed the bad JSON that was preventing the Slack alerts from sending.