### PR TITLE
Add documentation for retiring RDS instances

### DIFF
--- a/source/manual/retiring-an-application.html.md
+++ b/source/manual/retiring-an-application.html.md
@@ -106,6 +106,12 @@ See step 1.
 - Edit the application in the release app (you'll need the `deploy` permission to do this)
 - Press the 'Delete application' button.
 
+### Retire any related RDS Instances
+
+- Find the relevant "variable-set-rds" modules for each Environment.
+- Find the correct "tfvars" blocks for any relevant Databases and make sure that `deletion_protecton = false` is set and applied for each environment
+- Remove the Terraform variables that define the Databases and run the apply again - the Databases should produce a final snapshot and then be destroyed
+
 ### Manually delete any AWS resources not managed by Terraform
 
 If your app is particularly unique/legacy and uses any resources that are not managed by Terraform, those resources will need manually deleting in AWS.


### PR DESCRIPTION
## What?
This updates the Developer Docs to specifically mention setting `deletion_protection` to `false` in the event that you need to retire or destroy an RDS instance (assuming this to most likely happen when an Application is being retired).