### PR TITLE
Retire siteimprove_api_client repo

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -796,15 +796,6 @@
   alerts_team: "#govuk-content-apis-system-alerts"
   production_hosted_on: eks
 
-- repo_name: siteimprove_api_client
-  team: "#govuk-publishing-content-reuse-dev"
-  alerts_team: "#govuk-publishing-content-reuse-automations"
-  type: Gems
-  sentry_url: false
-  description: |
-    Used by content-data-admin Siteimprove integration.
-  skip_docs: true
-
 - repo_name: smart-answers
   type: Frontend apps
   team: "#govuk-publishing-mainstream-experience-tech"


### PR DESCRIPTION
I have followed the steps to retire the gem itself.

The repo has now been archived and this step is to fully retire the repo.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
