### PR TITLE
Fix hyperlink syntax in 'Retire a Gem' page

### DIFF
--- a/source/manual/retiring-a-gem.html.md
+++ b/source/manual/retiring-a-gem.html.md
@@ -33,10 +33,10 @@ Follow the ['Archiving repositories'](https://github.com/alphagov/govuk-infrastr
 
 ## 4. Remove references and update docs
 
-Do a [code search on GitHub][https://github.com/search?q=org%3Aalphagov+panopticon&type=Code] to find any references to the gem
+Do a [code search on GitHub](https://github.com/search?q=org%3Aalphagov+panopticon&type=Code) to find any references to the gem
 and update or remove them.
 
-Mark the gem as `retired` in [govuk-developer-docs][https://github.com/alphagov/govuk-developer-docs].
+Mark the gem as `retired` in [govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs).
 
 ## 5. Yank the gem (optional)
 


### PR DESCRIPTION
A couple of these links were written as `[text][url]` instead of `[text](url)`

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
<img width="716" height="213" alt="Screenshot 2026-08-14 at 13 34 25" src="https://github.com/user-attachments/assets/4a7a413a-a375-4844-838e-0794e182f14f" />

