### PR TITLE
Mention and reinforce readonly role usage in Kubernetes getting access guide

### DIFF
--- a/source/kubernetes/get-started/access-eks-cluster/index.html.md
+++ b/source/kubernetes/get-started/access-eks-cluster/index.html.md
@@ -15,6 +15,8 @@ This document assumes that you have already followed the steps in [Get started d
 ## Obtain AWS credentials for your role in the cluster's AWS account
 
 1. Choose the [AWS IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) that you will use to access the cluster:
+    - `readonly`: has read-only access to AWS and the Kubernetes `apps` and `datagovuk` namespaces. In AWS, access to
+     secrets and objects in S3 is not granted.
     - `developer`: has read-write access to most things in the `apps` and `datagovuk` namespaces, but cannot view or modify secrets
     - `fulladmin`: has read-write "cluster-admin" access to everything in the cluster, across all namespaces, including secrets
     - `platformengineer`: also has read-write "cluster-admin access to everything in the cluster, across all namespaces, including secrets, but can be used by Platform Engineers on a regular basis without requiring an approval process
@@ -32,9 +34,9 @@ This document assumes that you have already followed the steps in [Get started d
 
 ## Note: About using the correct role
 
-You should always assume the correct role for the job. For the majority of tasks, you should try to assume the `developer` role first. Platform Engineers may use the `platformengineer` role if they need to perform actions in the EKS cluster that require "Cluster Admin" permissions but don't need Admin access to other AWS services.
+You should always assume the correct role for the job. By default, you should use the `readonly` role because it will give you access to all the information you need, without elevated privileges. If your task will require you to restart a pod or deployment, for example, you can use the `developer` role. Platform Engineers may use the `platformengineer` role if they need to perform actions in the EKS cluster that require "Cluster Admin" permissions but don't need Admin access to other AWS services.
 
-Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin` role, and should only do so if they have proven the `developer` or `platformengineer` roles are insufficient. Usage of the `fulladmin` role is monitored and may cause an alert to be raised in future.
+Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin` role, and should only do so if they have proven the `developer` or `platformengineer` roles are insufficient. Usage of the `fulladmin` role is monitored and may cause an alert to be raised in the future.
 
 ## Access a cluster for the first time
 
@@ -90,7 +92,7 @@ To switch to a cluster that you have previously configured in `~/.kube/config` a
 
     where:
     - `<govuk-environment>` is `integration`, `staging`, or `production`
-    - `<role>` is `developer`, `fulladmin` or `platformengineer`
+    - `<role>` is `readonly`, `developer`, `fulladmin` or `platformengineer`
 
 1. Switch to the corresponding kubectl context:
 


### PR DESCRIPTION
We have added a readonly role (ADR0015). We also update our docs to reflect its existence and reinforce the default usage of it.