### PR TITLE
Remove URLs from email exemptions doc

### DIFF
--- a/source/manual/get-emails-about-this-page.html.md
+++ b/source/manual/get-emails-about-this-page.html.md
@@ -32,4 +32,4 @@ If departments ask for any more pages to be excluded, we should try to refuse th
 If you must add or remove an exemption, update the [exemption list][exemption-list] by adding or removing the `content_id` of the publication which needs to be added or removed from the list.
 
 [get-emails-about-this-page]: https://components.publishing.service.gov.uk/component-guide/single_page_notification_button
-[exemption-list]: https://github.com/alphagov/government-frontend/blob/6ecd50c198565dc9bafdb72cb42b15411e795ad2/app/presenters/content_item/single_page_notification_button.rb#L4
+[exemption-list]: https://github.com/alphagov/frontend/blob/01235d11381a43f0ea961c4d659bb4dc09c59b92/app/models/concerns/single_page_notification_button.rb#L5


### PR DESCRIPTION
We have recently reviewed the exemption list and these pages are no longer live.

Reference:
- https://github.com/alphagov/government-frontend/blob/deb2c61424e86cea14cc363c18f68b89dcc7fe85/app/presenters/content_item/single_page_notification_button.rb

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
