### PR TITLE
Remove `fastly-exporter` repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -158,12 +158,6 @@
   team: "#govuk-patterns-and-pages"
   production_hosted_on: eks
 
-- repo_name: fastly-exporter
-  team: "#govuk-platform-engineering"
-  alerts_team: "#govuk-platform-support"
-  type: Utilities
-  sentry_url: false
-
 - repo_name: feedback
   type: Frontend apps
   team: "#govuk-patterns-and-pages"


### PR DESCRIPTION
Description:
- Repository is now archived

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
