### PR TITLE
[WHIT-3439] Replace removed rake tasks in Whitehall runbook

### DIFF
--- a/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
+++ b/source/manual/alerts/whitehall-scheduled-publishing.html.md.erb
@@ -21,28 +21,17 @@ from a scheduled queue.
 You can see whether Sidekiq picked up the job for processing, and the current
 state of the job using [Sidekiq monitoring apps][link-2].
 
-You can verify that there are overdue published documents using:
+To publish any overdue editions, run the
+`publishing:scheduled:requeue_all_jobs` Rake task. It dequeues every
+scheduled-publishing job and re-queues all scheduled editions (along with
+opening/closing actions for Consultations and CallForEvidence):
 
-<%= RunRakeTask.links("whitehall-admin", "publishing:overdue:list") %>
-
-You'll see output like this:
-
-```
-ID  Scheduled date             Title
-```
-
-If there are overdue publications you can publish by running the
-following:
-
-<%= RunRakeTask.links("whitehall-admin", "publishing:overdue:publish") %>
+<%= RunRakeTask.links("whitehall-admin", "publishing:scheduled:requeue_all_jobs") %>
 
 ### After a database restore
 
-If the above rake tasks aren't working, it could be because the database was
-recently restored, perhaps due to the data sync. In that case, you can try
-running the following Rake task on a `whitehall_backend` machine:
-
-<%= RunRakeTask.links("whitehall-admin", "publishing:scheduled:requeue_all_jobs") %>
+If the alert keeps firing after running the above, it may be because the
+database was recently restored, perhaps due to the data sync.
 
 Due to the overnight [data anonymisation process][link-4] you may notice
 that some of the pending documents have one or more edition that is in a


### PR DESCRIPTION
## Summary
The runbook references two rake tasks (`publishing:overdue:list` and `publishing:overdue:publish`) that were removed from Whitehall in alphagov/whitehall@41ae17e71d (Nov 2024). Per that commit message, neither task is needed: the PagerDuty alert is itself the verification of overdue editions, and `publishing:scheduled:requeue_all_jobs` already covers the bulk publish case.

Point both alert sections at `publishing:scheduled:requeue_all_jobs`, and trim the "After a database restore" subsection since it's no longer routing the reader to a different rake task.