### PR TITLE
Content modelling: remove email address content block reference

### DIFF
--- a/app/document_types.rb
+++ b/app/document_types.rb
@@ -34,7 +34,7 @@ class DocumentTypes
   end
 
   def self.schema_names_by_document_type
-    @schema_names_by_document_type ||= SchemaNames.all.each_with_object({}) do |schema_name, memo|
+    @schema_names_by_document_type ||= GovukSchemas::Schema.schema_names.each_with_object({}) do |schema_name, memo|
       # Notification schema is used as that is the only schema type that is currently generated for every type
       schema = GovukSchemas::Schema.find(notification_schema: schema_name)
       document_types = schema.dig("properties", "document_type", "enum")

--- a/app/proxy_pages.rb
+++ b/app/proxy_pages.rb
@@ -37,7 +37,7 @@ class ProxyPages
   end
 
   def self.govuk_schema_names
-    SchemaNames.all.map do |schema_name|
+    GovukSchemas::Schema.schema_names.map do |schema_name|
       schema = ContentSchema.new(schema_name)
 
       {

--- a/app/schema_names.rb
+++ b/app/schema_names.rb
@@ -1,9 +1,0 @@
-class SchemaNames
-  # TODO: We can't use `content_block_email_address`, as is relies on functionality
-  # in the later versions of `GovukSchemas`, which is blocked by dependency issues
-  # with Middleman. We have an upstream PR (https://github.com/middleman/middleman/pull/2709)
-  # that, once merged will unblock this issue
-  def self.all
-    (GovukSchemas::Schema.schema_names - %w[content_block_email_address])
-  end
-end

--- a/source/content-modelling/schemas/index.html.md.erb
+++ b/source/content-modelling/schemas/index.html.md.erb
@@ -54,7 +54,7 @@ becomes `rate-1`. This is immutable, so if a title changes, the key remains the 
 
 ### Currently supported schemas
 
-<% schemas = SchemaNames.all.select { |s| s.start_with?("content_block") } %>
+<% schemas = GovukSchemas::Schema.schema_names.select { |s| s.start_with?("content_block") } %>
 
 There are currently <%= schemas.count %> supported schemas in Content Block Manager:
 

--- a/source/content-modelling/schemas/index.html.md.erb
+++ b/source/content-modelling/schemas/index.html.md.erb
@@ -55,10 +55,6 @@ becomes `rate-1`. This is immutable, so if a title changes, the key remains the 
 ### Currently supported schemas
 
 <% schemas = SchemaNames.all.select { |s| s.start_with?("content_block") } %>
-<%
-  # Note - we have to add `content_block_email_address` manually - see https://github.com/alphagov/govuk-developer-docs/blob/main/app/schema_names.rb#L1
-  schemas << "content_block_email_address"
-%>
 
 There are currently <%= schemas.count %> supported schemas in Content Block Manager:
 

--- a/source/layouts/schema_layout.erb
+++ b/source/layouts/schema_layout.erb
@@ -7,7 +7,7 @@
     <li>
       <%= sidebar_link 'Content schemas', '/content-schemas.html' %>
       <ul>
-        <% SchemaNames.all.sort.each do |schema_name| %>
+        <% GovukSchemas::Schema.schema_names.sort.each do |schema_name| %>
           <li>
             <%= sidebar_link schema_name, "/content-schemas/#{schema_name}.html" %>
             <% if current_page.path.include?("content-schemas/#{schema_name}.html") %>

--- a/spec/app/document_types_spec.rb
+++ b/spec/app/document_types_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DocumentTypes do
   describe "#schema_names_by_document_type" do
     it "returns schema names by document type" do
       schema_name = "aaib_report"
-      allow(SchemaNames).to receive(:all).and_return([schema_name])
+      allow(GovukSchemas::Schema).to receive(:schema_names).and_return([schema_name])
       allow(GovukSchemas::Schema).to receive(:find).with(notification_schema: schema_name).and_return({
         properties: {
           document_type: {

--- a/spec/app/schema_names_spec.rb
+++ b/spec/app/schema_names_spec.rb
@@ -1,7 +1,0 @@
-RSpec.describe SchemaNames do
-  it "ignores content_block_email_address" do
-    allow(GovukSchemas::Schema).to receive(:schema_names).and_return(%w[foo bar content_block_email_address])
-
-    expect(SchemaNames.all).to eql(%w[foo bar])
-  end
-end


### PR DESCRIPTION
Updates the Content Modelling documentation to reflect changes to the way email address is handled.

The "email address" content block schema no longer exists. Email address is now (since [May 23, 2025 42ecacc3b99eba8e087e4e60f7b33e59d17469f2](https://github.com/alphagov/publishing-api/commit/42ecacc3b99eba8e087e4e60f7b33e59d17469f2)) a part of the "content_block_contact"
schema.

(This PR replaces https://github.com/alphagov/govuk-developer-docs/pull/5150 which is proving difficult to merge, perhaps due to a misconfiguration of permissions or user accounts, which may now be resolved.) Second replacement PR.