### PR TITLE
Update GOV.UK Chat related repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -237,7 +237,8 @@
   sentry_url: false
 
 - repo_name: govuk-chat
-  team: "#dev-notifications-ai-govuk"
+  team: "#ai-govuk"
+  alerts_team: "#dev-notifications-ai-govuk"
   type: AI apps
   production_hosted_on: eks
   production_url: https://chat.publishing.service.gov.uk/
@@ -246,7 +247,8 @@
   kibana_worker_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:whitehall-admin-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:govuk-chat-worker)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())
 
 - repo_name: govuk-chat-evaluation
-  team: "#dev-notifications-ai-govuk"
+  team: "#ai-govuk"
+  alerts_team: "#dev-notifications-ai-govuk"
   type: Utilities
   sentry_url: false
 
@@ -458,7 +460,8 @@
   description: |
     Private gem for storing code/config for GOV.UK Chat which isn't suitable
     for open source.
-  team: "#dev-notifications-ai-govuk"
+  team: "#ai-govuk"
+  alerts_team: "#dev-notifications-ai-govuk"
   type: Gems
 
 - repo_name: govuk_content_block_tools


### PR DESCRIPTION
This adds a missing GOV.UK Chat repo and updates information on the existing two.