### PR TITLE
Revise EKS cluster access instructions

### DIFF
--- a/source/kubernetes/get-started/access-eks-cluster/index.html.md
+++ b/source/kubernetes/get-started/access-eks-cluster/index.html.md
@@ -12,44 +12,26 @@ There are 3 GOV.UK clusters: integration, staging and production. These correspo
 
 This document assumes that you have already followed the steps in [Get started developing on GOV.UK](https://docs.publishing.service.gov.uk/manual/get-started.html).
 
-## Obtain AWS credentials for your role in the cluster's AWS account
+## Set up all three GOV.UK EKS clusters for the first time
 
-1. Choose the [AWS IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) that you will use to access the cluster:
-    - `readonly`: has read-only access to AWS and the Kubernetes `apps` and `datagovuk` namespaces. In AWS, access to
-     secrets and objects in S3 is not granted.
-    - `developer`: has read-write access to most things in the `apps` and `datagovuk` namespaces, and can read the value
-      of secrets with the `2ndline/` or `govuk/` prefixes. It cannot modify the secrets in any way.
-    - `fulladmin`: has read-write "cluster-admin" access to everything in the cluster, across all namespaces, including secrets
-    - `platformengineer`: also has read-write "cluster-admin access to everything in the cluster, across all namespaces, including secrets, but can be used by Platform Engineers on a regular basis without requiring an approval process
+You'll need to do the following three times: one for each environment. Swap `govuk-environment` as appropriate.
 
-1. Obtain AWS credentials using `gds-cli` for the desired GOV.UK environment and role:
+1. Assume a role in the environment:
 
-     ```sh
-     eval $(gds aws govuk-<govuk-environment>-<role> -e --art 8h)
-     export AWS_REGION=eu-west-1
-     ```
+```
+export AWS_REGION=eu-west-1
+eval $(gds aws govuk-<govuk-environment>-readonly -e --art 8h)
+```
 
-    where:
-    - `<govuk-environment>` is `integration`, `staging`, or `production`
-    - `<role>` is `developer`, or `fulladmin`
-
-## Note: About using the correct role
-
-You should always assume the correct role for the job. By default, you should use the `readonly` role because it will give you access to all the information you need, without elevated privileges. If your task will require you to restart a pod or deployment, for example, you can use the `developer` role. Platform Engineers may use the `platformengineer` role if they need to perform actions in the EKS cluster that require "Cluster Admin" permissions but don't need Admin access to other AWS services.
-
-Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin` role, and should only do so if they have proven the `developer` or `platformengineer` roles are insufficient. Usage of the `fulladmin` role is monitored and may cause an alert to be raised in the future.
-
-## Access a cluster for the first time
-
-1. If it's your first time accessing the cluster through kubectl, add the `govuk` cluster to your kubectl configuration in `~/.kube/config`:
+1. Add this environment's `govuk` cluster to your kubectl configuration in `~/.kube/config`:
 
     ```sh
     aws eks update-kubeconfig --name govuk
     ```
 
-1. To make it easier to switch between clusters, namespaces or users, you can rename the new context to match the name of the environment:
+1. Rename the new context to match the name of the environment (to make it easier to switch between clusters, namespaces or users):
 
-    Edit the `name` field of the last context in `~/.kube/config`. For example, for the staging environment you could set `name` to `govuk-staging`.
+    Edit the `name` field of the last context in `~/.kube/config`. For example, for the staging environment you could set `name` to `govuk-staging` or simply `staging`.
 
     See the [Kubernetes documentation on configuring access to multiple clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for more information.
 
@@ -59,9 +41,9 @@ Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin`
     kubectl config use-context <govuk-environment>
     ```
 
-    Where `govuk-environment` is the name of the context from step 2.
+    Where `govuk-environment` is the name of the context you chose in the step above.
 
-1. Set the [default namespace](/kubernetes/manage-app/get-app-info/#choose-and-set-a-namespace)
+1. Set the [default namespace](/kubernetes/manage-app/get-app-info/#choose-and-set-a-namespace) of the context:
 
     ```sh
     kubectl config set-context --current --namespace=apps
@@ -80,20 +62,18 @@ Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin`
     frontend   2/2     2            2           399d
     ```
 
-## Access a cluster that you have accessed before
+Now repeat for the other two environments.
+
+## Access a GOV.UK EKS cluster that you have configured already
 
 To switch to a cluster that you have previously configured in `~/.kube/config` as above:
 
-1. Obtain AWS credentials using `gds-cli` for the desired GOV.UK environment and role:
+1. Obtain AWS credentials using `gds-cli` for the desired GOV.UK environment and [role](#choosing-the-correct-role-for-accessing-the-cluster):
 
      ```sh
      eval $(gds aws govuk-<govuk-environment>-<role> -e --art 8h)
      export AWS_REGION=eu-west-1
      ```
-
-    where:
-    - `<govuk-environment>` is `integration`, `staging`, or `production`
-    - `<role>` is `readonly`, `developer`, `fulladmin` or `platformengineer`
 
 1. Switch to the corresponding kubectl context:
 
@@ -106,6 +86,19 @@ To switch to a cluster that you have previously configured in `~/.kube/config` a
      ```sh
      kubectl config get-contexts
      ```
+
+## Choosing the correct role for accessing the cluster
+
+The following [AWS IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) can be used to access a GOV.UK EKS cluster:
+
+- `readonly`: has read-only access to AWS and the Kubernetes `apps` and `datagovuk` namespaces. In AWS, access to secrets and objects in S3 is not granted.
+- `developer`: has read-write access to most things in the `apps` and `datagovuk` namespaces, and can read the value of secrets with the `2ndline/` or `govuk/` prefixes. It cannot modify the secrets in any way.
+- `fulladmin`: has read-write "cluster-admin" access to everything in the cluster, across all namespaces, including secrets
+- `platformengineer`: also has read-write "cluster-admin access to everything in the cluster, across all namespaces, including secrets, but can be used by Platform Engineers on a regular basis without requiring an approval process
+
+You should always assume the correct role for the job. By default, you should use the `readonly` role because it will give you access to all the information you need, without elevated privileges. If your task will require you to restart a pod or deployment, for example, you can use the `developer` role. Platform Engineers may use the `platformengineer` role if they need to perform actions in the EKS cluster that require "Cluster Admin" permissions but don't need Admin access to other AWS services.
+
+Only "Platform Engineer" and "Production Admin" users can assume the `fulladmin` role, and should only do so if they have proven the `developer` or `platformengineer` roles are insufficient. Usage of the `fulladmin` role is monitored and may cause an alert to be raised in the future.
 
 ## Working with multiple clusters at once
 

--- a/source/kubernetes/get-started/access-eks-cluster/index.html.md
+++ b/source/kubernetes/get-started/access-eks-cluster/index.html.md
@@ -23,25 +23,19 @@ export AWS_REGION=eu-west-1
 eval $(gds aws govuk-<govuk-environment>-readonly -e --art 8h)
 ```
 
-1. Add this environment's `govuk` cluster to your kubectl configuration in `~/.kube/config`:
+1. Add this environment's `govuk` cluster to your kubectl configuration in `~/.kube/config`, and name it (e.g. `--alias govuk-integration` or `--alias integration`):
 
     ```sh
-    aws eks update-kubeconfig --name govuk
+    aws eks update-kubeconfig --name govuk --alias govuk-<govuk-environment>
     ```
-
-1. Rename the new context to match the name of the environment (to make it easier to switch between clusters, namespaces or users):
-
-    Edit the `name` field of the last context in `~/.kube/config`. For example, for the staging environment you could set `name` to `govuk-staging` or simply `staging`.
-
-    See the [Kubernetes documentation on configuring access to multiple clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) for more information.
 
 1. Set the current context:
 
     ```sh
-    kubectl config use-context <govuk-environment>
+    kubectl config use-context <alias>
     ```
 
-    Where `govuk-environment` is the name of the context you chose in the step above.
+    Where `alias` is the name of the context you chose in the step above.
 
 1. Set the [default namespace](/kubernetes/manage-app/get-app-info/#choose-and-set-a-namespace) of the context:
 


### PR DESCRIPTION
Updated instructions for accessing GOV.UK EKS clusters, including role selection and kubectl context management.

This has been optimised to be easier for new starters or those who are setting up their dev machine for the first time - which I expect to be the majority of human traffic to this page.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
