### PR TITLE
Include app workers in rolling restart instructions

### DIFF
--- a/source/kubernetes/manage-app/set-env-var/index.html.md
+++ b/source/kubernetes/manage-app/set-env-var/index.html.md
@@ -62,10 +62,13 @@ To update an existing secret:
     k delete secret foo-app-api-key
     ```
 
-3. Do a rolling restart of the affected app:
+3. Do a rolling restart of the affected app (and its workers if it has any):
 
     ```sh
     k rollout restart deploy/foo-app
+    k rollout status !$
+
+    k rollout restart deploy/foo-app-workers
     k rollout status !$
     ```
 


### PR DESCRIPTION
When restarting an app in kubernetes, only the app pods will be restarted. A second command is necessary to restart worker pods.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
