### PR TITLE
Document the Platform Engineer role and access

### DIFF
--- a/source/kubernetes/get-started/access-eks-cluster/index.html.md
+++ b/source/kubernetes/get-started/access-eks-cluster/index.html.md
@@ -15,8 +15,9 @@ This document assumes that you have already followed the steps in [Get started d
 ## Obtain AWS credentials for your role in the cluster's AWS account
 
 1. Choose the [AWS IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) that you will use to access the cluster:
-    - `fulladmin`: has read-write "cluster-admin" access to everything in the cluster, across all namespaces, including secrets
     - `developer`: has read-write access to most things in the `apps` and `datagovuk` namespaces, but cannot view or modify secrets
+    - `fulladmin`: has read-write "cluster-admin" access to everything in the cluster, across all namespaces, including secrets
+    - `platformengineer`: also has read-write "cluster-admin access to everything in the cluster, across all namespaces, including secrets, but can be used by Platform Engineers on a regular basis without requiring an approval process
 
 1. Obtain AWS credentials using `gds-cli` for the desired GOV.UK environment and role:
 
@@ -31,9 +32,9 @@ This document assumes that you have already followed the steps in [Get started d
 
 ## Note: About using the correct role
 
-You should always assume the correct role for the job. For the majority of tasks, you should try to assume the `developer` role first.
+You should always assume the correct role for the job. For the majority of tasks, you should try to assume the `developer` role first. Platform Engineers may use the `platformengineer` role if they need to perform actions in the EKS cluster that require "Cluster Admin" permissions but don't need Admin access to other AWS services.
 
-Only "Production Admin" users can assume the `fulladmin` role, and should only do so if they have proven the `developer` role is insufficient. Usage of the `fulladmin` role is monitored and may cause a notification to be raised in future.
+Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin` role, and should only do so if they have proven the `developer` or `platformengineer` roles are insufficient. Usage of the `fulladmin` role is monitored and may cause an alert to be raised in future.
 
 ## Access a cluster for the first time
 
@@ -89,7 +90,7 @@ To switch to a cluster that you have previously configured in `~/.kube/config` a
 
     where:
     - `<govuk-environment>` is `integration`, `staging`, or `production`
-    - `<role>` is `fulladmin` or `developer`
+    - `<role>` is `developer`, `fulladmin` or `platformengineer`
 
 1. Switch to the corresponding kubectl context:
 

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -20,6 +20,7 @@ We have two types of production access:
 
 1. [Production Deploy access](#production-deploy-access)
 2. [Production Admin access](#production-admin-access)
+3. [Platform Engineer access](#platform-engineer-access)
 
 We have a [spreadsheet documenting the full list of permissions for both access levels](https://docs.google.com/spreadsheets/d/1oqy7tKpB8mHBhHQ9jAZu0NR0GKKZXOqtQGBKHYVnpmk/edit?usp=sharing).
 
@@ -83,6 +84,14 @@ A new starter/engineer will be expected to work through the following checklist 
 - The deployment pipeline - how code gets from your machine to running on production. E.g. by reading [the deployment docs](/manual#deployment), and learning on the job.
 - The incident management process. E.g. by reading through the [So, you're having an incident](/manual/incident-what-to-do) doc and completing the [incident preparedness quizzes](https://drive.google.com/drive/folders/1X9eGQMIl9ifb3X2jYcdjqrt01P9JYJzR).
 - Best practices around the principle of least privilege, how to safely debug production issues, and how to work with credentials and accounts. E.g. by pairing with another developer to practise a drill on your product team.
+
+### Platform Engineer access
+
+Platform Engineer access is a special set of access permissions that are very similar to Production Admin, except with specific additional access to aid Platform Engineers with their day-to-day operational needs. In addition to the access granted by Production Admin, it also gives:
+
+- A special set of `-platformengineer` IAM roles for each environment that provide an access level similar to the `-developer` roles except also grants "Cluster Admin" access to our EKS clusters to allow Platform Engineers to access and manage all namespaces and resources
+
+This is necessary because without this, the only way to obtain Cluster Admin access would be to assule the `fulladmin` role on a regular basis, which we are trying to discourage except for "break glass" type scenarios that may trigger alerting.
 
 ## Temporarily revoking access
 

--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -91,7 +91,7 @@ Platform Engineer access is a special set of access permissions that are very si
 
 - A special set of `-platformengineer` IAM roles for each environment that provide an access level similar to the `-developer` roles except also grants "Cluster Admin" access to our EKS clusters to allow Platform Engineers to access and manage all namespaces and resources
 
-This is necessary because without this, the only way to obtain Cluster Admin access would be to assule the `fulladmin` role on a regular basis, which we are trying to discourage except for "break glass" type scenarios that may trigger alerting.
+This is necessary because without this, the only way to obtain Cluster Admin access would be to assume the `fulladmin` role on a regular basis, which we are trying to discourage except for "break glass" type scenarios that may trigger alerting.
 
 ## Temporarily revoking access
 


### PR DESCRIPTION
## What?
This documents the new `platformengineer` roles that have been implemented for use by GOV.UK Platform Engineers.