### PR TITLE
Clarify which email address should be used when requesting AWS accounts

### DIFF
--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -42,7 +42,7 @@ Help others know who you are by [updating your Slack profile's 'title' field](ht
 
 ## 4. Set up your AWS IAM user account
 
-1. [Request a AWS user account][request-aws-user].
+1. [Request a AWS user account][request-aws-user] using your `digital.cabinet-office.gov.uk` email address.
 1. You should receive an email when your account is created.
 1. Follow instructions in the email to sign into the `gds-users` AWS account for the first time.
 1. [Enable Multi-factor Authentication (MFA)][enable-mfa] for your IAM User.


### PR DESCRIPTION
We are onboarding a new starter and this was not clear.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
