### PR TITLE
Nudge folks to remove URIs from all environments

### DIFF
--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -31,7 +31,8 @@ in [docker compose] or throughout the repo.
 ### Remove public DNS entries
 
 Request any public DNS entries be removed. If the app had an admin UI, it will
-have had public DNS entries in the `publishing.service.gov.uk` domain.
+have had public DNS entries in the `publishing.service.gov.uk` domain (likely one per
+environment, all of which need removing).
 
 Follow the [instructions for DNS changes][dns-changes] in order to remove
 these.


### PR DESCRIPTION
This got missed in https://github.com/alphagov/govuk-dns-tf/pull/407 so let's try to signpost it more explicitly.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
