### PR TITLE
Link to Content Block Manager config vars

### DIFF
--- a/source/content-modelling/schemas/adding-a-new-content-block-type.html.md.erb
+++ b/source/content-modelling/schemas/adding-a-new-content-block-type.html.md.erb
@@ -42,10 +42,9 @@ in Content Block Manager (and, if necessary, the [`valid_schemas` method](https:
 ## Add any customisations
 
 There is a [config file](https://github.com/alphagov/whitehall/blob/main/lib/engines/content_block_manager/config/content_block_manager.yml)
-which allows you to configure (amongst other things):
+which allows you to configure how the schema is presented in Content Block Manager.
 
-- The order of the fields; and
-- What fields are judged to be "embeddable" (this will ensure a `Copy Code` link appears by that field)
+[See all available configuration variables](https://github.com/alphagov/whitehall/blob/main/docs/content_block_manager/configuration.md)
 
 ## Open another pull request
 


### PR DESCRIPTION
We've added some detailed documentation on how to configure how schemas are presented in Content Block Manager, so let's link out to it