### PR TITLE
Sch 2050 update documentation for new vertex name

### DIFF
--- a/source/manual/boost-or-demote-a-document-in-search.html.md
+++ b/source/manual/boost-or-demote-a-document-in-search.html.md
@@ -6,7 +6,7 @@ layout: manual_layout
 section: Search on GOV.UK
 ---
 
-Some kinds of content are more useful to our users than others. To account for this, we configure the VAIS engine to always apply certain “boosts” to search results. These are generally applied by [document type] but some documents are boosted based on their [base path].
+Some kinds of content are more useful to our users than others. To account for this, we configure Discovery Engine to always apply certain “boosts” to search results. These are generally applied by [document type] but some documents are boosted based on their [base path].
 
 Boosts and demotions are configured in the [serving config] in the [govuk-infrastructure] repo and applied through [Terraform].
 

--- a/source/manual/get-or-delete-a-document-from-discovery-engine.html.md
+++ b/source/manual/get-or-delete-a-document-from-discovery-engine.html.md
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#govuk-search"
-title: "How to get or delete a document from Vertex"
+title: "How to get or delete a document from Discovery Engine"
 parent: "/manual.html"
 layout: manual_layout
 section: Search on GOV.UK

--- a/source/manual/govuk-search.html.md
+++ b/source/manual/govuk-search.html.md
@@ -17,7 +17,7 @@ Site search is available on the GOV.UK homepage and from the blue super navigati
 
 The url of site search is https://www.gov.uk/search/all which is rendered by finder frontend, and referred to in code as the all_content finder.
 
-Search results for site search are usually provided by [search-api-v2][] and Google Vertex AI Search. Except in the following cases when site search falls back to using [search-api][]
+Search results for site search are usually provided by [search-api-v2][] and Google Cloud Platform (GCP)'s Agent Search ("Discovery Engine"). Except in the following cases when site search falls back to using [search-api][]
 
 1. When [no search query][no-keyword-link] is provided.
 2. When the [query param `use_v1=true`][use-v1-link] is present, eg https://www.gov.uk/search/all?order=updated-newest&use_v1=true
@@ -41,7 +41,7 @@ Documentation on how finder frontend queries the two search api applications is 
 
 ## Search API versus Search API V2
 
-[search-api-v2][] was built to improve the quality of search results for the majority of GOV.UK users (when compared with search-api) and retains a "minimally compatible" API with search-api. It uses Google Cloud Platform (GCP)'s Vertex AI Search ("Discovery Engine") product as its underlying search engine.
+[search-api-v2][] was built to improve the quality of search results for the majority of GOV.UK users (when compared with search-api) and retains a "minimally compatible" API with search-api. It uses Google Cloud Platform (GCP)'s Agent Search ("Discovery Engine") product as its underlying search engine.
 
 [search-api][] uses an old version of Elasticsearch as its underlying search engine. There is currently no clear roadmap for retiring search-api.
 

--- a/source/manual/govuk-site-search.html.md
+++ b/source/manual/govuk-site-search.html.md
@@ -11,17 +11,21 @@ type: learn
 
 The core functionality of the site search stack consists of three main parts:
 
-- **Synchronisation** (sometimes called “indexing”): Continuous ingestion of data from the GOV.UK content ecosystem (via Publishing API), extracting relevant content and metadata, and storing it in Google Vertex AI Search
-- **Querying**: Providing an API that acts as a translation layer between Finder Frontend and Google Vertex AI Search, executing search queries with optional filters, and transforming results into the expected data format for display to the user
-- **Analytics pipeline**: Daily ingestion of user interaction data from GA4 used by Vertex AI Search to improve the ranking model.
+- **Synchronisation** (sometimes called “indexing”): Continuous ingestion of data from the GOV.UK content ecosystem (via Publishing API), extracting relevant content and metadata, and storing it in the Google Cloud Agent Search Datastore.
+- **Querying**: Providing an API that acts as a translation layer between Finder Frontend and Google Cloud Agent Search, executing search queries with optional filters, and transforming results into the expected data format for display to the user.
+- **Analytics pipeline**: Daily ingestion of user interaction data from GA4 used by Google Cloud Agent Search to improve the ranking model.
 
 ### Explainer: Google product names
 
