### PR TITLE
♻️ Change CKAN ownership

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -43,8 +43,8 @@
 
 - repo_name: ckan-helm
   type: Utilities
-  team: "#govuk-platform-engineering"
-  alerts_team: "#govuk-platform-support"
+  team: "#govuk-datagovuk"
+  alerts_team: "#govuk-datagovuk"
 
 - repo_name: ckan-mock-harvest-sources
   type: data.gov.uk apps


### PR DESCRIPTION
This is incorrectly listed as Platform Engineering. This commit corrects that.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
