### PR TITLE
Install Homebrew with more secure .pkg method

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -32,13 +32,10 @@ xcode-select --install
 
 ## 2. Install the Homebrew package manager
 
-Run the following in your command line to install the [Homebrew package manager](https://brew.sh):
+To install the [Homebrew package manager](https://brew.sh):
 
-```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-This command works for macOS or Linux.
+1. Download the latest .pkg from the [Homebrew releases](https://github.com/Homebrew/brew/releases/)
+1. Double click on the downloaded .pkg file, and complete the installer steps
 
 ## 3. Fill out your Slack profile
 


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

This PR switches the Homebrew install method from the "curl|bash" method to the ".pkg" method, which Homebrew introduced as another official install method a couple of years ago.

The reason for this switch is a security improvement. I buy this LLM reasoning:
> Why is it better security than bash|curl?
> * Malicious Homebrew insiders need only modify the install.sh script via GitHub repository access to achieve immediate global impact across all new installations. Whereas the .pkg would also require the attacker to have privilege for their GitHub Actions release workflows, and obtain access to the Apple Developer ID Installer certificate. This creates higher privilege thresholds and additional detection opportunities throughout the attack chain. The 2024 malvertising campaign that created fake "brewe.sh" domains demonstrates how adversaries actively target this installation vector.
> * The shell script runs without sandboxing, verification that the full bash script downloaded or integrity checks. The .pkg offers:
>     * Gatekeeper verification pipeline with real-time revocation checking
>     * Automatic malware scanning through XProtect on first execution

I tested this by uninstalling bash, reinstalling with this .pkg (which is a quick and painless GUI installer), and installing gds-cli. As far as I can tell brew works the same as with the old method.