### PR TITLE
Fix codeblock for mermaid rendering

### DIFF
--- a/source/manual/logging.html.md
+++ b/source/manual/logging.html.md
@@ -33,6 +33,7 @@ stack.](https://docs.google.com/drawings/d/1m0ls6d7dEkHeRgLLnrXrtDOUSnptF3npzJCx
 ### Architecture of Kubernetes Events log delivery
 
 <pre lang="mermaid">
+<code>
 flowchart LR
 subgraph EKS["EKS Cluster"]
   kubernetes-events-shipper --read--> events-api
@@ -49,6 +50,7 @@ style ELK stroke-dasharray: 5 5
 kubernetes-events-shipper --write--> elasticsearch
 kibana --read--> elasticsearch
 user((user)) --> kibana
+</code>
 </pre>
 
 ## Components in the logging path for applications


### PR DESCRIPTION
My mermaid diagram still doesn't render (see https://docs.publishing.service.gov.uk/manual/logging.html#architecture-of-kubernetes-events-log-delivery), I didn't realise that it needs to be a code block, inside a pre (with lang=mermaid).

You can see the query selector https://github.com/alphagov/govuk-developer-docs/blob/85d04764b0b0f6e9ce6f1eebb2226ed8962789fd/source/javascripts/mermaid-init.js#L5 so I'm confident this change should work

