### PR TITLE
Update the "Retire an application" documentation

### DIFF
--- a/source/manual/architecture.html.md
+++ b/source/manual/architecture.html.md
@@ -7,21 +7,20 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-[//]: # (1 - Visit https://app.diagrams.net/#G1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm)
-[//]: # (2 - File > Embed > IFrame...)
-[//]: # (3 - Uncheck Edit / Layers / Tags)
-[//]: # (4 - Create)
-[//]: # (5 - Copy the snippet and paste below, replacing the inline style attribute with class="architecture-diagram")
+## Diagram of technical architecture of GOV.UK
+
+> You can [open the diagram below in Full Screen Mode](https://viewer.diagrams.net/?tags=%7B%7D&highlight=0000ff&edit=https%3A%2F%2Fapp.diagrams.net%2F%23G1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm&layers=1&nav=1&title=GOV.UK%20Logical%20architecture%20diagram#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload) if you'd prefer.
 
 <iframe frameborder="0" class="architecture-diagram" src="https://viewer.diagrams.net/?highlight=0000ff&nav=1&title=GOV.UK%20Logical%20architecture%20diagram#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload"></iframe>
 
-[Open in Full Screen Mode](https://viewer.diagrams.net/?tags=%7B%7D&highlight=0000ff&edit=https%3A%2F%2Fapp.diagrams.net%2F%23G1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm&layers=1&nav=1&title=GOV.UK%20Logical%20architecture%20diagram#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm%26export%3Ddownload)
+To edit the diagram, visit <https://app.diagrams.net/#G1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm>. If you see an "Error loading file" popup, click the "Try opening via this page" button and then use the "Open with" dropdown (at the top of the screen) to select "Open with draw.io".
 
-[Source diagram][src] in the [GOV.UK architecture folder][arch-folder].
+## Diagram of GOV.UK's publishing architecture
 
-If you'd like to explore further, read the [architectural deep-dive](/manual/architecture-deep-dive.html).
+A more recent architecture diagram, created for the publishing teams, is available at <https://app.mural.co/t/govukdelivery7534/m/govukdelivery7534/1732703920854/dbbca4b19d526e8e791c0b1e3972fe0ddb8cb28e>.
 
-A more recent architecture diagram, created for the publishing teams, is available at <https://app.mural.co/t/govuk1422/m/govuk1422/1694525134284/5fea5844e36344eb1bc98c20cd0755d2a0c2266e>.
+## Other resources
 
-[src]: https://drive.google.com/open?id=1qTEpv2kCzghqZpUF86UyQj4o0dZ97gTm
-[arch-folder]: https://drive.google.com/drive/folders/1xIjPkD_MSKMR65FbDAb-ToXy2GmBcaJ5
+You can [sign up for a Introduction to GOV.UK Architecture](https://docs.google.com/spreadsheets/d/1pDQavKZoZbRpoprlouk5YDZWS6mjSw3ILvCYmFkGWwE/edit) session or watch [a recording of a past session](https://drive.google.com/file/d/1-az_Y_JeKJ2Xhqrc7VNVt1sKOTEpHbcM/view).
+
+You can also read the [architectural deep-dive](/manual/architecture-deep-dive.html) in the Developer Docs, or have a look at in the [GOV.UK architecture folder](https://drive.google.com/drive/folders/1xIjPkD_MSKMR65FbDAb-ToXy2GmBcaJ5) for other resources.


### PR DESCRIPTION
Also updates the "Architectural overview" doc, since the "Retire an application" doc tells you to update it and it needed a bit of work. See commits for details.

Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin