### PR TITLE
Mark govuk-content-metadata repository as retired

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -265,6 +265,7 @@
   team: "#data-engineering"
   type: Data science
   sentry_url: false
+  retired: true
 
 - repo_name: govuk-crd-library
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
Updated repos.yml to mark the data-science repository `govuk-content-metadata` as retired
