### PR TITLE
Specify where govuk-mirror is hosted to fix 'Out of sync deploy' alert

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -378,6 +378,7 @@
   type: Utilities
   description: A simple Go program used by GOV.UK to populate mirrors hosted by AWS S3 and GCP Storage
   sentry_url: false
+  production_hosted_on: gcp
 
 - repo_name: govuk-pact-broker
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
The notifications for `govuk-mirror` owned by `#govuk-platform-engineering` fallback to `#govuk-developers` because we don't define where it's hosted in the docs (`"production_hosted_on": null`) and consequently it's not returned by the apps.json endpoint used by Release app for the Out of sync deploy notifications. 

Example: https://gds.slack.com/archives/CAB4Q3QBW/p1755502203426649

This should route the notification to the correct slack channel.

Note this program is hosted by both AWS S3 and GCP Storage. While there's no validation for the `production_hosted_on`, currently the only entries are "eks", "heroku" and "gcp".
