### PR TITLE
Remove publisher-on-pg

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -619,13 +619,6 @@
   team: "#govuk-publishing-mainstream-experience-tech"
   production_hosted_on: eks
 
-- repo_name: publisher
-  app_name: publisher-on-pg
-  type: Publishing apps
-  team: "#govuk-publishing-mainstream-experience-tech"
-  production_hosted_on: eks
-  description: Temporary app for testing Publisher on PostgreSQL during our database migration work
-
 - repo_name: publishing-api
   type: APIs
   team: "#govuk-publishing-platform"


### PR DESCRIPTION
This was a temporary app created to enable the migration of Mainstream Publisher from MongoDB to PostgreSQL. That migration is now complete, and the publisher-on-pg app has been deleted.