### PR TITLE
Update Prod Deploy and Prod Admin descriptions.

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -31,8 +31,9 @@ systems. Access includes:
 - Permission to [deploy apps](/manual/development-pipeline.html#deployment) via the [GOV.UK Production Deploy Github team](https://github.com/orgs/alphagov/teams/gov-uk-production-deploy)
 - Permission to [merge pull requests](/manual/merge-pr.html#header) in continuously deployed applications
 - Read-only access to logging systems such as Logit, etc.
-- Read-only access to dashboards in staging and production, such as the Argo CD web UI.
-- AWS read-only access in Staging and Production environments (via the `production_deploy_access` role [in `govuk-user-reviewer`](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml).)
+- Read-only access to dashboards in staging and production, such as the Argo CD web UI
+- AWS "developer" access in Staging and Production environments (via the `production_deploy_access` role [in `govuk-user-reviewer`](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml)) which grants read-only access to all services plus additional access to Athena, EKS and other components that are regarded as having a low potential for misuse
+- The AWS "developer" Role will also grant to access to most resources and actions in EKS (using `kubectl`) through RBAC (Role-Based Access Control)
 - "Normal" role in to GOV.UK Signon on Staging and Production (with app permissions granted as needed)
 
 The steps above are outlined in the [GOV.UK Production Deploy template Trello card](https://trello.com/c/S9sex2XU/1391-govuk-production-deploy-access-for-name), which can be copied to
@@ -60,7 +61,7 @@ Note that a technologist apprentice is limited to Production Deploy access. Howe
 Gives:
 
 - Write access to Argo CD in staging and production via the [GOV.UK Production GitHub team](https://github.com/orgs/alphagov/teams/gov-uk-production-admin)
-- Privileged AWS Access in Production and Staging environments (via the `production_admin_access` role [in `govuk-user-reviewer`](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml).)
+- Privileged AWS Access in Production and Staging environments (via the `production_admin_access` role [in `govuk-user-reviewer`](https://github.com/alphagov/govuk-user-reviewer/blob/main/config/govuk_tech.yml))
 - [Google Cloud Platform (GCP)](/manual/google-cloud-platform-gcp.html) access to role to manage [static mirrors](/manual/fall-back-to-mirror.html) and DNS
 - Signon "Super Admin" access in production
 - `engineer` and "Access all services" permissions in Fastly


### PR DESCRIPTION
## What?
This updates the Dev Docs to keep them up to date with the role changes that are being applied to our AWS Accounts. Further info will be available on our govuk-user-reviewer (internal) repo.

### Related
See:

* https://github.com/alphagov/govuk-user-reviewer/pull/1540