### PR TITLE
[PP-7701] Remove reference to side-by-side browser

### DIFF
--- a/source/manual/configure-transition-mappings.html.md
+++ b/source/manual/configure-transition-mappings.html.md
@@ -9,9 +9,9 @@ related_repos: [bouncer, transition]
 
 Sometimes the requester will want to specify redirects for specific paths, e.g. if they want to maintain links from old documents to their new equivalent. In these cases, there are a number of steps to follow.
 
-## 1) Consider AKA domains
+## 1) Set up AKA domains if required
 
-If the department want to use the side-by-side browser to preview how their redirects will appear after transitioning they will need to set up AKA domains.
+If the department want to preview how their redirects will appear after transitioning they will need to set up AKA domains.
 
 They will need one new CNAME DNS entry for each domain/subdomain they wish to preview according to the following pattern:
 


### PR DESCRIPTION
This guidance was added in a9f7e7de61cfbbb0dee357965568929232cf349c to support using an old feature (app?) called side-by-side browser that allowed you to proxy a web site to preview redirections ahead of it being transitioned to GOV.UK. However, the side-by-side browser repo (https://github.com/alphagov/side-by-side-browser) has been archived since 2022 and its README says:

> Side-by-side browser has been retired and is no longer a part of GOV.UK Transition. It was retired due to the extremely low usage, being years after the transition project, which no longer justified the effort to maintain it.

We have had a need for AKA domains more recently, however, so this updates the guidance to remove the confusing reference and revise the wording of the step heading