### PR TITLE
BAU - Add search-with-select-component and govuk-design-guide repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -288,6 +288,12 @@
   type: Utilities
   production_hosted_on: eks
 
+- repo_name: govuk-design-guide
+  team: "#govuk-publishing-design-guide"
+  type: Publishing apps
+  description: GOV.UK Publishing Design Guide
+  production_url: https://design-guide.publishing.service.gov.uk/
+
 - repo_name: govuk-developer-docs
   team: "#govuk-developers"
   type: Utilities
@@ -667,6 +673,10 @@
   type: APIs
   team: "#govuk-search-improvement"
   production_hosted_on: eks
+
+- repo_name: select-with-search-component
+  type: Publishing apps
+  team: "#govuk-whitehall-experience-team"
 
 - repo_name: service-manual-publisher
   type: Publishing apps


### PR DESCRIPTION
Description:
- Add `search-with-select-component` repo
- Add `govuk-design-guide` repo

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
