### PR TITLE
Add private repo flags to more repos

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -356,6 +356,7 @@
   private_repo: true
 
 - repo_name: govuk-feedback-processing
+  private_repo: true
   type: Data Engineering
   team: "#govuk-insights-and-analytics-team"
   alerts_team: "#insights-and-analytics-alerts"

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -399,6 +399,7 @@
   production_hosted_on: gcp
 
 - repo_name: govuk-measures-pipeline
+  private_repo: true
   type: Data engineering
   team: "#govuk-insights-and-analytics-team"
   alerts_team: "#insights-and-analytics-alerts"


### PR DESCRIPTION
Adds the `private_repo` flag to one private repo and one internal one. I'm guessing that as far as dev docs is concerned private and internal repos are the same

Very similar to https://github.com/alphagov/govuk-developer-docs/pull/5537

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
