### PR TITLE
Remove references to Contacts Admin

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -81,7 +81,6 @@ redirects:
   /apps/ckanext-datagovuk.html: /repos/ckanext-datagovuk.html
   /apps/collections.html: /repos/collections.html
   /apps/collections-publisher.html: /repos/collections-publisher.html
-  /apps/contacts-admin.html: /repos/contacts-admin.html
   /apps/contacts-frontend.html: /repos/contacts-frontend.html
   /apps/content-data-admin.html: /repos/content-data-admin.html
   /apps/content-data-api.html: /repos/content-data-api.html

--- a/source/manual/govuk-env-sync.html.md
+++ b/source/manual/govuk-env-sync.html.md
@@ -13,7 +13,7 @@ Staging is overwritten every night, whereas integration is overwritten [every Mo
 
 ## Troubleshooting
 
-To check whether the env sync has succeeded for a given app and environment, visit the 'db-backup' application in Argo in the relevant environment, and search for the corresponding cronjob (or use the `kubectl` command line). For example, to check Contacts Admin on Integration, you could [visit the db-backup application in Argo Integration](https://argo.eks.integration.govuk.digital/applications/db-backup) and check the logs for the latest `db-backup-contacts-admin-mysql` job.
+To check whether the env sync has succeeded for a given app and environment, visit the 'db-backup' application in Argo in the relevant environment, and search for the corresponding cronjob (or use the `kubectl` command line). For example, to check Contacts Admin on Integration, you could [visit the db-backup application in Argo Integration](https://argo.eks.integration.govuk.digital/applications/db-backup) and check the logs for the latest `db-backup-whitehall-mysql` job.
 
 ## How it works
 

--- a/source/manual/naming.html.md
+++ b/source/manual/naming.html.md
@@ -32,7 +32,6 @@ Good:
 Not so good:
 
 - publisher (too generic)
-- contacts-admin (could be contacts-publisher)
 
 ### Frontend applications
 

--- a/source/manual/pact-testing.html.md
+++ b/source/manual/pact-testing.html.md
@@ -20,7 +20,7 @@ For example, the Places Manager API has a "pact" or "contract" with GDS API Adap
 - when these tests are run they output a JSON pactfile which is published to [our pact broker](https://github.com/alphagov/govuk-pact-broker) ([live site](https://govuk-pact-broker-6991351eca05.herokuapp.com/))
 - the build of Places Manager will setup a [test environment](https://github.com/alphagov/places-manager/blob/9a4801da9d58be0af886d9095328894aac56917c/spec/service_consumers/pact_helper.rb) and use this pactfile to test the real API
 
-GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. The gem includes [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) for use in each app's own tests ([example](https://github.com/alphagov/contacts-admin/blob/e935fa54bf71c0063bb92faeaf8a27d1618e00ee/spec/interactors/admin/clone_contact_spec.rb#L11)). Using the stubs ensures each app stays in sync with GDS API Adapters, which can then do contract testing on their behalf.
+GDS API Adapters is really a proxy for real "consumer" apps, like Whitehall. The gem includes [a set of shared stubs](https://github.com/alphagov/gds-api-adapters/tree/master/lib/gds_api/test_helpers) for use in each app's own tests ([example](https://github.com/alphagov/finder-frontend/blob/9173056e7c992c5546aacc394fdf60a025591fec/spec/lib/healthchecks/registries_cache_spec.rb#L21)). Using the stubs ensures each app stays in sync with GDS API Adapters, which can then do contract testing on their behalf.
 
 ## Running Pact tests locally
 


### PR DESCRIPTION
The app is being retired.

Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin
