### PR TITLE
Add missing host data to fix Release app alert destination

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -128,6 +128,7 @@
   type: Publishing apps
   alerts_team: "#govuk-publishing-mainstream-experience-tech"
   team: "#govuk-publishing-mainstream-experience-tech"
+  production_hosted_on: eks
 
 - repo_name: feedback
   type: Frontend apps
@@ -195,6 +196,7 @@
 - repo_name: govuk-ai-accelerator
   team: "#publishing-classification-systems-metadata"
   alerts_team: "#publishing-csm-alerts"
+  production_hosted_on: eks
   type: AI apps
   sentry_url: false
 


### PR DESCRIPTION
Those apps are missing from the apps JSON[^1] used by Release app to notify the about undedeployed changes. Because of that Release app falls back to the generic Slack channel #govuk-developers [^2].

Both apps currently don’t run in production.

While the key name is slightly misleading, the value is only used to determine if a repo is an app [^3] and consequently if it’s included in `apps.json`

[^1]: https://docs.publishing.service.gov.uk/apps.json
[^2]: https://github.com/alphagov/release/blob/c45bd46316ae17424abd8c31bd7371ad4e917f4b/app/models/application.rb#L159
[^3]: https://github.com/alphagov/govuk-developer-docs/blob/65963556a37954fed58f042da19cc4f86957a3b2/app/repo.rb#L36-L38

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