-We use Vertex AI Search (VAIS, “Vertex” for short) to describe the search product we use.
+The brand name for the Google Cloud Platform search product we use is "Agent Search" (under the umbrella of "AI Applications").
 
-During the lifetime of our implementation project, this search product has been renamed several times (starting off as “Gen AI App Builder: Enterprise Search”, then “Vertex AI Search and Conversation”, now just “Vertex AI Search”) and now comes under the umbrella of (Vertex AI) Agent Builder as part of Google’s overall Vertex AI brand for all things AI. It’s not to be confused with the plain Vertex AI product though (their overall AI development platform which provides access to Gemini LLMs).
+During the lifetime of our implementation project, this search product has been renamed several times. Previous names include:
 
-Discovery Engine is the name of the API used by integrations with VAIS, which is partly shared with a similar-but-different product named Cloud Retail Search (CRS). In the code and code-adjacent documentation, we prefer to use Discovery Engine naming over VAIS where possible to future proof ourselves for the next product renaming.
+- Vertex AI Search (under the umbrella of "Vertex AI Agent Builder"), also known as "Vertex" or VAIS
+- Vertex AI Search and Conversation
+- Gen AI App Builder: Enterprise Search
+
+Discovery Engine is the name of the API used by integrations with Agent Search. In the code and code-adjacent documentation, we prefer to use Discovery Engine naming over Agent Search where possible to future-proof ourselves for the next product renaming.
 
 ## Architecture
 
@@ -40,19 +44,19 @@ To edit the diagram, visit <https://app.diagrams.net/#Uhttps%3A%2F%2Fraw.githubu
 
 Broadly, the new search stack for site search introduces the following new components to the GOV.UK technical ecosystem:
 
-- A deployment of **Vertex AI Search** (VAIS) in Google Cloud Platform (GCP) managed by Terraform, comprising per-environment GCP projects with a datastore (and schema), an engine, and serving configuration and controls
+- A deployment of **Discovery Engine** in Google Cloud Platform (GCP) managed by Terraform, comprising per-environment GCP projects with a datastore (and schema), an engine, and serving configuration and controls.
 
-- **Search API v2**: A Ruby on Rails application deployed on the standard GOV.UK AWS Kubernetes infrastructure, providing an API for querying (search and autocomplete) the VAIS serving configuration, and a synchronisation module for updating the state of the VAIS datastore.
+- **Search API v2**: A Ruby on Rails application deployed on the standard GOV.UK AWS Kubernetes infrastructure, providing an API for querying (search and autocomplete) the Discovery Engine serving configuration, and a synchronisation module for updating the state of the Discovery Engine datastore.
 
 - **Search API v2 beta features**: A Ruby on Rails application deployed on the standard GOV.UK AWS Kubernetes infrastructure, providing a scheduled task performing ongoing automated relevance evaluations.
 
-- **User event data pipeline**: BigQuery tables of GA4 user interaction data that are populated via a dataform pipeline, and used by Vertex to train the model serving relevant search results.
+- **User event data pipeline**: BigQuery tables of GA4 user interaction data that are populated via a Dataform pipeline, and used by Discovery Engine to train the model serving relevant search results.
 
 The new search stack has a direct dependency on the following existing projects:
 
 - **Finder Frontend**: to display results to users (modified by us to be able to call either the legacy Search API or Search API v2)
 
-- **Search Admin**: Formerly used to configure the legacy search stack, this has been cleaned up to remove legacy functionality but is still used to publish external links (a content type only used in search on GOV.UK) and will be extended in the future to allow configuration of VAIS without requiring developer input
+- **Search Admin**: Formerly used to configure the legacy search stack, this has been cleaned up to remove legacy functionality but is still used to publish external links (a content type only used in search on GOV.UK) and will be extended in the future to allow configuration of Discovery Engine without requiring developer input
 
 - **Publishing API**: to receive event messages over the publishing message queue (AWS managed RabbitMQ). Note that unlike Search API, there are no direct API calls from or to Whitehall, all content changes go through the MQ
 
@@ -64,7 +68,7 @@ The new search stack has a direct dependency on the following existing projects:
 
 - Publishing API processes the content change and pushes an update message to its RabbitMQ message queue
 
