### PR TITLE
Remove accessible-autocomplete-multiselect from list of repos.

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -1,7 +1,3 @@
-- repo_name: accessible-autocomplete-multiselect
-  type: Utilities
-  team: "#govuk-whitehall-experience-tech"
-
 - repo_name: account-api
   type: APIs
   team: "#govuk-patterns-and-pages"


### PR DESCRIPTION
## What
Remove `accessible-autocomplete-multiselect` from the list of repos.

## Why
The component/repo is now retired.
