### PR TITLE
Add information about content block schemas

### DIFF
--- a/source/content-modelling/schemas/adding-a-new-content-block-type.html.md.erb
+++ b/source/content-modelling/schemas/adding-a-new-content-block-type.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: Adding a new content block type
+weight: 2
+layout: multipage_layout
+---
+
+# Adding a new content block type
+
+To add a new content block type, follow the instructions below:
+
+## Create a new schema in Publishing API
+
+Follow steps 1 to 5 in the [instructions in Publishing API for adding a new schema](https://github.com/alphagov/publishing-api/blob/main/docs/content_schemas/adding-a-new-schema.md)
+
+**NOTE:** Schemas MUST be prefixed with `content_block_*` for Content Block Manager to pick them up.
+
+If a content block type has embedded objects, you can use the `embedded_object` helper, which ensures that all embedded
+objects have a title and a key to ensure they can be referenced correctly ([Example here](https://github.com/alphagov/publishing-api/blob/9d4ce614ee3e95e82e5399201e4315ec9625e152/content_schemas/formats/content_block_pension.jsonnet#L13))
+
+## Add expansion rules for your new schema
+
+A good example is in [this commit](https://github.com/alphagov/publishing-api/commit/ae69bd878c87d475ace819acc6b7d76b60f5c360). Failure
+to do this will mean that updates to content will not get picked up when changes are made
+
+## Open a pull request
+
+Once these changes are made, open a pull request to Publishing API and get it approved
+
+## Add the schema to Content Block Manager
+
+Update the [`VALID_SCHEMAS` constant](https://github.com/alphagov/whitehall/blob/65a5c382d64466d666317b0eee8957c98b27b276/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb#L6)
+in Content Block Manager (and, if necessary, the [`valid_schemas` method](https://github.com/alphagov/whitehall/blob/65a5c382d64466d666317b0eee8957c98b27b276/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb#L12C13-L12C26)).
+
+## Add any customisations
+
+There is a [config file](https://github.com/alphagov/whitehall/blob/main/lib/engines/content_block_manager/config/content_block_manager.yml)
+which allows you to configure (amongst other things):
+
+- The order of the fields; and
+- What fields are judged to be "embeddable" (this will ensure a `Copy Code` link appears by that field)
+
+## Open another pull request
+
+Once these changes are made, open pull request to Whitehall and get these changes approved
+
+## Optional: Add a presenter to Content Block Tools
+
+If there are any custom behaviours required for a content block, you can add a presenter to the
+[Content Block Tools gem](https://github.com/alphagov/govuk_content_block_tools).
+
+You can see [an example presenter here](https://github.com/alphagov/govuk_content_block_tools/blob/main/lib/content_block_tools/presenters/pension_presenter.rb).

--- a/source/content-modelling/schemas/index.html.md.erb
+++ b/source/content-modelling/schemas/index.html.md.erb
@@ -1,0 +1,73 @@
+---
+title: Content Block Schemas
+weight: 2
+layout: multipage_layout
+---
+
+# Content Block Schemas
+
+## Anatomy of a schema
+
+All content block types are managed in the schemas in [Publishing API](https://github.com/alphagov/publishing-api/tree/main/content_schemas).
+
+Schemas are prefixed with `content_block_*` and are picked up by Content Block Manager via the [`Schema` class](https://github.com/alphagov/whitehall/blob/main/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb).
+
+When creating a new content block, we fetch all the supported schemas from Publishing API and give the user a list of
+valid block types to create. Once a block type is chosen the form is then populated using all the fields within a
+schema's `details` object (apart from embedded objects, more on this later), as well as the title, lead organisation
+and instructions to publishers.
+
+All fields within `details` generate a standard input field by default. If a schema has an `enum` type, this generates
+a select field populated with the valid enum values.
+
+### Embedded objects
+
+Schemas also support embedded objects (for example, the [Pension schema](https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json)
+has rates embedded). If any embedded objects are included, a user has the ability to create these objects on a seperate
+screen after creating the initial object. Embedded objects look like this (using `rates` as an example):
+
+```
+"rates": {
+  "rate-1": {
+    "title": "Rate 1",
+    "amount": "£221.20",
+    "frequency": "a week",
+    "description": "Your weekly pension amount"
+  },
+  "rate-2": {
+    "title": "Rate without decimal point",
+    "amount": "£221",
+    "frequency": "a week",
+    "description": "Your weekly pension amount"
+  },
+  "rate-3": {
+    "title": "Rate with big value",
+    "amount": "£1,223",
+    "frequency": "a week",
+    "description": "Your weekly pension amount"
+  }
+}
+```
+
+Each object has a key, which Content Block Manager automatically generates from the given title, so `Rate 1`
+becomes `rate-1`. This is immutable, so if a title changes, the key remains the same.
+
+### Currently supported schemas
+
+<% schemas = SchemaNames.all.select { |s| s.start_with?("content_block") } %>
+<%
+  # Note - we have to add `content_block_email_address` manually - see https://github.com/alphagov/govuk-developer-docs/blob/main/app/schema_names.rb#L1
+  schemas << "content_block_email_address"
+%>
+
+There are currently <%= schemas.count %> supported schemas in Content Block Manager:
+
+<ul>
+<% schemas.each do |schema| %>
+  <li>
+    <a href="https://github.com/alphagov/publishing-api/blob/main/content_schemas/formats/<%= schema %>.jsonnet">
+<%= schema %>
+    </a>
+  </li>
+<% end %>
+</ul>


### PR DESCRIPTION
Trello card: https://trello.com/c/JfbTFW0e/917-tech-documentation

This adds some documentation about how schemas work in Content Block Manager, as well as guidance on how to add a new schema.