### PR TITLE
Rename Search section to GOV.UK Search

### DIFF
--- a/source/manual/add-a-best-bet.html.md
+++ b/source/manual/add-a-best-bet.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "Add a best bet to site search"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 ### What is a best bet?

--- a/source/manual/boost-or-demote-a-document-in-search.html.md
+++ b/source/manual/boost-or-demote-a-document-in-search.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "Boost or demote a document in site search"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 Some kinds of content are more useful to our users than others. To account for this, we configure the VAIS engine to always apply certain “boosts” to search results. These are generally applied by [document type] but some documents are boosted based on their [base path].

--- a/source/manual/get-or-delete-a-document-from-VAIS.html.md
+++ b/source/manual/get-or-delete-a-document-from-VAIS.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "How to get or delete a document from Vertex"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 [link-1]: https://cloud.google.com/generative-ai-app-builder/docs/reference/rest
 [link-2]: /google-cloud-platform-gcp.html.md

--- a/source/manual/govuk-search.html.md
+++ b/source/manual/govuk-search.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "GOV.UK Search: how it works"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 type: learn
 ---
 

--- a/source/manual/govuk-site-search.html.md
+++ b/source/manual/govuk-site-search.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "GOV.UK Site search: How it works"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 type: learn
 ---
 

--- a/source/manual/how-to-clear-the-redis-cache.html.md
+++ b/source/manual/how-to-clear-the-redis-cache.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "How to clear the Redis cache"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 Search API V2 uses [Redis] to track the latest synced payload version for a document. It compares the payload version of the document being synced with the `latest_synced_version` number for that version in the cache.

--- a/source/manual/how-to-resync-content-in-vertex.html.md
+++ b/source/manual/how-to-resync-content-in-vertex.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "How to resync content in Vertex"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 To resync content items in Vertex search, publishing-api needs to push the documents to search-api-v2.

--- a/source/manual/prevent-a-page-being-returned-in-search-results.html.md
+++ b/source/manual/prevent-a-page-being-returned-in-search-results.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "Prevent a page being returned in search results"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 ## How to filter a page from Site search results

--- a/source/manual/prevent-an-unhelpful-autocomplete-suggestion.html.md
+++ b/source/manual/prevent-an-unhelpful-autocomplete-suggestion.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "Prevent an unhelpful autocomplete suggestion"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 To prevent unhelpful autocomplete suggestions on GOV.UK, you can add them to a 'denylist' using the [Search Admin] application. This mechanism allows you to override and exclude undesirable terms from being returned by the autocomplete feature.

--- a/source/manual/search-synchronisation-errors.html.md
+++ b/source/manual/search-synchronisation-errors.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "Search synchronisation errors"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 ## A document doesn't appear in site search after it is published

--- a/source/manual/what-to-do-if-search-is-down.html.md
+++ b/source/manual/what-to-do-if-search-is-down.html.md
@@ -3,7 +3,7 @@ owner_slack: "#govuk-search"
 title: "What to do if someone says search is down"
 parent: "/manual.html"
 layout: manual_layout
-section: Search
+section: Search on GOV.UK
 ---
 
 As described in [GOV.UK Search: how it works][link-1], there are two Search stacks on GOV.UK. This documentation aims to provide some debugging steps to take in the event that someone tells you "search is down".


### PR DESCRIPTION
The anchor link for the [Search section] wasn't working.

[Search section]: https://docs.publishing.service.gov.uk/manual.html#search

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
