### PR TITLE
[PP-7559] Remove govuk-graphql

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -369,13 +369,6 @@
   description: Definitions for and implementation of data pipelines for reading and processing feedback left on GOV.UK
   production_hosted_on: gcp
 
-- repo_name: govuk-graphql
-  team: "#govuk-content-apis"
-  alerts_team: "#govuk-content-apis-system-alerts"
-  type: Publishing apps
-  description: Experimental high-performance GraphQL API for GOV.UK
-  sentry_url: false
-
 - repo_name: govuk-helm-charts
   type: Utilities
   team: "#govuk-platform-engineering-team"


### PR DESCRIPTION
It has now been retired and archived, so removing the application from the list of repos.

Depends on https://github.com/alphagov/govuk-graphql/pull/299, https://github.com/alphagov/govuk-infrastructure/pull/4228 and https://github.com/alphagov/govuk-infrastructure/pull/4229.