### PR TITLE
Update adding users to Sentry

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -95,9 +95,11 @@ You should [use your Yubikey as your MFA device][yubikey-aws-mfa] if you have on
 
 ## 6. Get permissions for AWS, GitHub and other third party services
 
-Permissions to GOV.UK's AWS, [GitHub], [Fastly], [Sentry] and [Pagerduty] accounts are managed by the [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer) private repository. You won't be able to see this repo until you are added to the alphagov GitHub organisation.
+Permissions to GOV.UK's AWS, [GitHub], [Fastly] and [Pagerduty] accounts are managed by the [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer) private repository. You won't be able to see this repo until you are added to the alphagov GitHub organisation.
 
 Ask your tech lead to follow the [instructions] in govuk-user-reviewer to grant you access.
+
+For [Sentry], your tech lead should manually add you via the Sentry UI. Once you've been added, you can [sign in](https://sentry.io/auth/login/) using your GDS Google account.
 
 [Fastly]: /manual/cdn.html
 [GitHub]: /manual/github.html

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -29,7 +29,7 @@ Useful links:
 
 ## Getting access to Sentry
 
-Your tech lead should raise a PR to give you Sentry access in the [govuk_tech.yml file in govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml). Once the PR is merged and the Terraform has been applied, you'll be able to [sign in](https://sentry.io/auth/login/) using your GDS Google account.
+Your tech lead should manually add you to Sentry via the Sentry UI. Once you've been added, you'll be able to [sign in](https://sentry.io/auth/login/) using your GDS Google account.
 
 ## Nomenclature
 


### PR DESCRIPTION
We're not managing Sentry users with Terraform anymore.

https://github.com/alphagov/govuk-user-reviewer/issues/1520