### PR TITLE
Enforce only 1 deployment workflow at a time (always latest)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
     types: [completed]
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This workflow calls actions-gh-pages and triggers a Slack notification if it fails. This works great if there's an issue with the build script, but is also firing if the deployment action fails "as intended":

1. When two deployments are triggered in quick succession (e.g. two documentation PRs are merged within a couple of minutes of one another), the first deployment fails with an error at the actions-gh-pages step, along the lines of:

   ``` To https://github.com/alphagov/govuk-developer-docs.git ! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages': is at cf14548dd550851ca839b1378a51feda827f46b1 but expected c7de622d49bcde05531980b279f7defcfa23b931) error: failed to push some refs to 'https://github.com/alphagov/govuk-developer-docs.git' ```

2. This is causing a Slack notification announcing that the Developer Docs deployment failed

3. Behind the scenes, the second deployment then succeeds. Meanwhile, devs may be wasting time looking into the first 'failed' deployment!

Examples:

* bad deployment: https://github.com/alphagov/govuk-developer-docs/actions/runs/14752185211
* followed by good deployment: https://github.com/alphagov/govuk-developer-docs/actions/runs/14752188079

The fix is to enforce a namespaced 'concurrency' so that only one job in that group name runs at any one time. (Group name in this case translates to something like "Deploy-refs/heads/main"). This, in combination with `cancel-in-progress: true`, should mean that any existing deployment job will be automatically cancelled if a newer deployment job is triggered in the meantime, and we should no longer get this race condition.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
