### PR TITLE
Add govuk-chat-gradio-prototype to repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -252,6 +252,14 @@
   type: Utilities
   sentry_url: false
 
+- repo_name: govuk-chat-gradio-prototype
+  private_repo: true
+  team: "#ai-govuk"
+  alerts_team: "#dev-notifications-ai-govuk"
+  type: AI apps
+  sentry_url: false
+  description: A private repo used for rapid experiments related to GOV.UK Chat utilising gradio's chatbot UI
+
 - repo_name: govuk-content-api-docs
   team: "#govuk-publishing-platform"
   alerts_team: "#govuk-publishing-platform-system-alerts"


### PR DESCRIPTION
We've added a new private repo for AI experiments related to GOV.UK Chat.
