### PR TITLE
add instructions for adding new schema to Content Data API

### DIFF
--- a/source/content-modelling/schemas/adding-a-new-content-block-type.html.md.erb
+++ b/source/content-modelling/schemas/adding-a-new-content-block-type.html.md.erb
@@ -8,6 +8,14 @@ layout: multipage_layout
 
 To add a new content block type, follow the instructions below:
 
+## Add the new type to Content Data API
+
+We need to add the new type to the `no_content` Parser as they do not need frontend Parsers, [as in this commit](https://github.com/alphagov/content-data-api/commit/e02a85381dac95a7a08964e81587a1b49e384554)
+
+## Open a pull request
+
+Once these changes are made, open a pull request to Content Data API and get it approved
+
 ## Create a new schema in Publishing API
 
 Follow steps 1 to 5 in the [instructions in Publishing API for adding a new schema](https://github.com/alphagov/publishing-api/blob/main/docs/content_schemas/adding-a-new-schema.md)


### PR DESCRIPTION
https://trello.com/c/Fa5E0qo6/1031-tech-task-create-basic-contact-content-block-schema

This adds step to add the new schema type to Content Data API, so that its integration tests don't stop Publishing API merging https://gds.slack.com/archives/CAB4Q3QBW/p1745595957204829 

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
