### PR TITLE
fix: 🐛 app_name is not the repo_name, surface the repo_name too

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -8,6 +8,7 @@ class Repo
   def api_payload
     {
       app_name:, # beware renaming the key - it's used here: https://github.com/alphagov/seal/blob/36a897b099943713ea14fa2cfe1abff8b25a83a7/lib/team_builder.rb#L97
+      repo_name:,
       team:,
       alerts_team:,
       shortname:,

--- a/spec/app/repo_spec.rb
+++ b/spec/app/repo_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Repo do
         "production_hosted_on" => "aws",
       }
       payload = Repo.new(app_details).api_payload
+      expect(payload[:repo_name]).to eq(app_details["repo_name"])
       expect(payload[:app_name]).to eq(app_details["repo_name"])
       expect(payload[:team]).to eq(app_details["team"])
       expect(payload[:alerts_team]).to eq(app_details["alerts_team"])


### PR DESCRIPTION
When mapping `repos.yml` to the `/repos.json` endpoint we are swallowing the `repo_name` field. This is problematic because we are treating the `app_name` field as the `repo_name` and `app_name` doesn't always point to a repo eg. `licensify-backend`

This causes infra to fail as we are iterating over `app_name` https://github.com/alphagov/govuk-infrastructure/blob/4bb3e8a65c9a7475bcebf4efaa15e91348606856/terraform/deployments/github/main.tf#L98
