### PR TITLE
[SCH-2037] Update docs re change to weekly integration sync for search

### DIFF
--- a/source/manual/fix-out-of-date-search-indices.html.md
+++ b/source/manual/fix-out-of-date-search-indices.html.md
@@ -39,7 +39,7 @@ updates this index. To update it manually, you can run the [associated rake task
 There are cron jobs that [synchronise elasticsearch][sync-job] environments. Staging is synced with production every night, and integration is synced with staging on a Monday morning.
 These jobs work in sequence to take a snapshot of a higher level environment (e.g. production) and then restore the snapshot in the lower level environment (e.g. staging), before the snapshot for that environment is taken.
 
-If documents that are published or unpublished in production are not reflected in integration and staging after 1 day, that
+If documents that are published or unpublished in production are not reflected in staging after 1 day or in integration after 1 week, that
 could be because of issues with the synchronisation jobs. If any part of the workflow needs to be rerun, this can be done manually in Argo:
 
 1. Login to [Argo][argo] for the relevant environment


### PR DESCRIPTION
Update docs to suggest possible error if integration doc not updated after a week

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
