### PR TITLE
Update references to deprecated AWS roles

### DIFF
--- a/source/kubernetes/cheatsheet.html.md
+++ b/source/kubernetes/cheatsheet.html.md
@@ -25,16 +25,15 @@ general quick-reference guide.
     ```
 
 1. Obtain credentials to access the cluster. Use an IAM role with sufficient permissions:
-    - `-readonly` roles can view logs and configuration
-    - `-poweruser` roles can run Rake tasks or open a shell
-    - `-administrator` roles can modify base cluster services (you should not
+    - `-developer` roles can view logs, configuration and run Rake tasks or open a shell
+    - `-fulladmin` roles can modify base cluster services (you should not
       normally need this)
 
     For example:
 
     ```sh
     # Obtain IAM credentials for the AWS account (integration, staging, production).
-    eval $(gds aws govuk-integration-poweruser -e --art 8h)
+    eval $(gds aws govuk-integration-developer -e --art 8h)
 
     # Select the corresponding kubectl context. `k config get-contexts` lists them.
     k config use-context integration

--- a/source/manual/create-a-local-transaction.html.md
+++ b/source/manual/create-a-local-transaction.html.md
@@ -70,7 +70,7 @@ We'll want to pick a `local-links-manager` pod to connect to the Console - norma
 List the LLM pods and select one:
 
 ```bash
-gds aws govuk-integration-poweruser -e
+gds aws govuk-integration-developer -e
 k get pods -l=app=local-links-manager
 
 NAME                                  READY   STATUS    RESTARTS   AGE

--- a/source/manual/dns.html.md
+++ b/source/manual/dns.html.md
@@ -12,7 +12,7 @@ parent: "/manual.html"
 GOV.UK is responsible for managing several DNS zones, spanning a number of `*.gov.uk` domains. As of February 2024, there are 45 hosted zones, configuring many hundreds of domains. A list of hosted zones is retrievable from a terminal using:
 
 ```sh
-gds aws govuk-production-poweruser -- aws route53 list-hosted-zones | grep Name
+gds aws govuk-production-developer -- aws route53 list-hosted-zones | grep Name
 ```
 
 ## Records for GOV.UK systems

--- a/source/manual/fall-back-to-aws-cloudfront.html.md
+++ b/source/manual/fall-back-to-aws-cloudfront.html.md
@@ -28,7 +28,7 @@ This backup CDN is currently provided by AWS CloudFront.
 1. Confirm that Fastly is the cause of the incident (check [https://status.fastly.com/](https://status.fastly.com/)
   and keep an eye on twitter - if there's a major Fastly outage there will be a lot of noise)
 2. Escalate to GOV.UK SMT as soon as you begin to consider failing over
-3. Sign in to the AWS console as an admin (`gds aws govuk-production-admin -l`, or however you prefer to sign in to AWS)
+3. Sign in to the AWS console as an fulladmin (`gds aws govuk-production-fulladmin -l`, or however you prefer to sign in to AWS)
 4. Sign in to [the `govuk-production` project on GCP console](https://console.cloud.google.com/home/dashboard?project=govuk-production)
 
 Now follow the steps below for [**Production**](#production) or for [**Staging**](#staging), depending on your scenario:
@@ -55,10 +55,10 @@ You can also get the `CNAME`s to use for the secondary CDN from the AWS CLI:
 
 ```bash
   # www-cdn.production.govuk.service.gov.uk
-  gds aws govuk-production-readonly aws cloudfront list-distributions \
+  gds aws govuk-production-developer aws cloudfront list-distributions \
     --query "DistributionList.Items[?Aliases.Items[0]=='www.gov.uk'].DomainName | [0]"
   # assets.publishing.service.gov.uk
-  gds aws govuk-production-readonly aws cloudfront list-distributions \
+  gds aws govuk-production-developer aws cloudfront list-distributions \
     --query "DistributionList.Items[?Aliases.Items[0]=='assets.publishing.service.gov.uk'].DomainName | [0]"
 ```
 
@@ -95,10 +95,10 @@ You can get the `CNAME`s to use for the secondary CDN from the AWS CLI:
 
 ```bash
   # www.staging.publishing.service.gov.uk
-  gds aws govuk-staging-readonly aws cloudfront list-distributions \
+  gds aws govuk-staging-developer aws cloudfront list-distributions \
     --query "DistributionList.Items[?Aliases.Items[0]=='www.staging.publishing.service.gov.uk'].DomainName | [0]"
   # assets.staging.publishing.service.gov.uk
-  gds aws govuk-staging-readonly aws cloudfront list-distributions \
+  gds aws govuk-staging-developer aws cloudfront list-distributions \
     --query "DistributionList.Items[?Aliases.Items[0]=='assets.staging.publishing.service.gov.uk'].DomainName | [0]"
 ```
 

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -149,7 +149,7 @@ You must be a member of the [alphagov GitHub org](https://github.com/alphagov/) 
     1. Run any `gds aws` command to start the first-time setup process:
 
         ```sh
