### PR TITLE
Linking to the correct Licensing Guidelines for new repos

### DIFF
--- a/source/manual/github-new-repo.html.md
+++ b/source/manual/github-new-repo.html.md
@@ -10,7 +10,7 @@ When creating a new GOV.UK repo in Github, you must:
 
 - make a well-written README (see [READMEs for GOV.UK applications](/manual/readmes.html), or the [GDS Way guidance](https://gds-way.digital.cabinet-office.gov.uk/manuals/readme-guidance.html#writing-readmes) for general repositories)
 - tag it with the [`govuk`](https://github.com/search?q=topic:govuk) topic
-- add a licence following [Licensing Guidelines](/manual/licensing.html)
+- add a licence following [Licensing Guidelines](https://gds-way.digital.cabinet-office.gov.uk/manuals/licensing.html#specifying-the-licence)
 - add [Dependency Review](/manual/dependency-review.html) and [CodeQL](/manual/codeql.html) scans to its CI pipeline
 - add it to the [repos.yml](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml) file
 - add it to [repos.yml in govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/repos.yml). This:


### PR DESCRIPTION
Link to the GDS Way docs for licensing rather than developer docs licensing.html which is a licensify manual.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
