### PR TITLE
Fix links for assets documentation

### DIFF
--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -21,8 +21,8 @@ For example, for `https://assets.publishing.service.gov.uk/government/uploads/up
 
 * For debugging Whitehall asset workflows, check the [asset flow diagrams in Whitehall](https://docs.publishing.service.gov.uk/repos/whitehall/assets.html#file-attachments-change-flows)
 * For more information on the asset state machine, see [this documentation](https://docs.publishing.service.gov.uk/repos/asset-manager/asset_state_machine_overview.html).
-* Look at [Whitehall's existing known bugs here](asset flow diagrams in Whitehall](https://docs.publishing.service.gov.uk/repos/whitehall/assets.html#current-known-bugs).
-* Whitehall's [currently unsupported asset features](asset flow diagrams in Whitehall](https://docs.publishing.service.gov.uk/repos/whitehall/assets.html#current-unsupported-workflows).
+* Look at [Whitehall's existing known bugs here](https://docs.publishing.service.gov.uk/repos/whitehall/assets.html#current-known-bugs).
+* Whitehall's [currently unsupported asset features](https://docs.publishing.service.gov.uk/repos/whitehall/assets.html#current-unsupported-workflows).
 
 ## Remove an asset
 


### PR DESCRIPTION
Fix accidental copy paste that broke links.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
