### PR TITLE
Update escalation process for Technical On-Call support

### DIFF
--- a/source/manual/ask-for-help.html.md
+++ b/source/manual/ask-for-help.html.md
@@ -24,7 +24,18 @@ There are channels for each area of GOV.UK:
 - `#govuk-publishing-service-support`
 - `#govuk-web-support`
 
-In addition, there's a `#govuk-technical-on-call` channel that can be used to communicate with the on-call engineers in a public forum. However, bear in mind that Slack does not page their phones, so whereas in-hours you may be able to `@` the on-call engineer, out-of-hours you'll need to contact via PagerDuty.
+## Escalate to Technical On-Call
+
+There's a `#govuk-technical-on-call` channel that can be used to communicate with the on-call engineers in a public forum, in-hours only.
+
+Out of hours, or if you need to escalate urgently in-hours, create an incident in PagerDuty:
+
+- Impacted Service: "GOV.UK"
+- Urgency" "High"
+- Assignee: “GOV.UK Regular Coverage”)
+- Fill out the incident detail and create the incident
+
+This causes the engineer(s) to be paged by PagerDuty.
 
 ## Ask the developer communities
 


### PR DESCRIPTION
Added instructions for escalating issues to Technical On-Call via PagerDuty.

This copies over instructions that exist in the "So, you’re having an incident" document. In my haste to try to escalate something this morning, I didn't look there, and instead looked at the 'ask for help' page in the Dev Docs, which did not document these steps. I ended up figuring out how to create the incident but I wasn't entirely sure I had set the right parameters until the incident was created and I saw who was auto-assigned.

<!-- The documentation you're adding here is **publicly visible**.
If the information is sensitive, such as containing personally identifiable information (PII), consider adding it to the [GOV.UK Wiki](https://gov-uk.atlassian.net/wiki/spaces/PLOPS/pages/46301383/GOV.UK+Technical+2nd+line) instead. -->
