### PR TITLE
Make govuk-rota-generator private [TECH-29]

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -465,6 +465,7 @@
   type: Utilities
 
 - repo_name: govuk-rota-generator
+  private_repo: true
   team: "#govuk-platform-engineering-team"
   alerts_team: "#govuk-platform-support"
   type: Utilities


### PR DESCRIPTION
We're making changes to the generator which will involve committing some developer data to the repo. Best make it private first.

https://gov-uk.atlassian.net/browse/TECH-29

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
