### PR TITLE
Update 'Retire a repo' step about updating dev docs

### DIFF
--- a/source/manual/retiring-a-repo.html.md
+++ b/source/manual/retiring-a-repo.html.md
@@ -43,9 +43,7 @@ Follow the steps in [GOV.UK GitHub Infrastructure configuration terraform projec
 
 ## 6. Update the Developer Docs
 
-If the repo is listed in [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml), mark the application as `retired`.
-
-If the repo wasn't already listed in Developer Docs then don't add it.
+Remove the repo's entry from [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml).
 
 ([#4259](https://github.com/alphagov/govuk-developer-docs/issues/4259) would eliminate this toil if fixed.)
 


### PR DESCRIPTION
We have a check that ensures all repos are listed in dev docs so it’s fair to assume this will always be the case.

We no longer mark repos as retired with `retired: true` as they were included in the Dev docs search results making the search results less relevant and harder to find information.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
