### PR TITLE
Add `content-block-manager` to `repos.yml`

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -78,6 +78,16 @@
   type: Utilities
   sentry_url: false
 
+- repo_name: content-block-manager
+  type: Publishing apps
+  production_url: https://content-block-manager.publishing.service.gov.uk
+  team: "#govuk-publishing-content-modelling-dev"
+  argo_cd_apps:
+    - content-block-manager
+  production_hosted_on: eks
+  kibana_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/data-explorer/discover/#?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(discover:(columns:!(level,request,status,message),interval:auto,sort:!()),metadata:(indexPattern:'filebeat-*',view:discover))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:content-block-manager),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:content-block-manager)))),query:(language:kuery,query:''))
+  kibana_worker_url: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover?security_tenant=global#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3h,to:now))&_a=(columns:!(level,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:whitehall-admin-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:content-block-manager-worker)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())
+
 - repo_name: content-data-admin
   type: Supporting apps
   team: "#govuk-platform-engineering"


### PR DESCRIPTION
This adds the new [Content Block Manager](https://github.com/alphagov/content-block-manager/) repo to the repos.yml config. We'll need to migrate some of the docs from Whitehall, but this will at least stop the alerts.