### PR TITLE
Bump govuk_schemas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,8 +203,8 @@ GEM
       rouge
       sprockets (>= 3)
       sprockets-rails
-    govuk_schemas (5.0.2)
-      json-schema (>= 2.8, < 4.4)
+    govuk_schemas (6.2.0)
+      json-schema (>= 2.8, < 6.1)
     govuk_tech_docs (5.1.0)
       autoprefixer-rails (~> 10.2)
       base64
@@ -241,8 +241,9 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.13.2)
-    json-schema (4.3.0)
-      addressable (>= 2.8)
+    json-schema (6.0.0)
+      addressable (~> 2.8)
+      bigdecimal (~> 3.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
We’ve now removed the dependency on `faker` (see https://github.com/alphagov/govuk_schemas/pull/172), so we can now bump the gem and unblock the broken deploy pipeline.