-- Search API v2’s synchronisation worker picks up a change message, acquires a lock on the content ID, extracts content and metadata from the content item based on a set of rules (data paths), and updates the document in VAIS
+- Search API v2’s synchronisation worker picks up a change message, acquires a lock on the content ID, extracts content and metadata from the content item based on a set of rules (data paths), and updates the document in the Discovery Engine Datastore
 
 #### When a user performs a search
 
@@ -72,15 +76,15 @@ The new search stack has a direct dependency on the following existing projects:
 
 - When the user submits a search request, it is processed by Finder Frontend, which constructs a search query to Search API v2 (according to the same API contract as the legacy Search API)
 
-- Search API v2 receives the query, applies some query-time boosts to it and translates it to a VAIS API call, then maps the API response back to the format expected by Finder Frontend
+- Search API v2 receives the query, applies some query-time boosts to it and translates it to a Discovery Engine API call, then maps the API response back to the format expected by Finder Frontend
 
-- Finder Frontend renders the results, together with a VAIS attribution token that is tracked by the analytics code
+- Finder Frontend renders the results, together with a Discovery Engine attribution token that is tracked by the analytics code
 
 - Google Analytics (GA4) tracks how the user interacts with results
 
 - GA4 data is processed overnight by the existing GOV.UK analytics pipeline, and ingested into GCP BigQuery.
 
-- Three times a day, the GA4 data is imported and pushed into VAIS as user events. VAIS adjusts the internal ranking model for the engine based on these user events (and some data from its own proprietary search and internet analytics data)
+- Three times a day, the GA4 data is imported and pushed into Discovery Engine as user events. Discovery Engine adjusts the internal ranking model for the engine based on these user events (and some data from its own proprietary search and internet analytics data)
 
 ## Infrastructure
 
@@ -90,7 +94,7 @@ The new search stack follows the same environment conventions as other GOV.UK ap
 
 The Search API v2 application is deployed as a standard GOV.UK application on the Kubernetes platform, following all the usual conventions.
 
-As a SaaS product, it isn’t possible to run Vertex locally. We previously had a separate “dev” environment in GCP with Vertex resources provisioned for each active developer on the team, but the extra complexity and manual overrides didn’t feel worth it (especially since the bulk of requirements for local use revolved around read access). We now point local development environments for Search API v2 at integration.
+As a SaaS product, it isn’t possible to run Discovery Engine locally. We previously had a separate “dev” environment in GCP with Discovery Engine resources provisioned for each active developer on the team, but the extra complexity and manual overrides didn’t feel worth it (especially since the bulk of requirements for local use revolved around read access). We now point local development environments for Search API v2 at integration.
 
 ### Infrastructure as code (IaC)
 
@@ -99,7 +103,7 @@ All infrastructure for the new search stack is defined through Terraform in the 
 There are two separate top level Terraform deployments in the infrastructure repo:
 
 - [gcp-search-api-v2][link-4]: Bootstraps the GCP project itself that all other resources live in (including IAM ownership, enabled APIs, quotas, and identity federation with Terraform Cloud to enable it to manage resources)
-- [search-api-v2][link-5]: Manages the actual VAIS (and overall GCP) resources for each environment, applied through Terraform Cloud through a PR-based workflow
+- [search-api-v2][link-5]: Manages the actual Discovery Engine (and overall GCP) resources for each environment, applied through Terraform Cloud through a PR-based workflow
 
 ### Monitoring & alerting
 

--- a/source/manual/how-to-clear-the-redis-cache.html.md
+++ b/source/manual/how-to-clear-the-redis-cache.html.md
@@ -16,7 +16,7 @@ If the new `payload_version` is less or equal to the `latest_synced_version` the
 If this error is occurring for a lot of documents then the best option may be to clear the Redis cache.
 The [comparison logic] only executes if publishing-api sends a payload ID and the content_id has been seen before. If the content item isn't present in the cache, then `latest_synced_version` is nil and `sync?` [returns true], so it doesn't reach the comparison logic. Clearing the cache would make it seem as though the content_id hasn't been seen before. So the next time the content item is requeued by publishing-api it will trigger a sync regardless of payload version.
 
