### PR TITLE
Add all content modelling repos to the section

### DIFF
--- a/source/content-modelling/index.html.md.erb
+++ b/source/content-modelling/index.html.md.erb
@@ -28,13 +28,13 @@ The Content Modelling Team are available via Slack at [#govuk-publishing-content
 <% end %>
 </ul>
 
-### Content Block Tools
+<% Repos.active.select { |r| r.team == "#govuk-publishing-content-modelling-dev" }.each do |repo| %>
+  <h3><%= repo.repo_name.underscore.humanize.titleize %></h3>
 
-<ul>
-<li><a href="/repos/govuk_content_block_tools.html">README</a></li>
-<% (GitHubRepoFetcher.instance.docs("govuk_content_block_tools") || []).each do |page| %>
-  <li><a href="<%= page[:path] %>"><%= page[:title] %></a>
+  <ul>
+    <li><a href="/repos/<%= repo.repo_name %>.html">README<span class="govuk-visually-hidden"> for <%= repo.repo_name.humanize %></span></a></li>
+    <% (GitHubRepoFetcher.instance.docs(repo.repo_name.to_s) || []).each do |page| %>
+      <li><a href="<%= page[:path] %>"><%= page[:title] %></a>
+    <% end %>
+  </ul>
 <% end %>
-</ul>
-
-


### PR DESCRIPTION
This loops through all the repos owned by the content modelling team and displays a link to their README and any other docs (if they exist)