-        gds aws govuk-integration-readonly -l
+        gds aws govuk-integration-developer -l
         ```
 
     1. Enter your Access Key ID and Secret Access Key when prompted.
@@ -170,7 +170,7 @@ You must be a member of the [alphagov GitHub org](https://github.com/alphagov/) 
 You can now use `gds aws` to run [AWS CLI](https://aws.amazon.com/cli/) commands by prefixing them with `gds aws <role>`. You can use `--` to avoid ambiguity between `gds` options and options for the wrapped command. For example:
 
 ```sh
-gds aws govuk-integration-readonly -- aws s3 ls
+gds aws govuk-integration-developer -- aws s3 ls
 ```
 
 [gds-users-aws-signin]: https://gds-users.signin.aws.amazon.com/console

--- a/source/manual/github-unavailable.html.md
+++ b/source/manual/github-unavailable.html.md
@@ -37,7 +37,7 @@ docker build --platform linux/amd64 -t $REGISTRY/$REPO:$IMAGE_TAG .
 5. Log into ECR and push the image:
 
 ```
-gds aws govuk-production-poweruser aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin $REGISTRY
+gds aws govuk-production-developer aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin $REGISTRY
 docker push $REGISTRY/$REPO:$IMAGE_TAG
 ```
 

--- a/source/manual/how-to-escalate-to-AWS-support.html.md
+++ b/source/manual/how-to-escalate-to-AWS-support.html.md
@@ -10,6 +10,6 @@ Sign in to the AWS Management Console.
 
 `gds aws <command> -l`
 
-Where `<command>` maps to an AWS account and IAM role you have permissions to assume into. This should be the AWS account that the problem is associated with e.g. `govuk-production-poweruser`.
+Where `<command>` maps to an AWS account and IAM role you have permissions to assume into. This should be the AWS account that the problem is associated with e.g. `govuk-production-developer`.
 
 Then follow steps 2-6 in the official AWS docs: [Creating a support case](https://docs.aws.amazon.com/awssupport/latest/user/case-management.html#creating-a-support-case)

--- a/source/manual/how-to-query-mysql-database-on-eks.html.md
+++ b/source/manual/how-to-query-mysql-database-on-eks.html.md
@@ -20,7 +20,7 @@ In order to run the SQL queries and extract files from EKS pods, you would need 
 2. Switch to desired environment, e.g.
 
 ```
-eval $(gds aws govuk-integration-poweruser -e --art 8h)
+eval $(gds aws govuk-integration-developer -e --art 8h)
 kubectl config use-context integration
 ```
 
@@ -41,7 +41,7 @@ echo $GOVUK_ENVIRONMENT
 1. Log into the AWS console with the desired role
 
 ```
-gds aws govuk-integration-poweruser -l
+gds aws govuk-integration-developer -l
 ```
 
 2. Choose Secrets Manager from the Services menu

--- a/source/manual/howto-change-slug-and-create-redirect.html.md
+++ b/source/manual/howto-change-slug-and-create-redirect.html.md
@@ -27,7 +27,7 @@ To run a Rake task you need to:
 
 ```bash
 export AWS_REGION=eu-west-1
-eval $(gds aws govuk-integration-poweruser -e --art 8h)
+eval $(gds aws govuk-integration-developer -e --art 8h)
 kubectl config use-context <your-context-name>
 ```
 

--- a/source/manual/howto-checkout-and-commit-to-codecommit.html.md
+++ b/source/manual/howto-checkout-and-commit-to-codecommit.html.md
@@ -20,7 +20,7 @@ This example demonstrates a simple workflow using the `govuk-replatform-test-app
 
 ```
 # Clone the repo.
-gds aws govuk-tools-poweruser git clone codecommit::eu-west-2://govuk-replatform-test-app
+gds aws govuk-tools-developer git clone codecommit::eu-west-2://govuk-replatform-test-app
 
 # Create a local branch.
 cd govuk-replatform-test-app
@@ -31,10 +31,10 @@ touch mychange
 git commit -m "DO NOT MERGE: testing push to CodeCommit" -- mychange
 
 # Push the branch to CodeCommit.
-gds aws govuk-tools-poweruser git push origin mybranch
+gds aws govuk-tools-developer git push origin mybranch
 
 # Clean up by deleting the example branch we just created.
-gds aws govuk-tools-poweruser git push -d origin mybranch
+gds aws govuk-tools-developer git push -d origin mybranch
 ```
 
 ## Install dependencies and set up local environment