-The side effect of doing this is that if you represent every document from publishing-api, every document will be resynced, whereas if it existed in the cache, the sync would have been skipped as it would be known that Vertex already has the latest version of the document.
+The side effect of doing this is that if you represent every document from publishing-api, every document will be resynced, whereas if it existed in the cache, the sync would have been skipped as it would be known that Discovery Engine already has the latest version of the document.
 
 Using [kubectl]:
 

--- a/source/manual/how-to-resync-content-in-discovery-engine.html.md
+++ b/source/manual/how-to-resync-content-in-discovery-engine.html.md
@@ -1,12 +1,12 @@
 ---
 owner_slack: "#govuk-search"
-title: "How to resync content in Vertex"
+title: "How to resync content in Discovery Engine"
 parent: "/manual.html"
 layout: manual_layout
 section: Search on GOV.UK
 ---
 
-To resync content items in Vertex search, publishing-api needs to push the documents to search-api-v2.
+To resync content items in Discovery Engine, publishing-api needs to push the documents to search-api-v2.
 There are various rake tasks to achieve this.
 
 ### Resyncing all content

--- a/source/manual/search-alerts-and-monitoring.html.md
+++ b/source/manual/search-alerts-and-monitoring.html.md
@@ -35,7 +35,7 @@ All environments are configured for Slack notifications. Production alerts are r
 
 ### Degradation of service alerts
 
-We monitor and alert on both Search API v2 success rates, and Google Vertex response times.
+We monitor and alert on both Search API v2 success rates, and Google Discovery Engine response times.
 
 #### Search API v2 success rates
 
@@ -49,9 +49,9 @@ We have an informal SLO to maintain a search and autocomplete success rate of ab
 
 - [AutocompleteDegradedAcute][link-9] 5 minute rolling success rate for autocomplete requests has dropped below 90% for more than 10 minutes.
 
-#### Google Vertex AI Search request durations
+#### Google Cloud Discovery Engine request durations
 
-There is currently one Alertmanager rule configured in govuk-helm-charts, [HighVertexP90Latency](link-14), which sends notifications in Slack if requests to Google Vertex's Search endpoint exceed acceptable duration thresholds.
+There is currently one Alertmanager rule configured in govuk-helm-charts, [HighVertexP90Latency](link-14), which sends notifications in Slack if requests to Google Cloud Discovery Engine search endpoint exceed acceptable duration thresholds.
 
 #### Causes and steps to take in the event of a degradation of service alert firing
 
@@ -61,11 +61,11 @@ We are aware of the following occasional errors which should not be considered c
 - `Google::Cloud::InternalError` An internal error occurred on the Google API
 - `AMQ::Protocol::EmptyResponseError` RabbitMQ sent an unexpected response, possibly due to restarting (the listener will restart by itself in most cases)
 
-If these errors persist and trigger the degradation of service alerts, this indicates an issue with GCP or Google Vertex AI Search.
+If these errors persist and trigger the degradation of service alerts, this indicates an issue with GCP or Discovery Engine.
 
 1. Login to the [Google Cloud console][link-12], and make sure that the project Search API v2 Production is selected.
 2. Under "APIs & Services" in the GCP Console, review the Discovery Engine API usage for traffic and error rates.
