### PR TITLE
wip add content modelling team row

### DIFF
--- a/source/repos.html.md.erb
+++ b/source/repos.html.md.erb
@@ -27,6 +27,7 @@ You can also view a [breakdown of repositories by team and type](/repos/by-team-
 <% Repos.active.group_by(&:team).sort.each do |name, repos| %>
 | # <%= name %> | <%= repos.count %> | <%= repos.map { |repo| "[#{repo.repo_name}](/repos/#{repo.repo_name}.html)" }.join(", ") %> |
 <% end %>
+| # <%= "#content-modelling-dev" %> | <%= "1" %> | <%= "[Content Block Manager](/repos/whitehall/content_block_manager.html)" %> |
 
 ## Reuse this data
 


### PR DESCRIPTION
The Content Block Manager sits within the
Whitehall repository, but is managed by a separate
team[1]

We want to ensure it's clear what team owns the
code and where to direct issues/queries - it would
seem this page is the best to update, but it's
powered by the `Repos` data which is validated
against the actual GitHub Repos... Do we add our
team as a bit of a hacky addendum to the Teams
table, or would there be a more elegant solution?

[1] https://github.com/alphagov/whitehall/blob/main/docs/adr/0004-content-object-store-added-with-a-rails-engine.md