### PR TITLE
Update `select-with-search-component` and `govuk-design-guide` repo types

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -290,7 +290,7 @@
 
 - repo_name: govuk-design-guide
   team: "#govuk-publishing-design-guide"
-  type: Publishing apps
+  type: Design System
   description: GOV.UK Publishing Design Guide
   production_url: https://design-guide.publishing.service.gov.uk/
 
@@ -675,8 +675,9 @@
   production_hosted_on: eks
 
 - repo_name: select-with-search-component
-  type: Publishing apps
+  type: Gems
   team: "#govuk-whitehall-experience-team"
+  sentry_url: false
 
 - repo_name: service-manual-publisher
   type: Publishing apps


### PR DESCRIPTION
`govuk-design-guide` is owned by a team outside of Publishing so should have it's own category similar to Data science.

`select-with-search-component` is a gem so should have this type listed so it can be picked by automation such as Gem auto release workflow.

@minhngocd, @nnagewad We added those repos to the list. Please ensure you follow all the remaining steps in [Configure a new GOV.UK repository](https://docs.publishing.service.gov.uk/manual/github-new-repo.html) guide (alternatively remove the `govuk` GitHub topic).