@@ -75,7 +75,7 @@ Repository names should exactly match those in GitHub. If you are unsure whether
 1. Log into the AWS console to see the available repositories using [the GDS command line tool](/manual/get-started.html#3-install-gds-command-line-tools)
 
     ```
-    gds aws govuk-tools-poweruser --login
+    gds aws govuk-tools-developer --login
     ```
 
 1. Select the London (`eu-west-2`) region.
@@ -92,13 +92,13 @@ Repository names should exactly match those in GitHub. If you are unsure whether
 2. In your shell, obtain AWS credentials and run `git clone` to clone the repository.
 
     ```
-    gds aws govuk-tools-poweruser git clone <repository url>
+    gds aws govuk-tools-developer git clone <repository url>
     ```
 
     For example:
 
     ```
-    gds aws govuk-tools-poweruser git clone codecommit::eu-west-2://govuk-replatform-test-app
+    gds aws govuk-tools-developer git clone codecommit::eu-west-2://govuk-replatform-test-app
     ```
 
 > `git clone` on CodeCommit can sometimes be very slow initially. If `git
@@ -112,5 +112,5 @@ Once you have cloned a repository from CodeCommit, you can create local branches
 For example:
 
 ```
-gds aws govuk-tools-poweruser git push origin mybranch
+gds aws govuk-tools-developer git push origin mybranch
 ```

--- a/source/manual/manage-assets.html.md.erb
+++ b/source/manual/manage-assets.html.md.erb
@@ -82,7 +82,7 @@ If it isn't feasible to remove the asset in the publishing app, you can use thes
 8. Remove the asset from the Amazon Web Services (AWS) mirror:
 
     ```
-    gds aws govuk-production-poweruser aws s3 rm s3://govuk-production-mirror/assets.publishing.service.gov.uk/<slug>
+    gds aws govuk-production-developer aws s3 rm s3://govuk-production-mirror/assets.publishing.service.gov.uk/<slug>
     ```
 
 ## Redirect an asset

--- a/source/manual/purge-cache.html.md
+++ b/source/manual/purge-cache.html.md
@@ -78,7 +78,7 @@ purge its cache.
 If an item urgently needs to be removed from the cache, you can create an
 invalidation from the AWS console.
 
-1. Log into the AWS console with `gds aws govuk-production-poweruser -l`.
+1. Log into the AWS console with `gds aws govuk-production-developer -l`.
 1. Under the [CloudFront distributions page](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=eu-west-1#/distributions),
    choose the appropriate distribution: `WWW` for www.gov.uk or `Assets` for assets.publishing.service.gov.uk.
 1. Select the "Invalidations" tab, and click "Create invalidation".

--- a/source/manual/redirect-routes.html.md
+++ b/source/manual/redirect-routes.html.md
@@ -173,7 +173,7 @@ To access an app's Rails console you’ll need to set your region and context as
 
 ```bash
 export AWS_REGION=eu-west-1
-eval $(gds aws govuk-integration-poweruser -e --art 8h)
+eval $(gds aws govuk-integration-developer -e --art 8h)
 kubectl config use-context <your-context-name>
 ```
 

--- a/source/manual/reindex-elasticsearch.html.md.erb
+++ b/source/manual/reindex-elasticsearch.html.md.erb
@@ -58,7 +58,7 @@ If the free storage is below 250GB, check to see if there are any old indices fr
 Sign in as a poweruser:
 
 ```sh
-eval $(gds aws govuk-production-poweruser -e --art 8h)
+eval $(gds aws govuk-production-developer -e --art 8h)
 ```
 
 List the search indices (sorting by index name):

--- a/source/manual/secrets-manager.html.md
+++ b/source/manual/secrets-manager.html.md
@@ -26,7 +26,7 @@ machine-readable secrets.
 
 ## Retrieve a credential from Secrets Manager
 
-1. Log into the __production__ AWS account. You'll need to assume the admin role (`govuk-production-admin`).
+1. Log into the __production__ AWS account. You'll need to assume the fulladmin role (`govuk-production-fulladmin`).
 1. Choose [Secrets
    Manager](https://eu-west-1.console.aws.amazon.com/secretsmanager/listsecrets?region=eu-west-1)
    from the Services menu.

--- a/source/manual/web_application_firewall_rules.html.md
+++ b/source/manual/web_application_firewall_rules.html.md
@@ -53,6 +53,6 @@ We should not enable the role unless we are [engaged with the team](https://docs
 
 To enable the role:
 
-1. Open the AWS console for the affected environment, eg `gds aws govuk-integration-poweruser -l`
+1. Open the AWS console for the affected environment, eg `gds aws govuk-integration-developer -l`
 1. Navigate to the [Edit AWS Shield Response Team (SRT) access page](https://console.aws.amazon.com/wafv2/shieldv2#/drt_settings/edit)
 1. In the AWS Shield Response Team (SRT) access section, select the "Choose an existing role for the SRT to access my accounts." radio button.


### PR DESCRIPTION
`readonly` and `admin` roles were deprecated and removed from gds-cli in https://github.com/alphagov/gds-cli/pull/955/files `developer` and `fulladmin` roles should be used.

This naively replaced:
- `readonly` and `poweruser` with `developer`
- `admin` with `fulladmin`

I'd appreciated a through review especially around CDN docs.

Related to https://github.com/alphagov/govuk-infrastructure/issues/1833 https://github.com/alphagov/govuk-infrastructure/issues/1757

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
