### PR TITLE
Add content-block-editor repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -83,6 +83,11 @@
   team: "#govuk-whitehall-experience-tech"
   production_hosted_on: eks
 
+- repo_name: content-block-editor
+  team: "#govuk-publishing-content-modelling-dev"
+  type: Utilities
+  sentry_url: false
+
 - repo_name: content-data-admin
   type: Supporting apps
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
This is a protoype JS library to demonstrate how we could highlight content blocks within publishing apps.