### PR TITLE
Changes to security alerts guidance

### DIFF
--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -8,8 +8,8 @@ parent: "/manual.html"
 ---
 
 [Brakeman][brakeman] is a static analysis tool which checks Rails applications
-for security vulnerabilities. It is effectively a type of linter, similar to
-[rubocop][]. It is configured as a [reusable workflow][] and should be included
+for security vulnerabilities. It's effectively a type of linter, similar to
+[rubocop][]. It's configured as a [reusable workflow][] and should be included
 as a job in the CI pipeline of all GOV.UK Ruby repositories.
 
 [brakeman]: https://github.com/presidentbeef/brakeman
@@ -32,7 +32,7 @@ security-analysis:
 
 ## Where to find Security Alerts
 
-To find the security alerts for a repo, first go to the Security tab of the repo and then the Code Scanning option under the Vulnerability Alerts in the sub menu. This is where [all alerts][alerts] can be found.
+To find the security alerts for a repo, go to the Security tab of the repo and select the Code Scanning option in the Vulnerability Alerts sub menu. This is where [all alerts][alerts] can be found.
 
 Additionally, when a PR is created, Brakeman scans the diff to identify vulnerabilities in the new code. These [PR specific alerts][pr-alerts] can be found on the Checks tab of the PR: select "Code scanning results" and then "Brakeman".
 
@@ -41,12 +41,12 @@ Additionally, when a PR is created, Brakeman scans the diff to identify vulnerab
 
 ## Dealing with false positives
 
-There will be times when Brakeman flags up false positives in your code. You
+Brakeman may occasionally flag up false positives in your code. You
 should try to refactor the code to satisfy Brakeman in such a way that it would
-also pass a code review. There is no benefit to refactoring the code just for
+also pass a code review. There's no benefit to refactoring the code just for
 Brakeman, if the resulting code is harder to understand.
 
-There is an [example of refactoring the Content Store][content-store-example]
+There's an [example of refactoring the Content Store][content-store-example]
 to satisfy Brakeman where the resulting code could be considered slightly less
 elegant, but still suitable without having to ignore the warning.
 
