### PR TITLE
Add new GA4 schema attributes to implementation record

### DIFF
--- a/data/analytics/attributes.yml
+++ b/data/analytics/attributes.yml
@@ -30,7 +30,7 @@
 
 - name: content_id
   description:
-  value: content attribute of meta tag govuk:content-id
+  value: content attribute of meta tag govuk:content-id or used in event_data to record the document that an interacted form is associated with
   example: a6bb0fc8-753f-4732-aabc-ff727dcf1262
   required: no
   type: string
@@ -672,3 +672,12 @@
   redact: false
   gtm_parameter: withdrawn
   ga4_display_name: Content withdrawn
+
+- name: user_id
+  value: ID of the user that has interacted with a form
+  example: random consistent string
+  required: no
+  type: string
+  redact: false
+  gtm_parameter: user_id
+  ga4_display_name: User ID

--- a/data/analytics/schemas.yml
+++ b/data/analytics/schemas.yml
@@ -42,6 +42,8 @@
       value: undefined
     - name: video_percent
       value: undefined
+    - name: user_id
+      value: undefined
   - name: timestamp
     value: "(user's unix timestamp)"
 - name: page view schema

--- a/data/analytics/schemas.yml
+++ b/data/analytics/schemas.yml
@@ -42,6 +42,8 @@
       value: undefined
     - name: video_percent
       value: undefined
+    - name: content_id
+      value: undefined
     - name: user_id
       value: undefined
   - name: timestamp


### PR DESCRIPTION
## What

- Add `user_id` to implementation record
- Add `content_id` to `event_data` of `schemas.yml`

# Why

These are new attributes requested to be added by Publishing PAs to the schema so should be also documented here.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
