### PR TITLE
Update pages for querying kubernetes events via logit

### DIFF
--- a/source/kubernetes/manage-app/get-app-info/index.html.md
+++ b/source/kubernetes/manage-app/get-app-info/index.html.md
@@ -88,9 +88,44 @@ You can filter the logs in Logit by app, pod, container and other parameters.
 
 ## View Kubernetes events
 
-An event is any action that Kubernetes takes. For example, starting a container in a pod.
+An event is any action that Kubernetes takes. For example, starting a pod, pulling an image, a pod crashing.
 
 Viewing Kubernetes events is helpful for debugging an app.
+
+### Via logit
+
+Events are stored in Logit for 14 days in production, and 7 days in other environments. They are stored in an ElasticSearch index with the name prefix of `kubernetes-events-`.
+
+In logit, when viewing Kibana, on the left side of the interface there is a dropdown box which defaults to `filebeat-*`, you should change this to `kubernetes-events-*`, alternatively you can use the links below:
+
+- [Kubernetes Events in Logit for Production](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'918b7520-6d5c-11f0-a0c2-616481b44018',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_q=(filters:!(),query:(language:lucene,query:'')))
+- [Kubernetes Events in Logit for Staging](https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'192c7c50-6d5c-11f0-a036-ab90a4a466d2',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_q=(filters:!(),query:(language:lucene,query:'')))
+- [Kubernetes Events in Logit for Integration](https://kibana.logit.io/s/42f4d2d5-e9ce-451f-8ffc-cdb25bd624f8/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:fd31bca0-6d28-11f0-aee7-6b9a180d0701,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_q=(filters:!(),query:(language:lucene,query:'')))
+
+Logit supports querying via either the Lucene syntax, or the DQL syntax, to the right of the search box it will show you which you are set to, all the following queries use DQL, to do them in lucene the syntax is `field = value` instead of `field: value`.
+
+To see Kubernetes events for a namespace, search for:
+
+```
+involvedObject.namespace: "<namespace>"
+```
+
+To get events for a specific Kubernetes resource, search for:
+
+```sh
+involvedObject.name: "<resource>"
+```
+
+For example, to get events for the pod `publisher-7795bd698-v6bfc`, search for:
+
+```sh
+involvedObject.name: "publisher-7795bd698-v6bfc"
+```
+
+### Via kubectl (only the last 1 hour)
+
+Logs are available via the cli for only 1 hour, if you wish to see logs older than this you should [view them
+using Logit](#via-logit)
 
 To see Kubernetes events for a namespace, run:
 

--- a/source/manual/kibana.html.md
+++ b/source/manual/kibana.html.md
@@ -9,7 +9,7 @@ important: true
 All logs for GOV.UK on all environments are collected in Kibana, which you can
 access through [Logit](logit.html).
 
-Kibana can be [searched using the Lucene search syntax or full JSON-based
+Kibana can be [searched using DQL syntax, Lucene search syntax or full JSON-based
 Elasticsearch queries][kibana-search]. See an [example Elasticsearch query](#example-elasticsearch-query) below.
 
 ## Set up the UI
@@ -28,7 +28,9 @@ You can specify a field in the logs list by navigating the "Available Fields" li
 
 You can additionally remove fields by following the same steps above for "Selected Fields" and clicking "remove".
 
-You can also manage the timeline bar chart at the top fo the view by changing the dropdown above the bar chart from "auto" to whichever delimitater suits your needs (hourly, daily, weekly etc) and specify the time frame of the bar chart by clicking the time range in the top right-hand corner.
+You can also manage the timeline bar chart at the top of the view by changing the dropdown above the bar chart from "auto" to whichever delimitater suits your needs (hourly, daily, weekly etc) and specify the time frame of the bar chart by clicking the time range in the top right-hand corner.
+
+You can change which indices you are searching, in the top left of the Kibana interface there is a dropdown which will default to `filebeat-*`. If you wish to query the kubernetes events you need to change this to `kubernetes-events-*`.
 
 ## Examples
 
@@ -96,6 +98,36 @@ syslog_program:"govuk_sync_mirror"
 
 ```rb
 message:"TimedOutException" AND (application:"specialist-publisher" OR application:"whitehall" OR application:"content-tagger")
+```
+
+### Kubernetes events
+
+Change the index pattern in the top left to `kubernetes-events-*` (it will default to `filebeat-*`), then you can execute the following queries.
+
+In all cases the "message" field will give you a human readable description of the event.
+
+#### Publisher kubernetes events
+
+```rb
+involvedObject.name: "publisher"
+```
+
+#### Search for pods in a backoff restart
+
+```rb
+reason: "BackOff"
+```
+
+#### Search for pods which fail to be started
+
+```rb
+reason: "Failed"
+```
+
+#### Search for all events about deployment of a specific appear
+
+```rb
+involvedObject.kind: "Deployment" AND involvedObject.name: "frontend"
 ```
 
 ### Example Elasticsearch query

--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -32,7 +32,7 @@ stack.](https://docs.google.com/drawings/d/1m0ls6d7dEkHeRgLLnrXrtDOUSnptF3npzJCx
 
 ### Architecture of Kubernetes Events log delivery
 
-```mermaid
+<pre lang="mermaid">
 flowchart LR
 subgraph EKS["EKS Cluster"]
   kubernetes-events-shipper --read--> events-api
@@ -49,7 +49,7 @@ style ELK stroke-dasharray: 5 5
 kubernetes-events-shipper --write--> elasticsearch
 kibana --read--> elasticsearch
 user((user)) --> kibana
-```
+</pre>
 
 ## Components in the logging path for applications
 

--- a/source/manual/logit.html.md
+++ b/source/manual/logit.html.md
@@ -11,6 +11,10 @@ software-as-a-service log storage and retrieval system based on the
 [Elasticsearch, Logstash, Kibana
 stack](https://logit.io/blog/post/elk-stack-guide/#what-is-the-elk-stack).
 
+GOV.UK also sends Kubernetes Events to logit, these are stored in a separate set of
+indexes which all begin with the prefix `kubernetes-events-`. There is an index pattern
+already created in Kibana in every environment to query these indexes.
+
 > **Fastly CDN logs are not stored in Logit.** See [Query CDN
 > logs](/manual/query-cdn-logs.html).
 


### PR DESCRIPTION
This is a follow on to #5184 updating more pages with information about querying the kubernetes events via logit

* Fixes the mermaid rendering on the "How logging works" page (it needs to be a pre tag with lang=mermaid, backticks codeblocks wont get rendered)
* Add example kibana queries
* Add info about querying logit to get an apps kubernetes events in logit
* Update the logit page to say we also send kubernetes events