### PR TITLE
docs: ✏️ point helm repo to ask channel

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -373,7 +373,7 @@
 
 - repo_name: govuk-helm-charts
   type: Utilities
-  team: "#govuk-platform-engineering-team"
+  team: "#govuk-ask-platform-engineering"
   alerts_team: "#govuk-platform-support"
 
 - repo_name: govuk-infrastructure


### PR DESCRIPTION
Some users have been posting helm repo PRs into our main channel recently, they have been pointed there by these docs. The docs should point users to the ask channel.

https://gds.slack.com/archives/C09ALJB14GZ/p1780996274610799
