### PR TITLE
Document special route / search api quirks

### DIFF
--- a/source/manual/publish-special-routes.html.md
+++ b/source/manual/publish-special-routes.html.md
@@ -11,3 +11,5 @@ old_paths:
 [Publishing API](https://github.com/alphagov/publishing-api) has a set of rake tasks for loading routes (a map of URL path to a rendering app and content ID) from a YAML file into Publishing API.
 
 See [Publishing special routes](https://github.com/alphagov/publishing-api/blob/main/docs/admin-tasks.md#publishing-special-routes) for usage.
+
+Note that, by default, special routes won't appear in GOV.UK search. There is an [override list in search-api-v2](https://github.com/alphagov/search-api-v2/blob/main/config/document_type_ignorelist_path_overrides.yml) where you can opt specific special routes into being indexed.


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
