### PR TITLE
Remove Contacts Admin from repos list

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -77,12 +77,6 @@
   team: "#govuk-publishing-mainstream-experience-tech"
   production_hosted_on: eks
 
-- repo_name: contacts-admin
-  type: Publishing apps
-  shortname: contacts
-  team: "#govuk-whitehall-experience-tech"
-  production_hosted_on: eks
-
 - repo_name: content-block-editor
   team: "#govuk-publishing-content-modelling-dev"
   type: Utilities


### PR DESCRIPTION
The repo is now archived.

NB, since https://github.com/alphagov/govuk-developer-docs/pull/4497, we seem to encourage removing the repo from the repos.yml entirely, rather than adding `retired: true` and a `description`.

I'll update https://docs.publishing.service.gov.uk/manual/retiring-a-repo.html#6-update-the-developer-docs in a separate PR.

Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin