### PR TITLE
Add simple script to start up docs without scraping github

### DIFF
--- a/startup-without-scraping-github.sh
+++ b/startup-without-scraping-github.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+
+set -eu
+
+export SKIP_PROXY_PAGES=true
+
+"$(dirname "${BASH_SOURCE[0]}")"/startup.sh


### PR DESCRIPTION
I keep forgetting this is even possible, and it now takes over 6 minutes to scrape the github api, so this adds an _extremely_ simple bash script which sets the required env var, and then executes the original script (I've done this so that if startup.sh changes in future we don't need to remember to copy and paste)