### PR TITLE
Add govuk-chat-gradio-user-research to repos.yml

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -260,6 +260,14 @@
   sentry_url: false
   description: A private repo used for rapid experiments related to GOV.UK Chat utilising gradio's chatbot UI
 
+- repo_name: govuk-chat-gradio-user-research
+  private_repo: true
+  team: "#ai-govuk"
+  alerts_team: "#dev-notifications-ai-govuk"
+  type: AI apps
+  sentry_url: false
+  description: A private repo used for user research related to GOV.UK Chat utilising gradio's chatbot UI
+
 - repo_name: govuk-content-api-docs
   team: "#govuk-publishing-platform"
   alerts_team: "#govuk-publishing-platform-system-alerts"


### PR DESCRIPTION
This adds a private repo entry for the new govuk-chat-gradio-user-research repo. This repo will be used for rapidly developing prototypes for user research utilising gradio's chatbot UI.