-3. Issues with Vertex should be [raised with Google](#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-google-vertex-ai-search).
+3. Issues with Discovery Engine should be [raised with Google](#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-discovery-engine).
 
 ### Degradation of search quality alerts
 
@@ -77,7 +77,7 @@ We have additional Alertmanager rules related to search result quality configure
 
 #### Steps to take in the event of a degradation of search quality firing
 
-Significant drops in search quality need to be investigated by the search team to diagnose the issue and [raise a support ticket with Google](#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-google-vertex-ai-search), if appropriate. If you notice a drop in search quality, make sure the Performance Analyst, Product Manager and Delivery Manager on the search team are aware.
+Significant drops in search quality need to be investigated by the search team to diagnose the issue and [raise a support ticket with Google](#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-discovery-engine), if appropriate. If you notice a drop in search quality, make sure the Performance Analyst, Product Manager and Delivery Manager on the search team are aware.
 
 ### Failures running evaluations related rake tasks
 
@@ -116,7 +116,7 @@ If an evaluation fails for a reason other than a sample query set not existing, 
 
 5. **Restore usual schedule of evaluation runs.** This is only relevant if scheduled evaluations were temporarily paused in step 3.
 
-## How to contact Google if there is a critical issue with GCP or Google Vertex AI Search
+## How to contact Google if there is a critical issue with GCP or Discovery Engine
 
 1. To raise a support ticket, you will first need to login to the [GCP console][link-12]
 2. Navigate to the [Support/Cases section][link-13] and press the GET HELP button, ensuring to provide comprehensive reproduction steps.

--- a/source/manual/search-synchronisation-errors.html.md
+++ b/source/manual/search-synchronisation-errors.html.md
@@ -10,7 +10,7 @@ section: Search on GOV.UK
 
 When a document is published, publishing API places a message on Rabbit MQ's  `search_api_published_documents` queue.
 
-Search API v2's `document_sync_worker` listens to this queue, and co-ordinates the creation of a PublishingAPIDocument that is then synchronised to the VAIS datastore.
+Search API v2's `document_sync_worker` listens to this queue, and co-ordinates the creation of a PublishingAPIDocument that is then synchronised to the Discovery Engine datastore.
 
 If a document has been successfully published, is live on gov.uk, but is not being returned in search results, the first step is to confirm if this is the expected behaviour.
 
@@ -29,7 +29,7 @@ If you are sure that the document should be visible in results, you can try the 
 ## An unpublished/withdrawn document is still present in search results
 
 When a document is withdrawn or unpublished via the UI in Whitehall, a message is placed on Rabbit MQ's `search_api_published_documents` queue.
-Search API v2's document_sync_worker listens to this queue, and co-ordinates the desynchronisation of the document from the VAIS datastore if the document type is on the [UNPUBLISH_DOCUMENT_TYPES list].
+Search API v2's document_sync_worker listens to this queue, and co-ordinates the desynchronisation of the document from the Discovery Engine datastore if the document type is on the [UNPUBLISH_DOCUMENT_TYPES list].
 
 If an unpublished document is still visible in search results, you can take the following debugging steps
 
@@ -41,7 +41,7 @@ If an unpublished document is still visible in search results, you can take the 
 
 When documents are published or unpublished via a publishing app a message is placed on Rabbit MQ's `search_api_published_documents` queue.
 
-Search API v2's document_sync_worker listens to this queue and should co-ordinate the creation of a PublishingAPIDocument that is then synchronised to or desynchronised from the VAIS datastore.
+Search API v2's document_sync_worker listens to this queue and should co-ordinate the creation of a PublishingAPIDocument that is then synchronised to or desynchronised from the Discovery Engine datastore.
 
 If all documents that have been successfully published or unpublished on gov.uk, but are not being returned as expected in search results it could be a sign that synchronisation process is failing in general for all documents. You can take the following debugging steps.
 
@@ -49,16 +49,16 @@ If all documents that have been successfully published or unpublished on gov.uk,
 1. Confirm if the document_sync_worker received a request to update the document. Do this by checking in Kibana by searching by [content_id] for a few example documents.
 2. Check for messages which explains why the desynchronisation failed.
 4. One cause is that the payload version of the message received from the queue is lower than the previous time the document was synced. If this is the cause, [clear the redis cache] and then [resynchronise] all documents.
-5. If you are see a lot of `Google::Cloud` errors in the logs the likely cause is that VAIS is having issues. [Check the error rates for site search] and follow the steps for what to do [if site search is unavailable].
+5. If you see a lot of `Google::Cloud` errors in the logs the likely cause is that Discovery Engine is having issues. [Check the error rates for site search] and follow the steps for what to do [if site search is unavailable].
 
 [document_type_ignorelist]: https://github.com/alphagov/search-api-v2/blob/1c3e8115b15703a44691311a2971ce2dbee10c59/config/document_type_ignorelist.yml
 [filter by]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-worker)))),query:(language:kuery,query:''))
 [content_id]: https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.labels.app_kubernetes_io%2Fname,negate:!f,params:(query:search-api-v2-worker),type:phrase),query:(match_phrase:(kubernetes.labels.app_kubernetes_io%2Fname:search-api-v2-worker)))),query:(language:kuery,query:%22225d80c5-01bb-47d0-b57c-6862efbed7b3%22))
 [ignore list]: https://github.com/alphagov/search-api-v2/blob/main/config/document_type_ignorelist.yml
 [clear the redis cache]: /manual/how-to-clear-the-redis-cache
