### PR TITLE
Update documentation to reflect allowed_formats rename

### DIFF
--- a/source/manual/make-a-new-document-type-available-to-search.html.md
+++ b/source/manual/make-a-new-document-type-available-to-search.html.md
@@ -39,9 +39,9 @@ fields is [ElasticsearchPresenter][e-s-presenter].
 Modify this if there is anything special you want search to do with your
 documents (for example: appending additional information to the title).
 
-### 2. Add the document type to migrated_formats.yaml
+### 2. Add the document type to allowed_formats.yaml
 
-Add the document_type name to the [`migrated` list][migrated-list] in Search
+Add the document_type name to the [`allowed_formats` list][allowed-formats] in Search
 API.
 
 ### 3. Reindex
@@ -71,7 +71,7 @@ You can test that the documents appear in search through the API using a query s
 [mapped-doc-types]: https://github.com/alphagov/search-api/blob/main/config/govuk_index/mapped_document_types.yaml
 [i-c-presenter]: https://github.com/alphagov/search-api/blob/main/lib/govuk_index/presenters/indexable_content_presenter.rb
 [e-s-presenter]: https://github.com/alphagov/search-api/blob/main/lib/govuk_index/presenters/elasticsearch_presenter.rb
-[migrated-list]: https://github.com/alphagov/search-api/blob/main/config/govuk_index/migrated_formats.yaml
+[allowed-formats]: https://github.com/alphagov/search-api/blob/main/config/govuk_index/allowed_formats.yaml
 [reindex]: reindex-elasticsearch.html
 [task]: https://github.com/alphagov/publishing-api/blob/main/lib/tasks/represent_downstream.rake
 [query-1]: https://www.gov.uk/api/search.json?count=0&filter_content_store_document_type=guide

--- a/source/manual/rename-a-country.html.md
+++ b/source/manual/rename-a-country.html.md
@@ -47,7 +47,7 @@ This will update `www.gov.uk/world/<country_slug>` to `www.gov.uk/world/<new_cou
 
 In [Search API](https://github.com/alphagov/search-api):
 
-1. Create a [pull request](https://github.com/alphagov/search-api/pull/2884/files) with a change to the relevant country taxon in `config/govuk_index/migrated_formats.yaml`
+1. Create a [pull request](https://github.com/alphagov/search-api/pull/2884/files) with a change to the relevant country taxon in `config/govuk_index/allowed_formats.yaml`
 2. Deploy Search API
 
 In [Content Tagger](https://content-tagger.integration.publishing.service.gov.uk/):


### PR DESCRIPTION
The documentation still referred to migrated_formats.yaml, which was recently renamed to allowed_formats.yaml. Update the references to use the current filename.

See also: https://github.com/alphagov/search-api/pull/3634

Jira: https://gov-uk.atlassian.net/browse/SCH-2035
