### PR TITLE
Update Manage Assets manual

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -17,12 +17,14 @@ For assets that do not start `/media`, obtain the ID by running the following ra
 
 For example, for `https://assets.publishing.service.gov.uk/government/uploads/uploaded/hmrc/realtimepayetools-update-v23.xml"`, you would pass `/government/uploads/uploaded/hmrc/realtimepayetools-update-v23.xml` as the argument.
 
+## Useful information
+
+* For debugging Whitehall asset workflows, check the [asset flow diagrams in Whitehall](https://docs.publishing.service.gov.uk/repos/whitehall/assets.html#file-attachments-change-flows)
+* For more information on the asset state machine, see [this documentation](https://docs.publishing.service.gov.uk/repos/asset-manager/asset_state_machine_overview.html).
+
 ## Remove an asset
 
-When looking to remove an asset, keep in mind that some cases can be fixed less destructively, by setting a redirect or replacement.
-It depends on the case and user need.
-For Whitehall assets, see the [known bugs](#whitehall-known-asset-bugs) section below.
-For more information on the asset state machine, see [this documentation](https://docs.publishing.service.gov.uk/repos/asset-manager/asset_state_machine_overview.html).
+When looking to remove an asset, keep in mind that some cases can be fixed less destructively, by setting a redirect or replacement. It depends on the case and user need.
 
 ### Remove an asset via the originating publishing app
 
@@ -205,46 +207,3 @@ steps to remove the asset in Asset Manager:
     attachment_data = Asset.find_by(asset_manager_id: asset_id).assetable # e.g. 57a9c52b40f0b608a700000a
     attachment_data.update(file_size: 123, number_of_pages: 28) # file_size in bytes
     ```
-
-## Whitehall known asset bugs
-
-There are a few known bugs in Whitehall, that cause assets to be live when they should not be.
-These are currently (end of 2024) being worked on, and a data clean up has been run.
-In case you see anything that matches the patterns below, here's how you can fix it.
-You can still just delete the asset, but this approach is less destructive and more aligned with the intended behaviour.
-
-1. On a new draft of a published edition, if the user replaces a previously published attachment, then deletes it, and publishes the draft. The original asset remains live. However, the attachment is deleted, so the user does not know anything has gone wrong.
-
-    The problem seems to be that the deleted replacement's draft state is not set to false.
-
-    NB: The issue is specific to assets with draft replacements. Do not change the replacement unless it is in draft!
-    The original asset must only serve superseded editions.
-    To check that the original asset is not used on a public edition run, from a Whitehall console:
-
-       ```ruby
-       # This should be an array of "superseded" and nil ("deleted" state) attachables.
-       Asset.find_by(asset_manager_id: <your_asset_manager_id>).assetable.attachments.map(&:attachable).pluck(:state)
-       ```
-
-    Fix the replacement asset by running the following code from an Asset Manager console:
-
-       ```ruby
-       replacement = Asset.find(<your_asset_manager_id>).replacement
-       replacement.destroy! # if not already deleted
-       replacement.draft = false
-       replacement.save!
-       ```
-
-2. On a draft of a published edition, the user replaces a previously published attachment at least two successive times, without saving the draft first (or in between). The original asset remains live.
-
-    To fix this, you can populate the `replacement_id` manually, mimicking the behaviour that happens on publish.
-    After a publish event, all the assets in a chain of replacements will point to the last one.
-    This fix is preferable to a deletion, especially if a redirected is needed anyway.
-    You can extract the required `replacement_id` by following the chain of `AttachmentData` `replaced_by_id`s until the last. In a Whitehall console, run:
-
-       ```ruby
-       original_attachment_data = Asset.where(asset_mnager_id: <your_asset_manager_id>).first&.assetable
-       next_attachment_data1 = AttachmentData.find(original_attachment_data.replaced_by_id)
-       next_attachment_data2 = AttachmentData.find(next_attachment_data1.replaced_by_id)
-       AssetManager::AssetUpdater.call(<your_asset_manager_id>, { "replacement_id" => next_attachment_data2.assets.first.asset_manager_id })
-       ```


### PR DESCRIPTION
- Known bugs have been fixed and are no longer an issue
- Added links to the flow diagrams in the repos for useful debugging

 
https://trello.com/c/UTDPROlf/3576-consolidate-existing-asset-diagrams

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
