### PR TITLE
Fix channel for graphql repo alerts

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -371,7 +371,7 @@
 
 - repo_name: govuk-graphql
   team: "#govuk-content-apis"
-  alerts_team: "UAEH5J62J"
+  alerts_team: "#govuk-content-apis-system-alerts"
   type: Publishing apps
   description: Experimental high-performance GraphQL API for GOV.UK
   sentry_url: false


### PR DESCRIPTION
Channel IDs don't seem to work - need to use the actual channel name. 