### PR TITLE
Remove the govuk-data-science-workshop repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -270,10 +270,6 @@
   alerts_team: "#govuk-platform-support"
   type: Utilities
 
-- repo_name: govuk-data-science-workshop
-  team: "#data-engineering"
-  type: Data science
-
 - repo_name: govuk-dependabot-merger
   team: "#govuk-platform-engineering"
   alerts_team: "#govuk-platform-support"


### PR DESCRIPTION
The repo is no longer used and so needs to be archived

Part of https://github.com/alphagov/govuk-infrastructure/issues/2711
