### PR TITLE
Retire markdown-toolbar-element (WHIT-2020)

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -573,10 +573,6 @@
   team: "#govuk-whitehall-experience-tech"
   production_hosted_on: eks
 
-- repo_name: markdown-toolbar-element
-  type: Utilities
-  team: "#govuk-whitehall-experience-tech"
-
 - repo_name: miller-columns-element
   type: Utilities
   team: "#govuk-whitehall-experience-tech"


### PR DESCRIPTION
JIRA: https://gov-uk.atlassian.net/browse/WHIT-2020

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
