### PR TITLE
Highlight that GitHub config managed via Terraform needs care

### DIFF
--- a/source/manual/retiring-a-repo.html.md
+++ b/source/manual/retiring-a-repo.html.md
@@ -37,9 +37,11 @@ Archiving a repo does not remove its GitHub Pages site (if any). The site stays 
 Before you proceed with archving the repo, ensure that all workflow runs listed under "Actions" have completed or [cancel them](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/canceling-a-workflow#canceling-a-workflow-run).
 Go into the repository settings in GitHub, and [archive the repo](https://github.com/blog/2460-archiving-repositories).
 
-## 5. Remove GitHub configuration for the repo
+## 5. Stop managing GitHub configuration via Terraform
 
-Follow the steps in [GOV.UK GitHub Infrastructure configuration terraform project](https://github.com/alphagov/govuk-infrastructure/tree/main/terraform/deployments/github#removing-repositories) to remove the repo from our GitHub configuration.
+⚠️ Ensure you follow this step, otherwise your repo will be automatically deleted rather than archived.
+
+Follow the steps in [GOV.UK GitHub Infrastructure configuration terraform project](https://github.com/alphagov/govuk-infrastructure/tree/main/terraform/deployments/github#removing-repositories) to remove the repo configuration from our terraform state.
 
 ## 6. Update the Developer Docs
 

--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -73,6 +73,8 @@ Note that this will automatically destroy the corresponding resources in AWS (e.
 
 Follow the steps at [Retire a repo](/manual/retiring-a-repo.html).
 
+Pay special attention to the Terraform aspects of those steps: you'll want to ensure those steps are followed prior merging your govuk-infrastructure PR from earlier.
+
 ### Remove from Heroku
 
 If relevant (e.g. if Heroku was used for previews).


### PR DESCRIPTION
This was documented but easily overlooked if you're just skimming the page (one might assume that "Remove GitHub configuration for the repo" is some low-risk clickops in the GitHub UI, for example). It's quite surprising behaviour that we manage our GitHub repos externally (via Terraform) and that if we don't log into the Terraform console and run some steps manually, our repo that we're trying to carefully archive will actually be deleted!

Until this workaround is tackled (in https://github.com/alphagov/govuk-infrastructure/issues/1865), let's make it clearer what the risk/impact is of failing to follow the step, and also signpost it from the canonical "retire an app" doc.

Related Trello: https://trello.com/c/MiBvG4Xs/

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
