### PR TITLE
Update documentation about GOV.UK Notify service account

### DIFF
--- a/source/manual/govuk-notify.html.md
+++ b/source/manual/govuk-notify.html.md
@@ -43,11 +43,9 @@ for each environment):
 
 - **GOV.UK**
 
-  This service is for any public-facing application that does not use the Email Alert Api
-  to send emails.
-
-  Currently it is used by [Feedback](https://github.com/alphagov/feedback) to email a survey link
-  to users who click a survey banner or use the `Is this page useful?` feature.
+  This service is reserved for public-facing applications that do not use the Email Alert Api
+  to send emails. It is currently not used, and has no API Keys (which avoids the overhead
+  of rotating them).
 
 [Email Alert API Product dashboard]: https://grafana.blue.production.govuk.digital/dashboard/file/email_alert_api_product.json?refresh=1m&orgId=1
 [SendEmailJob]: https://github.com/alphagov/email-alert-api/blob/main/app/jobs/send_email_job.rb#L4


### PR DESCRIPTION
Removes reference to Feedback and makes clear that nothing is using this service at the moment and it doesn't have keys.

TODO:
- [x] Confirm that's true of all environments

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
