### PR TITLE
[SCH-2037] Update env sync docs re search

### DIFF
--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -36,9 +36,10 @@ updates this index. To update it manually, you can run the [associated rake task
 
 ## Environment syncs
 
-There are nightly cron jobs that [synchronise elasticsearch][sync-job] in integration and staging with the production environment.
-These jobs work in sequence to take a snapshot of a higher level environment (e.g. production) and then restore the snapshot in the lower
-level environment (e.g. staging). If documents that are published or unpublished in production are not reflected in integration and staging after 1 day, that
+There are cron jobs that [synchronise elasticsearch][sync-job] environments. Staging is synced with production every night, and integration is synced with staging on a Monday morning.
+These jobs work in sequence to take a snapshot of a higher level environment (e.g. production) and then restore the snapshot in the lower level environment (e.g. staging), before the snapshot for that environment is taken.
+
+If documents that are published or unpublished in production are not reflected in integration and staging after 1 day, that
 could be because of issues with the synchronisation jobs. If any part of the workflow needs to be rerun, this can be done manually in Argo:
 
 1. Login to [Argo][argo] for the relevant environment

--- a/source/manual/govuk-env-sync.html.md
+++ b/source/manual/govuk-env-sync.html.md
@@ -36,7 +36,7 @@ $ kubectl logs -n apps db-backup-link-checker-api-postgres-29220583-abcde -c 0-r
 
 ## How it works
 
-The env sync process is made up of a lot of small Kubernetes cronjobs - one per app and environment - [configured in the 'db-backup' chart](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/db-backup/values.yaml). There is also a [search-index-env-sync](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/search-index-env-sync) chart for copying search index data.
+The env sync process is made up of a lot of small Kubernetes cronjobs - one per app and environment - [configured in the 'db-backup' chart](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/db-backup/values.yaml). There is also a [search-index-env-sync](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/search-index-env-sync) chart for copying search API's elasticsearch index data.
 
 The 'production' cronjobs back up their respective application's database data to a production S3 bucket called `govuk-production-database-backups` (using a 'backup' operation - see [example](https://github.com/alphagov/govuk-helm-charts/blob/4b922fc7eb79757080570d33b1ae668c4d9dbb4f/charts/db-backup/values.yaml#L107-L111)). The bucket is [configured to automatically replicate](https://github.com/alphagov/govuk-infrastructure/blob/4f451dd56d43042e3fe0477235e9f2126618c957/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf) to S3 buckets [in the other environments](https://github.com/alphagov/govuk-infrastructure/blob/4f451dd56d43042e3fe0477235e9f2126618c957/terraform/deployments/govuk-publishing-infrastructure/db_backup_iam.tf#L1-L8). You can read more about [how GOV.UK data backups are configured in AWS](/manual/backups.html).
 


### PR DESCRIPTION
Updates GOV.UK env sync documentation to clarify that it is Search API's elasticsearch index that is synced.

Update Fix Out of Date Search Indices to reflect change to weekly syncing of search integration index.

Documentation changes related to [PR 4374 on govuk-infrastructure](https://github.com/alphagov/govuk-helm-charts/pull/4374) arising from [Jira ticket SCH-2037](https://gov-uk.atlassian.net/browse/SCH-2037)

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
