### PR TITLE
Add publisher-on-pg as an app

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -605,6 +605,13 @@
   team: "#govuk-publishing-mainstream-experience-tech"
   production_hosted_on: eks
 
+- repo_name: publisher
+  app_name: publisher-on-pg
+  type: Publishing apps
+  team: "#govuk-publishing-mainstream-experience-tech"
+  production_hosted_on: eks
+  description: Temporary app for testing Publisher on PostgreSQL during our database migration work
+
 - repo_name: publishing-api
   type: APIs
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
This is a temporary app, created while we work on migrating Publisher from MongoDB to PostgreSQL.
