### PR TITLE
[WHIT-2530] Add worldwide org check instructions when renaming country

### DIFF
--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -78,6 +78,15 @@ In [Whitehall](https://github.com/alphagov/whitehall):
 
 4. Update World Location News
    * Go to the relevant country in [World Location News](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/world_location_news). In the "Details" tab, edit the `Title`, `Mission statement` and relevant `Featured links`.
+5. Check and republish any `WorldwideOrganisations` linked to the country
+   * In the Whitehall Rails console, run:
+
+   ```
+   location = WorldLocation.where(slug: <location_slug>)
+   location.published_editions.where(type: "WorldwideOrganisation")
+   ```
+
+   * Check that the renamed location is being surfaced as expected. If not, use the [republish tool](https://whitehall-admin.publishing.service.gov.uk/government/admin/republishing) to trigger an update on the worldwide organisation pages.
 
 ### 4. Update Smart-answers
 


### PR DESCRIPTION
An expected World Location update did not come through on a Worldwide Organisation Page, after a recent [country rename](https://github.com/alphagov/whitehall/pull/10677). Adding an instruction for the person running the renaming to check on WWOrgs. 

We've roped in Publishing Platform to ensure there is no underlying issue with the dependency resolution.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2530)