### PR TITLE
Add a link to Production Admin Preparedness checklist MS form

### DIFF
--- a/source/manual/rules-for-getting-production-access.html.md
+++ b/source/manual/rules-for-getting-production-access.html.md
@@ -70,7 +70,7 @@ Gives:
 
 - You have a minimum of BPSS security clearance (blue building pass), AND
 - You have passed your probation period, AND
-- You have completed the [Production Admin Preparedness checklist](https://docs.google.com/forms/d/e/1FAIpQLSeY5H8ei89AJFaQLuDrd6CpWjCighCvF3d2iXx7QsyJdQjL-Q/viewform), covering the [learning objectives](#production-admin-learning-objectives) below, and have had your form response reviewed by [someone in Senior Tech](/manual/ask-for-help.html#contact-senior-tech).
+- You have completed the Production Admin Preparedness checklist [Google form](https://docs.google.com/forms/d/e/1FAIpQLSeY5H8ei89AJFaQLuDrd6CpWjCighCvF3d2iXx7QsyJdQjL-Q/viewform) or [Microsoft form](https://forms.cloud.microsoft/e/Q9YjUYCrhg) covering the [learning objectives](#production-admin-learning-objectives) below, and have had your form response reviewed by [someone in Senior Tech](/manual/ask-for-help.html#contact-senior-tech) (N.B. let them know which version of the form you have completed).
 
 To grant access, the senior tech person should create an issue for ["GOV.UK Production Admin" access](https://github.com/alphagov/govuk-platform-internal/issues/new?template=2-govuk-production-admin.md) and follow the steps listed in the issue.
 


### PR DESCRIPTION
<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->

The Production Admin Preparedness checklist has been recreated as a MS Form. Whilst we're dual running, a link to both versions of the form has been provided. The link to the Google form will be removed in July after the full switch over to MS.
