### PR TITLE
Fix some broken links

### DIFF
--- a/source/manual/development-pipeline.html.md
+++ b/source/manual/development-pipeline.html.md
@@ -84,5 +84,5 @@ Refer to the [deployments documentation](/manual/deployments.html#deployment-fre
 After a deployment:
 
 - [Check Sentry for any new errors](/manual/error-reporting.html).
-- Check the [Deployment Dashboard](/manual/graphite-and-deployment-dashboards.htmll) for any issues.
+- Check the [Release app](https://release.publishing.service.gov.uk/applications) for any issues.
 - Run a build of [end-to-end tests](https://github.com/alphagov/govuk-e2e-tests) in the environment you're deploying to.

--- a/source/manual/heroku.html.md
+++ b/source/manual/heroku.html.md
@@ -6,7 +6,7 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-We use Heroku to host some non-critical applications like the [monitoring screens](screens.html) and for auto-deploying [review apps](review-apps.html)
+We use Heroku to host some non-critical applications like the [live GOV.UK content analytics screen](/repos/govuk-display-screen.html) and for auto-deploying [review apps](review-apps.html).
 
 The credentials for Heroku are in `2ndline/heroku` in [Secrets Manager](secrets-manager.html).
 


### PR DESCRIPTION
This fixes two broken links, as spotted and reported by @hezzimo.

It fixes https://github.com/alphagov/govuk-developer-docs/issues/5497 and https://github.com/alphagov/govuk-developer-docs/issues/5494
