### PR TITLE
Add private repo flag to gds-looker

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -160,6 +160,7 @@
   sentry_url: false
 
 - repo_name: gds-looker
+  private_repo: true
   type: Data Engineering
   team: "#govuk-insights-and-analytics-team"
   alerts_team: "#insights-and-analytics-alerts"


### PR DESCRIPTION
I forgot to add it in and not having it breaks deployments

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