-[resynchronise]: /manual/how-to-resync-content-in-vertex
+[resynchronise]: /manual/how-to-resync-content-in-discovery-engine
 [document_sync_worker]: https://github.com/alphagov/search-api-v2/blob/1c3e8115b15703a44691311a2971ce2dbee10c59/lib/tasks/document_sync_worker.rake
 [UNPUBLISH_DOCUMENT_TYPES list]: https://github.com/alphagov/search-api-v2/blob/1c3e8115b15703a44691311a2971ce2dbee10c59/app/models/concerns/publishing_api/action.rb#L6
-[delete the document from the datastore]: /manual/get-or-delete-a-document-from-VAIS#delete-a-document-from-the-datastore
+[delete the document from the datastore]: /manual/get-or-delete-a-document-from-discovery-engine#delete-a-document-from-the-datastore
 [Check the error rates for site search]: /manual/what-to-do-if-search-is-down#check-the-error-rates-for-site-search
 [if site search is unavailable]: /manual/what-to-do-if-search-is-down#if-site-search-is-unavailable

--- a/source/manual/search-synchronisation-errors.html.md
+++ b/source/manual/search-synchronisation-errors.html.md
@@ -15,7 +15,7 @@ Search API v2's `document_sync_worker` listens to this queue, and co-ordinates t
 If a document has been successfully published, is live on gov.uk, but is not being returned in search results, the first step is to confirm if this is the expected behaviour.
 
 1. Check the locale of the missing content_item. The document_sync_worker only sends documents with an `en` locale to the datastore.
-2. Check the document_type of the missing ContentItem. If it's is on the [document_type_ignorelist] the content has been intentionally ignored by the worker.
+2. Check the document_type of the missing ContentItem. If it's on the [document_type_ignorelist] the content has been intentionally ignored by the worker.
 3. Check the state of the missing ContentItem. Withdrawn content is desynchronised i.e. removed from the datastore.
 
 If you are sure that the document should be visible in results, you can try the following debugging steps:
@@ -35,7 +35,7 @@ If an unpublished document is still visible in search results, you can take the 
 
 1. Confirm if the document_sync_worker received a request to update the document. Do this by checking in Kibana by searching for the [content_id].
 2. Check for a message which explains why the desynchronisation failed.
-3. If there is no log for this request, it could be that the document was manually deleted from the   whitehall database and so no message was placed on the search_api_published_documents queue. If this is the case, you can manually [delete the document from the datastore].
+3. If there is no log for this request, it could be that the document was manually deleted from the Whitehall database and so no message was placed on the search_api_published_documents queue. If this is the case, you can manually [delete the document from the datastore].
 
 ## Wider synchronisation issues
 

--- a/source/manual/what-to-do-if-search-is-down.html.md
+++ b/source/manual/what-to-do-if-search-is-down.html.md
@@ -8,7 +8,7 @@ section: Search on GOV.UK
 
 As described in [GOV.UK Search: how it works][link-1], there are two Search stacks on GOV.UK. This documentation aims to provide some debugging steps to take in the event that someone tells you "search is down".
 
