### PR TITLE
Fix list markup and document list parsing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ We host GOV.UK Developer Docs as a static site on GitHub Pages. The [ci.yml] Git
 - when a PR is merged to the default branch
 - on an hourly schedule, to pick up changes to docs included from other repos
 
+## List markup
+
+The Tech Docs template uses Redcarpet as its [Markdown engine][], which is quite
+particular about how to nest lists and different types of content within them.
+The gem has an infrequent release cadence and many known [issues with list
+parsing][].
+
+A different number of line breaks and spaces (for indentation) are needed for
+different types/combinations of content, and existing code is not guaranteed to
+be 'correct' as far as Redcarpet is concerned, so be sure to pay attention to
+how lists get rendered by running the app locally or deploying to integration
+before merging changes. Formatters like Prettier are unlikely format lists in a
+Redcarpet-compliant way.
+
+Example of addressing list parsing issues:
+
+- 75666849c773549572decedf883cea1e8f1743ee
+- 897595e7704e96fc302a58b913e7b3f5a0594953
+
+[issues with list parsing]:
+  https://github.com/vmg/redcarpet/issues?q=is%3Aissue%20state%3Aopen%20list
+[Markdown engine]:
+  https://github.com/alphagov/tech-docs-gem/blob/3720daadaf3f8e4693fe74c1c591493fe567b7fc/lib/govuk_tech_docs.rb#L56
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/source/kubernetes/get-started/access-eks-cluster/index.html.md
+++ b/source/kubernetes/get-started/access-eks-cluster/index.html.md
@@ -15,21 +15,20 @@ This document assumes that you have already followed the steps in [Get started d
 ## Obtain AWS credentials for your role in the cluster's AWS account
 
 1. Choose the [AWS IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) that you will use to access the cluster:
-
     - `admin`: has read-write access to everything in the cluster, including secrets
     - `poweruser`: has read-write access to everything in the `apps` namespace, but cannot view or modify secrets
     - `readonly`: can read everything in the `apps` namespace, except for secrets
 
 1. Obtain AWS credentials using `gds-cli` for the desired GOV.UK environment and role:
 
-  ```sh
-  eval $(gds aws govuk-<govuk-environment>-<role> -e --art 8h)
-  export AWS_REGION=eu-west-1
-  ```
+     ```sh
+     eval $(gds aws govuk-<govuk-environment>-<role> -e --art 8h)
+     export AWS_REGION=eu-west-1
+     ```
 
-  where:
-  - `<govuk-environment>` is `integration`, `staging`, or `production`
-  - `<role>` is `admin`, `poweruser`, or `readonly`
+    where:
+    - `<govuk-environment>` is `integration`, `staging`, or `production`
+    - `<role>` is `admin`, `poweruser`, or `readonly`
 
 ## Access a cluster for the first time
 

--- a/source/manual/how-to-upgrade-rails.html.md
+++ b/source/manual/how-to-upgrade-rails.html.md
@@ -77,12 +77,11 @@ example process is provided below. The first step is the key entry point.
 
 1. Run the following command to start the interactive update process.
 
-   ```sh
-   bundle exec rails app:update
-   ```
+    ```sh
+    bundle exec rails app:update
+    ```
 
 1. Accept all the changes with `a`.
-
    > You can alternatively review each individual change via the interactive
    > update process if you're comfortable reviewing and making decisions on
    > diffs in the command line. It's a similar interface to `git add --patch`.
@@ -90,12 +89,11 @@ example process is provided below. The first step is the key entry point.
 1. Run Rubocop to bring the code changes in line with our formatting/linting
    standards (and remove superficial changes from the diff).
 
-   ```sh
-   bundle exec rubocop --autocorrect
-   ```
+    ```sh
+    bundle exec rubocop --autocorrect
+    ```
 
 1. Review the diff and decide which changes to accept and commit.
-
    > The changes that get suggested by the update task will vary between apps.
    > They are based on a few settings, including which railties and engines are
    > enabled in `config/application.rb` and whether `config.api_only` is set to
@@ -105,11 +103,11 @@ example process is provided below. The first step is the key entry point.
    appropriate version-specific guide) and in the commit message, following the
    [GDS guidance on commit messages][].
 
-   Even if your decision is to accept a default, it's useful to know whether
-   you're just opting into a new default in the absence of a strong opinion, or
-   if you think the new setting is important and should be retained in future
-   upgrades. Documenting this will make decisions easier when performing future
-   upgrades.
+    Even if your decision is to accept a default, it's useful to know whether
+    you're just opting into a new default in the absence of a strong opinion, or
+    if you think the new setting is important and should be retained in future
+    upgrades. Documenting this will make decisions easier when performing future
+    upgrades.
 
 [GDS guidance on commit messages]:
   https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/working-with-git.html#commit-messages
@@ -125,19 +123,18 @@ guidance][] that follows.
 - For changes to settings in `config/environment`, work out if we were using a
   previous Rails default.
 
-  If we weren't using a previous Rails default, look for an explanation in the
-  app's git history.
+    If we weren't using a previous Rails default, look for an explanation in the
+    app's git history.
 
-  If we were using a previous Rails default, consult the following to inform
-  your decision on whether to move to the new default:
-
-  - [GOV.UK Helm Charts][] - does the config change affect an environment
+    If we were using a previous Rails default, consult the following to inform
+    your decision on whether to move to the new default:
+    - [GOV.UK Helm Charts][] - does the config change affect an environment
     variable that we've set for the app?
-  - The app’s git history
-  - [Rails version-specific guidance][official Rails guidance]
-  - [Rails source code][] and git history related to the change
-  - [Rails change log][] for the given release
-  - [Rails configuration documentation][]
+    - The app’s git history
+    - [Rails version-specific guidance][official Rails guidance]
+    - [Rails source code][] and git history related to the change
+    - [Rails change log][] for the given release
+    - [Rails configuration documentation][]
 
 - For changes in `public/*`, in general you can leave out HTML and image files
   (and consider removing any existing ones). We serve our own error pages and


### PR DESCRIPTION
The Markdown engine used by the tech docs template is very particular about how it parses lists. I think quite a few lists in the docs are parsed in unintentional ways. This fixes a couple of guides and adds some guidance to be wary of this in future

Auditing all existing content would be nice but very time consuming, so it's probably a fix it when you see it job. Hopefully the brief notes here will help with that

## Screenshots

I've included full page screenshots so that comparison can be made with other markup on the affected pages

### EKS

Pay attention to the numbers, indentation, and element types of the first ordered list

#### Before

![EKS before](https://github.com/user-attachments/assets/8bdcf4bf-38f0-41d2-9881-5382876a283f)

#### After

![EKS after](https://github.com/user-attachments/assets/7802c1f3-118f-41e2-b69e-fcb912b01f21)

### Rails upgrades

Pay attention to the "Update configuration using the Rails update task" section:
- its ordered list
- its subsection "Guidance for all upgrades"

[Trello](https://trello.com/c/xIZCRMny/1559-write-down-how-to-do-a-rails-upgrade)

#### Before

![Rails before](https://github.com/user-attachments/assets/7265ca3b-5344-4be8-91a3-041a4c195020)

#### After

![Rails after](https://github.com/user-attachments/assets/25695803-040b-4888-9d8b-9ed1eb4ab958)