@@ -60,13 +60,11 @@ useful tool for ignoring warnings:
 $ brakeman -I
 ```
 
-It will help you decide what to do with each individual warning step by step.
+It'll help you decide what to do with each individual warning step by step.
 
-If you do decide to ignore a warning, you must include a note outlining why
-it is a false positive and not a security vulnerability.
+If you decide to ignore a warning, you must include a note outlining why
+it's a false positive and not a security vulnerability.
 
 ## Dealing with Security Alerts
 
-If you do decide to ignore a Brakeman alert, as described above, you will also need to close the security alert in GitHub.
-
-Alerts can be resolved by dismissing the alert as a false positive. You must include a note outlining why it is a false positive and not a security vulnerability.
+See [this guidance on security alerts](/manual/security-alerts.html).

--- a/source/manual/codeql.html.md
+++ b/source/manual/codeql.html.md
@@ -7,7 +7,7 @@ type: learn
 parent: "/manual.html"
 ---
 
-[CodeQL][codeql] is a Static Application Security Testing (SAST) tool which checks for vulnerability signatures in a repository's codebase. It is [configured as a reusable workflow][reusable-codeql] and should be included as a job in the CI pipeline of all GOV.UK repositories. A reusable workflow design was selected so that enhancements to the scanning process can be managed centrally.
+[CodeQL][codeql] is a Static Application Security Testing (SAST) tool which checks for vulnerability signatures in a repository's codebase. It's [configured as a reusable workflow][reusable-codeql] and should be included as a job in the CI pipeline of all GOV.UK repositories. The reusable workflow enables enhancements to the scanning process to be managed centrally.
 
 [codeql]: https://codeql.github.com/
 [reusable-codeql]: https://github.com/alphagov/govuk-infrastructure/pull/936
@@ -26,7 +26,7 @@ codeql-sast:
 
 ## Where to find Security Alerts
 
-To find the security alerts for a repo, first go to the Security tab of the repo and then the Code Scanning option under the Vulnerability Alerts in the sub menu. This is where [all alerts][codeql-alerts] can be found.
+To find the security alerts for a repo, go to the Security tab of the repo and select the Code Scanning option in the Vulnerability Alerts sub menu. This is where [all alerts][codeql-alerts] can be found.
 
 Additionally, when a PR is created, CodeQL scans the diff to identify vulnerabilities in the new code. These [PR specific alerts][codeql-pr-alerts] can be found on the Checks tab of the PR: select "Code scanning results" and then "CodeQL".
 
@@ -35,14 +35,7 @@ Additionally, when a PR is created, CodeQL scans the diff to identify vulnerabil
 
 ## Dealing with Security Alerts
 
-Currently, CodeQL is configured to [only identify vulnerabilities of a high severity and high precision][codeql-config]. Additionally, it will not fail the test when vulnerabilities are found: it will only create an alert and move on. This is to reduce the number of false positives and avoid wasting developer time. Over time, we intend to tune the dial to make CodeQL more strict.
-
-CodeQL will provide a recommendation on how to resolve a vulnerability along with references for additional research.
-
-Alerts can be resolved either by fixing the identified vulnerability or by dismissing the alert as a false positive. More details on this can be found in the [CodeQL documentation][codeql-docs]. If you do decide to ignore a warning, you must include a note outlining why it is a false positive and not a security vulnerability.
-
-[codeql-config]: https://github.com/alphagov/govuk-infrastructure/blob/f9c3b2bddf407d78c04552563a4ba23a89c8af61/.github/workflows/codeql-analysis.yml#L24-L35
-[codeql-docs]: https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/managing-code-scanning-alerts-for-your-repository
+See [this guidance on security alerts](/manual/security-alerts.html).
 
 ## Troubleshooting
 

--- a/source/manual/dependency-review.html.md
+++ b/source/manual/dependency-review.html.md
@@ -7,7 +7,7 @@ type: learn
 parent: "/manual.html"
 ---
 
-The [Dependency Review action][dependency-review-action] is a Software Composition Analysis (SCA) scan which diffs the old code and new code to identify whether there are any changes to the dependencies included in the project. It is [configured as a reusable workflow][reusable-workflow] and should be included as a job in the CI pipeline of all GOV.UK repositories. A reusable workflow design was selected so that enhancements to the scanning process can be managed centrally.
+The [Dependency Review action][dependency-review-action] is a Software Composition Analysis (SCA) scan which diffs the old code and new code to identify whether there are any changes to the dependencies included in the project. It's [configured as a reusable workflow][reusable-workflow] and should be included as a job in the CI pipeline of all GOV.UK repositories. The reusable workflow enables enhancements to the scanning process to be managed centrally.
 
 [dependency-review-action]: https://github.com/marketplace/actions/dependency-review
 [reusable-workflow]: https://github.com/alphagov/govuk-infrastructure/pull/966
@@ -24,14 +24,8 @@ dependency-review:
 
 ## Where to find Security Alerts
 
-Alerts can always be found in the job logs. Additionally, there is a job summary displayed beneath the GitHub Action run. Here, changes are summarised along with any vulnerabilities found.
+Alerts can always be found in the job logs. There's also a job summary displayed beneath the GitHub Action run where changes are summarised, along with any vulnerabilities found.
 
 ## Dealing with Security Alerts
 
-Currently, Dependency Review is [configured to find "critical" issues][dependency-review-config]. If issues are found, the check automatically 'fails' and therefore blocks merging of the PR. We therefore want to avoid false positives and wasting developer time, so have set the bar high and only alert on critical issues. Over time, we intent to tune the dial so this becomes more strict.
-
-Alerts can be resolved only by fixing the issue and running the tests again. Vulnerability alerts provide a link to the [GitHub advisory][gh-advisory] database where advice on resolving the issue can be found. Dismissing an alert requires adding the GitHub Advisory Database ID (GHSA) to the inline configuration [via the `allow-ghsas` property][skip-alert]. As the workflow is a communal resource, this should be done sparingly and include a well detailed comment about why it is being skipped.
-
-[dependency-review-config]: https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/dependency-review.yml
-[gh-advisory]: https://github.com/advisories
-[skip-alert]: https://github.com/marketplace/actions/dependency-review#inline-configuration
+See [this guidance on security alerts](/manual/security-alerts.html).

--- a/source/manual/security-alerts.html.md
+++ b/source/manual/security-alerts.html.md
@@ -21,13 +21,7 @@ When a security alert is raised, follow these steps:
 
 ### Dismissing Alerts
 
-When dismissing an alert, choose one of the predefined reasons in GitHub:
-
-- False positive
-- Used in tests
-- Won't fix
-
-You must add a comment explaining your reasoning and any supporting investigation. This ensures traceability and context for future reviewers.
+When dismissing an alert, choose one of the predefined reasons in GitHub. You must add a comment explaining your reasoning and any supporting investigation. This ensures traceability and context for future reviewers.
 
 ---
 
@@ -42,15 +36,15 @@ Brakeman alerts are static analysis results for Ruby applications.
 
 ### CodeQL (Code Scanning)
 
-CodeQL identifies vulnerabilities of **high severity and precision**.
+CodeQL is currently [configured to only identify vulnerabilities of high severity and precision](https://github.com/alphagov/govuk-infrastructure/blob/f9c3b2bddf407d78c04552563a4ba23a89c8af61/.github/workflows/codeql-analysis.yml#L24-L35).
 
 - CodeQL does **not block builds**; it simply creates alerts for later review.
-- Alerts include recommendations and references for resolving issues.
+- Alerts include recommendations and references for resolving issues. More details on this can be found in the [CodeQL documentation](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/managing-code-scanning-alerts-for-your-repository).
 - You may fix or dismiss alerts, but dismissals **must** include a comment explaining why.
 
 ### Dependency Review
 
-Dependency Review checks for known critical vulnerabilities in pull requests.
+Dependency Review checks for known vulnerabilities in pull requests. It's currently [configured to find "critical" issues](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/dependency-review.yml).
 
 - It **blocks merges** when critical issues are found.
 - Alerts are resolved by updating the dependency and re-running the checks.


### PR DESCRIPTION
A few tweaks to the guidance on dealing with security alerts:

- removes duplicate content from the individual pages and instead links to the general page
- removes the list of reasons for alert dismissal - it didn't match what was in Github and it may change anyway. Users can see the up to date list in Github. 
- some general language simplification

Part of https://github.com/alphagov/govuk-platform-internal/issues/3
