### PR TITLE
Update references to GOV.UK Chat notification channel

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -234,7 +234,7 @@
 
 - repo_name: govuk-chat
   team: "#ai-govuk"
-  alerts_team: "#dev-notifications-ai-govuk"
+  alerts_team: "#ai-govuk-chat-devs"
   type: AI apps
   production_hosted_on: eks
   production_url: https://chat.publishing.service.gov.uk/
@@ -244,21 +244,21 @@
 
 - repo_name: govuk-chat-evaluation
   team: "#ai-govuk"
-  alerts_team: "#dev-notifications-ai-govuk"
+  alerts_team: "#ai-govuk-chat-devs"
   type: Utilities
   sentry_url: false
 
 - repo_name: govuk-chat-monitoring
   private_repo: true
   team: "#ai-govuk"
-  alerts_team: "#dev-notifications-ai-govuk"
+  alerts_team: "#ai-govuk-chat-devs"
   type: Supporting apps
   sentry_url: false
   description: A repo used to identify unintended responses by GOV.UK Chat
 
 - repo_name: govuk-chat-opensearch
   team: "#ai-govuk"
-  alerts_team: "#dev-notifications-ai-govuk"
+  alerts_team: "#ai-govuk-chat-devs"
   type: AI apps
   sentry_url: false
   description: A repo for managing GOV.UK Chat's OpenSearch snapshots
@@ -266,7 +266,7 @@
 - repo_name: govuk-chat-v1-iterations-2026
   private_repo: true
   team: "#ai-govuk"
-  alerts_team: "#dev-notifications-ai-govuk"
+  alerts_team: "#ai-govuk-chat-devs"
   type: AI apps
   sentry_url: false
   description: A private repo used for experimenting and iterating on GOV.UK Chat v.1 in Python
@@ -555,7 +555,7 @@
     Private gem for storing code/config for GOV.UK Chat which isn't suitable
     for open source.
   team: "#ai-govuk"
-  alerts_team: "#dev-notifications-ai-govuk"
+  alerts_team: "#ai-govuk-chat-devs"
   type: Gems
 
 - repo_name: govuk_content_block_tools

--- a/source/manual/alerts/chat-ai-alerts.html.md
+++ b/source/manual/alerts/chat-ai-alerts.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#dev-notifications-ai-govuk"
+owner_slack: "#ai-govuk-chat-devs"
 title: GOV.UK Chat Alerts
 parent: "/manual.html"
 layout: manual_layout
@@ -8,7 +8,7 @@ section: Monitoring and alerting
 
 > **Note**
 >
-> For any queries or assistance regarding Chat Alerts, please post in the [#dev-notifications-ai-govuk] Slack channel
+> For any queries or assistance regarding Chat Alerts, please post in the [#ai-govuk-chat-devs] Slack channel
 
 ## Alerts by Priority
 
@@ -80,7 +80,7 @@ The [ElevatedAnswerErrorStatuses] alert fires when three or more answers generat
 
 To determine what the the issue is you should naviate to the [questions page in the admin console] for the relevant environment (this link is for production). Then view each questions with an error status and navigate to to the error message row.
 
-[#dev-notifications-ai-govuk]: https://gds.slack.com/archives/C06AWTPNJMV
+[#ai-govuk-chat-devs]: https://gds.slack.com/archives/C06AWTPNJMV
 [Integration]: https://grafana.eks.integration.govuk.digital/d/govuk-chat-technical
 [Staging]: https://grafana.eks.staging.govuk.digital/d/govuk-chat-technical
 [Production]: https://grafana.eks.production.govuk.digital/d/govuk-chat-technical

--- a/source/manual/govuk-chat.html.md
+++ b/source/manual/govuk-chat.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#dev-notifications-ai-govuk"
+owner_slack: "#ai-govuk-chat-devs"
 title: Support GOV.UK Chat
 section: GOV.UK Chat
 type: learn


### PR DESCRIPTION
We're now using a combined dev and notification channel for GOV.UK Chat.