### PR TITLE
Remove govuk-dns-ui repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -324,13 +324,6 @@
   type: Utilities
   description: Terraform configuration for managing DNS records
 
-- repo_name: govuk-dns-ui
-  private_repo: true
-  team: "#govuk-platform-engineering-team"
-  alerts_team: "#govuk-platform-support"
-  type: Utilities
-  description: Simple UI to help with management of GOV.UK DNS records
-
 - repo_name: govuk-docker
   team: "#govuk-platform-engineering-team"
   alerts_team: "#govuk-platform-support"


### PR DESCRIPTION
This app has been retired, and the repo archived

(Part of https://github.com/alphagov/govuk-infrastructure/issues/2827)
