### PR TITLE
Add default dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adding a default configuration for dependabot [cooldown as per the developer docs](https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#schedule-and-cooldown).

Security updates are not affected by this setting.