### PR TITLE
Temporarily disable scheduled deploy to cut down on noise in deploy alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,13 @@ on:
         description: The branch, tag or SHA to checkout
         default: main
         type: string
-  schedule:
-    # Deploy hourly between 9am and 7pm on weekdays
-    - cron: "0 9-19 * * 1-5"
+# Temporarilily disabled while the developer docs deployment is broken.
+# govuk_schemas needs to be updated to >= 6.1.1 but dependency hell
+# is blocking it. All current builds and deploys of this repo are broken
+# and notifying us every hour, as well as on every real build
+#  schedule:
+#    # Deploy hourly between 9am and 7pm on weekdays
+#    - cron: "0 9-19 * * 1-5"
 
 jobs:
   test-ruby:


### PR DESCRIPTION
Currently all deploys of this repo are broken until we can resolve some dependency problems. In the meantime it's notifying us every hour and making it hard to spot other notifications.

So temporarily disable the scheduled deploys 