-If you are confident there is an outage caused by GCP or Google Vertex AI Search, skip to [How to contact Google if there is a critical issue with GCP or Google Vertex AI Search](./search-alerts-and-monitoring.html#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-google-vertex-ai-search)
+If you are confident there is an outage caused by GCP or Discovery Engine, skip to [How to contact Google if there is a critical issue with GCP or Discovery Engine](./search-alerts-and-monitoring.html#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-discovery-engine)
 
 This information is currently summarised as a [flow chart][link-2]
 
@@ -16,7 +16,7 @@ This information is currently summarised as a [flow chart][link-2]
 
 ## Identify what exactly is broken
 
-Searches from [search/all][link-5] with a query param are sent to SearchAPI v2, and google vertex. [Without a query param][link-12], requests are sent to SearchAPI (v1), which talks to Elasticsearch. So a quick way to identify which search stack is implicated is to see if searching with or without a query param results in different behaviour.
+Searches from [search/all][link-5] with a query param are sent to SearchAPI v2, and Discovery Engine. [Without a query param][link-12], requests are sent to SearchAPI (v1), which talks to Elasticsearch. So a quick way to identify which search stack is implicated is to see if searching with or without a query param results in different behaviour.
 
 ### Check the error rates for site search
 
@@ -37,7 +37,7 @@ If both of those pages fail to load, it is highly unlikely that the cause is a f
 
 ## If site search is unavailable
 
-If the problem appears to be with Site search, is the problem with SearchAPI v2 or with Google Vertex which provides our search results?
+If the problem appears to be with Site search, is the problem with SearchAPI v2 or with Discovery Engine which provides our search results?
 
 Check for unexpected errors in Sentry and Kibana that might help identify issues. See [GOV.UK Site search alerts and monitoring](./search-alerts-and-monitoring.html) for an overview of the alerting in place.
 
@@ -50,13 +50,13 @@ Check for unexpected errors in Sentry and Kibana that might help identify issues
 #### Synchronisation errors
 
 In addition to catching general exceptions,
-Sentry is [also used][link-6] to catch synchronisation errors (when new content is pushed to the VAIS datastore).
+Sentry is [also used][link-6] to catch synchronisation errors (when new content is pushed to the Discovery Engine datastore).
 
 A high number of synchronisation errors would suggest that new/updated content is failing to reach our datastore, rather than failing to be returned as search results.
 
 #### DiscoveryEngine::InternalError
 
-SearchAPIv2 raises a [DiscoveryEngine::InternalError][link-7] in the event of an error from Vertex. A quick hacky way to find these errors in Kibana is to search for the Rails logger message ["Did not get search results"][link-9]. A high number of these requests suggests a problem with Vertex, which should be raised with Google support, see [How to contact Google if there is a critical issue with GCP or Google Vertex AI Search](./search-alerts-and-monitoring.html#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-google-vertex-ai-search)
+SearchAPIv2 raises a [DiscoveryEngine::InternalError][link-7] in the event of an error from Discovery Engine. A quick hacky way to find these errors in Kibana is to search for the Rails logger message ["Did not get search results"][link-9]. A high number of these requests suggests a problem with Discovery Engine, which should be raised with Google support, see [How to contact Google if there is a critical issue with GCP or Discovery Engine](./search-alerts-and-monitoring.html#how-to-contact-google-if-there-is-a-critical-issue-with-gcp-or-discovery-engine)
 
 ## If site search is returning bad results
 
@@ -64,7 +64,7 @@ Search result relevance is fine tuned via a combination of:
 
 1. Boosts and demotions applied at the [serving configuration level][link-13]
 2. Boosts for [recency][link-14] applied at the application level at query time
-3. Constant training of the model on [user event (GA4) data][link-15] sent to vertex from our BiqQuery account.
+3. Constant training of the model on [user event (GA4) data][link-15] sent to Discovery Engine from our BiqQuery account.
 
 Recent changes to these files, or a failure of the user event data import would all be candidate causes of a reduction in search result quality. But they would be unlikely to have a catastrophically bad impact.
 

--- a/source/manual/what-to-do-if-search-is-down.html.md
+++ b/source/manual/what-to-do-if-search-is-down.html.md
@@ -60,7 +60,7 @@ SearchAPIv2 raises a [DiscoveryEngine::InternalError][link-7] in the event of an
 
 ## If site search is returning bad results
 
-Search result relevance is fine tuned via a combination of:
+Search result relevance is fine-tuned via a combination of:
 
 1. Boosts and demotions applied at the [serving configuration level][link-13]
 2. Boosts for [recency][link-14] applied at the application level at query time


### PR DESCRIPTION
Google have rebranded Vertex AI Search to Agent Search, so we need to update the marketing name in the docs.

We are also changing some of the internal documentation to use "Discovery Engine", which is the more stable API name, to avoid future re-namings and because it should be a more familiar name for developers.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2050
