### PR TITLE
[WHIT-2527] Add content publishing guidance as official repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -277,6 +277,12 @@
   alerts_team: "#govuk-publishing-platform-system-alerts"
   type: Utilities
 
+- repo_name: govuk-content-publishing-guidance
+  team: "#govuk-content-operations"
+  type: Content Guidance
+  description: GOV.UK Content Publishing Guidance
+  production_url: https://guidance.publishing.service.gov.uk/
+
 - repo_name: govuk-crd-library
   team: "#govuk-platform-engineering"
   alerts_team: "#govuk-platform-support"


### PR DESCRIPTION
Making this publisher guidance repo official, so we can tag it appropriately and include it in any bulk changes. 

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2527)