### PR TITLE
Assign public-asset-checker to P&P

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -615,7 +615,7 @@
   sentry_url: false
 
 - repo_name: public-asset-checker
-  team: "#govuk-publishing-components"
+  team: "#govuk-patterns-and-pages"
   type: Utilities
   description: |
     Checks publicly hosted asset files against a known baseline and notifies the owning team if any require attention.


### PR DESCRIPTION
## What
Update the repos section so that `public-asset-checker` is owned by Patterns and Pages.

## Why
This repo currently has no ownership and no one was updating any of its packages, so there were some significant security warnings in place. Those have mostly now been dealt with, but there needs to be more ownership of this repo from this point on.

`public-asset-checker` is a tool developed during the GA4 migration to do two things - monitor the size of the JS on GOV.UK (to ensure that changes to GTM/GA4 don't artificially inflate our asset size) and to alert when new versions of [RUM](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/real-user-metrics.md) are available (a dependency that needs to be manually updated in `govuk-publishing-components` fairly regularly). It posts the results of these checks daily to `#govuk-publishing-components`.

Admittedly, it hasn't been working entirely correctly for a little while now. It would be nice to get it working again, but until we decide whether we should fix or retire it, we should probably have an owner for it.