### PR TITLE
Add alerts team for govuk_publishing_components

### DIFF
--- a/data/repos.yml
+++ b/data/repos.yml
@@ -587,6 +587,7 @@
 
 - repo_name: govuk_publishing_components
   team: "#govuk-ruby-frontenders"
+  alerts_team: "#govuk-publishing-components"
   type: Gems
   production_url: https://components.publishing.service.gov.uk
   sentry_url: false


### PR DESCRIPTION
There was a mismatch between team names in here and seal repo and as a result the notifications are not being sent out.  The #govuk-publishing-components channel was created as a departure from #govuk-ruby-frontenders channel because there was too much noise, and real people's comments were being overlooked.

Dependency: 
- https://github.com/alphagov/seal/pull/723

