### PR TITLE
Update dependency management docs

### DIFF
--- a/source/manual/manage-dependencies.html.md
+++ b/source/manual/manage-dependencies.html.md
@@ -7,33 +7,32 @@ layout: manual_layout
 parent: "/manual.html"
 ---
 
-We're [obliged to keep our software current](/manual/keeping-software-current.html). To help with this, we use a
-service called Dependabot (by GitHub) to open automated dependency upgrade PRs, and we use an in-house tool called the [Seal](/repos/seal.html) to notify us of Dependabot PRs that have not yet been merged. We also have an in-house tool, [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger), for automatically merging [certain Dependabot PRs](#auto-merging-dependabot-prs).
+We're [obliged to keep our software current](/manual/keeping-software-current.html). To help with this, we use Github's Dependabot service to open automated dependency upgrade PRs, and an in-house tool called the [Seal](/repos/seal.html) to notify teams of Dependabot PRs that have not yet been merged. We also have an in-house tool, [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger), for automatically merging [certain Dependabot PRs](#auto-merging-dependabot-prs).
 
 ## Responsibility
 
-Each service team is responsible for setting up and maintaining dependency management for their own repositories. This includes configuring Dependabot, reviewing and merging dependency PRs, and opting in to auto-merging where appropriate.
+Each team is responsible for setting up and maintaining dependency management for their own repositories. This includes configuring Dependabot, reviewing and merging dependency PRs, and opting in to auto-merging where appropriate.
 
-GOV.UK Platform Engineering can provide advice and additional tooling (such as [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger)) to support this, but the day-to-day ownership sits with the service team.
+GOV.UK Platform Engineering can provide advice and tooling to support this, but day-to-day ownership sits with the team.
 
 ## Auto merging Dependabot PRs
 
 According to the [National Cyber Security Centre](https://www.ncsc.gov.uk/collection/vulnerability-management/guidance/policy-update-by-default), we should apply updates as soon as possible, and ideally automatically.
 
-To facilitate that, we have a [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger) service that can auto-merge certain Dependabot PRs, outlined in [RFC-167](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md).
+To facilitate that, the [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger) service can auto-merge certain Dependabot PRs, based on criteria outlined in [RFC-167](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md) and extended in [RFC-178](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-178-require-dependabot-cooldown-for-external-auto-merging.md).
 
-Repos that wish to opt in to this service must have a `.govuk_dependabot_merger.yml` file at the root of the repository, configured as per the govuk-dependabot-merger README instructions. They must then be added to the [repos_opted_in.yml](https://github.com/alphagov/govuk-dependabot-merger/blob/main/config/repos_opted_in.yml) list in govuk-dependabot-merger.
+Repos that wish to opt in to this service must have a `.govuk_dependabot_merger.yml` file at the root of the repository, configured as per the govuk-dependabot-merger README instructions. They must then be added to the [repos_opted_in.yml](https://github.com/alphagov/govuk-dependabot-merger/blob/main/config/repos_opted_in.yml) list.
 
 ## Reviewing Dependabot PRs
 
-Given the higher security risks associated with delaying updates, we should prioritize using the [auto merging tool](#auto-merging-dependabot-prs) whenever possible. However, in cases where that cannot be used or a PR needs manual reviewing, we should follow the instructions for reviewing Dependabot PRs:
+Teams should use the [auto merging tool](#auto-merging-dependabot-prs) whenever possible. However, where that cannot be used or a PR needs manual reviewing, you should follow the instructions for reviewing Dependabot PRs:
 
 - Expand the "Release notes" or "Changelog" details.
   - Click on the link to the `CHANGELOG` file (if there is one).
-  - Read the additions to the file to find out about any breaking changes or upgrade instructions.
+  - Check the additions to the file for any breaking changes or upgrade instructions.
   - Take extra care when this is a 'major' upgrade, e.g. `2.1.0` => `3.0.0`.
 
-If this is the first update the dependency has had in a while, or if this is an unfamiliar dependency that perhaps has a solo maintainer, you'll want to take extra due diligence in your review:
+If this is the first update to the dependency in a while, or it's an unfamiliar dependency that perhaps has a solo maintainer, you should take extra due diligence in your review:
 
 - Expand the "Commits" details
   - Click on the "compare view" link.
@@ -45,7 +44,7 @@ If this is the first update the dependency has had in a while, or if this is an 
 - You may want to verify the author of the version bump commit is a regular contributor to the repo.
 - If in doubt, get a second opinion from Senior Tech.
 
-It's crucial to acknowledge that the traditional human review process may not offer significant security benefits. Instead, we should prioritize comprehensive test coverage and security scanning as our primary safeguards.
+It's crucial to acknowledge that the traditional human review process may not offer significant security benefits. Instead, we should prioritise comprehensive test coverage and security scanning as our primary safeguards.
 RFC-167 [lists reasons](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#justification) why the above steps are not sufficient to detect malicious activity.
 
 ## Managing Dependabot
@@ -65,13 +64,13 @@ To configure Dependabot, a PR will need to be created that adds a configuration 
 
 By default Dependabot will bump dependencies at the frequency specified in the configuration file, but you can ask it to bump manually:
 
-Go to your project in GitHub and click on "Insights", then "Dependency graph", then "Dependabot", then "Last checked X minutes ago" next to the package manager of choice (e.g. Gemfile). Then you can click "Check for updates".
+Go to the repo in GitHub and click on "Insights", then "Dependency graph", then "Dependabot", then "Last checked X minutes ago" next to the package manager of choice (e.g. Gemfile). Then you can click "Check for updates".
 
 ## Configuring Dependabot for your repository
 
-The following are suggested configurations for `.github/dependabot.yml`. These are opinions, not rules. Adapt them to suit your project.
+The following are suggested configurations for `.github/dependabot.yml`. These are opinions, not rules. Adapt them to suit your repo.
 
-A good example to follow is the [govuk-frontend dependabot.yml](https://github.com/alphagov/govuk-frontend/blob/main/.github/dependabot.yml).
+A good example is [govuk-frontend dependabot.yml](https://github.com/alphagov/govuk-frontend/blob/main/.github/dependabot.yml).
 
 ### Schedule and cooldown
 
@@ -189,7 +188,7 @@ updates:
 - **`interval: monthly`**: security updates are still raised immediately regardless of schedule.
 - **`cooldown: default-days: 3`**: waits 3 days after a version is published before raising a PR. Infrastructure tooling (Terraform, Docker) uses 7 days, as these changes tend to carry more risk.
 - **`allow: dependency-type: direct`**: only updates top-level dependencies, not transitive ones.
-- **`groups`**: bundles related dependencies (e.g. all RuboCop gems) into a single PR. Tailor these to the libraries your project actually uses.
+- **`groups`**: bundles related dependencies (e.g. all RuboCop gems) into a single PR. Tailor these to the libraries your repo actually uses.
 - **`open-pull-requests-limit`**: the default is 5, which is easy to hit if you have a few dependencies that can't be auto-merged. A low cap has contributed to past incidents where security updates were blocked by the limit. We recommend setting this to at least 10 (see [alphagov/whitehall#11286](https://github.com/alphagov/whitehall/pull/11286) for prior art).
 
 ## Security


### PR DESCRIPTION
This includes:
 
- Adding a link to [RFC-178](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-178-require-dependabot-cooldown-for-external-auto-merging.md) which extends the criteria for automerging.
- general tweaks to improve readability, consistency and reduce wordage (and UK spelling)