### PR TITLE
Change who grants Notify access

### DIFF
--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -57,7 +57,7 @@ for each environment):
 **[👉 Sign in to the GOV.UK Notify dashboard](https://www.notifications.service.gov.uk/sign-in)**
 
 You'll need to use your own account, which should have been created as part of [getting production admin access](/manual/rules-for-getting-production-access.html#production-admin-access).
-If you lack an account, ask Platform Engineering to invite you to the [GOV.UK](https://www.notifications.service.gov.uk/services/ca5ec9d0-3074-4495-bb15-dd6cf176d7ce/users), [GOV.UK Email](https://www.notifications.service.gov.uk/services/539d63a1-701d-400d-ab11-f3ee2319d4d4/users) and [GOV.UK Publishing](https://www.notifications.service.gov.uk/services/a4b5303c-bea0-4aa7-b3bd-7e5f1d25ff65/users) services in Notify.
+If you lack an account, ask your tech lead or a [GOV.UK Senior Tech member](/manual/ask-for-help.html#contact-senior-tech) to invite you to the [GOV.UK](https://www.notifications.service.gov.uk/services/ca5ec9d0-3074-4495-bb15-dd6cf176d7ce/users), [GOV.UK Email](https://www.notifications.service.gov.uk/services/539d63a1-701d-400d-ab11-f3ee2319d4d4/users) and [GOV.UK Publishing](https://www.notifications.service.gov.uk/services/a4b5303c-bea0-4aa7-b3bd-7e5f1d25ff65/users) services in Notify.
 
 ## Getting urgent support
 


### PR DESCRIPTION
Given this access comes with production admin access, it should be the same as the ‘sponsor’ (Tech Lead, Senior Tech). 
All users have permissions to invite new users and "Manage settings, team and usage".

Platform Engineering team is unlikely to have enough context to be able to make a decision if a user should be granted access.
