### PR TITLE
Use shared 'notify Slack' GitHub Action workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,31 +55,9 @@ jobs:
           commit_message: ${{steps.commit_message_writer.outputs.commit_message}}
           force_orphan: true
       - name: Notify failure
-        uses: slackapi/slack-github-action@v1
         if: ${{ failure() }}
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
         with:
-          payload: |
-            {
-              "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/.github/workflows/deploy.yml|Developer Docs deployment script> failed.",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                     "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/.github/workflows/deploy.yml|Developer Docs deployment script> failed."
-                  },
-                  "accessory": {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Check the build logs for details"
-                    },
-                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                    "action_id": "button-view-workflow"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-deploy-alerts
+          message: "The <https://github.com/alphagov/govuk-developer-docs/blob/main/.github/workflows/deploy.yml|Developer Docs deployment script> failed."


### PR DESCRIPTION
Since the govuk-developer-docs' hand-rolled version was added, Platform Engineering have added a new pipeline that any GOV.UK repo can reuse:
https://github.com/alphagov/govuk-infrastructure/pull/1729

On merge, we should be able to delete the `SLACK_WEBHOOK_URL` secret from govuk-developer-docs, as we're now using the `GOVUK_SLACK_WEBHOOK_URL` secret which is "added to all GOV.UK repositories as an organisation secret in the GOV.UK GitHub Infrastructure configuration.":
https://github.com/alphagov/govuk-infrastructure/tree/main/.github/actions/report-run-failure#notes-on-using-this-action

The output of the alert should look the same, according to the [test](https://gds.slack.com/archives/C08D696LAEA/p1740667524061079), with our optional message included.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
